### PR TITLE
fix(ci): collapse Cypress e2e matrix from 2 runners to 1

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -256,7 +256,7 @@ cypress-run-all() {
   # UNCOMMENT the next few commands to monitor memory usage
   # monitor_memory &  # Start memory monitoring in the background
   # memoryMonitorPid=$!
-  python ../../scripts/cypress_run.py --parallelism $PARALLELISM --parallelism-id $PARALLEL_ID --group $PARALLEL_ID --retries 5 $USE_DASHBOARD_FLAG
+  python ../../scripts/cypress_run.py --retries 5 $USE_DASHBOARD_FLAG
   # kill $memoryMonitorPid
 }
 

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -57,19 +57,13 @@ jobs:
       pull-requests: read
     strategy:
       # when one test fails, DO NOT cancel the other
-      # parallel_id, because this will kill Cypress processes
+      # app_root variant, because this will kill Cypress processes
       # leaving the Dashboard hanging ...
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        parallel_id: [0, 1]
         browser: ["chrome"]
         app_root: ${{ github.event_name == 'push' && fromJSON('["", "/app/prefix"]') || fromJSON('[""]') }}
-        # The /app/prefix variant (push events only) is smoke-tested on a single
-        # shard rather than the full matrix, so exclude it from the other shards.
-        exclude:
-          - parallel_id: 1
-            app_root: "/app/prefix"
     env:
       SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -148,8 +142,6 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
-          PARALLEL_ID: ${{ matrix.parallel_id }}
-          PARALLELISM: 2
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
@@ -167,7 +159,7 @@ jobs:
         if: failure()
         with:
           path: ${{ github.workspace }}/superset-frontend/cypress-base/cypress/screenshots
-          name: cypress-artifact-${{ github.run_id }}-${{ github.job }}-${{ matrix.browser }}-${{ matrix.parallel_id }}--${{ steps.set-safe-app-root.outputs.safe_app_root }}
+          name: cypress-artifact-${{ github.run_id }}-${{ github.job }}-${{ matrix.browser }}--${{ steps.set-safe-app-root.outputs.safe_app_root }}
 
   playwright-tests:
     needs: changes

--- a/scripts/cypress_run.py
+++ b/scripts/cypress_run.py
@@ -113,12 +113,6 @@ def main() -> None:
         help="Use Cypress Dashboard for parallelization",
     )
     parser.add_argument(
-        "--parallelism", type=int, default=10, help="Number of parallel groups"
-    )
-    parser.add_argument(
-        "--parallelism-id", type=int, required=True, help="ID of the parallelism group"
-    )
-    parser.add_argument(
         "--filter", type=str, required=False, default=None, help="Filter to test"
     )
     parser.add_argument("--group", type=str, default="Default", help="Group name")
@@ -153,20 +147,8 @@ def main() -> None:
                 )
     print(f"Found {file_count} test files ({skipped_count} skipped).")
 
-    # Initialize groups for round-robin distribution
-    groups: dict[int, list[str]] = {i: [] for i in range(args.parallelism)}
-
-    # Sort test files to ensure deterministic distribution
-    sorted_test_files = sorted(test_files)
-
-    # Distribute test files in a round-robin manner
-    for index, test_file in enumerate(sorted_test_files):
-        group_index = index % args.parallelism
-        groups[group_index].append(test_file)
-
-    # Only run tests for the group that matches the parallelism ID
-    group_id = args.parallelism_id
-    spec_list = groups[group_id]
+    # Sort test files for deterministic, readable run order.
+    spec_list = sorted(test_files)
 
     # Run each test file independently with retry logic or dry-run
     processed_file_count: int = 0


### PR DESCRIPTION
### SUMMARY

The gantt-chart timing from a recent E2E run ([run 30826232203](https://github.com/apache/superset/actions/runs/30826232203?pr=42713)) shows the two-way Cypress shard split isn't buying real parallelism anymore. Both shards pay ~8-9 minutes of identical setup (checkout, postgres, test-data import, npm install, JS build, cypress install) before a single spec runs, and the actual "Run Cypress" step itself only took 2m15s on one shard and 35s on the other. Splitting across two runners roughly doubles billed runner-minutes for a suite whose combined actual test execution is well under 3 minutes, since the setup cost is fully duplicated per shard instead of amortized.

This collapses `cypress-matrix` to a single runner (drops the `parallel_id` matrix dimension and its `exclude` rule). `.asf.yaml` only requires the aggregate `cypress-matrix-required` bridge job, not the per-shard job names, so this doesn't affect required-check enforcement.

Also cleans up the parallelization plumbing that's now dead weight at a single shard: `scripts/cypress_run.py` drops the `--parallelism`/`--parallelism-id` round-robin distribution logic (confirmed via repo-wide grep this script has no other caller), and `bashlib.sh`'s `cypress-run-all()` no longer needs to forward `PARALLEL_ID`/`PARALLELISM` into it.

### TESTING INSTRUCTIONS

- CI on this PR will run the collapsed single-runner `cypress-matrix` job; compare its wall-clock time against a recent 2-shard run to confirm no regression.
- `python3 scripts/cypress_run.py --dry-run --retries 1` runs standalone without `--parallelism`/`--parallelism-id` and discovers/dry-runs every spec directly.
- `pre-commit run --files scripts/cypress_run.py .github/workflows/bashlib.sh .github/workflows/superset-e2e.yml` passes clean, including the `zizmor` GHA security audit.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [x] Removes existing feature or API