### PR TITLE
fix(mcp): expose table column formatting

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -24,6 +24,7 @@ generation that can be used by both generate_chart and generate_explore_link too
 
 import hashlib
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -573,6 +574,39 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
         }
 
     return form_data
+
+
+def merge_table_column_config(
+    existing_form_data: Mapping[str, Any], new_form_data: Dict[str, Any]
+) -> None:
+    """Merge MCP table formatting without discarding UI-only settings.
+
+    An omitted ``column_config`` preserves the saved value, an explicit empty
+    mapping clears it, and a non-empty mapping updates only the supplied labels
+    and properties. The nested merge is important because the Superset UI stores
+    additional column settings that the MCP schema does not expose.
+    """
+    if "column_config" not in new_form_data:
+        if "column_config" in existing_form_data:
+            new_form_data["column_config"] = existing_form_data["column_config"]
+        return
+
+    new_column_config = new_form_data["column_config"]
+    if not isinstance(new_column_config, dict) or not new_column_config:
+        return
+
+    existing_column_config = existing_form_data.get("column_config")
+    if not isinstance(existing_column_config, dict):
+        return
+
+    merged_column_config = dict(existing_column_config)
+    for label, settings in new_column_config.items():
+        existing_settings = existing_column_config.get(label)
+        if isinstance(existing_settings, dict) and isinstance(settings, dict):
+            merged_column_config[label] = {**existing_settings, **settings}
+        else:
+            merged_column_config[label] = settings
+    new_form_data["column_config"] = merged_column_config
 
 
 def create_metric_object(col: ColumnRef) -> Dict[str, Any] | str:

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -569,7 +569,7 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
     add_color_scheme(form_data, config.color_scheme)
     if config.column_config is not None:
         form_data["column_config"] = {
-            label: column.model_dump(by_alias=True, exclude_none=True)
+            label: column.model_dump(by_alias=True, exclude_unset=True)
             for label, column in config.column_config.items()
         }
 
@@ -586,6 +586,13 @@ def merge_table_column_config(
     and properties. The nested merge is important because the Superset UI stores
     additional column settings that the MCP schema does not expose.
     """
+    table_viz_types = {"table", "ag-grid-table"}
+    if (
+        existing_form_data.get("viz_type") not in table_viz_types
+        or new_form_data.get("viz_type") not in table_viz_types
+    ):
+        return
+
     if "column_config" not in new_form_data:
         if "column_config" in existing_form_data:
             new_form_data["column_config"] = existing_form_data["column_config"]

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -566,6 +566,11 @@ def map_table_config(config: TableChartConfig) -> Dict[str, Any]:
 
     form_data["row_limit"] = config.row_limit
     add_color_scheme(form_data, config.color_scheme)
+    if config.column_config is not None:
+        form_data["column_config"] = {
+            label: column.model_dump(by_alias=True, exclude_none=True)
+            for label, column in config.column_config.items()
+        }
 
     return form_data
 

--- a/superset/mcp_service/chart/plugins/table.py
+++ b/superset/mcp_service/chart/plugins/table.py
@@ -104,7 +104,10 @@ class TableChartPlugin(BaseChartPlugin):
         return getattr(config, "viz_type", "table")
 
     def normalize_column_refs(self, config: Any, dataset_context: Any) -> Any:
-        config_dict = config.model_dump()
+        # Preserve which nested column formatting fields were explicitly supplied.
+        # Round-tripping them through model_dump/model_validate would materialize
+        # omitted optional fields as None, turning a partial update into a clear.
+        config_dict = config.model_dump(exclude={"column_config"})
         get_canonical = DatasetValidator.get_canonical_column_name
         get_canonical_metric = DatasetValidator.get_canonical_metric_name
 
@@ -115,7 +118,9 @@ class TableChartPlugin(BaseChartPlugin):
                 col["name"] = get_canonical(col["name"], dataset_context)
 
         DatasetValidator.normalize_filters(config_dict, dataset_context)
-        return TableChartConfig.model_validate(config_dict)
+        normalized = TableChartConfig.model_validate(config_dict)
+        normalized.column_config = config.column_config
+        return normalized
 
     def schema_error_hint(self) -> ChartGenerationError | None:
         return ChartGenerationError(

--- a/superset/mcp_service/chart/plugins/table.py
+++ b/superset/mcp_service/chart/plugins/table.py
@@ -110,16 +110,24 @@ class TableChartPlugin(BaseChartPlugin):
         config_dict = config.model_dump(exclude={"column_config"})
         get_canonical = DatasetValidator.get_canonical_column_name
         get_canonical_metric = DatasetValidator.get_canonical_metric_name
+        raw_column_names: dict[str, str] = {}
 
         for col in config_dict.get("columns") or []:
             if col.get("saved_metric"):
                 col["name"] = get_canonical_metric(col["name"], dataset_context)
             elif not col.get("sql_expression"):
-                col["name"] = get_canonical(col["name"], dataset_context)
+                original_name = col["name"]
+                col["name"] = get_canonical(original_name, dataset_context)
+                if not col.get("aggregate") and not col.get("label"):
+                    raw_column_names[original_name] = col["name"]
 
         DatasetValidator.normalize_filters(config_dict, dataset_context)
         normalized = TableChartConfig.model_validate(config_dict)
-        normalized.column_config = config.column_config
+        if config.column_config is not None:
+            normalized.column_config = {
+                raw_column_names.get(label, label): column_config
+                for label, column_config in config.column_config.items()
+            }
         return normalized
 
     def schema_error_hint(self) -> ChartGenerationError | None:

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1548,7 +1548,11 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
 class TableColumnConfig(UnknownFieldCheckMixin):
     """Display formatting supported by the MCP table-chart schema."""
 
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        json_schema_extra={"additionalProperties": False},
+    )
 
     column_width: int | None = Field(
         None,

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1545,6 +1545,33 @@ class BigNumberChartConfig(UnknownFieldCheckMixin):
         return self
 
 
+class TableColumnConfig(UnknownFieldCheckMixin):
+    """Display formatting supported by the MCP table-chart schema."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    column_width: int | None = Field(
+        None,
+        alias="columnWidth",
+        description="Minimum column width in pixels.",
+        ge=0,
+    )
+    d3_number_format: str | None = Field(
+        None,
+        alias="d3NumberFormat",
+        description="D3 number format, for example ',.2f', '$,.2f', or '.1%'.",
+        min_length=1,
+        max_length=100,
+    )
+    d3_time_format: str | None = Field(
+        None,
+        alias="d3TimeFormat",
+        description="D3 time format, for example '%Y-%m-%d' or '%b %d, %Y'.",
+        min_length=1,
+        max_length=100,
+    )
+
+
 class TableChartConfig(UnknownFieldCheckMixin):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
@@ -1590,6 +1617,18 @@ class TableChartConfig(UnknownFieldCheckMixin):
             "(e.g. 'supersetColors')."
         ),
         max_length=100,
+    )
+    column_config: dict[str, "TableColumnConfig"] | None = Field(
+        None,
+        description=(
+            "Per-column display settings, keyed by the result column label "
+            "(for a raw column this is usually its column name; for a metric, use "
+            "its label). Use columnWidth for minimum width in pixels, "
+            "d3NumberFormat for D3 number formats such as ',.2f' or '.1%', and "
+            "d3TimeFormat for D3 time formats such as '%Y-%m-%d'. Example: "
+            "{'Total Sales': {'columnWidth': 120, 'd3NumberFormat': '$,.2f'}, "
+            "'Order Date': {'d3TimeFormat': '%Y-%m-%d'}}."
+        ),
     )
 
     @model_validator(mode="after")

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -40,6 +40,7 @@ from superset.mcp_service.chart.chart_utils import (
     analyze_chart_semantics,
     generate_chart_name,
     map_config_to_form_data,
+    merge_table_column_config,
 )
 from superset.mcp_service.chart.compile import validate_and_compile
 from superset.mcp_service.chart.schemas import (
@@ -60,6 +61,20 @@ from superset.mcp_service.utils.url_utils import get_superset_base_url
 from superset.utils import json
 
 logger = logging.getLogger(__name__)
+
+
+def _get_existing_form_data(chart: Any) -> dict[str, Any]:
+    """Return a chart's saved form data, treating malformed params as empty."""
+    if not getattr(chart, "params", None):
+        return {}
+    try:
+        parsed = json.loads(chart.params)
+    except (ValueError, TypeError):
+        parsed = None
+    if not isinstance(parsed, dict):
+        logger.warning("Failed to parse existing chart.params for chart %s", chart.id)
+        return {}
+    return parsed
 
 
 def _validation_error_response(message: str, details: str) -> GenerateChartResponse:
@@ -214,13 +229,7 @@ def _build_update_payload(
             parsed_config, dataset_id=effective_dataset_id
         )
         new_form_data.pop("_mcp_warnings", None)
-        if getattr(parsed_config, "column_config", None) is None:
-            try:
-                existing_form_data = json.loads(chart.params) if chart.params else {}
-            except (ValueError, TypeError):
-                existing_form_data = {}
-            if existing_column_config := existing_form_data.get("column_config"):
-                new_form_data["column_config"] = existing_column_config
+        merge_table_column_config(_get_existing_form_data(chart), new_form_data)
 
         chart_name = (
             request.chart_name
@@ -288,15 +297,7 @@ def _build_preview_form_data(
     GenerateChartResponse error when neither config nor chart_name is given.
     ``parsed_config`` is the pre-parsed chart config from the caller.
     """
-    existing_form_data: dict[str, Any] = {}
-    if getattr(chart, "params", None):
-        try:
-            existing_form_data = json.loads(chart.params) or {}
-        except (ValueError, TypeError):
-            logger.warning(
-                "Failed to parse existing chart.params for chart %s", chart.id
-            )
-            existing_form_data = {}
+    existing_form_data = _get_existing_form_data(chart)
 
     effective_dataset_id = (
         request.dataset_id
@@ -309,6 +310,7 @@ def _build_preview_form_data(
             parsed_config, dataset_id=effective_dataset_id
         )
         new_form_data.pop("_mcp_warnings", None)
+        merge_table_column_config(existing_form_data, new_form_data)
         # In the preview, an explicit filters list, including [], replaces saved
         # filters. An omitted filters field preserves them through the shallow merge.
         merged = _merge_replacement_config(

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -202,7 +202,11 @@ def _merge_replacement_config(
 ) -> dict[str, Any]:
     """Merge a replacement config, honoring an explicit empty filter list."""
     merged = {
-        **{key: value for key, value in existing_form_data.items() if key != "column_config"},
+        **{
+            key: value
+            for key, value in existing_form_data.items()
+            if key != "column_config"
+        },
         **new_form_data,
     }
     if getattr(parsed_config, "filters", None) == []:

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -201,7 +201,10 @@ def _merge_replacement_config(
     parsed_config: Any,
 ) -> dict[str, Any]:
     """Merge a replacement config, honoring an explicit empty filter list."""
-    merged = {**existing_form_data, **new_form_data}
+    merged = {
+        **{key: value for key, value in existing_form_data.items() if key != "column_config"},
+        **new_form_data,
+    }
     if getattr(parsed_config, "filters", None) == []:
         merged.pop("adhoc_filters", None)
     return merged

--- a/superset/mcp_service/chart/tool/update_chart.py
+++ b/superset/mcp_service/chart/tool/update_chart.py
@@ -214,6 +214,13 @@ def _build_update_payload(
             parsed_config, dataset_id=effective_dataset_id
         )
         new_form_data.pop("_mcp_warnings", None)
+        if getattr(parsed_config, "column_config", None) is None:
+            try:
+                existing_form_data = json.loads(chart.params) if chart.params else {}
+            except (ValueError, TypeError):
+                existing_form_data = {}
+            if existing_column_config := existing_form_data.get("column_config"):
+                new_form_data["column_config"] = existing_column_config
 
         chart_name = (
             request.chart_name

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -186,6 +186,10 @@ def update_chart_preview(  # noqa: C901
                 old_adhoc_filters = previous_form_data.get("adhoc_filters")
                 if old_adhoc_filters:
                     new_form_data["adhoc_filters"] = old_adhoc_filters
+            if getattr(config, "column_config", None) is None and previous_form_data:
+                old_column_config = previous_form_data.get("column_config")
+                if old_column_config:
+                    new_form_data["column_config"] = old_column_config
 
             # Tier-1 schema validation against the dataset (no DB roundtrip).
             # Runs AFTER the filter merge so filter columns are also validated.

--- a/superset/mcp_service/chart/tool/update_chart_preview.py
+++ b/superset/mcp_service/chart/tool/update_chart_preview.py
@@ -38,6 +38,7 @@ from superset.mcp_service.chart.chart_utils import (
     generate_chart_name,
     generate_explore_link,
     map_config_to_form_data,
+    merge_table_column_config,
 )
 from superset.mcp_service.chart.compile import validate_and_compile
 from superset.mcp_service.chart.preview_utils import (
@@ -186,10 +187,8 @@ def update_chart_preview(  # noqa: C901
                 old_adhoc_filters = previous_form_data.get("adhoc_filters")
                 if old_adhoc_filters:
                     new_form_data["adhoc_filters"] = old_adhoc_filters
-            if getattr(config, "column_config", None) is None and previous_form_data:
-                old_column_config = previous_form_data.get("column_config")
-                if old_column_config:
-                    new_form_data["column_config"] = old_column_config
+            if previous_form_data:
+                merge_table_column_config(previous_form_data, new_form_data)
 
             # Tier-1 schema validation against the dataset (no DB roundtrip).
             # Runs AFTER the filter merge so filter columns are also validated.

--- a/superset/mcp_service/chart/validation/pipeline.py
+++ b/superset/mcp_service/chart/validation/pipeline.py
@@ -261,7 +261,7 @@ class ValidationPipeline:
 
             # Create a new request with the normalized config
             request_dict = request.model_dump()
-            request_dict["config"] = normalized_config.model_dump()
+            request_dict["config"] = normalized_config.model_dump(exclude_unset=True)
 
             return GenerateChartRequest.model_validate(request_dict)
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -148,15 +148,17 @@ class TestMapFilterOperator:
 class TestMergeTableColumnConfig:
     def test_partial_update_preserves_other_labels_and_settings(self) -> None:
         existing = {
+            "viz_type": "table",
             "column_config": {
                 "Revenue": {"columnWidth": 80, "visible": False},
                 "Region": {"customColumnName": "Sales region"},
-            }
+            },
         }
         updated = {
+            "viz_type": "table",
             "column_config": {
                 "Revenue": {"columnWidth": 120, "d3NumberFormat": "$,.2f"}
-            }
+            },
         }
 
         merge_table_column_config(existing, updated)
@@ -171,15 +173,46 @@ class TestMergeTableColumnConfig:
         }
 
     def test_omitted_preserves_and_explicit_empty_clears(self) -> None:
-        existing = {"column_config": {"Revenue": {"columnWidth": 80}}}
-        omitted: dict[str, Any] = {}
-        explicit_empty: dict[str, Any] = {"column_config": {}}
+        existing = {
+            "viz_type": "table",
+            "column_config": {"Revenue": {"columnWidth": 80}},
+        }
+        omitted: dict[str, Any] = {"viz_type": "table"}
+        explicit_empty: dict[str, Any] = {
+            "viz_type": "table",
+            "column_config": {},
+        }
 
         merge_table_column_config(existing, omitted)
         merge_table_column_config(existing, explicit_empty)
 
         assert omitted["column_config"] == existing["column_config"]
         assert explicit_empty["column_config"] == {}
+
+    @pytest.mark.parametrize("existing_viz_type", ["line", None])
+    def test_does_not_copy_config_from_non_table_chart(
+        self, existing_viz_type: str | None
+    ) -> None:
+        existing = {
+            "viz_type": existing_viz_type,
+            "column_config": {"Revenue": {"columnWidth": 80}},
+        }
+        updated: dict[str, Any] = {"viz_type": "table"}
+
+        merge_table_column_config(existing, updated)
+
+        assert "column_config" not in updated
+
+    def test_does_not_copy_config_to_non_table_chart(self) -> None:
+        existing = {
+            "viz_type": "table",
+            "column_config": {"Revenue": {"columnWidth": 80}},
+        }
+        updated: dict[str, Any] = {"viz_type": "line"}
+
+        merge_table_column_config(existing, updated)
+
+        assert "column_config" not in updated
 
 
 class TestMapTableConfig:

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -38,6 +38,7 @@ from superset.mcp_service.chart.chart_utils import (
     map_filter_operator,
     map_table_config,
     map_xy_config,
+    merge_table_column_config,
     validate_chart_dataset,
 )
 from superset.mcp_service.chart.schemas import (
@@ -142,6 +143,43 @@ class TestMapFilterOperator:
     def test_map_filter_operator_unknown(self) -> None:
         """Test mapping of unknown operator returns original"""
         assert map_filter_operator("UNKNOWN") == "UNKNOWN"
+
+
+class TestMergeTableColumnConfig:
+    def test_partial_update_preserves_other_labels_and_settings(self) -> None:
+        existing = {
+            "column_config": {
+                "Revenue": {"columnWidth": 80, "visible": False},
+                "Region": {"customColumnName": "Sales region"},
+            }
+        }
+        updated = {
+            "column_config": {
+                "Revenue": {"columnWidth": 120, "d3NumberFormat": "$,.2f"}
+            }
+        }
+
+        merge_table_column_config(existing, updated)
+
+        assert updated["column_config"] == {
+            "Revenue": {
+                "columnWidth": 120,
+                "d3NumberFormat": "$,.2f",
+                "visible": False,
+            },
+            "Region": {"customColumnName": "Sales region"},
+        }
+
+    def test_omitted_preserves_and_explicit_empty_clears(self) -> None:
+        existing = {"column_config": {"Revenue": {"columnWidth": 80}}}
+        omitted: dict[str, Any] = {}
+        explicit_empty: dict[str, Any] = {"column_config": {}}
+
+        merge_table_column_config(existing, omitted)
+        merge_table_column_config(existing, explicit_empty)
+
+        assert omitted["column_config"] == existing["column_config"]
+        assert explicit_empty["column_config"] == {}
 
 
 class TestMapTableConfig:

--- a/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
+++ b/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
@@ -1240,6 +1240,41 @@ class TestTableFormattingOptions:
 
         assert "color_scheme" not in result
 
+    def test_column_config_in_form_data(self) -> None:
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [
+                    {"name": "order_date"},
+                    {"name": "revenue", "aggregate": "SUM", "label": "Revenue"},
+                ],
+                "column_config": {
+                    "order_date": {
+                        "columnWidth": 120,
+                        "d3TimeFormat": "%Y-%m-%d",
+                    },
+                    "Revenue": {"d3NumberFormat": "$,.2f"},
+                },
+            }
+        )
+
+        result = map_table_config(config)
+
+        assert result["column_config"] == {
+            "order_date": {"columnWidth": 120, "d3TimeFormat": "%Y-%m-%d"},
+            "Revenue": {"d3NumberFormat": "$,.2f"},
+        }
+
+    def test_column_config_rejects_unknown_setting(self) -> None:
+        with pytest.raises(ValidationError, match="Unknown field 'width'"):
+            TableChartConfig.model_validate(
+                {
+                    "chart_type": "table",
+                    "columns": [{"name": "product"}],
+                    "column_config": {"product": {"width": 120}},
+                }
+            )
+
 
 class TestCurrencyFormatModel:
     """CurrencyFormat schema validation."""

--- a/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
+++ b/tests/unit_tests/mcp_service/chart/test_new_chart_types.py
@@ -1275,6 +1275,31 @@ class TestTableFormattingOptions:
                 }
             )
 
+    def test_column_config_preserves_explicit_null_to_clear_formatting(self) -> None:
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [{"name": "revenue"}],
+                "column_config": {
+                    "revenue": {
+                        "columnWidth": None,
+                        "d3NumberFormat": None,
+                        "d3TimeFormat": None,
+                    }
+                },
+            }
+        )
+
+        result = map_table_config(config)
+
+        assert result["column_config"] == {
+            "revenue": {
+                "columnWidth": None,
+                "d3NumberFormat": None,
+                "d3TimeFormat": None,
+            }
+        }
+
 
 class TestCurrencyFormatModel:
     """CurrencyFormat schema validation."""

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py
@@ -53,6 +53,8 @@ class TestGetChartTypeSchema:
         assert "columnWidth" in description
         assert "d3NumberFormat" in description
         assert "d3TimeFormat" in description
+        column_config_schema = result["schema"]["$defs"]["TableColumnConfig"]
+        assert column_config_schema["additionalProperties"] is False
 
     def test_pie_schema_has_dimension_metric(self) -> None:
         result = _call_schema("pie")

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py
@@ -44,10 +44,15 @@ class TestGetChartTypeSchema:
         assert "y" in props
         assert "kind" in props
 
-    def test_table_schema_has_columns(self) -> None:
+    def test_table_schema_has_columns_and_column_config(self) -> None:
         result = _call_schema("table")
         props = result["schema"]["properties"]
         assert "columns" in props
+        assert "column_config" in props
+        description = props["column_config"]["description"]
+        assert "columnWidth" in description
+        assert "d3NumberFormat" in description
+        assert "d3TimeFormat" in description
 
     def test_pie_schema_has_dimension_metric(self) -> None:
         result = _call_schema("pie")

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -123,7 +123,10 @@ class TestUpdateChart:
     def test_unrelated_config_update_preserves_existing_column_config(self) -> None:
         chart = Mock(
             datasource_id=7,
-            params='{"column_config":{"Revenue":{"columnWidth":160}}}',
+            params=(
+                '{"viz_type":"table",'
+                '"column_config":{"Revenue":{"columnWidth":160}}}'
+            ),
             slice_name="Revenue table",
         )
         request = UpdateChartRequest(
@@ -160,10 +163,11 @@ class TestUpdateChart:
             datasource_id=7,
             params=json.dumps(
                 {
+                    "viz_type": "table",
                     "column_config": {
                         "Revenue": {"columnWidth": 80, "visible": False},
                         "Region": {"customColumnName": "Sales region"},
-                    }
+                    },
                 }
             ),
             slice_name="Revenue table",
@@ -183,6 +187,34 @@ class TestUpdateChart:
         assert json.loads(payload["params"])["column_config"] == {
             "Revenue": {"columnWidth": 120, "visible": False},
             "Region": {"customColumnName": "Sales region"},
+        }
+
+    def test_explicit_null_clears_saved_column_setting(self) -> None:
+        chart = Mock(
+            datasource_id=7,
+            params=json.dumps(
+                {
+                    "viz_type": "table",
+                    "column_config": {"Revenue": {"columnWidth": 80, "visible": False}},
+                }
+            ),
+            slice_name="Revenue table",
+        )
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [{"name": "revenue", "aggregate": "SUM"}],
+                "column_config": {"Revenue": {"columnWidth": None}},
+            }
+        )
+        request = UpdateChartRequest(identifier=123, config=config)
+
+        payload = _build_update_payload(request, chart, config)
+
+        assert isinstance(payload, dict)
+        assert json.loads(payload["params"])["column_config"]["Revenue"] == {
+            "columnWidth": None,
+            "visible": False,
         }
 
     @pytest.mark.asyncio
@@ -1253,10 +1285,11 @@ class TestBuildPreviewFormData:
             slice_name="Existing",
             params=json.dumps(
                 {
+                    "viz_type": "table",
                     "column_config": {
                         "Revenue": {"columnWidth": 80, "visible": False},
                         "Region": {"customColumnName": "Sales region"},
-                    }
+                    },
                 }
             ),
         )
@@ -1272,6 +1305,31 @@ class TestBuildPreviewFormData:
             },
             "Region": {"customColumnName": "Sales region"},
         }
+
+    def test_switching_from_table_removes_column_config(self) -> None:
+        config = XYChartConfig(
+            chart_type="xy",
+            x=ColumnRef(name="region"),
+            y=[ColumnRef(name="revenue", aggregate="SUM")],
+            kind="bar",
+        )
+        request = UpdateChartRequest(identifier=1, config=config)
+        chart = Mock(
+            id=42,
+            datasource_id=7,
+            slice_name="Existing",
+            params=json.dumps(
+                {
+                    "viz_type": "table",
+                    "column_config": {"Revenue": {"columnWidth": 80}},
+                }
+            ),
+        )
+
+        result = _build_preview_form_data(request, chart, parsed_config=config)
+
+        assert isinstance(result, dict)
+        assert "column_config" not in result
 
     def test_name_only_preview_keeps_existing_form_data(self):
         """Name-only preview preserves existing form_data and renames."""

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -140,6 +140,51 @@ class TestUpdateChart:
         assert isinstance(payload, dict)
         assert '"column_config": {"Revenue": {"columnWidth": 160}}' in payload["params"]
 
+    @pytest.mark.parametrize("params", ["null", "[]", '"text"', "1", "true"])
+    def test_config_update_treats_non_object_params_as_empty(self, params: str) -> None:
+        chart = Mock(datasource_id=7, params=params, slice_name="Revenue table", id=123)
+        request = UpdateChartRequest(
+            identifier=123,
+            config=TableChartConfig(
+                chart_type="table", columns=[ColumnRef(name="revenue")]
+            ),
+        )
+
+        payload = _build_update_payload(request, chart, request.config)
+
+        assert isinstance(payload, dict)
+        assert "column_config" not in json.loads(payload["params"])
+
+    def test_explicit_column_update_merges_saved_ui_settings(self) -> None:
+        chart = Mock(
+            datasource_id=7,
+            params=json.dumps(
+                {
+                    "column_config": {
+                        "Revenue": {"columnWidth": 80, "visible": False},
+                        "Region": {"customColumnName": "Sales region"},
+                    }
+                }
+            ),
+            slice_name="Revenue table",
+        )
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [{"name": "revenue", "aggregate": "SUM"}],
+                "column_config": {"Revenue": {"columnWidth": 120}},
+            }
+        )
+        request = UpdateChartRequest(identifier=123, config=config)
+
+        payload = _build_update_payload(request, chart, config)
+
+        assert isinstance(payload, dict)
+        assert json.loads(payload["params"])["column_config"] == {
+            "Revenue": {"columnWidth": 120, "visible": False},
+            "Region": {"customColumnName": "Sales region"},
+        }
+
     @pytest.mark.asyncio
     async def test_update_chart_preview_formats(self):
         """Test preview_formats options in update request."""
@@ -1190,6 +1235,43 @@ class TestBuildPreviewFormData:
         assert result["slice_id"] == 42
         assert result["datasource"] == "7__table"
         assert result["slice_name"] == "Existing"
+
+    def test_partial_column_config_merges_saved_ui_settings(self) -> None:
+        config = TableChartConfig.model_validate(
+            {
+                "chart_type": "table",
+                "columns": [{"name": "revenue", "aggregate": "SUM"}],
+                "column_config": {
+                    "Revenue": {"columnWidth": 120, "d3NumberFormat": "$,.2f"}
+                },
+            }
+        )
+        request = UpdateChartRequest(identifier=1, config=config)
+        chart = Mock(
+            id=42,
+            datasource_id=7,
+            slice_name="Existing",
+            params=json.dumps(
+                {
+                    "column_config": {
+                        "Revenue": {"columnWidth": 80, "visible": False},
+                        "Region": {"customColumnName": "Sales region"},
+                    }
+                }
+            ),
+        )
+
+        result = _build_preview_form_data(request, chart, parsed_config=config)
+
+        assert isinstance(result, dict)
+        assert result["column_config"] == {
+            "Revenue": {
+                "columnWidth": 120,
+                "d3NumberFormat": "$,.2f",
+                "visible": False,
+            },
+            "Region": {"customColumnName": "Sales region"},
+        }
 
     def test_name_only_preview_keeps_existing_form_data(self):
         """Name-only preview preserves existing form_data and renames."""

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -120,6 +120,26 @@ class TestUpdateChart:
         )
         assert request2.chart_name == "Updated Sales Report"
 
+    def test_unrelated_config_update_preserves_existing_column_config(self) -> None:
+        chart = Mock(
+            datasource_id=7,
+            params='{"column_config":{"Revenue":{"columnWidth":160}}}',
+            slice_name="Revenue table",
+        )
+        request = UpdateChartRequest(
+            identifier=123,
+            config=TableChartConfig(
+                chart_type="table",
+                columns=[ColumnRef(name="revenue", aggregate="SUM")],
+                row_limit=500,
+            ),
+        )
+
+        payload = _build_update_payload(request, chart, request.config)
+
+        assert isinstance(payload, dict)
+        assert '"column_config": {"Revenue": {"columnWidth": 160}}' in payload["params"]
+
     @pytest.mark.asyncio
     async def test_update_chart_preview_formats(self):
         """Test preview_formats options in update request."""

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart.py
@@ -123,10 +123,7 @@ class TestUpdateChart:
     def test_unrelated_config_update_preserves_existing_column_config(self) -> None:
         chart = Mock(
             datasource_id=7,
-            params=(
-                '{"viz_type":"table",'
-                '"column_config":{"Revenue":{"columnWidth":160}}}'
-            ),
+            params='{"viz_type":"table","column_config":{"Revenue":{"columnWidth":160}}}',
             slice_name="Revenue table",
         )
         request = UpdateChartRequest(

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -689,7 +689,8 @@ class TestUpdateChartPreview:
             }
         ]
         mock_get_previous_form_data.return_value = {
-            "adhoc_filters": cached_adhoc_filters
+            "adhoc_filters": cached_adhoc_filters,
+            "column_config": {"Sales": {"d3NumberFormat": "$,.2f"}},
         }
         mock_generate_explore_link.return_value = (
             "http://localhost:8088/explore/?form_data_key=new_preview_key"
@@ -718,6 +719,9 @@ class TestUpdateChartPreview:
 
         generated_form_data = mock_generate_explore_link.call_args.args[1]
         assert generated_form_data["adhoc_filters"] == cached_adhoc_filters
+        assert generated_form_data["column_config"] == {
+            "Sales": {"d3NumberFormat": "$,.2f"}
+        }
         assert result["success"] is True
         assert result["error"] is None
         assert result["warnings"] == []

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -689,6 +689,7 @@ class TestUpdateChartPreview:
             }
         ]
         mock_get_previous_form_data.return_value = {
+            "viz_type": "table",
             "adhoc_filters": cached_adhoc_filters,
             "column_config": {"Sales": {"d3NumberFormat": "$,.2f", "visible": False}},
         }

--- a/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
@@ -690,7 +690,7 @@ class TestUpdateChartPreview:
         ]
         mock_get_previous_form_data.return_value = {
             "adhoc_filters": cached_adhoc_filters,
-            "column_config": {"Sales": {"d3NumberFormat": "$,.2f"}},
+            "column_config": {"Sales": {"d3NumberFormat": "$,.2f", "visible": False}},
         }
         mock_generate_explore_link.return_value = (
             "http://localhost:8088/explore/?form_data_key=new_preview_key"
@@ -708,6 +708,7 @@ class TestUpdateChartPreview:
                     ColumnRef(name="sales", label="Sales", aggregate="SUM"),
                 ],
                 sort_by=["sales"],
+                column_config={"Sales": {"columnWidth": 120}},
             ),
             generate_preview=True,
             preview_formats=["table"],
@@ -720,7 +721,11 @@ class TestUpdateChartPreview:
         generated_form_data = mock_generate_explore_link.call_args.args[1]
         assert generated_form_data["adhoc_filters"] == cached_adhoc_filters
         assert generated_form_data["column_config"] == {
-            "Sales": {"d3NumberFormat": "$,.2f"}
+            "Sales": {
+                "columnWidth": 120,
+                "d3NumberFormat": "$,.2f",
+                "visible": False,
+            }
         }
         assert result["success"] is True
         assert result["error"] is None

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -210,6 +210,24 @@ class TestNormalizeColumnNames:
         ) == {"columnWidth": 120}
 
     @patch.object(DatasetValidator, "_get_dataset_context")
+    def test_table_normalization_canonicalizes_raw_column_config_key(
+        self, mock_get_context, mock_dataset_context: DatasetContext
+    ) -> None:
+        mock_get_context.return_value = mock_dataset_context
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="orderdate")],
+            column_config={"orderdate": TableColumnConfig(d3TimeFormat="%Y-%m-%d")},
+        )
+
+        normalized = DatasetValidator.normalize_column_names(config, dataset_id=18)
+
+        assert normalized.columns[0].name == "OrderDate"
+        assert normalized.column_config is not None
+        assert "orderdate" not in normalized.column_config
+        assert normalized.column_config["OrderDate"].d3_time_format == "%Y-%m-%d"
+
+    @patch.object(DatasetValidator, "_get_dataset_context")
     def test_table_sql_expression_column_skips_name_normalization(
         self, mock_get_context, mock_dataset_context: DatasetContext
     ) -> None:

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -30,12 +30,14 @@ import pytest
 from superset.mcp_service.chart.schemas import (
     ColumnRef,
     FilterConfig,
+    GenerateChartRequest,
     PivotTableChartConfig,
     TableChartConfig,
     TableColumnConfig,
     XYChartConfig,
 )
 from superset.mcp_service.chart.validation.dataset_validator import DatasetValidator
+from superset.mcp_service.chart.validation.pipeline import ValidationPipeline
 from superset.mcp_service.common.error_schemas import DatasetContext
 
 
@@ -206,6 +208,33 @@ class TestNormalizeColumnNames:
         assert normalized.columns[0].name == "Sales"
         assert normalized.column_config is not None
         assert normalized.column_config["SUM(Sales)"].model_dump(
+            by_alias=True, exclude_unset=True
+        ) == {"columnWidth": 120}
+
+    def test_pipeline_preserves_partial_table_column_config(
+        self, mock_dataset_context: DatasetContext
+    ) -> None:
+        """The request round trip must not turn omitted formats into nulls."""
+        request = GenerateChartRequest.model_validate(
+            {
+                "dataset_id": 18,
+                "config": {
+                    "chart_type": "table",
+                    "columns": [{"name": "sales", "aggregate": "SUM"}],
+                    "column_config": {"SUM(Sales)": {"columnWidth": 120}},
+                },
+            }
+        )
+
+        normalized = ValidationPipeline._normalize_column_names(
+            request,
+            mock_dataset_context,
+            typed_config=request.config,
+        )
+
+        assert isinstance(normalized.config, TableChartConfig)
+        assert normalized.config.column_config is not None
+        assert normalized.config.column_config["SUM(Sales)"].model_dump(
             by_alias=True, exclude_unset=True
         ) == {"columnWidth": 120}
 

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -32,6 +32,7 @@ from superset.mcp_service.chart.schemas import (
     FilterConfig,
     PivotTableChartConfig,
     TableChartConfig,
+    TableColumnConfig,
     XYChartConfig,
 )
 from superset.mcp_service.chart.validation.dataset_validator import DatasetValidator
@@ -187,6 +188,26 @@ class TestNormalizeColumnNames:
         assert normalized.columns[0].name == "OrderDate"
         assert normalized.columns[1].name == "ProductLine"
         assert normalized.columns[2].name == "Sales"
+
+    @patch.object(DatasetValidator, "_get_dataset_context")
+    def test_table_normalization_preserves_partial_column_config(
+        self, mock_get_context, mock_dataset_context: DatasetContext
+    ) -> None:
+        """Normalization must not materialize omitted formatting fields as null."""
+        mock_get_context.return_value = mock_dataset_context
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="sales", aggregate="SUM")],
+            column_config={"SUM(Sales)": TableColumnConfig(columnWidth=120)},
+        )
+
+        normalized = DatasetValidator.normalize_column_names(config, dataset_id=18)
+
+        assert normalized.columns[0].name == "Sales"
+        assert normalized.column_config is not None
+        assert normalized.column_config["SUM(Sales)"].model_dump(
+            by_alias=True, exclude_unset=True
+        ) == {"columnWidth": 120}
 
     @patch.object(DatasetValidator, "_get_dataset_context")
     def test_table_sql_expression_column_skips_name_normalization(


### PR DESCRIPTION
### SUMMARY

Expose per-column table formatting in MCP chart configurations. Table configs can set `columnWidth`, `d3NumberFormat`, and `d3TimeFormat`, keyed by result column label, and the generated schema documents concrete D3 format examples.

Existing table `column_config` values are preserved when an update omits the field, while explicit values are validated and serialized without silently dropping unknown settings.

### TESTING INSTRUCTIONS

```bash
pytest -q tests/unit_tests/mcp_service/chart/test_new_chart_types.py tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py tests/unit_tests/mcp_service/chart/tool/test_update_chart.py tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
uvx pre-commit run --files superset/mcp_service/chart/chart_utils.py superset/mcp_service/chart/schemas.py superset/mcp_service/chart/tool/update_chart.py superset/mcp_service/chart/tool/update_chart_preview.py tests/unit_tests/mcp_service/chart/test_new_chart_types.py tests/unit_tests/mcp_service/chart/tool/test_get_chart_type_schema.py tests/unit_tests/mcp_service/chart/tool/test_update_chart.py tests/unit_tests/mcp_service/chart/tool/test_update_chart_preview.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### BLAST RADIUS

Limited to MCP table chart configuration schemas and form-data mapping. It does not change authorization, database models, migrations, or non-MCP chart behavior.

### RISK AND ROLLBACK

The main risk is accepting a formatting value that the frontend renders differently than expected. Validation constrains field names and primitive types, and rollback is a normal revert with no data migration.

### REVIEW GUIDANCE

Start with `TableColumnConfig` in `schemas.py`, then review the form-data mapping and preservation paths in the two update tools.

### EVAL EVIDENCE

The deterministic schema and round-trip paths are covered by 189 passing focused MCP unit tests. No model-based evaluation suite was available in this checkout.

### COST AND LATENCY DELTA

No prompt, model, routing, or tool-call changes. The added local schema validation and dictionary serialization have negligible request cost and latency impact.

### PROMPT / NON-DETERMINISM

No prompt or non-deterministic behavior changed.
