### PR TITLE
fix(versioning): drop username from version-history attribution

### DIFF
--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -137,8 +137,10 @@ def _changed_by_from_row(row: Any) -> dict[str, Any] | None:
     if row["user_id"] is None:
         return None
     # Deliberately no ``username``: it is a login identifier, not display
-    # data, and the sibling activity payload already excludes it (pinned by
-    # a unit test there). Display names come from first/last name.
+    # data. The version and activity attribution shapes are kept identical
+    # so clients share one type — enforced by
+    # test_version_and_activity_attribution_schemas_match in
+    # tests/unit_tests/versioning/test_queries.py.
     return {
         "id": row["user_id"],
         "first_name": row["first_name"],

--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -122,7 +122,6 @@ def _user_select_cols(user_tbl: sa.Table) -> list[Any]:
     """
     return [
         user_tbl.c.id.label("user_id"),
-        user_tbl.c.username,
         user_tbl.c.first_name,
         user_tbl.c.last_name,
     ]
@@ -133,13 +132,15 @@ def _changed_by_from_row(row: Any) -> dict[str, Any] | None:
     ``changed_by`` shape, or ``None`` for saves with no Flask user context
     (CLI / Celery / import / unauthenticated). Expects the user columns to
     have been selected via :func:`_user_select_cols` so the row keys are
-    ``user_id`` / ``username`` / ``first_name`` / ``last_name``.
+    ``user_id`` / ``first_name`` / ``last_name``.
     """
     if row["user_id"] is None:
         return None
+    # Deliberately no ``username``: it is a login identifier, not display
+    # data, and the sibling activity payload already excludes it (pinned by
+    # a unit test there). Display names come from first/last name.
     return {
         "id": row["user_id"],
-        "username": row["username"],
         "first_name": row["first_name"],
         "last_name": row["last_name"],
     }

--- a/superset/versioning/schemas.py
+++ b/superset/versioning/schemas.py
@@ -29,10 +29,15 @@ from superset.versioning.changes import ACTION_KINDS
 
 
 class VersionChangedBySchema(Schema):
-    """Subset of the User model included in each version history entry."""
+    """Subset of the User model included in each version history entry.
+
+    Display fields only (``id`` + given/family name) — ``username`` is a
+    login identifier, not display data, and its sibling
+    :class:`ActivityChangedBySchema` already omits it by design. Keeping
+    the two attribution shapes identical also lets clients share one type.
+    """
 
     id = fields.Integer()
-    username = fields.String()
     first_name = fields.String()
     last_name = fields.String()
 

--- a/tests/unit_tests/versioning/test_queries.py
+++ b/tests/unit_tests/versioning/test_queries.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from superset.versioning.queries import _changed_by_from_row
+from superset.versioning.schemas import (
+    ActivityChangedBySchema,
+    VersionChangedBySchema,
+)
+
+
+def test_changed_by_exposes_display_fields_only() -> None:
+    """``username`` is a login identifier, not display data. The activity
+    payload has always excluded it (pinned in test_activity.py); the
+    version payload must match — it is breaking to remove after release."""
+    row = {
+        "user_id": 5,
+        "first_name": "Mike",
+        "last_name": "Bridge",
+        # A widened SELECT must not leak through the projection.
+        "username": "mbridge",
+    }
+    result = _changed_by_from_row(row)
+    assert result == {"id": 5, "first_name": "Mike", "last_name": "Bridge"}
+    assert "username" not in result
+
+
+def test_changed_by_is_none_without_user() -> None:
+    row = {"user_id": None, "first_name": None, "last_name": None}
+    assert _changed_by_from_row(row) is None
+
+
+def test_version_and_activity_attribution_schemas_match() -> None:
+    """The two attribution shapes are deliberately identical so clients can
+    share one type; a field added to one must be added to (or rejected
+    from) both."""
+    version_fields = set(VersionChangedBySchema().fields)
+    activity_fields = set(ActivityChangedBySchema().fields)
+    assert version_fields == activity_fields == {"id", "first_name", "last_name"}


### PR DESCRIPTION
### SUMMARY

The version-history endpoints' `changed_by` attribution carried `username`, while the sibling activity payload (`ActivityChangedBySchema`, same file) has always excluded it by design, with a unit test pinning the exclusion: `username` is a login identifier, not display data. Exposing it in one payload of the pair was an inconsistency that becomes a breaking change to fix the moment the API ships — flagged in the versioning capstone review as "cheap now, breaking later."

This PR trims the SELECT and the projection to `id` + `first_name`/`last_name`, aligns `VersionChangedBySchema` with `ActivityChangedBySchema`, and pins both directions:

- the projection excludes `username` even if the SELECT widens again
- a schema-parity test asserts the two attribution schemas keep the identical field set, so clients can share one type and a field added to one must be consciously added to (or rejected from) both

No known consumer reads it — the version-history frontend types the field but never renders it, and no test asserted its presence.

The version endpoints are part of the not-yet-released versioning feature set (behind `VERSION_HISTORY`, default off), so this is a pre-release contract correction, not a breaking change to a shipped API.

Disclosure: this change was developed with AI assistance (Claude), on behalf of and reviewed by @mikebridge.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API payload shape only; nothing rendered it.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/versioning/test_queries.py` — projection excludes `username` even when present in the row; `changed_by` still `None` for user-less commits; schema-parity assertion.
- `pytest tests/integration_tests/versioning/ tests/integration_tests/dashboards/version_restore_tests.py tests/integration_tests/charts/version_restore_tests.py tests/integration_tests/datasets/version_restore_tests.py` — payload consumers green.
- Manual: `GET /api/v1/dashboard/{uuid}/versions/` with `VERSION_HISTORY` enabled — `changed_by` is `{id, first_name, last_name}`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `VERSION_HISTORY` (endpoints affected are gated by it; default off)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
