### PR TITLE
test(deckgl): pin GeoJSON layer against multi-row payloads (#34748)

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/Geojson.test.tsx
@@ -350,6 +350,51 @@ test('getLayer coerces free-form string radius values to numbers', () => {
   expect(props.pointRadiusScale).toBe(0.25);
 });
 
+// Regression for https://github.com/apache/superset/issues/34748: pins the
+// consumer/render boundary (recurseGeoJson feeding GeoJsonLayer's `data`),
+// complementing the transformProps.test.ts coverage of the query->feature step.
+test('getLayer forwards every feature from transformProps output to GeoJsonLayer', () => {
+  const multiRowPayload = {
+    data: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [2.92, 47.38] },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [2.93, 47.39] },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [2.94, 47.4] },
+          properties: {},
+        },
+      ],
+    },
+  };
+
+  const layer = getLayer({
+    ...baseLayerArgs,
+    formData: baseFormData,
+    payload: multiRowPayload,
+  });
+
+  expect(layer.props.data).toHaveLength(3);
+  expect(
+    (layer.props.data as Array<{ geometry: { coordinates: number[] } }>).map(
+      f => f.geometry.coordinates,
+    ),
+  ).toEqual([
+    [2.92, 47.38],
+    [2.93, 47.39],
+    [2.94, 47.4],
+  ]);
+});
+
 type ControlConfig = {
   default?: unknown;
   validators?: unknown[];

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/transformProps.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/transformProps.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ChartProps, DatasourceType } from '@superset-ui/core';
+import transformProps from './transformProps';
+
+// Regression for https://github.com/apache/superset/issues/34748: reporters
+// on 5.0.0/6.0.0 found that only a single row's GeoJSON Feature ever
+// rendered on the map, no matter how many rows the query returned (setting
+// the row limit to 1 made no visible difference).
+test('transformProps builds a feature for every row, not just the first', () => {
+  const mockChartProps: Partial<ChartProps> = {
+    rawFormData: {
+      geojson: 'geometry',
+      viewport: {},
+    },
+    queriesData: [
+      {
+        data: [
+          {
+            geometry: JSON.stringify({
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [2.92, 47.38] },
+              properties: {},
+            }),
+          },
+          {
+            geometry: JSON.stringify({
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [2.93, 47.39] },
+              properties: {},
+            }),
+          },
+          {
+            geometry: JSON.stringify({
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [2.94, 47.4] },
+              properties: {},
+            }),
+          },
+        ],
+      },
+    ],
+    datasource: {
+      type: DatasourceType.Table,
+      id: 1,
+      name: 'test_datasource',
+      columns: [],
+      metrics: [],
+    },
+    height: 400,
+    width: 600,
+    hooks: {},
+    filterState: {},
+    emitCrossFilters: false,
+  };
+
+  const result = transformProps(mockChartProps as ChartProps);
+  const features = result.payload.data.features as Array<{
+    geometry: { coordinates: number[] };
+  }>;
+
+  expect(features).toHaveLength(3);
+  expect(features.map(f => f.geometry.coordinates)).toEqual([
+    [2.92, 47.38],
+    [2.93, 47.39],
+    [2.94, 47.4],
+  ]);
+});


### PR DESCRIPTION
### SUMMARY
Adds a regression test for #34748, which reports that a Deck.gl GeoJSON chart only ever renders a single feature on the map, no matter how many rows the query returns (the reporter found that capping the row limit to 1 made no visible difference).

Traced the pipeline: `Geojson/transformProps.ts` maps every row in `queriesData[0].data` into its own parsed Feature (`records.map(...)`), and `Geojson.tsx`'s `recurseGeoJson` correctly walks the resulting `{ features: [...] }` object, pushing every feature it finds. This looks like it was fixed by the frontend refactor in #39906, which moved GeoJSON row parsing out of the legacy backend `viz.py` `DeckGeoJson.get_properties` path (what the reporters, on 5.0.0/6.0.0, were most likely hitting) and into this per-row frontend transform.

The new test feeds `transformProps` a 3-row payload, each row a distinct GeoJSON `Feature` string, and asserts all 3 come out the other end. It passes on current `master`, proving the bug is already fixed.

### TESTING INSTRUCTIONS
```
cd superset-frontend
npm run test -- plugins/preset-chart-deckgl/src/layers/Geojson/transformProps.test.ts
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Closes #34748
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API