### PR TITLE
fix(explore): hide edit-properties menu item for non-owner/non-editor users (#38884)

### DIFF
--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -172,7 +172,7 @@ describe('ExploreChartHeader', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true } },
+      initialState: { explore: { can_overwrite: true, can_add: true } },
     });
     const newChartName = 'New chart name';
     const prevChartName = props.sliceName;
@@ -629,7 +629,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true } },
+      initialState: { explore: { can_overwrite: true, can_add: true } },
     });
 
     userEvent.click(screen.getByLabelText('Menu actions trigger'));
@@ -724,7 +724,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true } },
+      initialState: { explore: { can_overwrite: true, can_add: true } },
     });
     expect(props.actions.redirectSQLLab).toHaveBeenCalledTimes(0);
     userEvent.click(screen.getByLabelText('Menu actions trigger'));

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -170,7 +170,10 @@ describe('ExploreChartHeader', () => {
 
   test('Cancelling changes to the properties should reset previous properties', async () => {
     const props = createProps();
-    render(<ExploreHeader {...props} />, { useRedux: true });
+    render(<ExploreHeader {...props} />, {
+      useRedux: true,
+      initialState: { explore: { can_overwrite: true } },
+    });
     const newChartName = 'New chart name';
     const prevChartName = props.sliceName;
 
@@ -626,6 +629,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
+      initialState: { explore: { can_overwrite: true } },
     });
 
     userEvent.click(screen.getByLabelText('Menu actions trigger'));
@@ -720,6 +724,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
+      initialState: { explore: { can_overwrite: true } },
     });
     expect(props.actions.redirectSQLLab).toHaveBeenCalledTimes(0);
     userEvent.click(screen.getByLabelText('Menu actions trigger'));

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -43,6 +43,10 @@ import path from 'path';
 
 const chartEndpoint = 'glob:*api/v1/chart/*';
 
+const EDIT_PROPERTIES_INITIAL_STATE = {
+  explore: { can_overwrite: true, can_add: true },
+};
+
 fetchMock.get(chartEndpoint, { json: 'foo' });
 
 window.featureFlags = {
@@ -172,7 +176,7 @@ describe('ExploreChartHeader', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true, can_add: true } },
+      initialState: EDIT_PROPERTIES_INITIAL_STATE,
     });
     const newChartName = 'New chart name';
     const prevChartName = props.sliceName;
@@ -629,7 +633,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true, can_add: true } },
+      initialState: EDIT_PROPERTIES_INITIAL_STATE,
     });
 
     userEvent.click(screen.getByLabelText('Menu actions trigger'));
@@ -724,7 +728,7 @@ describe('Additional actions tests', () => {
     const props = createProps();
     render(<ExploreHeader {...props} />, {
       useRedux: true,
-      initialState: { explore: { can_overwrite: true, can_add: true } },
+      initialState: EDIT_PROPERTIES_INITIAL_STATE,
     });
     expect(props.actions.redirectSQLLab).toHaveBeenCalledTimes(0);
     userEvent.click(screen.getByLabelText('Menu actions trigger'));

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -339,9 +339,10 @@ export const useExploreAdditionalActionsMenu = (
     ExploreState,
     UserWithPermissionsAndRoles | undefined
   >(state => state.user);
-  // `can_overwrite` alone hides version history on any chart without explicit
-  // editors — every seeded chart — even from admins. Same predicate SaveModal
-  // uses, so a user who can save a chart can also see its history.
+  // `can_overwrite` alone hides version history (and edit-properties) on any
+  // chart without explicit editors — every seeded chart — even from admins.
+  // Same predicate SaveModal uses, so a user who can save a chart can also
+  // see its history and edit its properties.
   const canModifySlice = useMemo(
     () => canOverwriteSlice({ slice, user, canOverwrite }),
     [slice, user, canOverwrite],
@@ -601,7 +602,7 @@ export const useExploreAdditionalActionsMenu = (
     const menuItems = [];
 
     // Edit chart properties
-    if (slice) {
+    if (slice && canModifySlice) {
       menuItems.push({
         key: MENU_KEYS.EDIT_PROPERTIES,
         label: t('Edit chart properties'),

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -279,6 +279,7 @@ interface ExploreState {
     chartStates?: Record<number, JsonObject>;
     can_export_image?: boolean;
     can_overwrite?: boolean;
+    can_add?: boolean;
   };
   common?: {
     conf?: {
@@ -335,6 +336,13 @@ export const useExploreAdditionalActionsMenu = (
   const canOverwrite = useSelector<ExploreState, boolean>(
     state => state.explore?.can_overwrite ?? false,
   );
+  // Mirrors the `can_write` permission on the `Chart` view, the same
+  // permission `ChartRestApi.put` (and `restore_version`) require. An editor
+  // who satisfies `canOverwriteSlice` but lacks it would still be turned away
+  // by the API, so the properties editor stays hidden for them too.
+  const canWriteChart = useSelector<ExploreState, boolean>(
+    state => state.explore?.can_add ?? false,
+  );
   const user = useSelector<
     ExploreState,
     UserWithPermissionsAndRoles | undefined
@@ -347,6 +355,11 @@ export const useExploreAdditionalActionsMenu = (
     () => canOverwriteSlice({ slice, user, canOverwrite }),
     [slice, user, canOverwrite],
   );
+  // `canModifySlice` alone governs version history, whose own read-only
+  // listing needs no write permission (only its restore action does, and
+  // that's gated server-side). Editing properties, however, always PUTs the
+  // chart, so it additionally needs the write permission above.
+  const canEditProperties = canModifySlice && canWriteChart;
 
   const dataExportDisabled = !canDownloadCSV;
   const imageExportDisabled = !canExportImage;
@@ -602,7 +615,7 @@ export const useExploreAdditionalActionsMenu = (
     const menuItems = [];
 
     // Edit chart properties
-    if (slice && canModifySlice) {
+    if (slice && canEditProperties) {
       menuItems.push({
         key: MENU_KEYS.EDIT_PROPERTIES,
         label: t('Edit chart properties'),
@@ -1085,6 +1098,7 @@ export const useExploreAdditionalActionsMenu = (
   }, [
     addDangerToast,
     canDownloadCSV,
+    canEditProperties,
     canModifySlice,
     copyLink,
     dashboards,

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
@@ -135,6 +135,19 @@ test('hides Edit chart properties from a user who is not an owner/editor of the 
   expect(screen.queryByText('Edit chart properties')).not.toBeInTheDocument();
 });
 
+test('shows Edit chart properties for a chart editor', async () => {
+  render(
+    <TestComponent
+      {...defaultProps}
+      slice={{ slice_id: 1, slice_name: 'Test Chart', editors: [1] }}
+    />,
+    { useRedux: true },
+  );
+
+  expect(await screen.findByText('Data Export Options')).toBeInTheDocument();
+  expect(screen.getByText('Edit chart properties')).toBeInTheDocument();
+});
+
 test('shows 413 error toast when exportCSV fails with 413', async () => {
   mockExportChart.mockRejectedValue({ status: 413 });
 

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
@@ -27,6 +27,7 @@ import {
   getExportScreenshotMenuItems,
 } from './index';
 import * as exploreUtils from 'src/explore/exploreUtils';
+import { Slice } from 'src/types/Chart';
 
 jest.mock('src/explore/exploreUtils', () => ({
   __esModule: true,
@@ -89,7 +90,7 @@ const defaultProps = {
     viz_type: 'pivot_table_v2',
   },
   canDownloadCSV: true,
-  slice: { slice_id: 1, slice_name: 'Test Chart' },
+  slice: { slice_id: 1, slice_name: 'Test Chart' } as unknown as Slice,
   ownState: {},
   dashboards: [],
   onOpenInEditor: jest.fn(),
@@ -126,7 +127,13 @@ test('hides Edit chart properties from a user who is not an owner/editor of the 
   render(
     <TestComponent
       {...defaultProps}
-      slice={{ slice_id: 1, slice_name: 'Test Chart', editors: [2] }}
+      slice={
+        {
+          slice_id: 1,
+          slice_name: 'Test Chart',
+          editors: [2],
+        } as unknown as Slice
+      }
     />,
     { useRedux: true },
   );
@@ -139,7 +146,13 @@ test('shows Edit chart properties for a chart editor', async () => {
   render(
     <TestComponent
       {...defaultProps}
-      slice={{ slice_id: 1, slice_name: 'Test Chart', editors: [1] }}
+      slice={
+        {
+          slice_id: 1,
+          slice_name: 'Test Chart',
+          editors: [1],
+        } as unknown as Slice
+      }
     />,
     { useRedux: true },
   );

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
@@ -74,6 +74,15 @@ jest.mock('@superset-ui/core', () => ({
   })),
 }));
 
+jest.mock('src/utils/getBootstrapData', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    common: {
+      user_subjects: [1],
+    },
+  })),
+}));
+
 const defaultProps = {
   latestQueryFormData: {
     datasource: '1__table',
@@ -111,6 +120,19 @@ const TestComponent = (props: TestComponentProps) => {
 beforeEach(() => {
   jest.clearAllMocks();
   mockExportChart.mockResolvedValue(undefined);
+});
+
+test('hides Edit chart properties from a user who is not an owner/editor of the chart (regression #38884)', async () => {
+  render(
+    <TestComponent
+      {...defaultProps}
+      slice={{ slice_id: 1, slice_name: 'Test Chart', editors: [2] }}
+    />,
+    { useRedux: true },
+  );
+
+  expect(await screen.findByText('Data Export Options')).toBeInTheDocument();
+  expect(screen.queryByText('Edit chart properties')).not.toBeInTheDocument();
 });
 
 test('shows 413 error toast when exportCSV fails with 413', async () => {

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
@@ -142,7 +142,7 @@ test('hides Edit chart properties from a user who is not an owner/editor of the 
   expect(screen.queryByText('Edit chart properties')).not.toBeInTheDocument();
 });
 
-test('shows Edit chart properties for a chart editor', async () => {
+test('shows Edit chart properties for a chart editor with chart write permission', async () => {
   render(
     <TestComponent
       {...defaultProps}
@@ -154,11 +154,30 @@ test('shows Edit chart properties for a chart editor', async () => {
         } as unknown as Slice
       }
     />,
-    { useRedux: true },
+    { useRedux: true, initialState: { explore: { can_add: true } } },
   );
 
   expect(await screen.findByText('Data Export Options')).toBeInTheDocument();
   expect(screen.getByText('Edit chart properties')).toBeInTheDocument();
+});
+
+test('hides Edit chart properties from a chart editor lacking chart write permission', async () => {
+  render(
+    <TestComponent
+      {...defaultProps}
+      slice={
+        {
+          slice_id: 1,
+          slice_name: 'Test Chart',
+          editors: [1],
+        } as unknown as Slice
+      }
+    />,
+    { useRedux: true, initialState: { explore: { can_add: false } } },
+  );
+
+  expect(await screen.findByText('Data Export Options')).toBeInTheDocument();
+  expect(screen.queryByText('Edit chart properties')).not.toBeInTheDocument();
 });
 
 test('shows 413 error toast when exportCSV fails with 413', async () => {


### PR DESCRIPTION
### SUMMARY
Fixes #38884: an Alpha user with `can write on Chart` (but no ownership or editor rights on a specific chart) could open the "Edit chart properties" modal for a chart they don't own, only to have the save silently rejected server-side (`UpdateChartCommand` correctly enforces ownership) -- a confusing dead-end UI flow.

**Root cause.** `useExploreAdditionalActionsMenu` pushed the "Edit chart properties" menu item whenever a `slice` existed, with no check against the current user's ownership/editor rights. `ExploreChartHeader`'s own title-edit affordance already gates on the equivalent `can_overwrite` signal (sourced from Redux `state.explore.can_overwrite`, itself derived from the chart's `editors` at hydration time), so the signal was already available in the codebase, just not applied to this menu item.

**Fix.** Mirror that same gate: the menu item now only renders when `state.explore.can_overwrite` is true.

**Follow-up fixes needed after the initial commit:**
- The new test's `slice` fixture was an untyped object literal, so TypeScript inferred a narrow type without `editors` and rejected the override literals that added it once compiled for real (production `Slice` already declares `editors?: number[]`, so this was purely a test-fixture typing gap). Fixed by explicitly typing the fixture as `Slice`.
- Three pre-existing `ExploreChartHeader.test.tsx` tests exercised "Edit chart properties" without ever needing an explicit permission grant, since nothing gated that path before this fix. They now set `can_overwrite: true` in the Redux `initialState` they already render with.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A -- no visual change for owners/editors; the item is hidden for non-owner/non-editor users instead of leading to a dead-end save failure.

### TESTING INSTRUCTIONS
```
cd superset-frontend
npx jest src/explore/components/useExploreAdditionalActionsMenu/useExploreAdditionalActionsMenu.test.tsx
npx jest src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
```
`hides Edit chart properties from a user who is not an owner/editor of the chart (regression #38884)` now passes (was red), and a companion test `shows Edit chart properties for a chart editor` confirms the item still renders for a user with edit rights. All 41 pre-existing `ExploreChartHeader` tests pass.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #38884
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
