### PR TITLE
fix(alerts): wrap Jinja rendering errors in AlertCommand._execute_query

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -193,9 +193,9 @@ class AlertCommand(BaseCommand):
         sql_template = jinja_context.get_template_processor(
             database=self._report_schedule.database
         )
-        rendered_sql = sql_template.process_template(self._report_schedule.sql)
 
         try:
+            rendered_sql = sql_template.process_template(self._report_schedule.sql)
             limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
                 rendered_sql, ALERT_SQL_LIMIT
             )

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -20,10 +20,12 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import pytest
+from jinja2.exceptions import TemplateError
 from pytest_mock import MockerFixture
 
 from superset.commands.report.alert import AlertCommand
 from superset.commands.report.exceptions import (
+    AlertQueryError,
     AlertValidatorConfigError,
     ReportScheduleExecutorNotFoundError,
 )
@@ -531,4 +533,34 @@ def test_execute_query_raises_when_executor_user_missing(
     )
 
     with pytest.raises(ReportScheduleExecutorNotFoundError, match="ghost_user"):
+        command._execute_query()
+
+
+def test_execute_query_wraps_template_rendering_error(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A Jinja rendering error raised while templating the alert's SQL (e.g. an
+    undefined variable in the alert query) must surface as the documented
+    ``AlertQueryError``, not propagate as a raw ``jinja2.exceptions.TemplateError``.
+    """
+    template_processor_mock = mocker.Mock()
+    template_processor_mock.process_template.side_effect = TemplateError(
+        "'foo' is undefined"
+    )
+    mocker.patch(
+        "superset.commands.report.alert.jinja_context.get_template_processor",
+        return_value=template_processor_mock,
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.id = 1
+    report_schedule_mock.sql = "SELECT {{ foo }} FROM metrics"
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    with pytest.raises(AlertQueryError):
         command._execute_query()


### PR DESCRIPTION
### SUMMARY
`AlertCommand._execute_query()` in `superset/commands/report/alert.py` calls `sql_template.process_template(self._report_schedule.sql)` *before* the `try:` block a few lines below it, even though that block's `except Exception as ex: raise AlertQueryError(...) from ex` is clearly meant to cover the whole query-execution flow (the docstring documents `:raises AlertQueryError: SQL query is not valid`).

Because the Jinja render call sits outside the `try`, any exception raised while templating the alert's SQL — `SupersetSyntaxErrorException`, `SupersetTemplateException`, or a bare `jinja2.exceptions.TemplateError`/`UndefinedError` re-raised by `process_template()`'s own fallback path in `superset/jinja_context.py` — propagates unhandled instead of becoming the documented `AlertQueryError`.

Alert SQL is a normal user-editable field with documented Jinja templating support, so a user-authored alert query referencing an undefined Jinja variable currently crashes the alert-execution task with a raw exception instead of surfacing the typed, expected error. Same bug class (raw system/library exception escaping instead of a proper Superset exception) as #42366 and #42401.

### PROBLEM
A raw `jinja2.exceptions.TemplateError` (or a raw `SupersetSyntaxErrorException`/`SupersetTemplateException`) can propagate out of `AlertCommand._execute_query()` uncaught, because the Jinja-rendering line is physically placed one statement above the `try:` block that's supposed to wrap the whole alert-query execution.

### FIX
Move `rendered_sql = sql_template.process_template(self._report_schedule.sql)` to be the first statement inside the existing `try:` block, so it's covered by the same exception handling that already wraps the rest of the query-execution flow. `sql_template = jinja_context.get_template_processor(...)` is left in place — this is a 2-line, additive-only change with no behavior change for any alert query that renders successfully today.

### TESTING INSTRUCTIONS
- Added `tests/unit_tests/commands/report/alert_test.py::test_execute_query_wraps_template_rendering_error`, which mocks `process_template` to raise a `jinja2.exceptions.TemplateError` and asserts `_execute_query()` raises `AlertQueryError` instead of the raw error.
- Confirmed empirically that this test fails on pre-fix code (raises the raw `TemplateError` uncaught) and passes post-fix.
- `pytest tests/unit_tests/commands/report/alert_test.py` — 25 passed.
- `ruff check` / `ruff format --check` on both changed files — clean.
- `mypy` on changed files — no new errors.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Tradeoffs:** Additive exception-handling fix only, no change for any query that renders/executes successfully today. Two failure-path behaviors change, both bringing the code in line with the method's own documented contract:
1. A raw Jinja/Superset template exception during rendering now becomes `AlertQueryError` (the primary fix, per the docstring's `:raises AlertQueryError: SQL query is not valid`).
2. A celery `SoftTimeLimitExceeded` firing *during* template rendering (e.g. a pathological/slow Jinja macro) is now also caught by the existing `except SoftTimeLimitExceeded` handler and converted to `AlertQueryTimeout`, instead of propagating raw as it did before — consistent with the docstring's `:raises AlertQueryTimeout: The SQL query received a celery soft timeout`.

Related: #42366, #42401 (same bug class: raw Jinja/system exceptions propagating instead of typed Superset exceptions).