### PR TITLE
fix(sqllab): roll back session before retrying get_query after a broken transaction

### DIFF
--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -161,6 +161,9 @@ def get_query(query_id: int) -> Query:
     try:
         return db.session.query(Query).filter_by(id=query_id).one()
     except Exception as ex:
+        # roll back so a poisoned session (e.g. PendingRollbackError after a
+        # failed flush) doesn't fail every subsequent backoff retry identically
+        db.session.rollback()
         raise SqlLabException("Failed at getting query") from ex
 
 

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -162,8 +162,14 @@ def get_query(query_id: int) -> Query:
         return db.session.query(Query).filter_by(id=query_id).one()
     except Exception as ex:
         # roll back so a poisoned session (e.g. PendingRollbackError after a
-        # failed flush) doesn't fail every subsequent backoff retry identically
-        db.session.rollback()
+        # failed flush) doesn't fail every subsequent backoff retry identically.
+        # Swallow rollback failures so a session/connection too broken to roll
+        # back doesn't replace the original exception with one the backoff
+        # decorator won't retry on.
+        try:
+            db.session.rollback()
+        except Exception:  # pylint: disable=broad-except
+            logger.warning("Failed to roll back session in get_query", exc_info=True)
         raise SqlLabException("Failed at getting query") from ex
 
 

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -37,6 +37,7 @@ from superset.sql_lab import (
     execute_sql_statements,
     get_query,
     get_sql_results,
+    SqlLabException,
 )
 from superset.utils.rls import apply_rls, get_predicates_for_table
 from tests.conftest import with_config
@@ -98,6 +99,30 @@ def test_get_query_rolls_back_session_before_retrying(
     assert result is expected_query
     assert mock_one.return_value.filter_by.return_value.one.call_count == 2
     mock_rollback.assert_called_once()
+
+
+def test_get_query_swallows_rollback_failure(
+    mocker: MockerFixture, app: SupersetApp
+) -> None:
+    """
+    If the session/connection is too broken for `rollback()` itself to succeed,
+    that failure must not replace the original lookup error: `get_query` still
+    needs to raise `SqlLabException` so the `backoff` decorator's retry contract
+    (which only matches on `SqlLabException`) isn't bypassed.
+    """
+    mocker.patch("backoff._sync.time.sleep")
+
+    mock_one = mocker.patch("superset.sql_lab.db.session.query")
+    mock_one.return_value.filter_by.return_value.one.side_effect = Exception(
+        "session is broken"
+    )
+    mocker.patch(
+        "superset.sql_lab.db.session.rollback",
+        side_effect=Exception("connection already closed"),
+    )
+
+    with pytest.raises(SqlLabException):
+        get_query(query_id=1)
 
 
 @with_config(

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -35,6 +35,7 @@ from superset.sql.parse import SQLStatement, Table
 from superset.sql_lab import (
     execute_query,
     execute_sql_statements,
+    get_query,
     get_sql_results,
 )
 from superset.utils.rls import apply_rls, get_predicates_for_table
@@ -69,6 +70,34 @@ def test_execute_query(mocker: MockerFixture, app: None) -> None:
         query,
     )
     SupersetResultSet.assert_called_with([(42,)], cursor.description, db_engine_spec)
+
+
+def test_get_query_rolls_back_session_before_retrying(
+    mocker: MockerFixture, app: SupersetApp
+) -> None:
+    """
+    A broken transaction (e.g. `PendingRollbackError` following a failed flush)
+    leaves the session unusable until `session.rollback()` is called, so without
+    it every `backoff` retry would reuse the same poisoned session and fail
+    identically. `get_query` must roll back on failure so each retry gets a
+    clean session and has a real chance to succeed.
+    """
+    # avoid actually sleeping through the `backoff` decorator's retry interval
+    mocker.patch("backoff._sync.time.sleep")
+
+    expected_query = mocker.MagicMock()
+    mock_one = mocker.patch("superset.sql_lab.db.session.query")
+    mock_one.return_value.filter_by.return_value.one.side_effect = [
+        Exception("session is broken"),
+        expected_query,
+    ]
+    mock_rollback = mocker.patch("superset.sql_lab.db.session.rollback")
+
+    result = get_query(query_id=1)
+
+    assert result is expected_query
+    assert mock_one.return_value.filter_by.return_value.one.call_count == 2
+    mock_rollback.assert_called_once()
 
 
 @with_config(


### PR DESCRIPTION
## Sentry issue

[SUPERSET-PYTHON-WDZ](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-WDZ) — `SqlLabException: Failed at getting query` — **30,500 occurrences, 24 users impacted**, first seen 2025-04-05, still firing daily in production.

## Root cause

`superset/sql_lab.py::get_query` is wrapped in a `backoff.on_exception(SqlLabException, interval=1, max_tries=5)` retry loop:

```python
def get_query(query_id: int) -> Query:
    """attempts to get the query and retry if it cannot"""
    try:
        return db.session.query(Query).filter_by(id=query_id).one()
    except Exception as ex:
        raise SqlLabException("Failed at getting query") from ex
```

The Sentry event's exception chain shows a SQLAlchemy `PendingRollbackError` ("This Session's transaction has been rolled back due to a previous exception during flush... first issue Session.rollback()"), itself chained under an `OperationalError`/`QueryCanceled` from a dropped connection or statement timeout. Once a session enters this state, SQLAlchemy refuses **any** further operation on it until `.rollback()` is called explicitly.

Because `get_query`'s `except` block never rolls back, every one of the 5 `backoff` retries reuses the same poisoned session and fails identically with the same `PendingRollbackError` — the retry loop is guaranteed to burn all 5 attempts and give up, with zero chance to recover from what may have been a transient connection blip.

**Verified with a standalone repro** (pinned `sqlalchemy==1.4.54`, in-memory sqlite): poisoning a session via a failed flush, then calling a `get_query`-shaped function under the same `backoff.on_exception` decorator — without a rollback, all 5 retries fail identically; adding `session.rollback()` in the except block lets the very next retry succeed.

## Fix

Add `db.session.rollback()` in `get_query`'s `except` block before re-raising `SqlLabException`, so each `backoff` retry starts from a clean session and has a real chance of succeeding instead of a guaranteed-failure loop.

## Tradeoffs

None — this is additive-only. The exception raised (`SqlLabException`) and logged (via `get_query_backoff_handler`/`get_query_giveup_handler`) is unchanged; only the session state between retries changes, giving the existing retry mechanism a real chance to work as originally designed. No change to `execute_query`/`execute_sql_statements`/`handle_query_error`, and no change to the `backoff` decorator's parameters.

## Testing

- Added `test_get_query_rolls_back_session_before_retrying` to `tests/unit_tests/sql_lab_test.py`, asserting `get_query` recovers via retry after a first failure, and that `db.session.rollback()` is called before the successful retry.
- `tests/unit_tests/sql_lab_test.py` — 12 passed.
- `ruff check` / `ruff format --check` (pinned `0.9.7`) — clean on both changed files.

## Shortcut

sc-115684

Fixes SUPERSET-PYTHON-WDZ

🤖 Generated with [Claude Code](https://claude.com/claude-code)