### PR TITLE
fix(mcp): persist Handlebars template under camelCase key so it renders

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -1112,7 +1112,10 @@ def map_handlebars_config(config: HandlebarsChartConfig) -> Dict[str, Any]:
     """Map handlebars chart config to Superset form_data."""
     form_data: Dict[str, Any] = {
         "viz_type": "handlebars",
-        "handlebars_template": config.handlebars_template,
+        # Persist under the camelCase key the Handlebars renderer reads
+        # (`formData.handlebarsTemplate`); the snake_case `handlebars_template`
+        # is the tool's request-contract field, not the persisted form_data key.
+        "handlebarsTemplate": config.handlebars_template,
         "row_limit": config.row_limit,
         "order_desc": config.order_desc,
     }

--- a/tests/unit_tests/mcp_service/chart/test_handlebars_chart.py
+++ b/tests/unit_tests/mcp_service/chart/test_handlebars_chart.py
@@ -183,7 +183,9 @@ class TestMapHandlebarsConfig:
         result = map_handlebars_config(config)
 
         assert result["viz_type"] == "handlebars"
-        assert result["handlebars_template"] == "<p>{{data}}</p>"
+        # Persisted under the camelCase key the renderer reads, not snake_case.
+        assert result["handlebarsTemplate"] == "<p>{{data}}</p>"
+        assert "handlebars_template" not in result
         assert result["query_mode"] == "aggregate"
         assert result["row_limit"] == 1000
         assert result["order_desc"] is True


### PR DESCRIPTION
### SUMMARY

The MCP `generate_chart` / `update_chart` tools persisted the Handlebars chart
template under the snake_case `form_data` key `handlebars_template`, but the
Handlebars viz renderer reads the camelCase key `handlebarsTemplate`
(`plugins/plugin-chart-handlebars/src/Handlebars.tsx`). As a result, a saved
chart's template never matched what the renderer read, so it fell back to the
default `{{data}}` output — the custom template never applied, and since only
the default template was present, its CSS had nothing to style either.

This mirrors the fix already in place one line below for the CSS, which is
correctly stored under the camelCase `styleTemplate`. The template key was
simply missed. The change persists the template under the camelCase key the
renderer reads:

```diff
-        "handlebars_template": config.handlebars_template,
+        "handlebarsTemplate": config.handlebars_template,
```

- The persisted **output** key is the only thing that changes. The tool's
  snake_case **request-contract** field (`HandlebarsChartConfig.handlebars_template`),
  its schema, validator, and LLM-facing examples are unchanged and remain snake_case.
- One edit covers both `generate_chart` and `update_chart` — all persistence
  funnels through `map_config_to_form_data`.
- No backend code reads the persisted key back for query building (Handlebars
  renders client-side over rows), so blast radius is limited to making the
  renderer's primary read succeed. It can only fix, never regress.

Paired write-side companion to #39442, which added a snake→camel read-side
fallback in the two controls' `mapStateToProps`. That fallback rescues the
Explore / direct-link render but not the dashboard-tile or in-chat-preview
paths (which hydrate via `applyDefaultFormData` and never run `mapStateToProps`).
Persisting the correct key fixes every render path for newly created/updated charts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend `form_data` key fix; no visual change beyond the custom template
now rendering instead of the default `{{data}}` output.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/mcp_service/chart/test_handlebars_chart.py` (updated
  `test_aggregate_mode_basic` asserts the camelCase key and the absence of the
  snake_case key).
- End-to-end: via the MCP `generate_chart` tool, create a Handlebars chart with
  a custom template + CSS and save it. Open the saved chart in Explore, via
  direct link, and on a dashboard tile — the custom template + CSS render on all
  three and match the in-chat preview. Inspect the saved chart's `params` and
  confirm it contains `"handlebarsTemplate"` (not `"handlebars_template"`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related: #39442 (read-side control fallback).