### PR TITLE
feat(mcp): filter asset lists by certification

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -36,6 +36,7 @@ from pydantic import (
     field_validator,
     model_serializer,
     model_validator,
+    StrictBool,
     ValidationError,
 )
 from typing_extensions import Self
@@ -2203,7 +2204,7 @@ class ListChartsRequest(
     """Request schema for list_charts with clear, unambiguous types."""
 
     certified: Annotated[
-        bool | None,
+        StrictBool | None,
         Field(
             default=None,
             description=(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -2202,6 +2202,19 @@ class ListChartsRequest(
 ):
     """Request schema for list_charts with clear, unambiguous types."""
 
+    certified: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description=(
+                "Filter by governance certification status. Use true to return "
+                "only certified charts (preferred when selecting governed "
+                "assets), false to return only uncertified charts, or omit to "
+                "return both (default)."
+            ),
+        ),
+    ]
+
     deleted_state: Annotated[
         Literal["include", "only"] | None,
         Field(

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -80,7 +80,7 @@ async def list_charts(
     """List charts with filtering and search.
 
     Returns chart metadata including id, name, viz_type, URL, and last
-    modified time. Set ``request.certified`` to true to prioritize governed
+    modified time. Set ``request.certified`` to true to return only governed
     charts; false returns only uncertified charts, while omitting it preserves
     the unfiltered behavior.
 

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -23,13 +23,12 @@ import logging
 from typing import cast, TYPE_CHECKING
 
 from fastmcp import Context
-from flask_appbuilder.models.sqla.interface import SQLAInterface
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
-from superset.extensions import db, event_logger
+from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import (
     ChartError,
     ChartFilter,
@@ -39,7 +38,7 @@ from superset.mcp_service.chart.schemas import (
     ListChartsRequest,
     serialize_chart_object,
 )
-from superset.mcp_service.mcp_core import BoundFilter, ModelListCore
+from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.privacy import (
     DATA_MODEL_METADATA_ERROR_TYPE,
     remove_chart_data_model_columns,
@@ -184,11 +183,10 @@ async def list_charts(
         with event_logger.log_context(action="mcp.list_charts.query"):
             custom_filters = None
             if request.certified is not None:
-                certified_filter = ChartCertifiedFilter(
-                    "id", SQLAInterface(ChartDAO.model_cls, db.session)
-                )
                 custom_filters = {
-                    "certified": BoundFilter(certified_filter, request.certified)
+                    "certified": tool.build_bound_filter(
+                        ChartCertifiedFilter, request.certified
+                    )
                 }
             result = tool.run_tool(
                 filters=request.filters,

--- a/superset/mcp_service/chart/tool/list_charts.py
+++ b/superset/mcp_service/chart/tool/list_charts.py
@@ -23,12 +23,13 @@ import logging
 from typing import cast, TYPE_CHECKING
 
 from fastmcp import Context
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
-from superset.extensions import event_logger
+from superset.extensions import db, event_logger
 from superset.mcp_service.chart.schemas import (
     ChartError,
     ChartFilter,
@@ -38,7 +39,7 @@ from superset.mcp_service.chart.schemas import (
     ListChartsRequest,
     serialize_chart_object,
 )
-from superset.mcp_service.mcp_core import ModelListCore
+from superset.mcp_service.mcp_core import BoundFilter, ModelListCore
 from superset.mcp_service.privacy import (
     DATA_MODEL_METADATA_ERROR_TYPE,
     remove_chart_data_model_columns,
@@ -80,7 +81,9 @@ async def list_charts(
     """List charts with filtering and search.
 
     Returns chart metadata including id, name, viz_type, URL, and last
-    modified time.
+    modified time. Set ``request.certified`` to true to prioritize governed
+    charts; false returns only uncertified charts, while omitting it preserves
+    the unfiltered behavior.
 
     **IMPORTANT**: All parameters must be wrapped in a ``request`` object.
     Do NOT pass ``search``, ``page``, ``page_size``, etc. as top-level
@@ -124,7 +127,7 @@ async def list_charts(
         )
     )
 
-    from superset.charts.filters import ChartDeletedStateFilter
+    from superset.charts.filters import ChartCertifiedFilter, ChartDeletedStateFilter
     from superset.daos.chart import ChartDAO
     from superset.mcp_service.common.schema_discovery import (
         CHART_SORTABLE_COLUMNS,
@@ -179,6 +182,14 @@ async def list_charts(
 
     try:
         with event_logger.log_context(action="mcp.list_charts.query"):
+            custom_filters = None
+            if request.certified is not None:
+                certified_filter = ChartCertifiedFilter(
+                    "id", SQLAInterface(ChartDAO.model_cls, db.session)
+                )
+                custom_filters = {
+                    "certified": BoundFilter(certified_filter, request.certified)
+                }
             result = tool.run_tool(
                 filters=request.filters,
                 search=request.search,
@@ -190,6 +201,7 @@ async def list_charts(
                 created_by_me=request.created_by_me,
                 edited_by_me=request.edited_by_me,
                 deleted_state=request.deleted_state,
+                custom_filters=custom_filters,
             )
         count = len(result.charts) if hasattr(result, "charts") else 0
         total_pages = getattr(result, "total_pages", None)

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -32,6 +32,7 @@ from pydantic import (
     field_validator,
     model_serializer,
     model_validator,
+    StrictBool,
 )
 
 from superset.daos.base import ColumnOperator, ColumnOperatorEnum
@@ -247,7 +248,7 @@ class ListDatasetsRequest(
     """
 
     certified: Annotated[
-        bool | None,
+        StrictBool | None,
         Field(
             default=None,
             description=(

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -246,6 +246,19 @@ class ListDatasetsRequest(
     test_list_datasets_with_string_filters.
     """
 
+    certified: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description=(
+                "Filter by governance certification status. Use true to return "
+                "only certified datasets (preferred when selecting governed "
+                "semantic-layer assets), false to return only uncertified "
+                "datasets, or omit to return both (default)."
+            ),
+        ),
+    ]
+
     @field_validator("filters", mode="before")
     @classmethod
     def parse_filters(cls, v: Any) -> Any:

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -26,13 +26,12 @@ import logging
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
-from flask_appbuilder.models.sqla.interface import SQLAInterface
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
-from superset.extensions import db, event_logger
+from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
     DatasetError,
     DatasetFilter,
@@ -41,7 +40,7 @@ from superset.mcp_service.dataset.schemas import (
     ListDatasetsRequest,
     serialize_dataset_object,
 )
-from superset.mcp_service.mcp_core import BoundFilter, ModelListCore
+from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.privacy import (
     DATA_MODEL_METADATA_ERROR_TYPE,
     requires_data_model_metadata_access,
@@ -197,11 +196,10 @@ async def list_datasets(
         with event_logger.log_context(action="mcp.list_datasets.query"):
             custom_filters = None
             if request.certified is not None:
-                certified_filter = DatasetCertifiedFilter(
-                    "id", SQLAInterface(DatasetDAO.model_cls, db.session)
-                )
                 custom_filters = {
-                    "certified": BoundFilter(certified_filter, request.certified)
+                    "certified": tool.build_bound_filter(
+                        DatasetCertifiedFilter, request.certified
+                    )
                 }
             result = tool.run_tool(
                 filters=request.filters,

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -26,12 +26,13 @@ import logging
 from typing import TYPE_CHECKING
 
 from fastmcp import Context
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
 
-from superset.extensions import event_logger
+from superset.extensions import db, event_logger
 from superset.mcp_service.dataset.schemas import (
     DatasetError,
     DatasetFilter,
@@ -40,7 +41,7 @@ from superset.mcp_service.dataset.schemas import (
     ListDatasetsRequest,
     serialize_dataset_object,
 )
-from superset.mcp_service.mcp_core import ModelListCore
+from superset.mcp_service.mcp_core import BoundFilter, ModelListCore
 from superset.mcp_service.privacy import (
     DATA_MODEL_METADATA_ERROR_TYPE,
     requires_data_model_metadata_access,
@@ -94,7 +95,9 @@ async def list_datasets(
     """List datasets with filtering and search.
 
     Returns dataset metadata including table name, schema, and last modified
-    time.
+    time. Set ``request.certified`` to true to prioritize governed,
+    semantic-layer datasets; false returns only uncertified datasets, while
+    omitting it preserves the unfiltered behavior.
 
     **IMPORTANT**: All parameters must be wrapped in a ``request`` object.
     Do NOT pass ``search``, ``page``, ``page_size``, etc. as top-level
@@ -160,6 +163,7 @@ async def list_datasets(
 
     try:
         from superset.daos.dataset import DatasetDAO
+        from superset.datasets.filters import DatasetCertifiedFilter
         from superset.mcp_service.common.schema_discovery import (
             DATASET_SORTABLE_COLUMNS,
             get_all_column_names,
@@ -191,6 +195,14 @@ async def list_datasets(
         )
 
         with event_logger.log_context(action="mcp.list_datasets.query"):
+            custom_filters = None
+            if request.certified is not None:
+                certified_filter = DatasetCertifiedFilter(
+                    "id", SQLAInterface(DatasetDAO.model_cls, db.session)
+                )
+                custom_filters = {
+                    "certified": BoundFilter(certified_filter, request.certified)
+                }
             result = tool.run_tool(
                 filters=request.filters,
                 search=request.search,
@@ -201,6 +213,7 @@ async def list_datasets(
                 page_size=request.page_size,
                 created_by_me=request.created_by_me,
                 edited_by_me=request.edited_by_me,
+                custom_filters=custom_filters,
             )
 
         await ctx.info(

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -94,7 +94,7 @@ async def list_datasets(
     """List datasets with filtering and search.
 
     Returns dataset metadata including table name, schema, and last modified
-    time. Set ``request.certified`` to true to prioritize governed,
+    time. Set ``request.certified`` to true to return only governed,
     semantic-layer datasets; false returns only uncertified datasets, while
     omitting it preserves the unfiltered behavior.
 

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -137,6 +137,22 @@ class DeletedStateBoundFilter:
         return self._inner.apply(query, self._value)
 
 
+class BoundFilter:
+    """Bind a caller value to a FAB filter used by ``BaseDAO.list``.
+
+    ``BaseDAO.list`` invokes custom filters with ``None`` because REST filters
+    normally receive their values outside the DAO. MCP request fields already
+    contain the value, so this adapter preserves it for the shared FAB filter.
+    """
+
+    def __init__(self, inner: Any, value: Any) -> None:
+        self._inner = inner
+        self._value = value
+
+    def apply(self, query: Any, value: Any) -> Any:
+        return self._inner.apply(query, self._value)
+
+
 class ModelListCore(BaseCore, Generic[L]):
     """
     Generic tool for listing model objects with filtering, search, pagination, and
@@ -352,6 +368,7 @@ class ModelListCore(BaseCore, Generic[L]):
         created_by_me: bool = False,
         edited_by_me: bool = False,
         deleted_state: str | None = None,
+        custom_filters: Dict[str, Any] | None = None,
     ) -> L:
         # Clamp page_size to MAX_PAGE_SIZE as defense-in-depth
         page_size = min(page_size, MAX_PAGE_SIZE)
@@ -401,7 +418,9 @@ class ModelListCore(BaseCore, Generic[L]):
             "search": search,
             "columns_to_load": columns_to_load,
         }
+        dao_custom_filters = dict(custom_filters or {})
         if deleted_state_bound is not None:
+            dao_custom_filters["deleted_state"] = deleted_state_bound
             # The soft-delete ORM listener appends ``deleted_at IS NULL`` at
             # execution time, so the session-scoped bypass must span both
             # executions inside DAO.list (count + fetch). The context manager
@@ -410,11 +429,13 @@ class ModelListCore(BaseCore, Generic[L]):
             # which unhidden rows the caller may actually see.
             with skip_visibility_filter(db.session, deleted_state_bound.model):
                 items, total_count = self._call_dao_list(
-                    custom_filters={"deleted_state": deleted_state_bound},
+                    custom_filters=dao_custom_filters,
                     **dao_kwargs,
                 )
         else:
-            items, total_count = self._call_dao_list(**dao_kwargs)
+            items, total_count = self._call_dao_list(
+                custom_filters=dao_custom_filters or None, **dao_kwargs
+            )
         # Serialize items
         item_objs = []
         for item in items:

--- a/superset/mcp_service/mcp_core.py
+++ b/superset/mcp_service/mcp_core.py
@@ -115,34 +115,12 @@ class BaseCore(ABC):
         self.logger.warning(message)
 
 
-class DeletedStateBoundFilter:
-    """Adapt a FAB deleted-state filter for ``BaseDAO.list`` custom_filters.
-
-    ``BaseDAO.list`` invokes custom filters as ``apply(query, None)``, but the
-    ``BaseDeletedStateFilter`` subclasses interpret ``None`` as "live rows
-    only". Binding the value at construction lets the DAO-side invocation
-    reach the FAB filter with the caller's actual ``include``/``only`` choice.
-
-    ``model`` re-exposes the FAB filter's SoftDeleteMixin model class so the
-    caller can scope the session visibility bypass without re-consulting the
-    (Optional) filter-class attribute.
-    """
-
-    def __init__(self, inner: Any, value: str, model: type) -> None:
-        self._inner = inner
-        self._value = value
-        self.model = model
-
-    def apply(self, query: Any, value: Any) -> Any:
-        return self._inner.apply(query, self._value)
-
-
 class BoundFilter:
     """Bind a caller value to a FAB filter used by ``BaseDAO.list``.
 
-    ``BaseDAO.list`` invokes custom filters with ``None`` because REST filters
-    normally receive their values outside the DAO. MCP request fields already
-    contain the value, so this adapter preserves it for the shared FAB filter.
+    ``BaseDAO.list`` invokes custom filters as ``apply(query, None)``, but the
+    request value is already available to MCP callers. Binding it at
+    construction preserves that value for the DAO-side invocation.
     """
 
     def __init__(self, inner: Any, value: Any) -> None:
@@ -151,6 +129,14 @@ class BoundFilter:
 
     def apply(self, query: Any, value: Any) -> Any:
         return self._inner.apply(query, self._value)
+
+
+class DeletedStateBoundFilter(BoundFilter):
+    """Bound deleted-state filter carrying its visibility-bypass model."""
+
+    def __init__(self, inner: Any, value: str, model: type) -> None:
+        super().__init__(inner, value)
+        self.model = model
 
 
 class ModelListCore(BaseCore, Generic[L]):
@@ -355,6 +341,11 @@ class ModelListCore(BaseCore, Generic[L]):
         datamodel = SQLAInterface(model, db.session)
         inner = self._deleted_state_filter("id", datamodel)
         return DeletedStateBoundFilter(inner, normalized, model)
+
+    def build_bound_filter(self, filter_class: type, value: Any) -> BoundFilter:
+        """Bind an MCP value to a FAB filter for this core's DAO model."""
+        datamodel = SQLAInterface(self.dao_class.model_cls, db.session)
+        return BoundFilter(filter_class("id", datamodel), value)
 
     def run_tool(
         self,

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -148,6 +148,12 @@ class TestListChartsRequestSchema:
         assert request.page == 2
         assert request.page_size == 50
 
+    @pytest.mark.parametrize("value", ["true", "false", 0, 1])
+    def test_certified_requires_json_boolean(self, value):
+        """Reject values that Pydantic's non-strict bool would coerce."""
+        with pytest.raises(ValueError, match="valid boolean"):
+            ListChartsRequest(certified=value)
+
     def test_invalid_order_direction(self):
         """Test that invalid order direction raises validation error."""
         with pytest.raises(ValueError, match="Input should be 'asc' or 'desc'"):

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -20,6 +20,7 @@ Tests for the list_charts request schema
 """
 
 import importlib
+from copy import copy
 from unittest.mock import Mock, patch
 
 import pytest
@@ -354,3 +355,56 @@ async def test_list_charts_no_arguments(mock_list, mcp_server):
         result = await client.call_tool("list_charts", {})
     data = json.loads(result.content[0].text)
     assert "charts" in data
+
+
+@patch("superset.daos.chart.ChartDAO.list")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("certified", "expected_names"),
+    [
+        (True, ["Certified"]),
+        (False, ["Uncertified"]),
+        (None, ["Certified", "Uncertified"]),
+    ],
+)
+async def test_list_charts_certified_filter(
+    mock_list, mcp_server, mock_chart, certified, expected_names
+):
+    """Certification is opt-in and supports certified, uncertified, and all."""
+    certified_chart = copy(mock_chart)
+    certified_chart.id = 1
+    certified_chart.slice_name = "Certified"
+    certified_chart.certified_by = "Data Governance"
+    certified_chart.deleted_at = None
+    uncertified_chart = mock_chart
+    uncertified_chart.id = 2
+    uncertified_chart.slice_name = "Uncertified"
+    uncertified_chart.deleted_at = None
+    charts = [certified_chart, uncertified_chart]
+
+    def list_side_effect(**kwargs):
+        custom_filter = (kwargs.get("custom_filters") or {}).get("certified")
+        if custom_filter is None:
+            selected = charts
+        else:
+            selected = [
+                chart
+                for chart in charts
+                if bool(chart.certified_by) is custom_filter._value
+            ]
+        return selected, len(selected)
+
+    mock_list.side_effect = list_side_effect
+    request = ListChartsRequest(certified=certified)
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "list_charts", {"request": request.model_dump()}
+        )
+
+    data = json.loads(result.content[0].text)
+    actual_names = [chart["slice_name"] for chart in data["charts"]]
+    assert len(actual_names) == len(expected_names)
+    assert all(
+        expected in actual
+        for expected, actual in zip(expected_names, actual_names, strict=False)
+    )

--- a/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
@@ -387,11 +387,16 @@ async def test_list_charts_certified_filter(
         if custom_filter is None:
             selected = charts
         else:
-            selected = [
-                chart
-                for chart in charts
-                if bool(chart.certified_by) is custom_filter._value
-            ]
+            query = Mock()
+            custom_filter.apply(query, None)
+            predicate = str(query.filter.call_args.args[0])
+            expected_predicate = (
+                "slices.certified_by IS NOT NULL"
+                if certified
+                else "slices.certified_by IS NULL"
+            )
+            assert expected_predicate in predicate
+            selected = [charts[0] if certified else charts[1]]
         return selected, len(selected)
 
     mock_list.side_effect = list_side_effect

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -183,7 +183,7 @@ def mock_auth():
 
 
 @pytest.fixture(autouse=True)
-def allow_data_model_metadata():
+def allow_data_model_metadata():  # noqa: PT004
     """Keep dataset tests in the normal metadata-allowed path by default."""
     with (
         patch.object(
@@ -312,6 +312,48 @@ async def test_list_datasets_basic(mock_list, mcp_server):
         # Verify changed_on_humanized is in default columns
         assert "changed_on_humanized" in data["columns_requested"]
         assert "changed_on_humanized" in data["columns_loaded"]
+
+
+@patch("superset.daos.dataset.DatasetDAO.list")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("certified", "expected_names"),
+    [
+        (True, ["Certified"]),
+        (False, ["Uncertified"]),
+        (None, ["Certified", "Uncertified"]),
+    ],
+)
+async def test_list_datasets_certified_filter(
+    mock_list, mcp_server, certified, expected_names
+):
+    """Certification is opt-in and supports certified, uncertified, and all."""
+    certified_dataset = create_mock_dataset(1, "Certified")
+    certified_dataset.certified_by = "Data Governance"
+    uncertified_dataset = create_mock_dataset(2, "Uncertified")
+    datasets = [certified_dataset, uncertified_dataset]
+
+    def list_side_effect(**kwargs):
+        custom_filter = (kwargs.get("custom_filters") or {}).get("certified")
+        if custom_filter is None:
+            selected = datasets
+        else:
+            selected = [
+                dataset
+                for dataset in datasets
+                if bool(dataset.certified_by) is custom_filter._value
+            ]
+        return selected, len(selected)
+
+    mock_list.side_effect = list_side_effect
+    request = ListDatasetsRequest(certified=certified)
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "list_datasets", {"request": request.model_dump()}
+        )
+
+    data = json.loads(result.content[0].text)
+    assert [dataset["table_name"] for dataset in data["datasets"]] == expected_names
 
 
 @patch("superset.daos.dataset.DatasetDAO.list")

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -329,7 +329,7 @@ async def test_list_datasets_certified_filter(
 ):
     """Certification is opt-in and supports certified, uncertified, and all."""
     certified_dataset = create_mock_dataset(1, "Certified")
-    certified_dataset.certified_by = "Data Governance"
+    certified_dataset.extra = '{"certification": {"certified_by": "Governance"}}'
     uncertified_dataset = create_mock_dataset(2, "Uncertified")
     datasets = [certified_dataset, uncertified_dataset]
 
@@ -338,11 +338,15 @@ async def test_list_datasets_certified_filter(
         if custom_filter is None:
             selected = datasets
         else:
-            selected = [
-                dataset
-                for dataset in datasets
-                if bool(dataset.certified_by) is custom_filter._value
-            ]
+            query = MagicMock()
+            custom_filter.apply(query, None)
+            predicate = str(query.filter.call_args.args[0])
+            if certified:
+                assert "lower(tables.extra) LIKE lower" in predicate
+            else:
+                assert "tables.extra NOT LIKE" in predicate
+                assert "tables.extra IS NULL" in predicate
+            selected = [datasets[0] if certified else datasets[1]]
         return selected, len(selected)
 
     mock_list.side_effect = list_side_effect

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -53,6 +53,13 @@ get_dataset_info_module = importlib.import_module(
 )
 
 
+@pytest.mark.parametrize("value", ["true", "false", 0, 1])
+def test_list_datasets_certified_requires_json_boolean(value):
+    """Reject values that Pydantic's non-strict bool would coerce."""
+    with pytest.raises(ValueError, match="valid boolean"):
+        ListDatasetsRequest(certified=value)
+
+
 def _wrapped(value: str) -> str:
     return f"{LLM_CONTEXT_OPEN_DELIMITER}\n{value}\n{LLM_CONTEXT_CLOSE_DELIMITER}"
 


### PR DESCRIPTION
### SUMMARY

Adds an optional tri-state `certified` field to the MCP `list_datasets` and `list_charts` request schemas:

- `true` returns certified assets only
- `false` returns uncertified assets only
- omission preserves the existing unfiltered behavior

The tools reuse Superset's existing dataset and chart certification filters, keeping their semantics aligned with the REST APIs. The schema descriptions explicitly recommend the filter when an agent needs governed semantic-layer assets.

## Why

MCP consumers otherwise need to retrieve every visible dataset or chart and filter the response client-side. Server-side filtering makes governed asset discovery explicit and can reduce response tokens without changing defaults.

## What

A small adapter binds MCP request values to Flask-AppBuilder custom filters, and the shared list core passes those filters to the DAO. Both dataset and chart list tools expose the same tri-state request field.

## Blast radius

Limited to authenticated MCP dataset and chart list calls. Existing RBAC/base filters remain in place and run before the certification filter. No database, migration, RLS, workspace-isolation, UI, or feature-flag changes.

## Risk & rollback

Low risk. Omitted values retain the prior DAO query path. The main risk is divergence from certification semantics, mitigated by reusing the existing REST filter classes. Rollback is a normal revert.

## Review guidance

Start with the request fields in the chart and dataset schemas, then review the bound-filter adapter and tool wiring. The most important behavior is that `None` does not install a custom filter.

## Eval evidence

The affected MCP unit suites pass 99/99. The full staging agent eval suite was not run because this OSS worktree has no deployed staging build/workspace target.

## Cost & latency delta

No model, prompt, routing, or model-parameter changes (0). Omitted-filter requests execute the same asset query as before. Opt-in certified filtering adds one existing SQL predicate and reduces returned rows; no deployed before/after token or latency sample is available from this worktree.

## Prompt / non-determinism

No prompt or model-routing changes. The tool schema description is deterministic and is covered by request/tool tests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; no UI changes.

### TESTING INSTRUCTIONS

```bash
pytest -q tests/unit_tests/mcp_service/chart/tool/test_list_charts.py \
  tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py

pre-commit run --files \
  superset/mcp_service/mcp_core.py \
  superset/mcp_service/dataset/schemas.py \
  superset/mcp_service/dataset/tool/list_datasets.py \
  superset/mcp_service/chart/schemas.py \
  superset/mcp_service/chart/tool/list_charts.py \
  tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py \
  tests/unit_tests/mcp_service/chart/tool/test_list_charts.py
```

The tests cover `certified=true`, `certified=false`, and omitted certification for both asset types.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
