### PR TITLE
fix(pre-commit): exclude lockfiles from oxfmt-frontend to avoid hard-erroring on lockfile-only diffs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
         language: system
         pass_filenames: true
         files: ^superset-frontend/.*\.(js|jsx|ts|tsx|css|scss|sass|json)$
+        # oxfmt treats lockfiles as generated files and internally filters them
+        # out of its target list. If a diff only touches a lockfile, pre-commit
+        # still hands it to oxfmt as the sole target, and oxfmt hard-errors with
+        # "Expected at least one target file" once its internal filtering leaves
+        # zero files to format. Excluding lockfiles here keeps pre-commit from
+        # ever invoking oxfmt on a target set that's guaranteed to end up empty.
+        exclude: ^superset-frontend/(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$
   - repo: local
     hooks:
       - id: oxlint-frontend


### PR DESCRIPTION
### SUMMARY
The `oxfmt-frontend` pre-commit hook (added in #42434's prettier→oxfmt migration) matches `.json` files via its `files:` regex, which includes `superset-frontend/package-lock.json`. oxfmt itself treats lockfiles as generated files and internally filters them out of the target list it actually formats. So when a diff touches only a lockfile, pre-commit hands oxfmt a target list that resolves to zero real files after oxfmt's own filtering.

Unlike prettier - which no-ops cleanly on an empty target set - oxfmt treats zero targets as a hard error:

```
Expected at least one target file. All matched files may have been excluded by ignore rules.
```

and exits 2, which pre-commit reports as a hook failure.

This didn't surface until now because every merged dependabot PR since the #42434 migration happened to also touch `package.json` alongside the lockfile, giving oxfmt at least one real target. #42718 is the first lockfile-only dependency bump since the migration, and it's currently blocked by this on the `pre-commit (current)` CI check. Every future lockfile-only dependabot PR will hit the same wall until this is fixed on master.

The fix adds an `exclude:` pattern to the `oxfmt-frontend` hook for `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml`, so pre-commit never hands oxfmt a target set that's guaranteed to be empty. This does not weaken oxfmt's coverage of real frontend source files - it only excludes the three lockfile filenames.

Unblocks #42718.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - config-only change to `.pre-commit-config.yaml`.

### TESTING INSTRUCTIONS
Verified locally with `pre-commit run oxfmt-frontend --files <path>`:

- Before the fix: `pre-commit run oxfmt-frontend --files superset-frontend/package-lock.json` reproduces the exact failure - exit code 2, "Expected at least one target file..."
- After the fix:
  - `pre-commit run oxfmt-frontend --files superset-frontend/package-lock.json` -> hook reports `(no files to check) Skipped`, exit 0
  - `pre-commit run oxfmt-frontend --files superset-frontend/src/globals.d.ts` -> hook still runs and formats normally, exit 0 (real source files are unaffected)
  - `pre-commit run oxfmt-frontend --files superset-frontend/package-lock.json superset-frontend/src/globals.d.ts` -> the real file is still formatted; the lockfile is excluded, exit 0
- `pre-commit run --files .pre-commit-config.yaml` (yaml validation + related hooks) passes cleanly

Not independently re-verifiable here: full CI on this PR itself, since it can't be run locally end-to-end. The `pre-commit (current)` job on #42718 is the real-world case this is meant to unblock.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API