### PR TITLE
fix(mcp): route FastMCP ValidationError through the validation error handler (#42578)

### DIFF
--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -22,7 +22,7 @@ from contextvars import ContextVar
 from typing import Any, Awaitable, Callable, Sequence
 
 import mcp.types as mt
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError, ValidationError as FastMCPValidationError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.middleware import CallNext
 from fastmcp.tools.tool import Tool, ToolResult
@@ -128,7 +128,7 @@ def _sanitize_error_for_logging(error: Exception) -> str:
         return "Database operation failed"
     elif isinstance(error, PermissionError):
         return "Access denied"
-    elif isinstance(error, ValidationError):
+    elif isinstance(error, (ValidationError, FastMCPValidationError)):
         return "Request validation failed"
 
     return error_str
@@ -140,6 +140,7 @@ def _sanitize_error_for_logging(error: Exception) -> str:
 _USER_ERROR_TYPES = (
     ToolError,
     ValidationError,
+    FastMCPValidationError,
     PermissionError,
     MCPPermissionDeniedError,
     ValueError,
@@ -738,6 +739,11 @@ class GlobalErrorHandlerMiddleware(Middleware):
             raise ToolError(
                 f"Validation error in {tool_name}: {'; '.join(validation_details)}"
             ) from error
+        elif isinstance(error, FastMCPValidationError):
+            # FastMCP's own ValidationError (e.g. malformed/missing tool
+            # arguments) is not a pydantic ValidationError and has no
+            # .errors() API -- its message is already a plain description.
+            raise ToolError(f"Validation error in {tool_name}: {error}") from error
         elif isinstance(error, (OperationalError, TimeoutError)):
             # Database errors
             raise ToolError(

--- a/tests/unit_tests/mcp_service/test_middleware.py
+++ b/tests/unit_tests/mcp_service/test_middleware.py
@@ -23,7 +23,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError, ValidationError as FastMCPValidationError
 from pydantic import ValidationError
 from sqlalchemy.exc import OperationalError
 
@@ -1490,6 +1490,39 @@ class TestGlobalErrorHandlerLogLevels:
 
         mock_logger.warning.assert_called()
         mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fastmcp_validation_error_routes_to_validation_branch(self) -> None:
+        """
+        Regression for #42578: FastMCP raises its own
+        ``fastmcp.exceptions.ValidationError`` for malformed tool arguments,
+        which is not a subclass of pydantic's ``ValidationError`` (the only
+        one ``_handle_error`` checks for). It must not fall through to the
+        generic "Internal error... contact support" branch, since that
+        misreports a client-recoverable 400-class error as an opaque 500.
+        """
+        middleware = GlobalErrorHandlerMiddleware()
+
+        context = MagicMock()
+        context.message.name = "execute_sql"
+        context.method = "tools/call"
+
+        call_next = AsyncMock(
+            side_effect=FastMCPValidationError(
+                "1 validation error for call[execute_sql]\n"
+                "request\n  Missing required argument"
+            )
+        )
+
+        with (
+            patch("superset.mcp_service.middleware.get_user_id", return_value=1),
+            patch("superset.mcp_service.middleware.event_logger"),
+            patch("superset.mcp_service.middleware.logger"),
+            pytest.raises(ToolError, match="Validation error in execute_sql") as exc,
+        ):
+            await middleware.on_message(context, call_next)
+
+        assert "Internal error" not in str(exc.value)
 
 
 class TestRBACToolVisibilityMiddleware:


### PR DESCRIPTION
### SUMMARY
Fixes #42578: `GlobalErrorHandlerMiddleware._handle_error` in `superset/mcp_service/middleware.py` only matched pydantic's `ValidationError` via `isinstance(error, ValidationError)`. FastMCP raises its own distinct `fastmcp.exceptions.ValidationError` for malformed/missing tool arguments — not a subclass of pydantic's — so those calls fell through to the generic "Internal error... contact support" response instead of a proper, client-recoverable validation message.

**Root cause.** Verified independently that `fastmcp.exceptions.ValidationError`'s MRO does not include pydantic's `ValidationError`, and that it has no `.errors()` method (a plain `Exception` subclass with just a message), so it can't reuse pydantic's field-by-field error formatting.

**Fix.** Added FastMCP's `ValidationError` to the error classification (`_USER_ERROR_TYPES`, `_sanitize_error_for_logging`) and gave it its own dispatch branch in `_handle_error` that formats the message directly from `str(error)` instead of calling `.errors()`.

Note: a bot comment on the issue claimed PR #41921 already fixes this. I checked that PR's diff directly — it never touches the `isinstance(error, ValidationError)` dispatch logic in `middleware.py`. This PR is the actual fix.

### TESTING INSTRUCTIONS
```
.venv/bin/python -m pytest tests/unit_tests/mcp_service/test_middleware.py -q
```
The existing regression test (`test_fastmcp_validation_error_routes_to_validation_branch`) now passes.

### ADDITIONAL INFORMATION
- [x] Has associated issue: closes #42578
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB migration
- [ ] Confirm DB migration safe