### PR TITLE
fix(mcp): reject unknown fields in nested chart-config models too (#42626)

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -771,8 +771,8 @@ class UnknownFieldCheckMixin(BaseModel):
         return _check_unknown_fields(data, cls)
 
 
-class ColumnRef(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+class ColumnRef(UnknownFieldCheckMixin):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     name: str | None = Field(
         None,
@@ -892,21 +892,25 @@ class ColumnRef(BaseModel):
         )
 
 
-class AxisConfig(BaseModel):
+class AxisConfig(UnknownFieldCheckMixin):
+    model_config = ConfigDict(extra="ignore")
+
     title: str | None = Field(None, max_length=200)
     scale: Literal["linear", "log"] | None = "linear"
     format: str | None = Field(None, description="e.g. '$,.2f'", max_length=50)
 
 
-class LegendConfig(BaseModel):
+class LegendConfig(UnknownFieldCheckMixin):
+    model_config = ConfigDict(extra="ignore")
+
     show: bool = True
     position: Literal["top", "bottom", "left", "right"] | None = "right"
 
 
-class CurrencyFormat(BaseModel):
+class CurrencyFormat(UnknownFieldCheckMixin):
     """Currency symbol and placement applied to numeric values."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     symbol: str = Field(
         ...,
@@ -926,8 +930,8 @@ class CurrencyFormat(BaseModel):
 LEGEND_POSITION_LITERAL = Literal["top", "bottom", "left", "right"]
 
 
-class FilterConfig(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+class FilterConfig(UnknownFieldCheckMixin):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     column: str = Field(
         ...,
@@ -994,7 +998,7 @@ class FilterConfig(BaseModel):
         return self
 
 
-class SortByConfig(BaseModel):
+class SortByConfig(UnknownFieldCheckMixin):
     """Sort specification with explicit direction.
 
     Accepts either this object or a bare column-name string in `sort_by`
@@ -1002,7 +1006,7 @@ class SortByConfig(BaseModel):
     sort-by-metric "top N" pattern most commonly used for tables.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     column: str = Field(
         ...,

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -23,6 +23,7 @@ import pytest
 from pydantic import ValidationError
 
 from superset.mcp_service.chart.schemas import (
+    AxisConfig,
     BigNumberChartConfig,
     ColumnRef,
     FilterConfig,
@@ -719,6 +720,19 @@ class TestUnknownFieldDetection:
         assert config.stacked is True
         assert config.row_limit == 10000
         assert config.group_by is not None
+
+    def test_unknown_field_nested_one_level_down_is_rejected(self) -> None:
+        """
+        Regression for #42626: only the top-level chart config models
+        inherit UnknownFieldCheckMixin. Nested models like AxisConfig are
+        plain BaseModel, so a typo'd field one level down (e.g. inside
+        x_axis) is silently dropped by pydantic's default extra="ignore"
+        instead of raising the same "did you mean?" error a top-level typo
+        gets -- an MCP client (or the LLM driving it) gets no signal that
+        its setting was ignored.
+        """
+        with pytest.raises(ValidationError, match="Unknown field"):
+            AxisConfig.model_validate({"title": "State", "sort_by": "metric"})
 
 
 class TestColumnRefSavedMetric:

--- a/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_schemas.py
@@ -706,11 +706,20 @@ class TestUnknownFieldDetection:
             )
 
     def test_known_aliases_not_flagged_as_unknown(self) -> None:
-        """Test that known aliases pass validation without errors."""
+        """Test that known aliases pass validation without errors.
+
+        Uses ``x_column`` rather than ``x_axis`` to set the X column:
+        ``x_axis`` is ambiguous between that alias on ``x`` and the
+        unrelated ``x_axis: AxisConfig`` field of the same name, and
+        pydantic resolves the collision in favor of the real field name.
+        Now that nested models reject unknown fields (#42626), routing a
+        column dict through ``x_axis`` here would raise, not silently
+        no-op into ``AxisConfig`` the way it used to.
+        """
         config = XYChartConfig.model_validate(
             {
                 "chart_type": "xy",
-                "x_axis": {"name": "category"},
+                "x_column": {"name": "category"},
                 "metrics": [{"name": "sales", "aggregate": "SUM"}],
                 "groupby": [{"name": "region"}],
                 "stack": True,


### PR DESCRIPTION
### SUMMARY
Fixes #42626: only the 10 top-level MCP chart config models (`PieChartConfig`, `XYChartConfig`, etc.) inherited `UnknownFieldCheckMixin`, which rejects unknown fields with a "did you mean?" suggestion. The nested sub-models they're composed of — `AxisConfig`, `LegendConfig`, `CurrencyFormat`, `FilterConfig`, `SortByConfig`, `ColumnRef` — were plain `BaseModel`, so pydantic's default `extra="ignore"` silently dropped a typo'd field one level down instead of raising.

This was worse than a plain rejection for an MCP client (especially an LLM driving one): `update_chart` would return `success: true` with no warnings, so the caller had no signal the setting it just sent was silently dropped. The reporter's own repro showed three successive `update_chart` calls each returning success while changing nothing.

**Fix.** Give every nested config model the same `UnknownFieldCheckMixin` (and matching `extra="ignore"` config) the top-level models already use, since the mixin itself has no top-level-specific assumptions — it just inspects `model_fields` on whatever class it's mixed into.

**A separate, pre-existing wrinkle this surfaced, left as a follow-up (not fixed here):** `XYChartConfig.x` declares `x_axis` as one of its `validation_alias` choices, but the model also has its own field literally named `x_axis: AxisConfig`. That's a real alias/field-name collision — pydantic resolves it in favor of the actual field name, so a column dict sent through the `x_axis` key was always routed into `x_axis: AxisConfig`, not into `x: ColumnRef` as the alias implies. Before this fix that silently no-op'd (extra fields ignored); after this fix it would raise "Unknown field" for any `ColumnRef`-shaped payload sent that way. The one existing test that happened to rely on this (`test_known_aliases_not_flagged_as_unknown`) has been updated to use the unambiguous `x_column` alias instead, but the underlying alias collision on `XYChartConfig` itself is untouched — worth its own follow-up if it's confusing clients in practice.

### TESTING INSTRUCTIONS
```
pytest tests/unit_tests/mcp_service/chart/test_chart_schemas.py
pytest tests/unit_tests/mcp_service/ --ignore=tests/unit_tests/mcp_service/test_mcp_e2e_smoke.py
```
`test_unknown_field_nested_one_level_down_is_rejected` now passes (green). Full `mcp_service` unit suite (3132 tests, excluding the e2e ASGI-transport smoke file, which is unrelated and flaky under heavy parallel load) passes with no regressions.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #42626
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
