### PR TITLE
fix(mcp): resolve dashboard permalinks

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -125,8 +125,8 @@ Available tools:
 
 Dashboard Management:
 - list_dashboards: List dashboards with advanced filters (1-based pagination; deleted_state='only'/'include' surfaces trashed dashboards the caller may restore)
-- get_dashboard_info: Get detailed dashboard information by ID
-- get_dashboard_layout: Get parsed tabs and chart positions for a dashboard (companion to get_dashboard_info when its omitted_fields hint flags position_json)
+- get_dashboard_info: Resolve a dashboard by ID/UUID/slug or shared /dashboard/p/<key>/ permalink, including its active-tab and filter state
+- get_dashboard_layout: Get parsed tabs and chart positions by dashboard identifier or shared permalink, including the permalink's active-tab and filter context
 - get_dashboard_datasets: List the datasets used by a dashboard's charts, with columns and metrics (context for configuring native filters)
 - generate_dashboard: Create a dashboard from chart IDs (requires write access)
 - update_dashboard: Update an existing dashboard's title/description/slug/published/layout/theme/CSS (requires write access; editorship-checked per-instance)

--- a/superset/mcp_service/dashboard/permalink.py
+++ b/superset/mcp_service/dashboard/permalink.py
@@ -18,15 +18,30 @@
 """Helpers for resolving dashboard permalink keys and shared URLs."""
 
 import logging
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
 from urllib.parse import urlparse
 
 from flask import g, has_request_context
 
+from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
 from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.mcp_service.auth import load_user_with_relationships
 
 logger = logging.getLogger(__name__)
+
+LookupResultT = TypeVar("LookupResultT")
+
+
+@dataclass(frozen=True)
+class DashboardLookupResult(Generic[LookupResultT]):
+    """Result of resolving either a dashboard identifier or permalink."""
+
+    result: LookupResultT | None
+    permalink_key: str | None = None
+    permalink_value: DashboardPermalinkValue | None = None
+    permalink_error: bool = False
 
 
 def extract_dashboard_permalink_key(value: str) -> str:
@@ -67,7 +82,59 @@ def get_dashboard_permalink(
     refresh_request_user_for_permalink_access()
     try:
         value = GetDashboardPermalinkCommand(key).run()
-    except DashboardPermalinkGetFailedError as ex:
+    except (DashboardAccessDeniedError, DashboardPermalinkGetFailedError) as ex:
         logger.info("Dashboard permalink could not be resolved: %s", ex)
         return None
     return (key, value) if value else None
+
+
+def lookup_dashboard_reference(
+    *,
+    identifier: int | str | None,
+    permalink_key: str | None,
+    lookup: Callable[[int | str], LookupResultT],
+    is_found: Callable[[LookupResultT], bool],
+) -> DashboardLookupResult[LookupResultT]:
+    """Look up a dashboard while preserving identifier precedence.
+
+    A supplied identifier selects the dashboard and an explicit permalink only
+    contributes state. Shared permalink URLs and permalink-only requests select
+    the dashboard embedded in the permalink. Ambiguous bare strings use normal
+    identifier lookup first, then fall back to permalink resolution.
+    """
+    key = permalink_key
+    identifier_is_permalink_url = False
+    if isinstance(identifier, str):
+        extracted_key = extract_dashboard_permalink_key(identifier)
+        identifier_is_permalink_url = extracted_key != identifier
+        if identifier_is_permalink_url:
+            key = extracted_key
+
+    if identifier is not None and not identifier_is_permalink_url:
+        result = lookup(identifier)
+        if is_found(result):
+            resolved = get_dashboard_permalink(key) if key else None
+            return DashboardLookupResult(
+                result=result,
+                permalink_key=resolved[0] if resolved else key,
+                permalink_value=resolved[1] if resolved else None,
+            )
+        if permalink_key is not None or not isinstance(identifier, str):
+            return DashboardLookupResult(result=result, permalink_key=key)
+    else:
+        result = None
+
+    reference = key or (identifier if isinstance(identifier, str) else None)
+    resolved = get_dashboard_permalink(reference) if reference else None
+    if resolved is None:
+        return DashboardLookupResult(
+            result=result,
+            permalink_key=reference,
+            permalink_error=True,
+        )
+    key, value = resolved
+    return DashboardLookupResult(
+        result=lookup(value["dashboardId"]),
+        permalink_key=key,
+        permalink_value=value,
+    )

--- a/superset/mcp_service/dashboard/permalink.py
+++ b/superset/mcp_service/dashboard/permalink.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Helpers for resolving dashboard permalink keys and shared URLs."""
+
+import logging
+from urllib.parse import urlparse
+
+from flask import g, has_request_context
+
+from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
+from superset.dashboards.permalink.types import DashboardPermalinkValue
+from superset.mcp_service.auth import load_user_with_relationships
+
+logger = logging.getLogger(__name__)
+
+
+def extract_dashboard_permalink_key(value: str) -> str:
+    """Return a key from a dashboard permalink URL, or the bare input."""
+    path_parts = [part for part in urlparse(value).path.split("/") if part]
+    if len(path_parts) >= 3 and path_parts[-3:-1] == ["dashboard", "p"]:
+        return path_parts[-1]
+    return value
+
+
+def refresh_request_user_for_permalink_access() -> None:
+    """Reload the request user before permalink access checks."""
+    if not has_request_context() or not getattr(g, "user", None):
+        return
+    current_user = g.user
+    if getattr(current_user, "is_anonymous", False):
+        return
+    username = getattr(current_user, "username", None)
+    email = getattr(current_user, "email", None)
+    if not username and not email:
+        return
+    refreshed_user = (
+        load_user_with_relationships(username=username)
+        if username
+        else load_user_with_relationships(email=email)
+    )
+    if refreshed_user is not None:
+        g.user = refreshed_user
+
+
+def get_dashboard_permalink(
+    key_or_url: str,
+) -> tuple[str, DashboardPermalinkValue] | None:
+    """Resolve a dashboard permalink key or shared URL, returning its state."""
+    from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
+
+    key = extract_dashboard_permalink_key(key_or_url)
+    refresh_request_user_for_permalink_access()
+    try:
+        value = GetDashboardPermalinkCommand(key).run()
+    except DashboardPermalinkGetFailedError as ex:
+        logger.info("Dashboard permalink could not be resolved: %s", ex)
+        return None
+    return (key, value) if value else None

--- a/superset/mcp_service/dashboard/permalink.py
+++ b/superset/mcp_service/dashboard/permalink.py
@@ -25,9 +25,14 @@ from urllib.parse import urlparse
 from flask import g, has_request_context
 
 from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
+from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
 from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.mcp_service.auth import load_user_with_relationships
+from superset.mcp_service.dashboard.schemas import (
+    redact_filter_state_data_model_metadata,
+)
+from superset.mcp_service.privacy import user_can_view_data_model_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +47,14 @@ class DashboardLookupResult(Generic[LookupResultT]):
     permalink_key: str | None = None
     permalink_value: DashboardPermalinkValue | None = None
     permalink_error: bool = False
+
+
+@dataclass(frozen=True)
+class DashboardPermalinkState:
+    """Permalink state belonging to a resolved dashboard."""
+
+    key: str
+    state: dict[str, object]
 
 
 def extract_dashboard_permalink_key(value: str) -> str:
@@ -76,8 +89,6 @@ def get_dashboard_permalink(
     key_or_url: str,
 ) -> tuple[str, DashboardPermalinkValue] | None:
     """Resolve a dashboard permalink key or shared URL, returning its state."""
-    from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
-
     key = extract_dashboard_permalink_key(key_or_url)
     refresh_request_user_for_permalink_access()
     try:
@@ -138,3 +149,26 @@ def lookup_dashboard_reference(
         permalink_key=key,
         permalink_value=value,
     )
+
+
+def get_matching_dashboard_permalink_state(
+    lookup_result: DashboardLookupResult[LookupResultT],
+    dashboard_id: int | None,
+) -> DashboardPermalinkState | None:
+    """Return the permalink state when it belongs to ``dashboard_id``."""
+    value = lookup_result.permalink_value
+    key = lookup_result.permalink_key
+    if value is None or key is None:
+        return None
+    try:
+        permalink_dashboard_id = int(value["dashboardId"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if permalink_dashboard_id != dashboard_id:
+        return None
+
+    raw_state = value.get("state")
+    state: dict[str, object] = dict(raw_state) if isinstance(raw_state, dict) else {}
+    if not user_can_view_data_model_metadata():
+        state = redact_filter_state_data_model_metadata(state)
+    return DashboardPermalinkState(key=key, state=state)

--- a/superset/mcp_service/dashboard/permalink.py
+++ b/superset/mcp_service/dashboard/permalink.py
@@ -46,7 +46,8 @@ class DashboardLookupResult(Generic[LookupResultT]):
     result: LookupResultT | None
     permalink_key: str | None = None
     permalink_value: DashboardPermalinkValue | None = None
-    permalink_error: bool = False
+    resolved_from_permalink: bool = False
+    """True when the dashboard itself was selected from the permalink."""
 
 
 @dataclass(frozen=True)
@@ -138,34 +139,43 @@ def lookup_dashboard_reference(
     reference = key or (identifier if isinstance(identifier, str) else None)
     resolved = get_dashboard_permalink(reference) if reference else None
     if resolved is None:
-        return DashboardLookupResult(
-            result=result,
-            permalink_key=reference,
-            permalink_error=True,
-        )
+        return DashboardLookupResult(result=result, permalink_key=reference)
     key, value = resolved
     return DashboardLookupResult(
         result=lookup(value["dashboardId"]),
         permalink_key=key,
         permalink_value=value,
+        resolved_from_permalink=True,
     )
 
 
 def get_matching_dashboard_permalink_state(
     lookup_result: DashboardLookupResult[LookupResultT],
     dashboard_id: int | None,
+    dashboard_uuid: str | None = None,
+    dashboard_slug: str | None = None,
 ) -> DashboardPermalinkState | None:
-    """Return the permalink state when it belongs to ``dashboard_id``."""
+    """Return the permalink state when it belongs to the dashboard.
+
+    ``CreateDashboardPermalinkCommand`` stores ``dashboardId`` as the dashboard
+    UUID string, while older permalinks may hold a numeric ID or a slug, so the
+    reference is compared against every identifier the dashboard answers to.
+    """
     value = lookup_result.permalink_value
     key = lookup_result.permalink_key
     if value is None or key is None:
         return None
-    try:
-        permalink_dashboard_id = int(value["dashboardId"])
-    except (KeyError, TypeError, ValueError):
-        return None
-    if permalink_dashboard_id != dashboard_id:
-        return None
+    if not lookup_result.resolved_from_permalink:
+        # The identifier selected the dashboard, so the permalink only
+        # contributes state when it points at that same dashboard.
+        reference = value.get("dashboardId")
+        known_identifiers = {
+            str(candidate)
+            for candidate in (dashboard_id, dashboard_uuid, dashboard_slug)
+            if candidate is not None
+        }
+        if reference is None or str(reference) not in known_identifiers:
+            return None
 
     raw_state = value.get("state")
     state: dict[str, object] = dict(raw_state) if isinstance(raw_state, dict) else {}

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -242,7 +242,7 @@ DEFAULT_GET_DASHBOARD_INFO_COLUMNS: List[str] = [
 
 
 class GetDashboardInfoRequest(MetadataCacheControl):
-    """Request schema for get_dashboard_info with support for ID, UUID, or slug.
+    """Request schema for dashboard identifiers and shared permalink URLs.
 
     When permalink_key is provided, the tool will retrieve the dashboard's filter
     state from the permalink, allowing you to see what filters the user has applied
@@ -253,21 +253,23 @@ class GetDashboardInfoRequest(MetadataCacheControl):
     model_config = ConfigDict(populate_by_name=True)
 
     identifier: Annotated[
-        int | str,
+        int | str | None,
         Field(
             description=(
-                "Dashboard identifier - can be numeric ID, UUID string, or slug"
+                "Dashboard ID, UUID, slug, bare permalink key, or a shared URL "
+                "containing /superset/dashboard/p/<key>/. Omit when "
+                "permalink_key is provided."
             ),
+            default=None,
             validation_alias=AliasChoices("identifier", "id", "dashboard_id"),
         ),
     ]
     permalink_key: str | None = Field(
         default=None,
         description=(
-            "Optional permalink key for retrieving dashboard filter state. When a "
-            "user applies filters in a dashboard, the state can be persisted in a "
-            "permalink. If provided, the tool returns the filter configuration "
-            "from that permalink."
+            "Key from a shared dashboard URL such as "
+            "'/superset/dashboard/p/<key>/'. Resolves the dashboard and returns "
+            "the shared active-tab and filter context; no identifier is required."
         ),
     )
     select_columns: Annotated[
@@ -295,16 +297,41 @@ class GetDashboardInfoRequest(MetadataCacheControl):
         parsed = parse_json_or_list(value, "select_columns")
         return parsed if parsed else list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS)
 
+    @model_validator(mode="after")
+    def _require_identifier_or_permalink(self) -> "GetDashboardInfoRequest":
+        if self.identifier is None and self.permalink_key is None:
+            raise ValueError("Provide identifier or permalink_key")
+        return self
+
 
 class GetDashboardLayoutRequest(BaseModel):
     """Request schema for get_dashboard_layout."""
 
     identifier: Annotated[
-        int | str,
+        int | str | None,
         Field(
-            description="Dashboard identifier - can be numeric ID, UUID string, or slug"
+            default=None,
+            description=(
+                "Dashboard ID, UUID, slug, bare permalink key, or a shared URL "
+                "containing /superset/dashboard/p/<key>/. Omit when "
+                "permalink_key is provided."
+            ),
         ),
     ]
+    permalink_key: str | None = Field(
+        default=None,
+        description=(
+            "Key from a shared dashboard URL such as "
+            "'/superset/dashboard/p/<key>/'. Resolves the dashboard and includes "
+            "the shared active-tab and filter context in the layout response."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _require_identifier_or_permalink(self) -> "GetDashboardLayoutRequest":
+        if self.identifier is None and self.permalink_key is None:
+            raise ValueError("Provide identifier or permalink_key")
+        return self
 
 
 class GetDashboardDatasetsRequest(BaseModel):
@@ -1450,6 +1477,20 @@ class DashboardLayout(BaseModel):
     has_layout: bool = Field(
         default=False,
         description="False when position_json is missing or empty",
+    )
+    permalink_key: str | None = Field(
+        None, description="Resolved key when the input was a dashboard permalink"
+    )
+    filter_state: Dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Shared dashboard state, including activeTabs, anchor, dataMask, "
+            "chartStates, and urlParams when present."
+        ),
+    )
+    is_permalink_state: bool = Field(
+        False,
+        description="True when filter_state was resolved from a dashboard permalink",
     )
 
 

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -305,7 +305,11 @@ class GetDashboardInfoRequest(MetadataCacheControl):
 
 
 class GetDashboardLayoutRequest(BaseModel):
-    """Request schema for get_dashboard_layout."""
+    """Request a dashboard layout by its identifier or shared permalink.
+
+    Permalink requests resolve the dashboard while preserving shared active-tab
+    and filter state in the response.
+    """
 
     identifier: Annotated[
         int | str | None,

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -30,9 +30,10 @@ from fastmcp import Context
 from sqlalchemy.orm import subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.extensions import event_logger
 from superset.mcp_service.dashboard.permalink import (
+    DashboardLookupResult,
+    get_matching_dashboard_permalink_state,
     lookup_dashboard_reference,
 )
 from superset.mcp_service.dashboard.schemas import (
@@ -41,10 +42,8 @@ from superset.mcp_service.dashboard.schemas import (
     DashboardInfo,
     DEFAULT_GET_DASHBOARD_INFO_COLUMNS,
     GetDashboardInfoRequest,
-    redact_filter_state_data_model_metadata,
 )
 from superset.mcp_service.mcp_core import ModelGetInfoCore
-from superset.mcp_service.privacy import user_can_view_data_model_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,10 @@ def _apply_permalink_state(
 def _lookup_dashboard(
     tool: ModelGetInfoCore,
     request: GetDashboardInfoRequest,
-) -> tuple[DashboardInfo | DashboardError, str | None, DashboardPermalinkValue | None]:
+) -> tuple[
+    DashboardInfo | DashboardError,
+    DashboardLookupResult[DashboardInfo | DashboardError],
+]:
     """Resolve an ordinary identifier or dashboard permalink, then run lookup."""
     lookup_result = lookup_dashboard_reference(
         identifier=request.identifier,
@@ -85,7 +87,7 @@ def _lookup_dashboard(
             "expired; ask for a fresh shared dashboard link.",
             error_type,
         )
-    return result, lookup_result.permalink_key, lookup_result.permalink_value
+    return result, lookup_result
 
 
 @tool(
@@ -167,7 +169,9 @@ async def get_dashboard_info(
                 query_options=eager_options,
             )
 
-            result, permalink_key, permalink_value = _lookup_dashboard(tool, request)
+            result, lookup_result = _lookup_dashboard(tool, request)
+            permalink_key = lookup_result.permalink_key
+            permalink_value = lookup_result.permalink_value
 
         if isinstance(result, DashboardInfo):
             # If permalink_key is provided, retrieve filter state
@@ -178,51 +182,29 @@ async def get_dashboard_info(
                 )
 
                 if permalink_value:
-                    # Verify the permalink belongs to the requested dashboard
-                    # dashboardId in permalink is stored as str, result.id is int
-                    permalink_dashboard_id = permalink_value.get("dashboardId")
-                    try:
-                        permalink_dashboard_id_int = (
-                            int(permalink_dashboard_id)
-                            if permalink_dashboard_id
-                            else None
-                        )
-                    except (ValueError, TypeError):
-                        permalink_dashboard_id_int = None
-
-                    if (
-                        permalink_dashboard_id_int is not None
-                        and permalink_dashboard_id_int != result.id
-                    ):
+                    permalink_state = get_matching_dashboard_permalink_state(
+                        lookup_result,
+                        result.id,
+                    )
+                    if permalink_state is None:
                         await ctx.warning(
-                            "permalink_key dashboardId (%s) does not match "
-                            "requested dashboard id (%s); ignoring permalink "
-                            "filter state." % (permalink_dashboard_id, result.id)
+                            "permalink_key belongs to a different dashboard; "
+                            "ignoring permalink filter state."
                         )
                     else:
-                        # Extract the state from permalink value
-                        # Handle None or non-dict state gracefully
-                        raw_state = permalink_value.get("state")
-                        permalink_state = (
-                            dict(raw_state) if isinstance(raw_state, dict) else {}
-                        )
-                        if not user_can_view_data_model_metadata():
-                            permalink_state = redact_filter_state_data_model_metadata(
-                                permalink_state
-                            )
                         result = _apply_permalink_state(
                             result,
-                            permalink_key,
-                            permalink_state,
+                            permalink_state.key,
+                            permalink_state.state,
                         )
 
                         await ctx.info(
                             "Filter state retrieved from permalink: "
                             "has_dataMask=%s, has_chartStates=%s, has_activeTabs=%s"
                             % (
-                                "dataMask" in permalink_state,
-                                "chartStates" in permalink_state,
-                                "activeTabs" in permalink_state,
+                                "dataMask" in permalink_state.state,
+                                "chartStates" in permalink_state.state,
+                                "activeTabs" in permalink_state.state,
                             )
                         )
                 else:
@@ -246,7 +228,7 @@ async def get_dashboard_info(
             # override select_columns, ensure filter_state is present so the
             # caller gets the data they came for.
             effective_select_columns = list(request.select_columns)
-            if permalink_key and effective_select_columns == list(
+            if result.is_permalink_state and effective_select_columns == list(
                 DEFAULT_GET_DASHBOARD_INFO_COLUMNS
             ):
                 effective_select_columns.append("filter_state")

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -78,14 +78,13 @@ def _lookup_dashboard(
         is_found=lambda result: isinstance(result, DashboardInfo),
     )
     result = lookup_result.result
-    if result is None or lookup_result.permalink_error:
-        error_type = (
-            "permalink_not_found" if request.identifier is None else "not_found"
-        )
+    if result is None:
+        # Only reachable when the dashboard had to come from a permalink, so the
+        # identifier's own "not found" error (when there is one) is preserved.
         result = DashboardError.create(
             "Dashboard permalink could not be resolved. It may be invalid or "
             "expired; ask for a fresh shared dashboard link.",
-            error_type,
+            "permalink_not_found",
         )
     return result, lookup_result
 
@@ -185,6 +184,8 @@ async def get_dashboard_info(
                     permalink_state = get_matching_dashboard_permalink_state(
                         lookup_result,
                         result.id,
+                        result.uuid,
+                        result.slug,
                     )
                     if permalink_state is None:
                         await ctx.warning(

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -27,16 +27,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastmcp import Context
-from flask import g, has_request_context
 from sqlalchemy.orm import subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.extensions import event_logger
-from superset.mcp_service.auth import load_user_with_relationships
 from superset.mcp_service.dashboard.permalink import (
-    extract_dashboard_permalink_key,
-    get_dashboard_permalink,
+    lookup_dashboard_reference,
 )
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
@@ -50,26 +47,6 @@ from superset.mcp_service.mcp_core import ModelGetInfoCore
 from superset.mcp_service.privacy import user_can_view_data_model_metadata
 
 logger = logging.getLogger(__name__)
-
-
-def _refresh_request_user_for_permalink_access() -> None:
-    """Reload the request user before permalink access checks."""
-    if not has_request_context() or not getattr(g, "user", None):
-        return
-    current_user = g.user
-    if getattr(current_user, "is_anonymous", False):
-        return
-    username = getattr(current_user, "username", None)
-    email = getattr(current_user, "email", None)
-    if not username and not email:
-        return
-    refreshed_user = (
-        load_user_with_relationships(username=username)
-        if username
-        else load_user_with_relationships(email=email)
-    )
-    if refreshed_user is not None:
-        g.user = refreshed_user
 
 
 def _apply_permalink_state(
@@ -87,63 +64,28 @@ def _apply_permalink_state(
     )
 
 
-def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
-    """Retrieve dashboard filter state from permalink.
-
-    Returns the permalink value containing dashboardId and state if found,
-    None otherwise.
-    """
-    resolved = get_dashboard_permalink(permalink_key)
-    return resolved[1] if resolved else None
-
-
 def _lookup_dashboard(
     tool: ModelGetInfoCore,
     request: GetDashboardInfoRequest,
 ) -> tuple[DashboardInfo | DashboardError, str | None, DashboardPermalinkValue | None]:
     """Resolve an ordinary identifier or dashboard permalink, then run lookup."""
-    permalink_key = request.permalink_key
-    if isinstance(request.identifier, str):
-        extracted_key = extract_dashboard_permalink_key(request.identifier)
-        if extracted_key != request.identifier:
-            permalink_key = extracted_key
-    permalink_value = _get_permalink_state(permalink_key) if permalink_key else None
-    if permalink_key and permalink_value is None:
-        return (
-            DashboardError.create(
-                "Dashboard permalink could not be resolved. It may be invalid or "
-                "expired; ask for a fresh shared dashboard link.",
-                "permalink_not_found",
-            ),
-            permalink_key,
-            None,
-        )
-    if permalink_key:
-        permalink_key = extract_dashboard_permalink_key(permalink_key)
-
-    lookup_identifier = (
-        permalink_value.get("dashboardId")
-        if permalink_value is not None
-        else request.identifier
+    lookup_result = lookup_dashboard_reference(
+        identifier=request.identifier,
+        permalink_key=request.permalink_key,
+        lookup=tool.run_tool,
+        is_found=lambda result: isinstance(result, DashboardInfo),
     )
-    result = tool.run_tool(lookup_identifier)  # type: ignore[arg-type]
-    if (
-        not isinstance(result, DashboardInfo)
-        and isinstance(request.identifier, str)
-        and not permalink_key
-    ):
-        resolved = get_dashboard_permalink(request.identifier)
-        if resolved:
-            permalink_key, permalink_value = resolved
-            result = tool.run_tool(permalink_value["dashboardId"])
-        else:
-            result = DashboardError.create(
-                "No dashboard matched this identifier or permalink key. If it "
-                "came from a shared /dashboard/p/<key>/ link, the link may be "
-                "invalid or expired; ask for a fresh shared dashboard link.",
-                "not_found",
-            )
-    return result, permalink_key, permalink_value
+    result = lookup_result.result
+    if result is None or lookup_result.permalink_error:
+        error_type = (
+            "permalink_not_found" if request.identifier is None else "not_found"
+        )
+        result = DashboardError.create(
+            "Dashboard permalink could not be resolved. It may be invalid or "
+            "expired; ask for a fresh shared dashboard link.",
+            error_type,
+        )
+    return result, lookup_result.permalink_key, lookup_result.permalink_value
 
 
 @tool(

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -31,10 +31,13 @@ from flask import g, has_request_context
 from sqlalchemy.orm import subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.dashboards.permalink.exceptions import DashboardPermalinkGetFailedError
 from superset.dashboards.permalink.types import DashboardPermalinkValue
 from superset.extensions import event_logger
 from superset.mcp_service.auth import load_user_with_relationships
+from superset.mcp_service.dashboard.permalink import (
+    extract_dashboard_permalink_key,
+    get_dashboard_permalink,
+)
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
     DashboardError,
@@ -53,16 +56,13 @@ def _refresh_request_user_for_permalink_access() -> None:
     """Reload the request user before permalink access checks."""
     if not has_request_context() or not getattr(g, "user", None):
         return
-
     current_user = g.user
     if getattr(current_user, "is_anonymous", False):
         return
-
     username = getattr(current_user, "username", None)
     email = getattr(current_user, "email", None)
     if not username and not email:
         return
-
     refreshed_user = (
         load_user_with_relationships(username=username)
         if username
@@ -93,13 +93,57 @@ def _get_permalink_state(permalink_key: str) -> DashboardPermalinkValue | None:
     Returns the permalink value containing dashboardId and state if found,
     None otherwise.
     """
-    from superset.commands.dashboard.permalink.get import GetDashboardPermalinkCommand
+    resolved = get_dashboard_permalink(permalink_key)
+    return resolved[1] if resolved else None
 
-    try:
-        return GetDashboardPermalinkCommand(permalink_key).run()
-    except DashboardPermalinkGetFailedError as e:
-        logger.warning("Failed to retrieve permalink state: %s", e)
-        return None
+
+def _lookup_dashboard(
+    tool: ModelGetInfoCore,
+    request: GetDashboardInfoRequest,
+) -> tuple[DashboardInfo | DashboardError, str | None, DashboardPermalinkValue | None]:
+    """Resolve an ordinary identifier or dashboard permalink, then run lookup."""
+    permalink_key = request.permalink_key
+    if isinstance(request.identifier, str):
+        extracted_key = extract_dashboard_permalink_key(request.identifier)
+        if extracted_key != request.identifier:
+            permalink_key = extracted_key
+    permalink_value = _get_permalink_state(permalink_key) if permalink_key else None
+    if permalink_key and permalink_value is None:
+        return (
+            DashboardError.create(
+                "Dashboard permalink could not be resolved. It may be invalid or "
+                "expired; ask for a fresh shared dashboard link.",
+                "permalink_not_found",
+            ),
+            permalink_key,
+            None,
+        )
+    if permalink_key:
+        permalink_key = extract_dashboard_permalink_key(permalink_key)
+
+    lookup_identifier = (
+        permalink_value.get("dashboardId")
+        if permalink_value is not None
+        else request.identifier
+    )
+    result = tool.run_tool(lookup_identifier)  # type: ignore[arg-type]
+    if (
+        not isinstance(result, DashboardInfo)
+        and isinstance(request.identifier, str)
+        and not permalink_key
+    ):
+        resolved = get_dashboard_permalink(request.identifier)
+        if resolved:
+            permalink_key, permalink_value = resolved
+            result = tool.run_tool(permalink_value["dashboardId"])
+        else:
+            result = DashboardError.create(
+                "No dashboard matched this identifier or permalink key. If it "
+                "came from a shared /dashboard/p/<key>/ link, the link may be "
+                "invalid or expired; ask for a fresh shared dashboard link.",
+                "not_found",
+            )
+    return result, permalink_key, permalink_value
 
 
 @tool(
@@ -115,7 +159,7 @@ async def get_dashboard_info(
     request: GetDashboardInfoRequest, ctx: Context
 ) -> dict[str, Any] | DashboardError:
     """
-    Get dashboard metadata by ID, UUID, or slug.
+    Get dashboard metadata by ID, UUID, slug, or dashboard permalink.
 
     Returns title, charts, and layout details.
 
@@ -127,9 +171,9 @@ async def get_dashboard_info(
     with ``filters=[{"col": "dashboards", "opr": "eq", "value": <dashboard
     id>}]`` and page through the results using ``page``/``page_size``.
 
-    When permalink_key is provided, also returns the filter state from that
-    permalink, allowing you to see what filters the user has applied to the
-    dashboard (not just the default filter state).
+    If the user gives you a shared URL containing ``/dashboard/p/<key>/``, pass
+    the URL or bare key as ``identifier`` (or use ``permalink_key`` alone). The
+    response includes the dashboard ID plus active tab and filter state.
 
     Example usage:
     ```json
@@ -141,7 +185,6 @@ async def get_dashboard_info(
     With permalink (filter state from URL):
     ```json
     {
-        "identifier": 123,
         "permalink_key": "abc123def456"
     }
     ```
@@ -182,17 +225,15 @@ async def get_dashboard_info(
                 query_options=eager_options,
             )
 
-            result = tool.run_tool(request.identifier)
+            result, permalink_key, permalink_value = _lookup_dashboard(tool, request)
 
         if isinstance(result, DashboardInfo):
             # If permalink_key is provided, retrieve filter state
-            if request.permalink_key:
+            if permalink_key:
                 await ctx.info(
                     "Retrieving filter state from permalink: permalink_key=%s"
-                    % (request.permalink_key,)
+                    % (permalink_key,)
                 )
-                _refresh_request_user_for_permalink_access()
-                permalink_value = _get_permalink_state(request.permalink_key)
 
                 if permalink_value:
                     # Verify the permalink belongs to the requested dashboard
@@ -229,7 +270,7 @@ async def get_dashboard_info(
                             )
                         result = _apply_permalink_state(
                             result,
-                            request.permalink_key,
+                            permalink_key,
                             permalink_state,
                         )
 
@@ -263,7 +304,7 @@ async def get_dashboard_info(
             # override select_columns, ensure filter_state is present so the
             # caller gets the data they came for.
             effective_select_columns = list(request.select_columns)
-            if request.permalink_key and effective_select_columns == list(
+            if permalink_key and effective_select_columns == list(
                 DEFAULT_GET_DASHBOARD_INFO_COLUMNS
             ):
                 effective_select_columns.append("filter_state")

--- a/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
@@ -31,17 +31,17 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
-from superset.mcp_service.dashboard.permalink import lookup_dashboard_reference
+from superset.mcp_service.dashboard.permalink import (
+    get_matching_dashboard_permalink_state,
+    lookup_dashboard_reference,
+)
 from superset.mcp_service.dashboard.schemas import (
     dashboard_layout_serializer,
     DashboardError,
     DashboardLayout,
     GetDashboardLayoutRequest,
-    redact_filter_state_data_model_metadata,
 )
 from superset.mcp_service.mcp_core import ModelGetInfoCore
-from superset.mcp_service.privacy import user_can_view_data_model_metadata
-from superset.mcp_service.utils import sanitize_for_llm_context
 
 logger = logging.getLogger(__name__)
 
@@ -113,29 +113,14 @@ async def get_dashboard_layout(
 
         if isinstance(result, DashboardLayout):
             if lookup_result.permalink_value:
-                permalink_key = lookup_result.permalink_key
-                permalink_value = lookup_result.permalink_value
-                try:
-                    permalink_dashboard_id = int(permalink_value["dashboardId"])
-                except (TypeError, ValueError):
-                    permalink_dashboard_id = None
-                if permalink_dashboard_id == result.id:
-                    raw_state = permalink_value.get("state")
-                    filter_state = (
-                        dict(raw_state) if isinstance(raw_state, dict) else {}
-                    )
-                    if not user_can_view_data_model_metadata():
-                        filter_state = redact_filter_state_data_model_metadata(
-                            filter_state
-                        )
+                permalink_state = get_matching_dashboard_permalink_state(
+                    lookup_result, result.id
+                )
+                if permalink_state:
                     payload = result.model_dump(mode="python")
                     payload.update(
-                        permalink_key=permalink_key,
-                        filter_state=sanitize_for_llm_context(
-                            filter_state,
-                            field_path=("filter_state",),
-                            excluded_field_names=frozenset(),
-                        ),
+                        permalink_key=permalink_state.key,
+                        filter_state=permalink_state.state,
                         is_permalink_state=True,
                     )
                     result = DashboardLayout.model_validate(payload)

--- a/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
@@ -31,13 +31,20 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
+from superset.mcp_service.dashboard.permalink import (
+    extract_dashboard_permalink_key,
+    get_dashboard_permalink,
+)
 from superset.mcp_service.dashboard.schemas import (
     dashboard_layout_serializer,
     DashboardError,
     DashboardLayout,
     GetDashboardLayoutRequest,
+    redact_filter_state_data_model_metadata,
 )
 from superset.mcp_service.mcp_core import ModelGetInfoCore
+from superset.mcp_service.privacy import user_can_view_data_model_metadata
+from superset.mcp_service.utils import sanitize_for_llm_context
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +62,17 @@ async def get_dashboard_layout(
     request: GetDashboardLayoutRequest, ctx: Context
 ) -> DashboardLayout | DashboardError:
     """
-    Get parsed dashboard layout by ID, UUID, or slug.
+    Get parsed dashboard layout by ID, UUID, slug, or dashboard permalink.
 
     Returns the tabs and chart positions extracted from the dashboard's
     position_json. get_dashboard_info omits position_json to keep responses
     small; call this tool when you need the structured layout (e.g. to
     explain which charts live under which tab, or to locate a chart by
     its parent tab).
+
+    If the user gives you a shared URL containing ``/dashboard/p/<key>/``, pass
+    the URL or bare key as ``identifier`` (or use ``permalink_key`` alone). The
+    response identifies the active tab and includes the shared filter state.
 
     Example usage:
     ```json
@@ -86,9 +97,60 @@ async def get_dashboard_layout(
                 supports_slug=True,
                 logger=logger,
             )
-            result = core.run_tool(request.identifier)
+            permalink_key = request.permalink_key
+            if isinstance(request.identifier, str):
+                extracted_key = extract_dashboard_permalink_key(request.identifier)
+                if extracted_key != request.identifier:
+                    permalink_key = extracted_key
+            resolved = get_dashboard_permalink(permalink_key) if permalink_key else None
+            if permalink_key and resolved is None:
+                return DashboardError.create(
+                    "Dashboard permalink could not be resolved. It may be invalid "
+                    "or expired; ask for a fresh shared dashboard link.",
+                    "permalink_not_found",
+                )
+
+            lookup_identifier = (
+                resolved[1]["dashboardId"] if resolved else request.identifier
+            )
+            result = core.run_tool(lookup_identifier)  # type: ignore[arg-type]
+
+            if (
+                not isinstance(result, DashboardLayout)
+                and isinstance(request.identifier, str)
+                and not permalink_key
+            ):
+                resolved = get_dashboard_permalink(request.identifier)
+                if resolved:
+                    permalink_key, permalink_value = resolved
+                    result = core.run_tool(permalink_value["dashboardId"])
+                else:
+                    result = DashboardError.create(
+                        "No dashboard matched this identifier or permalink key. If "
+                        "it came from a shared /dashboard/p/<key>/ link, the link "
+                        "may be invalid or expired; ask for a fresh shared dashboard "
+                        "link.",
+                        "not_found",
+                    )
 
         if isinstance(result, DashboardLayout):
+            if resolved:
+                permalink_key, permalink_value = resolved
+                raw_state = permalink_value.get("state")
+                filter_state = dict(raw_state) if isinstance(raw_state, dict) else {}
+                if not user_can_view_data_model_metadata():
+                    filter_state = redact_filter_state_data_model_metadata(filter_state)
+                payload = result.model_dump(mode="python")
+                payload.update(
+                    permalink_key=permalink_key,
+                    filter_state=sanitize_for_llm_context(
+                        filter_state,
+                        field_path=("filter_state",),
+                        excluded_field_names=frozenset(),
+                    ),
+                    is_permalink_state=True,
+                )
+                result = DashboardLayout.model_validate(payload)
             await ctx.info(
                 "Dashboard layout retrieved: id=%s, tab_count=%s, chart_count=%s, "
                 "has_layout=%s"

--- a/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
@@ -101,20 +101,19 @@ async def get_dashboard_layout(
                 is_found=lambda value: isinstance(value, DashboardLayout),
             )
             result = lookup_result.result
-            if result is None or lookup_result.permalink_error:
-                error_type = (
-                    "permalink_not_found" if request.identifier is None else "not_found"
-                )
+            if result is None:
+                # Only reachable when the dashboard had to come from a permalink,
+                # so an identifier's own "not found" error is preserved below.
                 return DashboardError.create(
                     "Dashboard permalink could not be resolved. It may be invalid "
                     "or expired; ask for a fresh shared dashboard link.",
-                    error_type,
+                    "permalink_not_found",
                 )
 
         if isinstance(result, DashboardLayout):
             if lookup_result.permalink_value:
                 permalink_state = get_matching_dashboard_permalink_state(
-                    lookup_result, result.id
+                    lookup_result, result.id, result.uuid
                 )
                 if permalink_state:
                     payload = result.model_dump(mode="python")

--- a/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_layout.py
@@ -31,10 +31,7 @@ from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.extensions import event_logger
-from superset.mcp_service.dashboard.permalink import (
-    extract_dashboard_permalink_key,
-    get_dashboard_permalink,
-)
+from superset.mcp_service.dashboard.permalink import lookup_dashboard_reference
 from superset.mcp_service.dashboard.schemas import (
     dashboard_layout_serializer,
     DashboardError,
@@ -97,60 +94,56 @@ async def get_dashboard_layout(
                 supports_slug=True,
                 logger=logger,
             )
-            permalink_key = request.permalink_key
-            if isinstance(request.identifier, str):
-                extracted_key = extract_dashboard_permalink_key(request.identifier)
-                if extracted_key != request.identifier:
-                    permalink_key = extracted_key
-            resolved = get_dashboard_permalink(permalink_key) if permalink_key else None
-            if permalink_key and resolved is None:
+            lookup_result = lookup_dashboard_reference(
+                identifier=request.identifier,
+                permalink_key=request.permalink_key,
+                lookup=core.run_tool,
+                is_found=lambda value: isinstance(value, DashboardLayout),
+            )
+            result = lookup_result.result
+            if result is None or lookup_result.permalink_error:
+                error_type = (
+                    "permalink_not_found" if request.identifier is None else "not_found"
+                )
                 return DashboardError.create(
                     "Dashboard permalink could not be resolved. It may be invalid "
                     "or expired; ask for a fresh shared dashboard link.",
-                    "permalink_not_found",
+                    error_type,
                 )
-
-            lookup_identifier = (
-                resolved[1]["dashboardId"] if resolved else request.identifier
-            )
-            result = core.run_tool(lookup_identifier)  # type: ignore[arg-type]
-
-            if (
-                not isinstance(result, DashboardLayout)
-                and isinstance(request.identifier, str)
-                and not permalink_key
-            ):
-                resolved = get_dashboard_permalink(request.identifier)
-                if resolved:
-                    permalink_key, permalink_value = resolved
-                    result = core.run_tool(permalink_value["dashboardId"])
-                else:
-                    result = DashboardError.create(
-                        "No dashboard matched this identifier or permalink key. If "
-                        "it came from a shared /dashboard/p/<key>/ link, the link "
-                        "may be invalid or expired; ask for a fresh shared dashboard "
-                        "link.",
-                        "not_found",
-                    )
 
         if isinstance(result, DashboardLayout):
-            if resolved:
-                permalink_key, permalink_value = resolved
-                raw_state = permalink_value.get("state")
-                filter_state = dict(raw_state) if isinstance(raw_state, dict) else {}
-                if not user_can_view_data_model_metadata():
-                    filter_state = redact_filter_state_data_model_metadata(filter_state)
-                payload = result.model_dump(mode="python")
-                payload.update(
-                    permalink_key=permalink_key,
-                    filter_state=sanitize_for_llm_context(
-                        filter_state,
-                        field_path=("filter_state",),
-                        excluded_field_names=frozenset(),
-                    ),
-                    is_permalink_state=True,
-                )
-                result = DashboardLayout.model_validate(payload)
+            if lookup_result.permalink_value:
+                permalink_key = lookup_result.permalink_key
+                permalink_value = lookup_result.permalink_value
+                try:
+                    permalink_dashboard_id = int(permalink_value["dashboardId"])
+                except (TypeError, ValueError):
+                    permalink_dashboard_id = None
+                if permalink_dashboard_id == result.id:
+                    raw_state = permalink_value.get("state")
+                    filter_state = (
+                        dict(raw_state) if isinstance(raw_state, dict) else {}
+                    )
+                    if not user_can_view_data_model_metadata():
+                        filter_state = redact_filter_state_data_model_metadata(
+                            filter_state
+                        )
+                    payload = result.model_dump(mode="python")
+                    payload.update(
+                        permalink_key=permalink_key,
+                        filter_state=sanitize_for_llm_context(
+                            filter_state,
+                            field_path=("filter_state",),
+                            excluded_field_names=frozenset(),
+                        ),
+                        is_permalink_state=True,
+                    )
+                    result = DashboardLayout.model_validate(payload)
+                else:
+                    await ctx.warning(
+                        "permalink_key belongs to a different dashboard; ignoring "
+                        "its active-tab and filter state."
+                    )
             await ctx.info(
                 "Dashboard layout retrieved: id=%s, tab_count=%s, chart_count=%s, "
                 "has_layout=%s"

--- a/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
@@ -38,6 +38,7 @@ from superset.mcp_service.dashboard.schemas import (
     DuplicateDashboardResponse,
     GenerateDashboardRequest,
     GetDashboardInfoRequest,
+    GetDashboardLayoutRequest,
     ListDashboardsRequest,
     ManageDashboardOwnersResponse,
     ManageDashboardRolesResponse,
@@ -974,6 +975,29 @@ class TestRequestSchemaAliasChoices:
             {"id": 42, "columns": ["id", "dashboard_title"]}
         )
         assert req.select_columns == ["id", "dashboard_title"]
+
+    def test_get_dashboard_info_requires_reference(self) -> None:
+        with pytest.raises(ValidationError, match="identifier or permalink_key"):
+            GetDashboardInfoRequest.model_validate({})
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"identifier": 42},
+            {"permalink_key": "shared-key"},
+            {"identifier": 42, "permalink_key": "shared-key"},
+        ],
+    )
+    def test_get_dashboard_layout_accepts_reference(
+        self, payload: dict[str, Any]
+    ) -> None:
+        request = GetDashboardLayoutRequest.model_validate(payload)
+        assert request.identifier == payload.get("identifier")
+        assert request.permalink_key == payload.get("permalink_key")
+
+    def test_get_dashboard_layout_requires_reference(self) -> None:
+        with pytest.raises(ValidationError, match="identifier or permalink_key"):
+            GetDashboardLayoutRequest.model_validate({})
 
     def test_list_dashboards_select_columns_columns_alias(self) -> None:
         req = ListDashboardsRequest.model_validate(

--- a/tests/unit_tests/mcp_service/dashboard/test_permalink.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_permalink.py
@@ -28,8 +28,26 @@ from superset.mcp_service.dashboard.permalink import (
     extract_dashboard_permalink_key,
     get_dashboard_permalink,
     get_matching_dashboard_permalink_state,
+    lookup_dashboard_reference,
     refresh_request_user_for_permalink_access,
 )
+
+FOUND = "dashboard"
+PERMALINK_URL = "https://example.test/dashboard/p/shared-key/"
+
+
+def _lookup_finding(*found_identifiers: int | str):
+    """Build a ``lookup`` callable that only resolves ``found_identifiers``."""
+    known = {str(identifier) for identifier in found_identifiers}
+
+    def lookup(identifier: int | str) -> str | None:
+        return FOUND if str(identifier) in known else None
+
+    return lookup
+
+
+def _is_found(result: str | None) -> bool:
+    return result is not None
 
 
 @pytest.mark.parametrize(
@@ -189,3 +207,168 @@ def test_get_matching_dashboard_permalink_state_skips_check_when_permalink_resol
 
     assert state is not None
     assert state.key == "key-1"
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_identifier_only(mock_get_permalink) -> None:
+    result = lookup_dashboard_reference(
+        identifier=42,
+        permalink_key=None,
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key is None
+    assert result.permalink_value is None
+    assert result.resolved_from_permalink is False
+    mock_get_permalink.assert_not_called()
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_identifier_wins_but_permalink_adds_state(
+    mock_get_permalink,
+) -> None:
+    """An explicit identifier selects the dashboard; the permalink only adds state."""
+    value = {"dashboardId": "42", "state": {"activeTabs": ["TAB-A"]}}
+    mock_get_permalink.return_value = ("key-1", value)
+
+    result = lookup_dashboard_reference(
+        identifier=42,
+        permalink_key="key-1",
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key == "key-1"
+    assert result.permalink_value == value
+    assert result.resolved_from_permalink is False
+
+
+@patch(
+    "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+    return_value=None,
+)
+def test_lookup_dashboard_reference_keeps_dashboard_when_permalink_unresolvable(
+    mock_get_permalink,
+) -> None:
+    result = lookup_dashboard_reference(
+        identifier=42,
+        permalink_key="expired-key",
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key == "expired-key"
+    assert result.permalink_value is None
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_numeric_identifier_not_found(
+    mock_get_permalink,
+) -> None:
+    """A numeric identifier never falls back to permalink resolution."""
+    result = lookup_dashboard_reference(
+        identifier=99,
+        permalink_key=None,
+        lookup=_lookup_finding(),
+        is_found=_is_found,
+    )
+
+    assert result.result is None
+    assert result.permalink_key is None
+    mock_get_permalink.assert_not_called()
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_identifier_not_found_with_explicit_permalink(
+    mock_get_permalink,
+) -> None:
+    """An explicit permalink_key keeps the identifier's own not-found result."""
+    result = lookup_dashboard_reference(
+        identifier="missing-slug",
+        permalink_key="key-1",
+        lookup=_lookup_finding(),
+        is_found=_is_found,
+    )
+
+    assert result.result is None
+    assert result.permalink_key == "key-1"
+    mock_get_permalink.assert_not_called()
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_shared_url_identifier(mock_get_permalink) -> None:
+    value = {"dashboardId": "42", "state": {"activeTabs": ["TAB-A"]}}
+    mock_get_permalink.return_value = ("shared-key", value)
+
+    result = lookup_dashboard_reference(
+        identifier=PERMALINK_URL,
+        permalink_key=None,
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key == "shared-key"
+    assert result.permalink_value == value
+    assert result.resolved_from_permalink is True
+    mock_get_permalink.assert_called_once_with("shared-key")
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_permalink_only(mock_get_permalink) -> None:
+    value = {"dashboardId": "42", "state": {"activeTabs": ["TAB-A"]}}
+    mock_get_permalink.return_value = ("key-1", value)
+
+    result = lookup_dashboard_reference(
+        identifier=None,
+        permalink_key="key-1",
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key == "key-1"
+    assert result.resolved_from_permalink is True
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+def test_lookup_dashboard_reference_bare_string_falls_back_to_permalink(
+    mock_get_permalink,
+) -> None:
+    """An ambiguous bare string tries identifier lookup before permalink lookup."""
+    value = {"dashboardId": "42", "state": {"activeTabs": ["TAB-A"]}}
+    mock_get_permalink.return_value = ("maybe-key", value)
+
+    result = lookup_dashboard_reference(
+        identifier="maybe-key",
+        permalink_key=None,
+        lookup=_lookup_finding(42),
+        is_found=_is_found,
+    )
+
+    assert result.result == FOUND
+    assert result.permalink_key == "maybe-key"
+    assert result.resolved_from_permalink is True
+    mock_get_permalink.assert_called_once_with("maybe-key")
+
+
+@patch(
+    "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+    return_value=None,
+)
+def test_lookup_dashboard_reference_unresolvable_reference(mock_get_permalink) -> None:
+    result = lookup_dashboard_reference(
+        identifier="nonexistent",
+        permalink_key=None,
+        lookup=_lookup_finding(),
+        is_found=_is_found,
+    )
+
+    assert result.result is None
+    assert result.permalink_key == "nonexistent"
+    assert result.permalink_value is None
+    assert result.resolved_from_permalink is False

--- a/tests/unit_tests/mcp_service/dashboard/test_permalink.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_permalink.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for MCP dashboard permalink helpers."""
+
+from unittest.mock import patch
+
+import pytest
+from flask import g
+
+from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
+from superset.mcp_service.dashboard.permalink import (
+    extract_dashboard_permalink_key,
+    get_dashboard_permalink,
+    refresh_request_user_for_permalink_access,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("bare-key", "bare-key"),
+        ("/superset/dashboard/p/shared-key/", "shared-key"),
+        (
+            "https://example.test/prefix/dashboard/p/shared-key/?foo=bar#tab",
+            "shared-key",
+        ),
+        (
+            "https://example.test/dashboard/not-p/shared-key/",
+            "https://example.test/dashboard/not-p/shared-key/",
+        ),
+    ],
+)
+def test_extract_dashboard_permalink_key(value: str, expected: str) -> None:
+    assert extract_dashboard_permalink_key(value) == expected
+
+
+@patch(
+    "superset.commands.dashboard.permalink.get.GetDashboardPermalinkCommand.run",
+    side_effect=DashboardAccessDeniedError(),
+)
+@patch(
+    "superset.mcp_service.dashboard.permalink.refresh_request_user_for_permalink_access"
+)
+def test_get_dashboard_permalink_hides_access_denial(mock_refresh, mock_run) -> None:
+    assert get_dashboard_permalink("inaccessible-key") is None
+    mock_refresh.assert_called_once_with()
+    mock_run.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("username", "email", "expected_kwargs"),
+    [
+        ("admin", None, {"username": "admin"}),
+        (None, "admin@example.com", {"email": "admin@example.com"}),
+    ],
+)
+def test_refresh_request_user_for_permalink_access(
+    app, username: str | None, email: str | None, expected_kwargs: dict[str, str]
+) -> None:
+    current_user = type(
+        "CurrentUser",
+        (),
+        {"username": username, "email": email, "is_anonymous": False},
+    )()
+    refreshed_user = object()
+    with (
+        patch(
+            "superset.mcp_service.dashboard.permalink.load_user_with_relationships",
+            return_value=refreshed_user,
+        ) as mock_load,
+        app.test_request_context("/mcp"),
+    ):
+        g.user = current_user
+        refresh_request_user_for_permalink_access()
+        assert g.user is refreshed_user
+
+    mock_load.assert_called_once_with(**expected_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("username", "email", "is_anonymous"),
+    [("anonymous", "anonymous@example.com", True), (None, None, False)],
+)
+def test_refresh_request_user_for_permalink_access_skips_unresolvable_user(
+    app, username: str | None, email: str | None, is_anonymous: bool
+) -> None:
+    current_user = type(
+        "CurrentUser",
+        (),
+        {"username": username, "email": email, "is_anonymous": is_anonymous},
+    )()
+    with (
+        patch(
+            "superset.mcp_service.dashboard.permalink.load_user_with_relationships"
+        ) as mock_load,
+        app.test_request_context("/mcp"),
+    ):
+        g.user = current_user
+        refresh_request_user_for_permalink_access()
+        assert g.user is current_user
+
+    mock_load.assert_not_called()

--- a/tests/unit_tests/mcp_service/dashboard/test_permalink.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_permalink.py
@@ -24,8 +24,10 @@ from flask import g
 
 from superset.commands.dashboard.exceptions import DashboardAccessDeniedError
 from superset.mcp_service.dashboard.permalink import (
+    DashboardLookupResult,
     extract_dashboard_permalink_key,
     get_dashboard_permalink,
+    get_matching_dashboard_permalink_state,
     refresh_request_user_for_permalink_access,
 )
 
@@ -137,3 +139,53 @@ def test_refresh_request_user_for_permalink_access_keeps_user_when_reload_fails(
         assert g.user is current_user
 
     mock_load.assert_called_once_with(username="admin")
+
+
+@pytest.mark.parametrize(
+    ("reference", "expected_match"),
+    [
+        # CreateDashboardPermalinkCommand stores str(dashboard.uuid).
+        ("3f1a2b6c-9d4e-4f80-9c2a-7b1d5e6f8a90", True),
+        # Legacy permalinks may hold the numeric id or the slug.
+        ("42", True),
+        ("sales-dashboard", True),
+        ("99", False),
+        ("00000000-0000-0000-0000-000000000000", False),
+    ],
+)
+def test_get_matching_dashboard_permalink_state_accepts_every_identifier(
+    app, reference: str, expected_match: bool
+) -> None:
+    lookup_result = DashboardLookupResult(
+        result=object(),
+        permalink_key="key-1",
+        permalink_value={"dashboardId": reference, "state": {"activeTabs": ["TAB-A"]}},
+    )
+    with app.test_request_context("/mcp"):
+        state = get_matching_dashboard_permalink_state(
+            lookup_result,
+            42,
+            "3f1a2b6c-9d4e-4f80-9c2a-7b1d5e6f8a90",
+            "sales-dashboard",
+        )
+
+    assert (state is not None) is expected_match
+
+
+def test_get_matching_dashboard_permalink_state_skips_check_when_permalink_resolved(
+    app,
+) -> None:
+    """The permalink-only path already selected the dashboard from the permalink,
+    so its state is never re-verified against the resolved identifiers.
+    """
+    lookup_result = DashboardLookupResult(
+        result=object(),
+        permalink_key="key-1",
+        permalink_value={"dashboardId": "whatever", "state": {"activeTabs": ["TAB-A"]}},
+        resolved_from_permalink=True,
+    )
+    with app.test_request_context("/mcp"):
+        state = get_matching_dashboard_permalink_state(lookup_result, 42)
+
+    assert state is not None
+    assert state.key == "key-1"

--- a/tests/unit_tests/mcp_service/dashboard/test_permalink.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_permalink.py
@@ -115,3 +115,25 @@ def test_refresh_request_user_for_permalink_access_skips_unresolvable_user(
         assert g.user is current_user
 
     mock_load.assert_not_called()
+
+
+def test_refresh_request_user_for_permalink_access_keeps_user_when_reload_fails(
+    app,
+) -> None:
+    current_user = type(
+        "CurrentUser",
+        (),
+        {"username": "admin", "email": None, "is_anonymous": False},
+    )()
+    with (
+        patch(
+            "superset.mcp_service.dashboard.permalink.load_user_with_relationships",
+            return_value=None,
+        ) as mock_load,
+        app.test_request_context("/mcp"),
+    ):
+        g.user = current_user
+        refresh_request_user_for_permalink_access()
+        assert g.user is current_user
+
+    mock_load.assert_called_once_with(username="admin")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -29,6 +29,7 @@ from fastmcp.exceptions import ToolError
 
 from superset.mcp_service.app import mcp
 from superset.mcp_service.dashboard.schemas import (
+    DashboardError,
     DashboardInfo,
     ListDashboardsRequest,
 )
@@ -634,6 +635,87 @@ async def test_get_dashboard_info_identifier_takes_precedence_over_permalink(
     assert result.data["is_permalink_state"] is False
     assert "filter_state" not in result.data
     mock_run_tool.assert_called_once_with(10)
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_permalink_with_uuid_dashboard_id(
+    mock_permalink, mock_run_tool, mcp_server
+):
+    """CreateDashboardPermalinkCommand stores dashboardId as the dashboard UUID,
+    so an explicit identifier plus that permalink must still yield filter state.
+    """
+    dashboard_uuid = "3f1a2b6c-9d4e-4f80-9c2a-7b1d5e6f8a90"
+    mock_permalink.return_value = (
+        "uuid-key",
+        {"dashboardId": dashboard_uuid, "state": {"activeTabs": ["TAB-A"]}},
+    )
+    mock_run_tool.return_value = DashboardInfo(
+        id=42, dashboard_title="Sales Dashboard", uuid=dashboard_uuid
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info",
+            {"request": {"identifier": 42, "permalink_key": "uuid-key"}},
+        )
+
+    assert result.data["id"] == 42
+    assert result.data["is_permalink_state"] is True
+    assert result.data["permalink_key"] == "uuid-key"
+    assert result.data["filter_state"]["activeTabs"] == [_wrapped("TAB-A")]
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_permalink_with_slug_dashboard_id(
+    mock_permalink, mock_run_tool, mcp_server
+):
+    """Pre-3.1 permalinks can carry a slug in dashboardId."""
+    mock_permalink.return_value = (
+        "slug-key",
+        {"dashboardId": "sales-dashboard", "state": {"activeTabs": ["TAB-A"]}},
+    )
+    mock_run_tool.return_value = DashboardInfo(
+        id=42, dashboard_title="Sales Dashboard", slug="sales-dashboard"
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info",
+            {"request": {"identifier": 42, "permalink_key": "slug-key"}},
+        )
+
+    assert result.data["is_permalink_state"] is True
+    assert result.data["filter_state"]["activeTabs"] == [_wrapped("TAB-A")]
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
+@patch(
+    "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+    return_value=None,
+)
+@pytest.mark.asyncio
+async def test_get_dashboard_info_unknown_slug_keeps_not_found_error(
+    mock_permalink, mock_run_tool, mcp_server
+):
+    """A plain slug typo keeps its own not-found error instead of asking the
+    user for a shared link they never mentioned.
+    """
+    mock_run_tool.return_value = DashboardError.create(
+        "DashboardInfo with identifier 'sales-dashbord' not found", "not_found"
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"identifier": "sales-dashbord"}}
+        )
+
+    assert result.data["error_type"] == "not_found"
+    assert "sales-dashbord" in result.data["error"]
+    assert "fresh shared dashboard link" not in result.data["error"]
 
 
 @patch("superset.daos.dashboard.DashboardDAO.find_by_id")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -30,6 +30,7 @@ from flask import g
 
 from superset.mcp_service.app import mcp
 from superset.mcp_service.dashboard.schemas import (
+    DashboardInfo,
     ListDashboardsRequest,
 )
 from superset.mcp_service.dashboard.tool.get_dashboard_info import (
@@ -573,6 +574,43 @@ async def test_get_dashboard_info_permalink_key_includes_filter_state(
     assert "filter_state" in result.data
     assert result.data["is_permalink_state"] is True
     assert result.data["permalink_key"] == "some-key"
+
+
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
+@patch.object(get_dashboard_info_module, "_get_permalink_state")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_resolves_permalink_without_identifier(
+    mock_permalink, mock_run_tool, mcp_server
+):
+    mock_permalink.return_value = {
+        "dashboardId": "42",
+        "state": {"activeTabs": ["TAB-A"], "dataMask": {}},
+    }
+    mock_run_tool.return_value = DashboardInfo(id=42, dashboard_title="Sales Dashboard")
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"permalink_key": "shared-key"}}
+        )
+
+    assert result.data["id"] == 42
+    assert result.data["permalink_key"] == "shared-key"
+    assert result.data["filter_state"]["activeTabs"] == [_wrapped("TAB-A")]
+    mock_run_tool.assert_called_once_with("42")
+
+
+@patch.object(get_dashboard_info_module, "_get_permalink_state", return_value=None)
+@pytest.mark.asyncio
+async def test_get_dashboard_info_invalid_permalink_is_actionable(
+    mock_permalink, mcp_server
+):
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info", {"request": {"permalink_key": "expired-key"}}
+        )
+
+    assert result.data["error_type"] == "permalink_not_found"
+    assert "fresh shared dashboard link" in result.data["error"]
 
 
 def test_refresh_request_user_for_permalink_access(

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -26,15 +26,11 @@ from unittest.mock import Mock, patch
 import pytest
 from fastmcp import Client
 from fastmcp.exceptions import ToolError
-from flask import g
 
 from superset.mcp_service.app import mcp
 from superset.mcp_service.dashboard.schemas import (
     DashboardInfo,
     ListDashboardsRequest,
-)
-from superset.mcp_service.dashboard.tool.get_dashboard_info import (
-    _refresh_request_user_for_permalink_access,
 )
 from superset.utils import json
 
@@ -473,10 +469,9 @@ async def test_get_dashboard_info_permalink_does_not_double_sanitize(
             "user_can_view_data_model_metadata",
             return_value=True,
         ),
-        patch.object(
-            get_dashboard_info_module,
-            "_get_permalink_state",
-            return_value=permalink_value,
+        patch(
+            "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+            return_value=("permalink-1", permalink_value),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -557,10 +552,9 @@ async def test_get_dashboard_info_permalink_key_includes_filter_state(
             "user_can_view_data_model_metadata",
             return_value=True,
         ),
-        patch.object(
-            get_dashboard_info_module,
-            "_get_permalink_state",
-            return_value=permalink_value,
+        patch(
+            "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+            return_value=("some-key", permalink_value),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -577,15 +571,15 @@ async def test_get_dashboard_info_permalink_key_includes_filter_state(
 
 
 @patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
-@patch.object(get_dashboard_info_module, "_get_permalink_state")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
 @pytest.mark.asyncio
 async def test_get_dashboard_info_resolves_permalink_without_identifier(
     mock_permalink, mock_run_tool, mcp_server
 ):
-    mock_permalink.return_value = {
-        "dashboardId": "42",
-        "state": {"activeTabs": ["TAB-A"], "dataMask": {}},
-    }
+    mock_permalink.return_value = (
+        "shared-key",
+        {"dashboardId": "42", "state": {"activeTabs": ["TAB-A"], "dataMask": {}}},
+    )
     mock_run_tool.return_value = DashboardInfo(id=42, dashboard_title="Sales Dashboard")
 
     async with Client(mcp_server) as client:
@@ -599,7 +593,10 @@ async def test_get_dashboard_info_resolves_permalink_without_identifier(
     mock_run_tool.assert_called_once_with("42")
 
 
-@patch.object(get_dashboard_info_module, "_get_permalink_state", return_value=None)
+@patch(
+    "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+    return_value=None,
+)
 @pytest.mark.asyncio
 async def test_get_dashboard_info_invalid_permalink_is_actionable(
     mock_permalink, mcp_server
@@ -613,121 +610,29 @@ async def test_get_dashboard_info_invalid_permalink_is_actionable(
     assert "fresh shared dashboard link" in result.data["error"]
 
 
-def test_refresh_request_user_for_permalink_access(
-    app,
+@patch("superset.mcp_service.mcp_core.ModelGetInfoCore.run_tool")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_identifier_takes_precedence_over_permalink(
+    mock_permalink, mock_run_tool, mcp_server
 ):
-    refreshed_user = Mock()
-    refreshed_user.username = "admin"
-    refreshed_user.roles = []
-    refreshed_user.groups = []
+    mock_permalink.return_value = (
+        "dashboard-20-key",
+        {"dashboardId": "20", "state": {"activeTabs": ["TAB-20"]}},
+    )
+    mock_run_tool.return_value = DashboardInfo(
+        id=10, dashboard_title="Requested Dashboard"
+    )
 
-    current_user = Mock()
-    current_user.username = "admin"
-    current_user.email = None
-    current_user.is_anonymous = False
-
-    with (
-        patch.object(
-            get_dashboard_info_module,
-            "load_user_with_relationships",
-            return_value=refreshed_user,
-        ) as mock_load_user_with_relationships,
-        app.test_request_context("/mcp"),
-    ):
-        g.user = current_user
-        _refresh_request_user_for_permalink_access()
-
-        mock_load_user_with_relationships.assert_called_once_with(username="admin")
-        assert g.user is refreshed_user
-
-
-def test_refresh_request_user_for_permalink_access_uses_email_when_username_missing(
-    app,
-):
-    refreshed_user = Mock()
-    refreshed_user.email = "admin@example.com"
-
-    current_user = Mock()
-    current_user.username = None
-    current_user.email = "admin@example.com"
-    current_user.is_anonymous = False
-
-    with (
-        patch.object(
-            get_dashboard_info_module,
-            "load_user_with_relationships",
-            return_value=refreshed_user,
-        ) as mock_load_user_with_relationships,
-        app.test_request_context("/mcp"),
-    ):
-        g.user = current_user
-        _refresh_request_user_for_permalink_access()
-
-        mock_load_user_with_relationships.assert_called_once_with(
-            email="admin@example.com"
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_info",
+            {"request": {"identifier": 10, "permalink_key": "dashboard-20-key"}},
         )
-        assert g.user is refreshed_user
 
-
-def test_refresh_request_user_for_permalink_access_skips_anonymous_user(app):
-    current_user = Mock()
-    current_user.username = "anonymous"
-    current_user.email = "anonymous@example.com"
-    current_user.is_anonymous = True
-
-    with (
-        patch.object(
-            get_dashboard_info_module,
-            "load_user_with_relationships",
-        ) as mock_load_user_with_relationships,
-        app.test_request_context("/mcp"),
-    ):
-        g.user = current_user
-        _refresh_request_user_for_permalink_access()
-
-        mock_load_user_with_relationships.assert_not_called()
-        assert g.user is current_user
-
-
-def test_refresh_request_user_for_permalink_access_skips_missing_identifier(app):
-    current_user = Mock()
-    current_user.username = None
-    current_user.email = None
-    current_user.is_anonymous = False
-
-    with (
-        patch.object(
-            get_dashboard_info_module,
-            "load_user_with_relationships",
-        ) as mock_load_user_with_relationships,
-        app.test_request_context("/mcp"),
-    ):
-        g.user = current_user
-        _refresh_request_user_for_permalink_access()
-
-        mock_load_user_with_relationships.assert_not_called()
-        assert g.user is current_user
-
-
-def test_refresh_request_user_for_permalink_access_keeps_user_when_reload_fails(app):
-    current_user = Mock()
-    current_user.username = "admin"
-    current_user.email = None
-    current_user.is_anonymous = False
-
-    with (
-        patch.object(
-            get_dashboard_info_module,
-            "load_user_with_relationships",
-            return_value=None,
-        ) as mock_load_user_with_relationships,
-        app.test_request_context("/mcp"),
-    ):
-        g.user = current_user
-        _refresh_request_user_for_permalink_access()
-
-        mock_load_user_with_relationships.assert_called_once_with(username="admin")
-        assert g.user is current_user
+    assert result.data["id"] == 10
+    assert result.data["is_permalink_state"] is False
+    mock_run_tool.assert_called_once_with(10)
 
 
 @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
@@ -969,10 +874,9 @@ async def test_get_dashboard_info_restricted_user_redacts_permalink_filter_state
             "user_can_view_data_model_metadata",
             return_value=False,
         ),
-        patch.object(
-            get_dashboard_info_module,
-            "_get_permalink_state",
-            return_value=permalink_value,
+        patch(
+            "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+            return_value=("abc123", permalink_value),
         ),
     ):
         async with Client(mcp_server) as client:

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -464,8 +464,8 @@ async def test_get_dashboard_info_permalink_does_not_double_sanitize(
             "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
             return_value=True,
         ),
-        patch.object(
-            get_dashboard_info_module,
+        patch(
+            "superset.mcp_service.dashboard.permalink."
             "user_can_view_data_model_metadata",
             return_value=True,
         ),
@@ -547,8 +547,8 @@ async def test_get_dashboard_info_permalink_key_includes_filter_state(
             "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
             return_value=True,
         ),
-        patch.object(
-            get_dashboard_info_module,
+        patch(
+            "superset.mcp_service.dashboard.permalink."
             "user_can_view_data_model_metadata",
             return_value=True,
         ),
@@ -632,6 +632,7 @@ async def test_get_dashboard_info_identifier_takes_precedence_over_permalink(
 
     assert result.data["id"] == 10
     assert result.data["is_permalink_state"] is False
+    assert "filter_state" not in result.data
     mock_run_tool.assert_called_once_with(10)
 
 
@@ -869,8 +870,8 @@ async def test_get_dashboard_info_restricted_user_redacts_permalink_filter_state
             "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
             return_value=False,
         ),
-        patch.object(
-            get_dashboard_info_module,
+        patch(
+            "superset.mcp_service.dashboard.permalink."
             "user_can_view_data_model_metadata",
             return_value=False,
         ),

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
@@ -259,6 +259,65 @@ async def test_get_dashboard_layout_not_found(mock_find, mcp_server):
     assert data["error_type"] == "not_found"
 
 
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@patch(
+    "superset.mcp_service.dashboard.tool.get_dashboard_layout.get_dashboard_permalink"
+)
+@pytest.mark.asyncio
+async def test_get_dashboard_layout_resolves_shared_permalink(
+    mock_permalink, mock_find, mcp_server
+):
+    mock_permalink.return_value = (
+        "shared-key",
+        {
+            "dashboardId": "42",
+            "state": {
+                "activeTabs": ["TAB-2"],
+                "dataMask": {"FILTER-1": {"filterState": {"value": "EMEA"}}},
+            },
+        },
+    )
+    mock_find.return_value = _build_dashboard_mock(
+        dashboard_id=42, position_json=_tabbed_layout()
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_layout",
+            {
+                "request": {
+                    "identifier": "https://example.test/superset/dashboard/p/shared-key/"
+                }
+            },
+        )
+        data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["permalink_key"] == "shared-key"
+    assert data["is_permalink_state"] is True
+    assert data["filter_state"]["activeTabs"] == [_wrapped("TAB-2")]
+    assert mock_find.call_args_list[-1].args == (42,)
+
+
+@patch(
+    "superset.mcp_service.dashboard.tool.get_dashboard_layout.get_dashboard_permalink"
+)
+@pytest.mark.asyncio
+async def test_get_dashboard_layout_invalid_permalink_is_actionable(
+    mock_permalink, mcp_server
+):
+    mock_permalink.return_value = None
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_layout", {"request": {"permalink_key": "expired-key"}}
+        )
+        data = json.loads(result.content[0].text)
+
+    assert data["error_type"] == "permalink_not_found"
+    assert "fresh shared dashboard link" in data["error"]
+
+
 def test_extract_layout_handles_invalid_json():
     tabs, charts = _extract_layout_from_position("{ not json")
     assert tabs == []

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
@@ -260,9 +260,7 @@ async def test_get_dashboard_layout_not_found(mock_find, mcp_server):
 
 
 @patch("superset.daos.dashboard.DashboardDAO.find_by_id")
-@patch(
-    "superset.mcp_service.dashboard.tool.get_dashboard_layout.get_dashboard_permalink"
-)
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
 @pytest.mark.asyncio
 async def test_get_dashboard_layout_resolves_shared_permalink(
     mock_permalink, mock_find, mcp_server
@@ -299,9 +297,7 @@ async def test_get_dashboard_layout_resolves_shared_permalink(
     assert mock_find.call_args_list[-1].args == (42,)
 
 
-@patch(
-    "superset.mcp_service.dashboard.tool.get_dashboard_layout.get_dashboard_permalink"
-)
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
 @pytest.mark.asyncio
 async def test_get_dashboard_layout_invalid_permalink_is_actionable(
     mock_permalink, mcp_server
@@ -316,6 +312,32 @@ async def test_get_dashboard_layout_invalid_permalink_is_actionable(
 
     assert data["error_type"] == "permalink_not_found"
     assert "fresh shared dashboard link" in data["error"]
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@pytest.mark.asyncio
+async def test_get_dashboard_layout_identifier_takes_precedence_over_permalink(
+    mock_permalink, mock_find, mcp_server
+):
+    mock_permalink.return_value = (
+        "dashboard-20-key",
+        {"dashboardId": "20", "state": {"activeTabs": ["TAB-20"]}},
+    )
+    mock_find.return_value = _build_dashboard_mock(
+        dashboard_id=10, position_json=_tabbed_layout()
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_layout",
+            {"request": {"identifier": 10, "permalink_key": "dashboard-20-key"}},
+        )
+        data = json.loads(result.content[0].text)
+
+    assert data["id"] == 10
+    assert data["is_permalink_state"] is False
+    mock_find.assert_called_once_with(10, query_options=None)
 
 
 def test_extract_layout_handles_invalid_json():

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
@@ -340,6 +340,62 @@ async def test_get_dashboard_layout_identifier_takes_precedence_over_permalink(
     mock_find.assert_called_once_with(10, query_options=None)
 
 
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@pytest.mark.asyncio
+async def test_get_dashboard_layout_permalink_with_uuid_dashboard_id(
+    mock_permalink, mock_find, mcp_server
+):
+    """CreateDashboardPermalinkCommand stores dashboardId as the dashboard UUID,
+    so an explicit identifier plus that permalink must still yield filter state.
+    """
+    dashboard_uuid = "3f1a2b6c-9d4e-4f80-9c2a-7b1d5e6f8a90"
+    mock_permalink.return_value = (
+        "uuid-key",
+        {"dashboardId": dashboard_uuid, "state": {"activeTabs": ["TAB-2"]}},
+    )
+    mock_find.return_value = _build_dashboard_mock(
+        dashboard_id=42, uuid=dashboard_uuid, position_json=_tabbed_layout()
+    )
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_layout",
+            {"request": {"identifier": 42, "permalink_key": "uuid-key"}},
+        )
+        data = json.loads(result.content[0].text)
+
+    assert data["id"] == 42
+    assert data["is_permalink_state"] is True
+    assert data["permalink_key"] == "uuid-key"
+    assert data["filter_state"]["activeTabs"] == [_wrapped("TAB-2")]
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@patch(
+    "superset.mcp_service.dashboard.permalink.get_dashboard_permalink",
+    return_value=None,
+)
+@pytest.mark.asyncio
+async def test_get_dashboard_layout_unknown_slug_keeps_not_found_error(
+    mock_permalink, mock_find, mcp_server
+):
+    """A plain slug typo keeps its own not-found error instead of asking the
+    user for a shared link they never mentioned.
+    """
+    mock_find.return_value = None
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "get_dashboard_layout", {"request": {"identifier": "sales-dashbord"}}
+        )
+        data = json.loads(result.content[0].text)
+
+    assert data["error_type"] == "not_found"
+    assert "sales-dashbord" in data["error"]
+    assert "fresh shared dashboard link" not in data["error"]
+
+
 def test_extract_layout_handles_invalid_json():
     tabs, charts = _extract_layout_from_position("{ not json")
     assert tabs == []


### PR DESCRIPTION
### SUMMARY

Dashboard lookup tools can resolve shared `/dashboard/p/<key>/` links and bare permalink keys, returning the dashboard identifier together with the permalink's active-tab and filter state. This extends the existing tools rather than adding a resolver round trip: their response models already carry dashboard metadata and state, so transparent resolution keeps the workflow discoverable without losing context.

Invalid or expired permalinks return an actionable error asking for a fresh shared link. Numeric IDs, UUIDs, and slugs retain their existing lookup path; ambiguous bare strings are attempted as permalinks only after ordinary identifier lookup fails.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this changes MCP tool behavior and schemas only.

### TESTING INSTRUCTIONS

```bash
ruff format superset/mcp_service/dashboard/schemas.py superset/mcp_service/dashboard/permalink.py superset/mcp_service/dashboard/tool/get_dashboard_info.py superset/mcp_service/dashboard/tool/get_dashboard_layout.py tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
ruff check superset/mcp_service/dashboard/schemas.py superset/mcp_service/dashboard/permalink.py superset/mcp_service/dashboard/tool/get_dashboard_info.py superset/mcp_service/dashboard/tool/get_dashboard_layout.py tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
pytest -q tests/unit_tests/mcp_service/dashboard/
pre-commit run --files superset/mcp_service/app.py superset/mcp_service/dashboard/schemas.py superset/mcp_service/dashboard/permalink.py superset/mcp_service/dashboard/tool/get_dashboard_info.py superset/mcp_service/dashboard/tool/get_dashboard_layout.py tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py tests/unit_tests/mcp_service/dashboard/tool/test_get_dashboard_layout.py
```

The dashboard MCP unit suite passes (362 tests). Changed-file pre-commit passes. The repository-wide pre-commit run was also attempted; unrelated existing type/lint failures and missing frontend dependencies prevent that full-tree gate from completing.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

#### Blast radius

Apache Superset's optional MCP service only. No migrations, feature flags, authentication changes, workspace isolation changes, or database query behavior changes.

#### Risk and rollback

The main risk is interpreting an unknown slug-like identifier as a permalink after normal lookup fails. Existing identifiers are resolved first, and reverting this commit restores the previous behavior.

#### Eval evidence

The deployment-backed agent eval suite was not run for this draft because no deployed build is available. The deterministic MCP unit coverage exercises permalink resolution, active-tab/filter context, invalid links, and existing identifier forms.

#### Cost and latency delta

No model, prompt-routing, or token changes. A bare permalink key can add one permalink lookup after an unsuccessful ordinary identifier lookup; explicit permalink inputs and shared URLs resolve directly. Deployment-backed latency measurements were not available for this draft.

#### Prompt / non-determinism

Tool descriptions were updated to identify `/dashboard/p/<key>/` links and direct agents to the lookup tools. The resolution behavior is deterministic; no model prompt or routing behavior changed.

#### Review guidance

Start with `dashboard/permalink.py` and the request/response schema changes, then review how each lookup tool reuses the resolved dashboard ID and safely exposes permalink state. The most important behavior is the ordinary-identifier-first fallback for bare strings.
