### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Understanding the Superset Points of View
 
 - Deploying Superset
 
+  - [Managed Superset on Zenith](https://zenith.hosting/host/apache-superset) - one-click hosting with storage, backups and a free subdomain included
   - [Official Docker image](https://hub.docker.com/r/apache/superset)
   - [Helm Chart](https://github.com/apache/superset/tree/master/helm/superset)
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Superset to our marketplace, so this PR adds a line under Deploying Superset (links to https://zenith.hosting/host/apache-superset).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

### SUMMARY

one line added to the `- Deploying Superset` list in the readme. nothing existing edited or moved.

### TESTING INSTRUCTIONS

readme only, nothing to run. view the rendered readme and click the link.

### ADDITIONAL INFORMATION

happy to reword it, move it below the docker and helm entries, or close this if you'd rather not list managed hosts.
