### PR TITLE
fix(mcp): missing params in MCP tool call logs

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -246,7 +246,7 @@ class LoggingMiddleware(Middleware):
         dashboard_id = None
         slice_id = None
         dataset_id = None
-        params = getattr(context.message, "params", {}) or {}
+        params = getattr(context.message, "arguments", {}) or {}
         if hasattr(context, "metadata") and context.metadata:
             agent_id = context.metadata.get("agent_id")
         if not agent_id and hasattr(context, "session") and context.session:
@@ -1152,7 +1152,7 @@ class ResponseSizeGuardMiddleware(Middleware):
             )
 
         if estimated_tokens > self.token_limit:
-            params = getattr(context.message, "params", {}) or {}
+            params = getattr(context.message, "arguments", {}) or {}
             return self._handle_oversized_response(
                 tool_name, response, estimated_tokens, params
             )

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -95,7 +95,7 @@ class TestResponseSizeGuardMiddleware:
         # Create mock context
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {}
+        context.message.arguments = {}
 
         # Create mock call_next that returns small response
         small_response = {"charts": [{"id": 1, "name": "test"}]}
@@ -118,7 +118,7 @@ class TestResponseSizeGuardMiddleware:
         # Create mock context
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {"page_size": 100}
+        context.message.arguments = {"page_size": 100}
 
         # Create large response
         large_response = {
@@ -148,7 +148,7 @@ class TestResponseSizeGuardMiddleware:
         # Create mock context for excluded tool
         context = MagicMock()
         context.message.name = "health_check"
-        context.message.params = {}
+        context.message.arguments = {}
 
         # Create response that would exceed limit
         large_response = {"data": "x" * 10000}
@@ -173,7 +173,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {}
+        context.message.arguments = {}
 
         response = {"data": "approaching the limit"}
         call_next = AsyncMock(return_value=response)
@@ -201,7 +201,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {"page_size": 100}
+        context.message.arguments = {"page_size": 100}
 
         large_response = {"charts": [{"id": i} for i in range(1000)]}
         call_next = AsyncMock(return_value=large_response)
@@ -226,7 +226,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response = {"data": "x" * 10000}
         call_next = AsyncMock(return_value=large_response)
@@ -250,7 +250,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_dataset_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         # Large info tool response with a big description
         large_response = {
@@ -279,7 +279,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_chart_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response = {
             "id": 1,
@@ -305,7 +305,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "list_charts"  # Not an info tool
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response = {"data": "x" * 10000}
         call_next = AsyncMock(return_value=large_response)
@@ -324,7 +324,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_dashboard_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response = {
             "id": 1,
@@ -357,7 +357,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_dashboard_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response = {
             "id": 1,
@@ -387,7 +387,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -417,7 +417,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "query_dataset"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -446,7 +446,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_chart_data"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -476,7 +476,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -502,7 +502,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -529,7 +529,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_response = {
@@ -557,7 +557,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "get_chart_data"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_response: dict[str, Any] = {
             "chart_id": 1,
@@ -595,7 +595,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         huge_row = {"col": "x" * 5000}
         large_response = {
@@ -619,7 +619,7 @@ class TestResponseSizeGuardMiddleware:
 
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         small_response = {
             "status": "success",
@@ -949,7 +949,7 @@ class TestToolResultWrapping:
         middleware = ResponseSizeGuardMiddleware(token_limit=500)
         context = MagicMock()
         context.message.name = "get_dataset_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_payload = {"id": 1, "table_name": "test", "description": "x" * 50000}
         tool_result = self._make_tool_result(large_payload)
@@ -975,7 +975,7 @@ class TestToolResultWrapping:
         middleware = ResponseSizeGuardMiddleware(token_limit=25000)
         context = MagicMock()
         context.message.name = "get_chart_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         small_payload = {"id": 1, "name": "My Chart"}
         tool_result = self._make_tool_result(small_payload)
@@ -995,7 +995,7 @@ class TestToolResultWrapping:
         middleware = ResponseSizeGuardMiddleware(token_limit=100)
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {}
+        context.message.arguments = {}
 
         large_payload = {
             "charts": [{"id": i, "name": f"chart_{i}"} for i in range(500)]
@@ -1026,7 +1026,7 @@ class TestToolResultWrapping:
         middleware = ResponseSizeGuardMiddleware(token_limit=500)
         context = MagicMock()
         context.message.name = "execute_sql"
-        context.message.params = {}
+        context.message.arguments = {}
 
         row = {f"col_{i}": f"value_{i}" for i in range(10)}
         large_payload = {
@@ -1058,7 +1058,7 @@ class TestToolResultWrapping:
         middleware = ResponseSizeGuardMiddleware(token_limit=500)
         context = MagicMock()
         context.message.name = "get_dashboard_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         meta = {"request_id": "abc-123"}
         large_payload = {"id": 1, "title": "My Dashboard", "description": "x" * 50000}
@@ -1093,7 +1093,7 @@ class TestMiddlewareIntegration:
 
         context = MagicMock()
         context.message.name = "get_chart_info"
-        context.message.params = {}
+        context.message.arguments = {}
 
         response = ChartInfo(id=1, name="Test Chart")
         call_next = AsyncMock(return_value=response)
@@ -1113,7 +1113,7 @@ class TestMiddlewareIntegration:
 
         context = MagicMock()
         context.message.name = "list_charts"
-        context.message.params = {}
+        context.message.arguments = {}
 
         response = [{"id": 1}, {"id": 2}, {"id": 3}]
         call_next = AsyncMock(return_value=response)
@@ -1133,7 +1133,7 @@ class TestMiddlewareIntegration:
 
         context = MagicMock()
         context.message.name = "health_check"
-        context.message.params = {}
+        context.message.arguments = {}
 
         response = "OK"
         call_next = AsyncMock(return_value=response)

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -49,7 +49,7 @@ def _make_context(
     ctx.method = method
     message = MagicMock()
     message.name = name
-    message.params = params or {}
+    message.arguments = params or {}
     ctx.message = message
     if metadata is not None:
         ctx.metadata = metadata
@@ -502,6 +502,33 @@ class TestExtractContextInfo:
         _, _, _, slice_id, _, _ = middleware._extract_context_info(ctx)
 
         assert slice_id == 66
+
+    @patch("superset.mcp_service.middleware.get_user_id", return_value=1)
+    def test_extract_reads_arguments_on_real_call_tool_request_params(
+        self, mock_get_user_id
+    ) -> None:
+        """Regression test: the real MCP ``CallToolRequestParams`` object
+        exposes tool arguments as ``.arguments``, not ``.params`` -- a
+        ``MagicMock``-based context would auto-vivify a ``.params``
+        attribute and hide a mismatch. Using the real SDK type here
+        ensures params/dashboard_id/etc. are actually populated instead
+        of silently logging as empty."""
+        middleware = LoggingMiddleware()
+        message = mt.CallToolRequestParams(
+            name="get_dashboard_info",
+            arguments={"dashboard_id": 7},
+        )
+        ctx = MagicMock()
+        ctx.message = message
+        ctx.metadata = None
+        ctx.session = None
+
+        agent_id, user_id, dashboard_id, slice_id, dataset_id, params = (
+            middleware._extract_context_info(ctx)
+        )
+
+        assert params == {"dashboard_id": 7}
+        assert dashboard_id == 7
 
 
 class TestIsErrorResponse:


### PR DESCRIPTION
### SUMMARY
LoggingMiddleware and ResponseSizeGuardMiddleware extracted tool call parameters via getattr(context.message, "params", {}). The real MCP SDK type for a tools/call request (mcp.types.CallToolRequestParams) has no params attribute — it exposes name and arguments — so the getattr fallback always silently returned {}. As a result, every MCP tool call log recorded params: {} and dashboard_id/slice_id/dataset_id as null, regardless of what the caller actually sent, making the audit logs useless for debugging or analytics.

Fixed both call sites to read context.message.arguments instead. Also updated the existing unit test mocks, which had been setting context.message.params on MagicMock objects — mirroring the same wrong attribute name as the bug, which is why the regression went undetected — and added a regression test that constructs a real mcp.types.CallToolRequestParams object to catch this class of attribute-name mismatch going forward.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

```
{"tool": "get_dashboard_info", "agent_id": null, "params": {}, "method": "tools/call", "dashboard_id": null,
  "slice_id": null, "dataset_id": null, "success": false}
```

After:

```
{"tool": "get_dashboard_info", "agent_id": null, "params": {"request": {"identifier": 286}}, "method": "tools/call", "dashboard_id": null, "slice_id": null, "dataset_id": null, "success": false}
```

### TESTING INSTRUCTIONS

- pytest tests/unit_tests/mcp_service/test_middleware.py tests/unit_tests/mcp_service/test_middleware_logging.py -q — all 124 tests pass, including the new regression test (verified it fails against the pre-fix code).
- Manually verified end-to-end on a live dev pod: ran superset mcp run, called get_dashboard_info via a real MCP client, and confirmed via the logs table in the metadata DB that params now contains the actual call arguments (e.g. {"request": {"identifier": 286}}) instead of {}.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
