### PR TITLE
fix(mcp): supply required DBEventLogger args so mcp_tool_error events are logged (#42579)

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -964,6 +964,10 @@ class ResponseSizeGuardMiddleware(Middleware):
             event_logger.log(
                 user_id=user_id,
                 action="mcp_response_truncated",
+                dashboard_id=None,
+                duration_ms=None,
+                slice_id=None,
+                referrer=None,
                 curated_payload={
                     "tool": tool_name,
                     "original_tokens": estimated_tokens,
@@ -1036,6 +1040,10 @@ class ResponseSizeGuardMiddleware(Middleware):
             event_logger.log(
                 user_id=user_id,
                 action="mcp_response_truncated",
+                dashboard_id=None,
+                duration_ms=None,
+                slice_id=None,
+                referrer=None,
                 curated_payload={
                     "tool": tool_name,
                     "original_tokens": estimated_tokens,
@@ -1100,6 +1108,10 @@ class ResponseSizeGuardMiddleware(Middleware):
             event_logger.log(
                 user_id=user_id,
                 action="mcp_response_size_exceeded",
+                dashboard_id=None,
+                duration_ms=None,
+                slice_id=None,
+                referrer=None,
                 curated_payload={
                     "tool": tool_name,
                     "estimated_tokens": estimated_tokens,

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -719,7 +719,10 @@ class GlobalErrorHandlerMiddleware(Middleware):
             event_logger.log(
                 user_id=user_id,
                 action="mcp_tool_error",
+                dashboard_id=None,
                 duration_ms=duration_ms,
+                slice_id=None,
+                referrer=None,
                 curated_payload={
                     "tool": tool_name,
                     "error_type": type(error).__name__,

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -44,6 +44,7 @@ from superset.mcp_service.middleware import (
     RBACToolVisibilityMiddleware,
     ResponseSizeGuardMiddleware,
 )
+from superset.utils.log import DBEventLogger
 
 
 class TestResponseSizeGuardMiddleware:
@@ -1523,6 +1524,43 @@ class TestGlobalErrorHandlerLogLevels:
             await middleware.on_message(context, call_next)
 
         assert "Internal error" not in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_error_event_reaches_the_real_event_logger(self) -> None:
+        """
+        Regression for #42579: ``_handle_error`` calls
+        ``event_logger.log(user_id=..., action=..., duration_ms=...,
+        curated_payload=...)`` without the ``dashboard_id``/``slice_id``/
+        ``referrer`` arguments ``DBEventLogger.log`` requires (they have no
+        defaults), so the call raises ``TypeError`` on every single MCP
+        error, silently swallowed by the surrounding ``except Exception``.
+
+        Every other test in this class patches ``event_logger`` with a bare
+        ``MagicMock``, which accepts any kwargs and would never catch this --
+        this test uses the real ``DBEventLogger`` instead (with the DB
+        session calls stubbed out, so it doesn't need a live database) to
+        actually exercise the argument binding that's broken today.
+        """
+        middleware = GlobalErrorHandlerMiddleware()
+
+        context = MagicMock()
+        context.message.name = "execute_sql"
+        context.method = "tools/call"
+
+        call_next = AsyncMock(side_effect=ValueError("bad param"))
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger", DBEventLogger()),
+            patch("superset.db") as mock_db,
+            pytest.raises(ToolError),
+        ):
+            await middleware.on_message(context, call_next)
+
+        # If event_logger.log() actually bound its arguments successfully,
+        # it would go on to persist a Log row. Today the TypeError is raised
+        # (and swallowed) before it ever gets that far.
+        mock_db.session.bulk_save_objects.assert_called_once()
 
 
 class TestRBACToolVisibilityMiddleware:


### PR DESCRIPTION
### SUMMARY
Fixes #42579: MCP tool errors (`mcp_tool_error` audit events) were never actually reaching the `logs` table, because the logging call raised a silently-swallowed `TypeError`.

**Root cause.** `GlobalErrorHandlerMiddleware._handle_error` in `superset/mcp_service/middleware.py` calls `event_logger.log(user_id=..., action="mcp_tool_error", duration_ms=..., curated_payload=...)`, but `DBEventLogger.log()` requires `dashboard_id`, `slice_id`, and `referrer` as arguments with no defaults. Every call raised `TypeError: DBEventLogger.log() missing 3 required positional arguments`, caught by the surrounding `except Exception: logger.warning(...)`, so the failure only ever showed up as a warning log line, never as a real audit event.

**Fix.** Pass `dashboard_id=None, slice_id=None, referrer=None`, matching the sibling `mcp_message` call site in the same file (also outside any dashboard/chart context).

### TESTING INSTRUCTIONS
```
pytest tests/unit_tests/mcp_service/test_middleware.py -k test_error_event_reaches_the_real_event_logger
pytest tests/unit_tests/mcp_service/
```
Full `mcp_service` suite: 3134 passed, 1 pre-existing unrelated failure (`test_tools_call_health_check_over_real_asgi_transport`, a `sqlite3.IntegrityError` FK constraint issue in a different code path — reproduces identically on this branch without this fix, confirmed not a regression).

### ADDITIONAL INFORMATION
- [x] Has associated issue: closes #42579
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API