### PR TITLE
test(sql): pin optimizer hint blocks survive format() round-trip (#38189)

### DIFF
--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -955,8 +955,13 @@ LIMIT 100
     statement = SQLScript(sql, "starrocks").statements[0]
     formatted = statement.format()
 
-    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+    hint = "/*+ SET_VAR(query_timeout = 3000) */"
+    assert hint in formatted
     assert "SET_VAR(query_timeout /*" not in formatted
+    # the trailing comment must survive, and land outside (after) the hint
+    # block rather than being dropped or relocated into it
+    hint_end = formatted.index(hint) + len(hint)
+    assert "increase timeout for large scans" in formatted[hint_end:]
 
 
 @pytest.mark.xfail(
@@ -982,8 +987,11 @@ LIMIT 100;
     statement = SQLScript(sql, "starrocks").statements[0]
     formatted = statement.format()
 
-    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+    hint = "/*+ SET_VAR(query_timeout = 3000) */"
+    assert hint in formatted
     assert "SET_VAR(query_timeout /*" not in formatted
+    hint_end = formatted.index(hint) + len(hint)
+    assert "increase timeout for large scans" in formatted[hint_end:]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -959,6 +959,33 @@ LIMIT 100
     assert "SET_VAR(query_timeout /*" not in formatted
 
 
+@pytest.mark.xfail(
+    reason=(
+        "#38189 is not fully fixed: a `;`-terminated statement still hits "
+        "the comment-relocation branch and corrupts the hint block. Only "
+        "the no-semicolon form from the original repro was fixed."
+    ),
+    strict=True,
+)
+def test_sqlscript_format_preserves_optimizer_hint_block_with_semicolon() -> None:
+    """
+    Same as `test_sqlscript_format_preserves_optimizer_hint_block`, but with
+    a terminating `;` on the statement -- this still reproduces #38189: the
+    trailing `--` comment gets injected inside the `/*+ SET_VAR(...) */`
+    hint block, corrupting it for StarRocks/MySQL-style engines.
+    """
+    sql = """SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
+FROM my_table
+LIMIT 100;
+
+-- increase timeout for large scans"""
+    statement = SQLScript(sql, "starrocks").statements[0]
+    formatted = statement.format()
+
+    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+    assert "SET_VAR(query_timeout /*" not in formatted
+
+
 @pytest.mark.parametrize(
     "sql, engine, expected",
     [

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -938,6 +938,27 @@ Events | take 100""",
     assert query.get_settings() == {"querytrace": True}
 
 
+def test_sqlscript_format_preserves_optimizer_hint_block() -> None:
+    """
+    Regression for #38189: an inline `--` comment trailing a query with a
+    `/*+ SET_VAR(...) */` optimizer hint must not get repositioned inside
+    the hint block during `format()` -- that would corrupt the hint syntax
+    (StarRocks and other engines using the `/*+ ... */` convention reject
+    a nested `/* */` inside it). `format()` is what Superset's execution
+    path actually sends to the engine (see `executor.py`/`celery_task.py`).
+    """
+    sql = """SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
+FROM my_table
+LIMIT 100
+
+-- increase timeout for large scans"""
+    statement = SQLScript(sql, "starrocks").statements[0]
+    formatted = statement.format()
+
+    assert "/*+ SET_VAR(query_timeout = 3000) */" in formatted
+    assert "SET_VAR(query_timeout /*" not in formatted
+
+
 @pytest.mark.parametrize(
     "sql, engine, expected",
     [


### PR DESCRIPTION
### SUMMARY
Regression test for #38189, which reported that Superset's SQL parser injects a repositioned `--` comment inside a `/*+ SET_VAR(...) */` optimizer hint block, producing invalid SQL for StarRocks/MySQL-style engines that use the `/*+ ... */` hint convention.

The original repro (no terminating `;`) doesn't reproduce against the actual execution-time code path: `SQLStatement.format()`, the same method `superset/sql/execution/executor.py` and `superset/sql/execution/celery_task.py` call to build the SQL that's actually sent to the engine. With the currently pinned `sqlglot` 30.12.0, the trailing `--` comment is repositioned safely after the statement, not injected inside the hint block, for that form.

However, a `;`-terminated statement (as flagged in review) still hits the broken relocation branch and reproduces the corruption. So #38189 is only partially fixed and should stay open for that case. This PR adds two tests: one pinning the now-fixed no-semicolon form, and one `xfail(strict=True)` pinning the still-broken semicolon form so a future fix will surface as an unexpected pass and can flip to a real regression test.

### TESTING INSTRUCTIONS
```
pytest tests/unit_tests/sql/parse_tests.py -k optimizer_hint_block
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: #38189
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
