### PR TITLE
fix(versioning): narrow UUIDs in restore tests

### DIFF
--- a/tests/integration_tests/charts/version_restore_tests.py
+++ b/tests/integration_tests/charts/version_restore_tests.py
@@ -224,6 +224,7 @@ class TestChartRestoreApi(SupersetTestCase):
         chart_id = chart.id
         chart_uuid = str(chart.uuid)
         entity_uuid = chart.uuid
+        assert entity_uuid is not None
         original_name = chart.slice_name
         original_created_by = chart.created_by_fk
         before_changed_on = chart.changed_on
@@ -329,6 +330,8 @@ class TestChartRestoreApi(SupersetTestCase):
         assert alpha not in chart.editors
 
         ver_cls = version_class(Slice)
+        entity_uuid = chart.uuid
+        assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == chart.id)
@@ -337,7 +340,7 @@ class TestChartRestoreApi(SupersetTestCase):
             .scalar()
         )
         assert first_tx is not None
-        target_uuid = str(derive_version_uuid(chart.uuid, first_tx))
+        target_uuid = str(derive_version_uuid(entity_uuid, first_tx))
 
         self.login(ALPHA_USERNAME)
         rv = self._restore(str(chart.uuid), target_uuid)
@@ -387,6 +390,8 @@ class TestChartRestoreApi(SupersetTestCase):
         assert boys is not None
 
         ver_cls = version_class(Slice)
+        boys_uuid = boys.uuid
+        assert boys_uuid is not None
         boys_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == boys.id)
@@ -395,7 +400,7 @@ class TestChartRestoreApi(SupersetTestCase):
             .scalar()
         )
         assert boys_tx is not None
-        boys_version_uuid = str(derive_version_uuid(boys.uuid, boys_tx))
+        boys_version_uuid = str(derive_version_uuid(boys_uuid, boys_tx))
 
         self.login(ADMIN_USERNAME)
         rv = self._restore(str(girls.uuid), boys_version_uuid)
@@ -421,6 +426,8 @@ class TestChartRestoreApi(SupersetTestCase):
         db.session.commit()
 
         ver_cls = version_class(Slice)
+        entity_uuid = chart.uuid
+        assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == chart_id)
@@ -428,7 +435,7 @@ class TestChartRestoreApi(SupersetTestCase):
             .limit(1)
             .scalar()
         )
-        target_uuid = str(derive_version_uuid(chart.uuid, first_tx))
+        target_uuid = str(derive_version_uuid(entity_uuid, first_tx))
 
         self.login(ADMIN_USERNAME)
         rv = self._restore(str(chart.uuid), target_uuid)

--- a/tests/integration_tests/dashboards/version_restore_tests.py
+++ b/tests/integration_tests/dashboards/version_restore_tests.py
@@ -90,6 +90,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         original_title = dashboard.dashboard_title
         dashboard_id = dashboard.id
         entity_uuid = dashboard.uuid
+        assert entity_uuid is not None
 
         # Make two more edits so we have a known non-trivial history to
         # navigate: [initial, v1, v2].
@@ -151,6 +152,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         dashboard_uuid = str(dashboard.uuid)
         dashboard_id = dashboard.id
         entity_uuid = dashboard.uuid
+        assert entity_uuid is not None
 
         original_slice_ids = sorted(s.id for s in dashboard.slices)
         assert len(original_slice_ids) >= 2, (
@@ -225,6 +227,8 @@ class TestDashboardRestoreApi(SupersetTestCase):
         db.session.commit()
 
         ver_cls = version_class(Dashboard)
+        entity_uuid = dashboard.uuid
+        assert entity_uuid is not None
         target_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == dashboard_id)
@@ -232,7 +236,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
             .limit(1)
             .scalar()
         )
-        target_uuid = str(derive_version_uuid(dashboard.uuid, target_tx))
+        target_uuid = str(derive_version_uuid(entity_uuid, target_tx))
 
         # Edit the member chart AFTER the snapshot.
         member = db.session.query(Slice).filter(Slice.id == member_id).one()
@@ -282,6 +286,8 @@ class TestDashboardRestoreApi(SupersetTestCase):
         db.session.commit()
 
         ver_cls = version_class(Dashboard)
+        entity_uuid = dashboard.uuid
+        assert entity_uuid is not None
         target_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == dashboard_id)
@@ -289,7 +295,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
             .limit(1)
             .scalar()
         )
-        target_uuid = str(derive_version_uuid(dashboard.uuid, target_tx))
+        target_uuid = str(derive_version_uuid(entity_uuid, target_tx))
 
         # Detach, then hard-delete the victim via raw SQL so no live row
         # remains (bypasses the soft-delete listener deliberately — the
@@ -340,6 +346,8 @@ class TestDashboardRestoreApi(SupersetTestCase):
         assert alpha not in dashboard.editors
 
         ver_cls = version_class(Dashboard)
+        entity_uuid = dashboard.uuid
+        assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
             .filter(ver_cls.id == dashboard.id)
@@ -348,7 +356,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
             .scalar()
         )
         assert first_tx is not None
-        target_uuid = str(derive_version_uuid(dashboard.uuid, first_tx))
+        target_uuid = str(derive_version_uuid(entity_uuid, first_tx))
 
         self.login(ALPHA_USERNAME)
         rv = self._restore(str(dashboard.uuid), target_uuid)

--- a/tests/integration_tests/datasets/version_restore_tests.py
+++ b/tests/integration_tests/datasets/version_restore_tests.py
@@ -109,6 +109,7 @@ class TestDatasetRestoreApi(SupersetTestCase):
         assert table is not None
         table_uuid = str(table.uuid)
         entity_uuid = table.uuid
+        assert entity_uuid is not None
         table_id = table.id
         original_description = table.description
 
@@ -164,6 +165,7 @@ class TestDatasetRestoreApi(SupersetTestCase):
         assert table is not None
         table_uuid = str(table.uuid)
         entity_uuid = table.uuid
+        assert entity_uuid is not None
         table_id = table.id
 
         col = table.columns[0]
@@ -219,6 +221,7 @@ class TestDatasetRestoreApi(SupersetTestCase):
         table_id = table.id
         table_uuid = str(table.uuid)
         entity_uuid = table.uuid
+        assert entity_uuid is not None
 
         original_col_names = sorted(c.column_name for c in table.columns)
         removed_name = table.columns[0].column_name
@@ -285,6 +288,7 @@ class TestDatasetRestoreApi(SupersetTestCase):
         table_id = table.id
         table_uuid = str(table.uuid)
         entity_uuid = table.uuid
+        assert entity_uuid is not None
         removed_name = table.columns[0].column_name
         added_name = "__restore_full_diff_test__"
 
@@ -399,6 +403,7 @@ class TestDatasetRestoreApi(SupersetTestCase):
         table_id = table.id
         table_uuid = str(table.uuid)
         entity_uuid = table.uuid
+        assert entity_uuid is not None
         original_description = table.description
         original_col_names = sorted(c.column_name for c in table.columns)
 


### PR DESCRIPTION
### SUMMARY

Narrow the nullable SQLAlchemy UUID attributes in the chart, dashboard, and
dataset version-restore integration tests before passing them to
`derive_version_uuid`.

The scheduled pre-commit workflow on master reported 14 MyPy `arg-type` errors
after #42469 introduced these tests. The model fields are typed as `UUID | None`,
while the helper correctly requires `UUID`. Explicit non-null assertions at the
test setup boundaries retain the runtime test behavior and satisfy the stricter
contract.

Observed failure: https://github.com/apache/superset/actions/runs/30611617987

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; test-only typing fix.

### TESTING INSTRUCTIONS

- `pre-commit run mypy --files tests/integration_tests/charts/version_restore_tests.py tests/integration_tests/dashboards/version_restore_tests.py tests/integration_tests/datasets/version_restore_tests.py`
- `pre-commit run --files tests/integration_tests/charts/version_restore_tests.py tests/integration_tests/dashboards/version_restore_tests.py tests/integration_tests/datasets/version_restore_tests.py`
- `pre-commit run --all-files` was run. The affected MyPy hook passed; unrelated local baseline/environment failures remained in docs/frontend tooling and repository-wide linting.
- The three pytest files were attempted, but the host environment failed before collection because its `pytest-cov` plugin imports `coverage.results.display_covered`, which is absent from the installed `coverage` package.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
