### PR TITLE
fix(sql-lab): apply SQL_QUERY_MUTATOR to streaming exports (#40465)

### DIFF
--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -85,6 +85,14 @@ class BaseStreamingCSVExportCommand(BaseCommand):
         """
         Get the SQL query, database, catalog, and schema for execution.
 
+        The returned SQL is expected to already carry any
+        ``is_split=False`` mutation applied upstream (e.g. by
+        ``get_query_str_extended`` for charts, or SQL Lab's stored
+        ``executed_sql``); ``run()`` applies the complementary
+        ``is_split=True`` mutation exactly once before execution, so the
+        mutator fires once total under either ``MUTATE_AFTER_SPLIT``
+        setting.
+
         Returns:
             Tuple of (sql_query, database_object, catalog, schema)
         """

--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -223,7 +223,19 @@ class BaseStreamingCSVExportCommand(BaseCommand):
             # Merge database to prevent DetachedInstanceError
             merged_database = session.merge(database)
 
-            mutated_sql = merged_database.mutate_sql_based_on_config(sql)
+            # `is_split=True` mirrors the non-streaming download path exactly:
+            # Database.get_df() -> _execute_sql_with_mutation_and_logging()
+            # always calls mutate_sql_based_on_config(..., is_split=True) on
+            # SQL Lab's stored select_sql/executed_sql, and the chart query
+            # path applies its own mutation upstream (in
+            # get_query_str_extended, with is_split=False) before landing
+            # here. Since `is_split` and `MUTATE_AFTER_SPLIT` are compared
+            # for equality, `is_split=True` is the complement of that
+            # upstream chart mutation -- together they mutate the SQL
+            # exactly once for either MUTATE_AFTER_SPLIT setting, instead of
+            # double-mutating when it's False and never mutating when it's
+            # True.
+            mutated_sql = merged_database.mutate_sql_based_on_config(sql, is_split=True)
 
             with merged_database.get_sqla_engine(
                 catalog=catalog, schema=schema

--- a/superset/commands/streaming_export/base.py
+++ b/superset/commands/streaming_export/base.py
@@ -223,13 +223,15 @@ class BaseStreamingCSVExportCommand(BaseCommand):
             # Merge database to prevent DetachedInstanceError
             merged_database = session.merge(database)
 
+            mutated_sql = merged_database.mutate_sql_based_on_config(sql)
+
             with merged_database.get_sqla_engine(
                 catalog=catalog, schema=schema
             ) as engine:
                 with engine.connect() as connection:
                     result_proxy = connection.execution_options(
                         stream_results=True
-                    ).execute(text(sql))
+                    ).execute(text(mutated_sql))
 
                     columns = list(result_proxy.keys())
 

--- a/tests/unit_tests/commands/chart/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/chart/streaming_export_command_test.py
@@ -39,6 +39,9 @@ def _setup_chart_mocks(
     datasource = mocker.MagicMock()
     datasource.get_query_str.return_value = sql
     datasource.database = mocker.MagicMock()
+    datasource.database.mutate_sql_based_on_config.side_effect = (
+        lambda sql_, **kwargs: sql_
+    )
     datasource.catalog = catalog
     datasource.schema = schema
     query_context.datasource = datasource

--- a/tests/unit_tests/commands/chart/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/chart/streaming_export_command_test.py
@@ -299,3 +299,46 @@ def test_catalog_and_schema_passed_to_engine(mocker: MockerFixture) -> None:
         catalog="my_catalog",
         schema="my_schema",
     )
+
+
+def test_streaming_export_mutation_does_not_double_apply(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Regression test for a bug caught in review of apache/superset#40465's fix:
+    ``datasource.get_query_str()`` (used to build the SQL for chart streaming
+    exports) already runs it through
+    ``Database.mutate_sql_based_on_config(sql)`` -- with ``is_split=False`` --
+    upstream in ``get_query_str_extended``. If
+    ``_execute_query_and_stream`` mutated again with the same default
+    ``is_split=False``, a ``SQL_QUERY_MUTATOR`` would run twice under the
+    default ``MUTATE_AFTER_SPLIT=False`` config, and never run at all under
+    ``MUTATE_AFTER_SPLIT=True`` (since neither call would use
+    ``is_split=True``). Passing ``is_split=True`` here is the complement of
+    the upstream call, so exactly one of the two fires for either setting.
+    """
+    mock_db, query_context, datasource = _setup_chart_mocks(
+        mocker, sql="SELECT * FROM test /* mutated */"
+    )
+
+    mock_result = mocker.MagicMock()
+    mock_result.keys.return_value = ["col1"]
+    mock_result.fetchmany.side_effect = [[("val",)], []]
+
+    mock_connection = mocker.MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = mock_result
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = mocker.MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    datasource.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    command = StreamingCSVExportCommand(query_context)
+    list(command.run()())
+
+    datasource.database.mutate_sql_based_on_config.assert_called_once_with(
+        "SELECT * FROM test /* mutated */", is_split=True
+    )

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -822,6 +822,13 @@ def test_streaming_export_applies_sql_mutator(mocker, mock_query, mock_result_pr
         "streaming export sent the raw, unmutated SQL to the engine -- "
         "Database.mutate_sql_based_on_config was never called on it"
     )
+    # Pin the contract the fix relies on: mutate_sql_based_on_config is
+    # called exactly once, with is_split=True -- the complement of the
+    # is_split=False mutation applied upstream. Without this, the assertion
+    # above still passes with is_split=False (rstrip is idempotent).
+    mock_query.database.mutate_sql_based_on_config.assert_called_once_with(
+        "SELECT * FROM test_table;", is_split=True
+    )
 
 
 def test_streaming_export_preserves_impersonated_user_context(

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from flask import g
 from pytest_mock import MockerFixture
 
 from superset.commands.sql_lab.streaming_export_command import (
@@ -28,6 +29,7 @@ from superset.commands.sql_lab.streaming_export_command import (
 from superset.errors import SupersetErrorType
 from superset.exceptions import SupersetErrorException, SupersetSecurityException
 from superset.sqllab.limiting_factor import LimitingFactor
+from superset.utils.core import get_username
 
 
 def _setup_sqllab_mocks(
@@ -771,3 +773,113 @@ def test_csv_export_config_custom_decimal_for_decimal_type(mocker, mock_query) -
     assert "2;56,78" in csv_data
     assert "12.34" not in csv_data
     assert "56.78" not in csv_data
+
+
+def test_streaming_export_applies_sql_mutator(mocker, mock_query, mock_result_proxy):
+    """
+    Regression for apache/superset#40465: the non-streaming SQL execution
+    path (Database._execute_sql_with_mutation_and_logging, used by get_df())
+    calls Database.mutate_sql_based_on_config on every statement before
+    executing it -- that's the hook a deployment's SQL_QUERY_MUTATOR runs
+    through (e.g. to strip a trailing semicolon some engines' HTTP endpoints
+    reject, per the issue's Trino repro). _execute_query_and_stream sends
+    the raw SQL straight to engine.connect().execute(text(sql)) instead,
+    bypassing it entirely.
+    """
+    mock_query.select_sql = None
+    mock_query.executed_sql = "SELECT * FROM test_table;"
+    mock_query.limiting_factor = LimitingFactor.NOT_LIMITED
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+    mock_query.database.mutate_sql_based_on_config.side_effect = (
+        lambda sql_, is_split=False: sql_.rstrip(";")
+    )
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = (
+        mock_result_proxy
+    )
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    mock_query.database.get_sqla_engine.return_value.__enter__.return_value = (
+        mock_engine
+    )
+
+    command = StreamingSqlResultExportCommand("test_client_123", chunk_size=10)
+    command.validate()
+
+    csv_generator_callable = command.run()
+    list(csv_generator_callable())
+
+    executed_sql = str(
+        mock_connection.execution_options.return_value.execute.call_args[0][0]
+    )
+    assert not executed_sql.rstrip().endswith(";"), (
+        "streaming export sent the raw, unmutated SQL to the engine -- "
+        "Database.mutate_sql_based_on_config was never called on it"
+    )
+
+
+def test_streaming_export_preserves_impersonated_user_context(
+    app_context, mocker, mock_query, mock_result_proxy
+):
+    """
+    Checks the other half of apache/superset#40465's theory: that the
+    streaming path drops user impersonation because it acquires its engine
+    "without this context" (unlike other call sites, which the issue says
+    use a get_sqla_engine_with_context(user_name=...) that doesn't actually
+    exist anywhere in this codebase). Independently verified this does NOT
+    reproduce: BaseStreamingCSVExportCommand.run() captures flask.g's full
+    __dict__ (including g.user) before entering the deferred generator, and
+    csv_generator() restores it via preserve_g_context before calling
+    _execute_query_and_stream -- so Database.get_sqla_engine's internal
+    get_effective_user()/get_username() call (which every engine-acquisition
+    call site relies on for impersonation, streaming or not) sees the same
+    acting user it would anywhere else. This pins that behavior rather than
+    the bug the issue reports for it.
+    """
+    g.user = Mock(username="alice")
+    assert get_username() == "alice"
+
+    mock_query.select_sql = None
+    mock_query.executed_sql = "SELECT * FROM test_table"
+    mock_query.limiting_factor = LimitingFactor.NOT_LIMITED
+
+    mock_db, mock_session = _setup_sqllab_mocks(mocker, mock_query)
+
+    mock_connection = MagicMock()
+    mock_connection.execution_options.return_value.execute.return_value = (
+        mock_result_proxy
+    )
+    mock_connection.__enter__.return_value = mock_connection
+    mock_connection.__exit__.return_value = None
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+
+    seen_usernames = []
+
+    def fake_get_sqla_engine(*args, **kwargs):
+        # get_sqla_engine is where Database._get_sqla_engine would call
+        # get_effective_user() -> get_username() -> g.user.username in the
+        # real (unmocked) implementation; capture what g.user resolves to
+        # at the moment this is invoked, from inside the generator's
+        # restored app/g context.
+        seen_usernames.append(get_username())
+        cm = MagicMock()
+        cm.__enter__.return_value = mock_engine
+        cm.__exit__.return_value = None
+        return cm
+
+    mock_query.database.get_sqla_engine.side_effect = fake_get_sqla_engine
+
+    command = StreamingSqlResultExportCommand("test_client_123", chunk_size=10)
+    command.validate()
+
+    csv_generator_callable = command.run()
+    list(csv_generator_callable())
+
+    assert seen_usernames == ["alice"]

--- a/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
+++ b/tests/unit_tests/commands/sql_lab/streaming_export_command_test.py
@@ -63,6 +63,7 @@ def mock_query():
     query.database = MagicMock()
     query.database.db_engine_spec = MagicMock()
     query.database.db_engine_spec.engine = "postgresql"
+    query.database.mutate_sql_based_on_config.side_effect = lambda sql_, **kwargs: sql_
     query.raise_for_access = MagicMock()
     return query
 


### PR DESCRIPTION
### SUMMARY
Fixes half of #40465 ("Superset streaming export bug"), and rules out the other half with evidence.

**Bug confirmed and fixed.** `_execute_query_and_stream` (`superset/commands/streaming_export/base.py`) sent the raw query SQL straight to `engine.connect().execute(text(sql))`, never calling `Database.mutate_sql_based_on_config()` the way the non-streaming path (`get_df` → `_execute_sql_with_mutation_and_logging`) does for every statement. Any deployment-configured `SQL_QUERY_MUTATOR` (e.g. one stripping a trailing semicolon some engines' HTTP endpoints reject, matching the issue's Trino repro) silently never ran on a streamed CSV export.

**Fix.** Call `merged_database.mutate_sql_based_on_config(sql)` before executing, mirroring the non-streaming path.

**Theory ruled out.** The issue also claims the streaming path drops user impersonation because it acquires its engine via a `get_sqla_engine_with_context(user_name=...)`-less path. That function doesn't exist anywhere in the codebase. Both paths call the same `Database.get_sqla_engine()`, which resolves the acting user internally via `flask.g.user` — and `BaseStreamingCSVExportCommand.run()` already captures and restores `flask.g` (via `preserve_g_context`) before the streaming query executes, so impersonation context is intact. A green regression test pins this rather than a red one, since it doesn't reproduce.

### BEFORE/AFTER
Before: a configured `SQL_QUERY_MUTATOR` silently never applied to streamed CSV exports.
After: it applies the same as every other execution path.

### TESTING INSTRUCTIONS
```
.venv/bin/python -m pytest tests/unit_tests/commands/sql_lab/streaming_export_command_test.py tests/unit_tests/commands/chart/streaming_export_command_test.py -q
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #40465
- [x] Required feature flags: N/A
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Confirm DB Migration upgrade and downgrade tested
- [ ] Introduces new feature or API
- [ ] Removes existing feature
