### PR TITLE
test(versioning): un-skip the two obsolete activity-view skips

### DIFF
--- a/tests/integration_tests/versioning/activity_view_tests.py
+++ b/tests/integration_tests/versioning/activity_view_tests.py
@@ -527,7 +527,7 @@ class TestDashboardActivityView(SupersetTestCase):
         removed while the activity stream keeps working with a smaller
         count."""
         # pylint: disable=import-outside-toplevel
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         import sqlalchemy as sa
         from sqlalchemy_continuum import versioning_manager
@@ -556,19 +556,33 @@ class TestDashboardActivityView(SupersetTestCase):
             or 0
         )
 
+        def max_tx_id() -> int:
+            return (
+                db.session.connection()
+                .execute(sa.select(sa.func.max(tx_table.c.id)))
+                .scalar()
+                or 0
+            )
+
         try:
-            # Two separate commits → two transactions. The prune preserves
-            # any transaction still anchoring an open shadow row, so a
-            # single edit would (correctly) prune nothing: its row IS the
-            # chart's live state. The second edit closes the first row.
+            # Two separate commits → two transactions; the second edit
+            # closes the first row (see docstring for the keep-live guard).
             chart.slice_name = f"{original_name} (retention test)"
             db.session.commit()
+            closed_tx_id = max_tx_id()
             chart = db.session.query(Slice).filter(Slice.id == chart_id).one()
             chart.slice_name = f"{original_name} (retention test 2)"
             db.session.commit()
+            live_tx_id = max_tx_id()
+            assert closed_tx_id > max_tx_before
+            assert live_tx_id > closed_tx_id
 
             # Backdate the new transactions to before the 30-day cutoff.
-            old_timestamp = datetime.utcnow() - timedelta(days=60)
+            # Naive-UTC to match issued_at (Continuum stores it tz-naive);
+            # utcnow() is deprecated on 3.12+.
+            old_timestamp = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+                days=60
+            )
             db.session.connection().execute(
                 sa.update(tx_table)
                 .where(tx_table.c.id > max_tx_before)
@@ -590,6 +604,29 @@ class TestDashboardActivityView(SupersetTestCase):
             stats = _prune_old_versions_impl(retention_days=30)
             assert stats.get("pruned_transactions", 0) >= 1, (
                 f"Prune should have removed our backdated tx; stats={stats}"
+            )
+
+            # Membership, not just counts: on this persistent DB a leftover
+            # old transaction from a prior run could satisfy the count
+            # assertions while OUR backdated tx survived. Pin the exact
+            # claim — the closed transaction is gone, and the one anchoring
+            # the chart's live row is retained despite being equally old
+            # (the keep-live guard, asserted rather than narrated).
+            surviving = {
+                row[0]
+                for row in db.session.connection().execute(
+                    sa.select(tx_table.c.id).where(
+                        tx_table.c.id.in_([closed_tx_id, live_tx_id])
+                    )
+                )
+            }
+            assert closed_tx_id not in surviving, (
+                f"Closed tx {closed_tx_id} should have been pruned; "
+                f"surviving={surviving}"
+            )
+            assert live_tx_id in surviving, (
+                f"Live-anchoring tx {live_tx_id} must survive the prune "
+                f"regardless of age; surviving={surviving}"
             )
 
             # After the prune, the activity endpoint still works and the
@@ -665,7 +702,8 @@ class TestDashboardActivityView(SupersetTestCase):
     def test_activity_surfaces_dashboard_restore_event(self) -> None:
         """T044 / AV-015: restoring a dashboard to a prior version surfaces
         a synthetic ``kind='__meta__'`` headline record (path
-        ``['__meta__', 'restore']``, ``to_value`` carrying the restored-to
+        ``['__meta__']`` — the verb rides in ``action_kind``, never in the
+        path — with ``to_value`` carrying the restored-to
         version_uuid) in the dashboard's own activity stream
         (``source='self'``). The headline is emitted by the restore
         command via the listener's ACTION_META_KEY (PR #40988 feedback);

--- a/tests/integration_tests/versioning/activity_view_tests.py
+++ b/tests/integration_tests/versioning/activity_view_tests.py
@@ -510,12 +510,6 @@ class TestDashboardActivityView(SupersetTestCase):
             f"got {result[('SqlaTable', dataset.id)]}"
         )
 
-    @pytest.mark.skip(
-        reason="Depends on the retention prune (_prune_old_versions_impl), which "
-        "was extracted to sc-111099-version-history-retention. This test "
-        "exercises activity-view + retention together and runs once both PRs "
-        "merge; un-skip then."
-    )
     def test_activity_excludes_records_after_retention_prune(self) -> None:
         """T051 / AV-010: retention bounds the activity feed. After
         ``_prune_old_versions_impl`` drops shadow / change-record rows
@@ -523,10 +517,15 @@ class TestDashboardActivityView(SupersetTestCase):
         retention cutoff, the activity stream stops surfacing them.
 
         Test pattern: capture the highest ``version_transaction.id``
-        before our edits, edit a chart (creating a new transaction),
-        backdate that transaction's ``issued_at`` past the retention
-        cutoff, run the prune, and assert the chart-edit no longer
-        appears in the activity stream."""
+        before our edits, then edit a chart TWICE. The second edit closes
+        the first edit's shadow row (``end_transaction_id`` set), leaving
+        the first transaction genuinely prunable; the second transaction
+        anchors the chart's live row and is preserved by the prune's
+        keep-live guard regardless of age — an entity's current state is
+        never dropped, however old. Backdate both transactions past the
+        retention cutoff, run the prune, and assert the closed one is
+        removed while the activity stream keeps working with a smaller
+        count."""
         # pylint: disable=import-outside-toplevel
         from datetime import datetime, timedelta
 
@@ -558,7 +557,14 @@ class TestDashboardActivityView(SupersetTestCase):
         )
 
         try:
+            # Two separate commits → two transactions. The prune preserves
+            # any transaction still anchoring an open shadow row, so a
+            # single edit would (correctly) prune nothing: its row IS the
+            # chart's live state. The second edit closes the first row.
             chart.slice_name = f"{original_name} (retention test)"
+            db.session.commit()
+            chart = db.session.query(Slice).filter(Slice.id == chart_id).one()
+            chart.slice_name = f"{original_name} (retention test 2)"
             db.session.commit()
 
             # Backdate the new transactions to before the 30-day cutoff.
@@ -656,10 +662,6 @@ class TestDashboardActivityView(SupersetTestCase):
         overlap = page0_keys & page1_keys
         assert not overlap, f"page=0 and page=1 returned overlapping records: {overlap}"
 
-    @pytest.mark.skip(
-        reason="Restore endpoint ships in a later PR; re-enable when restore "
-        "lands. The activity layer's restore-event rendering is unit-tested."
-    )
     def test_activity_surfaces_dashboard_restore_event(self) -> None:
         """T044 / AV-015: restoring a dashboard to a prior version surfaces
         a synthetic ``kind='__meta__'`` headline record (path


### PR DESCRIPTION
### SUMMARY

Two activity-view integration tests were skipped waiting on work that has since merged:

- `test_activity_excludes_records_after_retention_prune` waited on the retention prune extracted to sc-111099; `_prune_old_versions_impl` is now in `superset/tasks/version_history_retention.py`.
- `test_activity_surfaces_dashboard_restore_event` waited on the restore endpoint, which landed in #42469. It passes with no changes.

The retention test needed one substantive update beyond removing the decorator: it was written against an age-only prune, but the shipped prune **preserves any transaction still anchoring an open shadow row** (`end_transaction_id IS NULL`) — an entity's current state is never dropped, however old. The test's single edit created exactly that row, so the prune correctly removed nothing and the assertion could never pass. The test now edits the chart twice: the second edit closes the first edit's shadow row, making the first transaction genuinely prunable, and the assertions exercise the keep-live guard as a side effect (the live transaction survives despite being backdated past the cutoff).

Full file passes 40/40 against the integration SQLite DB.

Disclosure: this change was developed with AI assistance (Claude), on behalf of and reviewed by @mikebridge.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — test-only change.

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/versioning/activity_view_tests.py
```

40 passed (was 38 passed, 2 skipped). The two un-skipped tests are `TestDashboardActivityView::test_activity_excludes_records_after_retention_prune` and `TestDashboardActivityView::test_activity_surfaces_dashboard_restore_event`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
