### PR TITLE
fix(mcp): stop false-flagging successful responses with error_type:null as failures (#42580)

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -227,13 +227,19 @@ class LoggingMiddleware(Middleware):
         """Check if a tool result contains an error schema response.
 
         MCP tools return error schemas (ChartError, DashboardError, etc.)
-        instead of raising exceptions. These serialize to JSON containing
-        an "error_type" field.
+        instead of raising exceptions. These serialize to JSON with a
+        populated "error_type" field. Success schemas also declare an
+        optional "error_type" field (defaulting to null) for a uniform
+        response shape, so its mere presence in the serialized JSON isn't
+        a reliable signal -- only a truthy value is.
         """
+        from superset.utils.json import loads as json_loads
+
         try:
-            return '"error_type"' in result.content[0].text
-        except (AttributeError, IndexError):
+            payload = json_loads(result.content[0].text)
+        except (AttributeError, IndexError, TypeError, ValueError):
             return False
+        return bool(isinstance(payload, dict) and payload.get("error_type"))
 
     def _extract_context_info(
         self, context: MiddlewareContext

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -559,6 +559,24 @@ class TestIsErrorResponse:
         middleware = LoggingMiddleware()
         assert middleware._is_error_response(ToolResult(content=[])) is False
 
+    def test_success_response_with_null_error_type_not_detected_as_error(
+        self,
+    ) -> None:
+        """Regression for #42580: response schemas like ExecuteSqlResponse
+        declare "error"/"error_type" as always-present nullable fields, so a
+        fully successful response still serializes the literal "error_type"
+        substring (as "error_type":null). The substring check must not treat
+        that the same as an actual error schema payload with a non-null
+        error_type value."""
+        middleware = LoggingMiddleware()
+        success_json = (
+            '{"success": true, "rows": [{"database": "bronze_layer", '
+            '"tables": 161}], "row_count": 1, "error": null, '
+            '"error_type": null}'
+        )
+        result = ToolResult(content=[mt.TextContent(type="text", text=success_json)])
+        assert middleware._is_error_response(result) is False
+
     @patch("superset.mcp_service.middleware.event_logger")
     @patch("superset.mcp_service.middleware.get_user_id", return_value=42)
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/test_middleware_logging.py
+++ b/tests/unit_tests/mcp_service/test_middleware_logging.py
@@ -278,7 +278,7 @@ class TestLoggingMiddlewareOnCallTool:
         ctx = _make_context(name="generate_chart", params={"dataset_id": 5})
         response_text = (
             '{"success": false, "chart": null, '
-            '"error": {"error_type": "validation_error"}}'
+            '"error": "invalid dataset", "error_type": "validation_error"}'
         )
         original_result = ToolResult(
             content=[mt.TextContent(type="text", text=response_text)]


### PR DESCRIPTION
### SUMMARY
Fixes #42580: successful `execute_sql` (and other tool) calls were logged as failures in the MCP audit log.

**Root cause.** `LoggingMiddleware._is_error_response` decided success/failure with a raw substring search, `'"error_type"' in result.content[0].text`. Success response schemas (the ones adjacent to `ChartError`/`DashboardError`) declare `error_type` as an optional field defaulting to `null`, for a uniform response shape — so every successful call's serialized JSON contains that substring too, and gets logged as `success=False`.

**Fix.** Parse the response body as JSON and check whether `error_type` is actually truthy, not merely present. The real error schemas (e.g. `DashboardError`) always populate `error_type` with a concrete type string on failure and never on success, so this is a reliable discriminator where the substring check wasn't.

Also corrected a pre-existing test fixture (`test_on_call_tool_does_not_extract_id_on_failed_response`) that modeled `error_type` nested under an `"error"` object — no schema in the codebase actually produces that shape; `error` is always a plain message string with `error_type` as its sibling field, not a container.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend audit-logging fix, no UI change.

### TESTING INSTRUCTIONS
```
.venv/bin/python -m pytest tests/unit_tests/mcp_service/test_middleware_logging.py -q
```
39 passed. Also ran the full `tests/unit_tests/mcp_service/` suite (3134 tests): 1 pre-existing unrelated failure (`test_tools_call_health_check_over_real_asgi_transport`, a test-isolation FK-constraint/version-field issue, confirmed unrelated by running it in isolation both before and after this change).

### ADDITIONAL INFORMATION
- [x] Has associated issue: #42580
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API