### PR TITLE
fix(dashboard): count extra_editors when deciding who may edit a dashboard

### DIFF
--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -132,6 +132,26 @@ test('isUserDashboardEditor returns false when editors is empty', () => {
   expect(isUserDashboardEditor(dashNoEditors)).toEqual(false);
 });
 
+test('isUserDashboardEditor counts editorship granted through extra_editors', () => {
+  // The server's is_editor unions EXTRA_EDITORS_RESOLVER output into the
+  // editor set, and the API attaches it after the response schema is dumped.
+  // Ignoring it here hid the Edit button from people the API would let
+  // through. extra_editors arrives as bare ids.
+  const dashExtraEditor = { ...dashboard, editors: [], extra_editors: [10] };
+  expect(isUserDashboardEditor(dashExtraEditor)).toEqual(true);
+  expect(canUserEditDashboard(dashExtraEditor, editorUser)).toEqual(true);
+});
+
+test('isUserDashboardEditor ignores extra_editors for other subjects', () => {
+  const dashOtherExtraEditor = {
+    ...dashboard,
+    editors: [],
+    extra_editors: [999],
+  };
+  expect(isUserDashboardEditor(dashOtherExtraEditor)).toEqual(false);
+  expect(canUserEditDashboard(dashOtherExtraEditor, editorUser)).toEqual(false);
+});
+
 test('canUserEditDashboard allows editors', () => {
   expect(canUserEditDashboard(dashboard, editorUser)).toEqual(true);
 });

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -134,12 +134,30 @@ test('isUserDashboardEditor returns false when editors is empty', () => {
 
 test('isUserDashboardEditor counts editorship granted through extra_editors', () => {
   // The server's is_editor unions EXTRA_EDITORS_RESOLVER output into the
-  // editor set, and the API attaches it after the response schema is dumped.
-  // Ignoring it here hid the Edit button from people the API would let
-  // through. extra_editors arrives as bare ids.
+  // editor set, and the API attaches it after the response schema is dumped
+  // (so it survives the columns projection). extra_editors arrives as bare
+  // ids, not Subjects.
   const dashExtraEditor = { ...dashboard, editors: [], extra_editors: [10] };
   expect(isUserDashboardEditor(dashExtraEditor)).toEqual(true);
   expect(canUserEditDashboard(dashExtraEditor, editorUser)).toEqual(true);
+});
+
+test('isUserDashboardEditor unions the two lists rather than preferring one', () => {
+  // Pins the union semantics: a refactor that consulted extra_editors only
+  // when editors is empty would pass the empty-editors cases above but
+  // fail here — non-matching editors must not mask a matching extra grant.
+  const dashUnion = {
+    ...dashboard,
+    editors: [{ id: 999, label: 'Other', type: 1 }],
+    extra_editors: [10],
+  };
+  expect(isUserDashboardEditor(dashUnion)).toEqual(true);
+});
+
+test('an empty extra_editors grants nothing on its own', () => {
+  // The resolver-configured-but-returns-nothing shape.
+  const dashEmptyExtra = { ...dashboard, editors: [], extra_editors: [] };
+  expect(isUserDashboardEditor(dashEmptyExtra)).toEqual(false);
 });
 
 test('isUserDashboardEditor ignores extra_editors for other subjects', () => {

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -33,10 +33,31 @@ const ADMIN_ROLE_NAME = 'admin';
 const getUserSubjects = (): number[] =>
   getBootstrapData()?.common?.user_subjects ?? [];
 
-const isUserInEditors = (editors: Subject[] = []): boolean => {
+/**
+ * Editor lists arrive either as full Subjects (`editors`) or as bare subject
+ * ids (`extra_editors`, which the API dumps straight from
+ * `get_extra_editor_subject_ids`).
+ */
+export type SubjectRef = number | { id: number };
+
+const subjectId = (subject: SubjectRef): number =>
+  typeof subject === 'number' ? subject : subject.id;
+
+/**
+ * Whether the viewer is any of the given subjects — their user, roles or
+ * groups — across every supplied list.
+ */
+export const isUserInSubjects = (
+  ...subjectLists: (SubjectRef[] | null | undefined)[]
+): boolean => {
   const userSubjects = getUserSubjects();
-  return editors.some(editor => userSubjects.includes(editor.id));
+  return subjectLists.some(subjects =>
+    (subjects ?? []).some(subject => userSubjects.includes(subjectId(subject))),
+  );
 };
+
+const isUserInEditors = (editors: Subject[] = []): boolean =>
+  isUserInSubjects(editors);
 
 export const isUserAdmin = (
   user?: UserWithPermissionsAndRoles | UndefinedUser,
@@ -51,8 +72,14 @@ export const isUserEditorOrAdmin = (
   editors: Subject[] = [],
 ): boolean => isUserInEditors(editors) || isUserAdmin(user);
 
+/**
+ * Editorship of *dashboard*, matching the server's `is_editor`: the explicit
+ * editor list unioned with any editorship granted indirectly by a
+ * deployment's EXTRA_EDITORS_RESOLVER. Leaving `extra_editors` out hid the
+ * Edit button from people the API would happily let through.
+ */
 export const isUserDashboardEditor = (dashboard: Dashboard): boolean =>
-  isUserInEditors(dashboard.editors);
+  isUserInSubjects(dashboard.editors, dashboard.extra_editors);
 
 export const canUserEditDashboard = (
   dashboard: Dashboard,

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -75,8 +75,9 @@ export const isUserEditorOrAdmin = (
 /**
  * Editorship of *dashboard*, matching the server's `is_editor`: the explicit
  * editor list unioned with any editorship granted indirectly by a
- * deployment's EXTRA_EDITORS_RESOLVER. Leaving `extra_editors` out hid the
- * Edit button from people the API would happily let through.
+ * deployment's EXTRA_EDITORS_RESOLVER. Must stay in step with the server's
+ * `is_editor` (security/manager.py): a predicate narrower than the server's
+ * hides actions the API permits.
  */
 export const isUserDashboardEditor = (dashboard: Dashboard): boolean =>
   isUserInSubjects(dashboard.editors, dashboard.extra_editors);

--- a/superset-frontend/src/types/Dashboard.ts
+++ b/superset-frontend/src/types/Dashboard.ts
@@ -34,6 +34,10 @@ export interface Dashboard {
   changed_on: string;
   charts: string[]; // just chart names, unfortunately...
   editors?: Subject[];
+  // Subject ids resolved by a deployment's EXTRA_EDITORS_RESOLVER; the API
+  // attaches them after the response schema is dumped, so they survive the
+  // `columns` projection. Bare ids, not Subjects.
+  extra_editors?: number[];
   viewers?: Subject[];
   theme?: {
     id: number;


### PR DESCRIPTION
### SUMMARY

The server's `is_editor` (`superset/security/manager.py`) unions the explicit editor list with subjects resolved by a deployment's `EXTRA_EDITORS_RESOLVER`, and the dashboard GET attaches those ids as `extra_editors` after the response schema is dumped (`superset/dashboards/api.py:614`), so they survive the `columns` projection. The frontend predicate `canUserEditDashboard` checked `editors` alone.

Result: anyone whose editorship comes only through the resolver sees no Edit button on a dashboard the API would happily let them write to. This bites exactly — and only — in deployments that configure the resolver.

This PR widens the shared predicate in `permissionUtils.ts` to `editors ∪ extra_editors`, matching the server, and types the field on `Dashboard`. Since `dash_edit_perm` is derived from this function at hydrate time, every consumer of that flag is corrected together. Behaviour is unchanged for deployments without the resolver.

Split out of #41551, where the gap was found during review (thanks @kgabryje) — it is a platform-wide fix independent of version history and shouldn't ride inside a feature-flagged PR.

Disclosure: this change was developed with AI assistance (Claude), on behalf of and reviewed by @mikebridge.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual change except the Edit button appearing for users the API already authorizes.

### TESTING INSTRUCTIONS

1. Configure `EXTRA_EDITORS_RESOLVER` in `superset_config.py` to return a subject id for a non-admin test user on some dashboard, e.g. a resolver granting a specific role's subject.
2. As that user (no explicit editor entry on the dashboard, no Admin role), open the dashboard.
3. Before: no Edit button, though `PUT /api/v1/dashboard/{id}` succeeds for this user. After: Edit button shows and editing works.
4. Unit coverage: `npm run test -- permissionUtils.test.ts` — includes cases for editorship granted through `extra_editors` and for `extra_editors` belonging to other subjects.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

**Scope boundary** (from review): this PR fixes the dashboard single-entity surface only, deliberately. Two adjacent gaps are known and out of scope here:

- **Chart-side Explore gates**: the chart payloads also carry `extra_editors` (`superset/models/slice.py`, `superset/charts/api.py`), and the in-flight version-history PR #41551 already fixes the Save-modal/menu gates via its shared `canOverwriteSlice` helper. The remaining chart gap after both merge is the editable-title `canEdit` gate in `ExploreChartHeader`, tracked as a follow-up.
- **List pages** (`DashboardCard`/`ChartCard`/list views) cannot be fixed client-side: the list endpoints never attach `extra_editors` (only the single-entity GETs do, post-dump). Extra editors see hover-edit hidden on cards while the entity itself is editable once opened — attaching per-row `extra_editors` in list payloads has a resolver-cost × page-size question and needs a backend decision.
