### PR TITLE
fix(charts): decode CSV bytes payload before feeding pandas StringIO (#32370)

### DIFF
--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -762,6 +762,21 @@ def apply_client_processing(  # noqa: C901
 
         data = query["data"]
 
+        csv_export_config = current_app.config.get("CSV_EXPORT", {})
+
+        if query["result_format"] == ChartDataResultFormat.CSV and isinstance(
+            data, bytes
+        ):
+            # QueryContextProcessor.get_data encodes CSV `data` to bytes using
+            # the configured CSV_EXPORT encoding (default utf-8), matching
+            # the encoding SQL Lab's own CSV export uses -- decode with that
+            # same encoding rather than assuming `data` is already a `str`.
+            # Decode before the empty-data check below so whitespace-only
+            # payloads (e.g. a columnless frame serialized as a bare
+            # newline) are caught rather than reaching `pd.read_csv` and
+            # raising `EmptyDataError`.
+            data = data.decode(csv_export_config.get("encoding", "utf-8"))
+
         if isinstance(data, str):
             data = data.strip()
 
@@ -769,7 +784,6 @@ def apply_client_processing(  # noqa: C901
             # do not try to process empty data
             continue
 
-        csv_export_config = current_app.config.get("CSV_EXPORT", {})
         sep = csv_export_config.get("sep", ",")
         decimal = csv_export_config.get("decimal", ".")
 
@@ -780,17 +794,8 @@ def apply_client_processing(  # noqa: C901
             # reports to avoid unwanted conversions
             # This allows users to control which values should be treated as null/NA
             na_values = current_app.config["REPORTS_CSV_NA_NAMES"]
-            # QueryContextProcessor.get_data encodes CSV `data` to bytes using
-            # the configured CSV_EXPORT encoding (default utf-8), matching
-            # the encoding SQL Lab's own CSV export uses -- decode with that
-            # same encoding rather than assuming `data` is already a `str`.
-            csv_data = (
-                data.decode(csv_export_config.get("encoding", "utf-8"))
-                if isinstance(data, bytes)
-                else data
-            )
             df = pd.read_csv(
-                StringIO(csv_data),
+                StringIO(data),
                 keep_default_na=na_values is None,
                 na_values=na_values,
                 sep=sep,

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -780,8 +780,17 @@ def apply_client_processing(  # noqa: C901
             # reports to avoid unwanted conversions
             # This allows users to control which values should be treated as null/NA
             na_values = current_app.config["REPORTS_CSV_NA_NAMES"]
+            # QueryContextProcessor.get_data encodes CSV `data` to bytes using
+            # the configured CSV_EXPORT encoding (default utf-8), matching
+            # the encoding SQL Lab's own CSV export uses -- decode with that
+            # same encoding rather than assuming `data` is already a `str`.
+            csv_data = (
+                data.decode(csv_export_config.get("encoding", "utf-8"))
+                if isinstance(data, bytes)
+                else data
+            )
             df = pd.read_csv(
-                StringIO(data),
+                StringIO(csv_data),
                 keep_default_na=na_values is None,
                 na_values=na_values,
                 sep=sep,

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2931,6 +2931,51 @@ def test_apply_client_processing_csv_format_escapes_formula_values():
     assert "\n=SUM(1+1)" not in processed["queries"][0]["data"]
 
 
+def test_apply_client_processing_csv_format_bytes_data():
+    """
+    Regression for #32370: "Export to pivoted .csv" fails with a 505 error.
+
+    For a real ``resultType=post_processed``/``resultFormat=csv`` request,
+    the query's ``data`` is CSV *bytes* by the time it reaches
+    ``apply_client_processing`` --
+    ``QueryContextProcessor.get_data`` encodes it to bytes for any CSV
+    result_format (``superset/common/query_context_processor.py``), and
+    that's the exact payload ``ChartDataRestApi._send_chart_response`` hands
+    to ``apply_client_processing`` for a POST_PROCESSED result. The CSV
+    branch here passes that straight into ``StringIO(data)``, which raises
+    ``TypeError: initial_value must be str or None, not bytes`` -- a crash
+    that reproduces for every pivoted CSV export, not only the reporter's
+    special-character metric labels (this test uses one anyway, to also
+    pin the originally reported symptom).
+    """
+
+    result = {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.CSV,
+                "data": b"name,% of total\nA,1\nB,2\n",
+            }
+        ]
+    }
+    form_data = {
+        "datasource": "19__table",
+        "viz_type": "pivot_table_v2",
+        "slice_id": 69,
+        "groupbyColumns": [],
+        "groupbyRows": ["name"],
+        "metrics": ["% of total"],
+        "metricsLayout": "COLUMNS",
+        "aggregateFunction": "Sum",
+        "rowOrder": "key_a_to_z",
+        "colOrder": "key_a_to_z",
+        "result_format": "csv",
+        "result_type": "post_processed",
+    }
+
+    processed = apply_client_processing(result, form_data)
+    assert "% of total" in processed["queries"][0]["data"]
+
+
 def test_apply_client_processing_csv_format_empty_string():
     """
     It should be able to process csv results with no data

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -3084,10 +3084,14 @@ def test_apply_client_processing_csv_format_empty_string():
     }
 
 
-@pytest.mark.parametrize("data", [None, "", "\n"])
+@pytest.mark.parametrize("data", [None, "", "\n", b"", b"\n"])
 def test_apply_client_processing_csv_format_no_data(data):
     """
-    It should be able to process csv results with no data
+    It should be able to process csv results with no data, including the
+    bytes forms ``QueryContextProcessor.get_data`` actually produces for a
+    columnless frame (e.g. a bare newline), which must be decoded before
+    the empty-data check runs or they'd reach ``pd.read_csv`` and raise
+    ``EmptyDataError``.
     """
 
     result = {"queries": [{"result_format": ChartDataResultFormat.CSV, "data": data}]}

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2976,6 +2976,43 @@ def test_apply_client_processing_csv_format_bytes_data():
     assert "% of total" in processed["queries"][0]["data"]
 
 
+@with_config({"CSV_EXPORT": {"encoding": "latin-1"}})
+def test_apply_client_processing_csv_format_bytes_data_non_default_encoding():
+    """
+    Regression for #32370: the CSV bytes payload must be decoded with the
+    configured ``CSV_EXPORT.encoding``, not a hardcoded ``utf-8``, since
+    ``QueryContextProcessor.get_data`` encodes with that same config value.
+    A UTF-8 decode of latin-1 bytes containing e.g. "é" (0xE9) would raise
+    ``UnicodeDecodeError`` instead of the intended CSV text.
+    """
+
+    result = {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.CSV,
+                "data": "name,city\nA,Montr\xe9al\n".encode("latin-1"),
+            }
+        ]
+    }
+    form_data = {
+        "datasource": "19__table",
+        "viz_type": "pivot_table_v2",
+        "slice_id": 69,
+        "groupbyColumns": [],
+        "groupbyRows": ["name"],
+        "metrics": ["city"],
+        "metricsLayout": "COLUMNS",
+        "aggregateFunction": "Sum",
+        "rowOrder": "key_a_to_z",
+        "colOrder": "key_a_to_z",
+        "result_format": "csv",
+        "result_type": "post_processed",
+    }
+
+    processed = apply_client_processing(result, form_data)
+    assert "Montréal" in processed["queries"][0]["data"]
+
+
 def test_apply_client_processing_csv_format_empty_string():
     """
     It should be able to process csv results with no data


### PR DESCRIPTION
### SUMMARY
Fixes #32370 ("Error 505 when exporting pivoted .csv with special characters").

Root cause: `QueryContextProcessor.get_data` encodes the query's `data` to **bytes** for any CSV `result_format` (`superset/common/query_context_processor.py`), using the configured `CSV_EXPORT.encoding` (default `utf-8`) — that's exactly the payload `ChartDataRestApi._send_chart_response` hands to `apply_client_processing` for a `resultType=post_processed` request (i.e. "Export to pivoted .csv"). `apply_client_processing`'s CSV branch fed that straight into `StringIO(data)`, which only accepts `str`:

```
TypeError: initial_value must be str or None, not bytes
```

This reproduced for **every** pivoted CSV export, not only the special-character metric labels the issue focuses on — metric labels containing `%`, `\`, `|` round-trip fine once the bytes/str mismatch is fixed, so the special characters weren't actually the trigger. The existing tests never caught this because they hand-construct `data` as a plain `str`, which doesn't match what the real query pipeline produces for CSV result_format.

**Fix.** Decode `data` with the same `CSV_EXPORT.encoding` config value the producer side used, before parsing with `pd.read_csv`/`StringIO`. Kept the configured encoding (rather than hardcoding `utf-8`) so this stays correct for deployments that configure a non-default `CSV_EXPORT.encoding`.

### TESTING INSTRUCTIONS
```
pytest tests/unit_tests/charts/test_client_processing.py -k "bytes_data"
```
Two cases: the originally reported special-character scenario, and a non-default-encoding case (`latin-1`) that would raise `UnicodeDecodeError` if the fix hardcoded `utf-8` instead of reading the config.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #32370
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
