### PR TITLE
fix(plugin-chart-echarts): exclude series limit metric from stacked total

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -318,6 +318,9 @@ export default function transformProps(
       rebaseToPercentChange(forecastRebasedData, xAxisLabel || DTTM_ALIAS)
     : forecastRebasedData;
   const isHorizontal = orientation === OrientationType.Horizontal;
+  const extraMetricLabels = extractExtraMetrics(chartProps.rawFormData).map(
+    getMetricLabel,
+  );
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,
     {
@@ -325,10 +328,8 @@ export default function transformProps(
       percentageThreshold,
       xAxisCol: xAxisLabel,
       legendState,
+      extraMetricLabels,
     },
-  );
-  const extraMetricLabels = extractExtraMetrics(chartProps.rawFormData).map(
-    getMetricLabel,
   );
 
   const isMultiSeries = groupBy.length || metrics?.length > 1;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -387,6 +387,7 @@ export function extractDataTotalValues(
     percentageThreshold: number;
     xAxisCol: string;
     legendState?: LegendState;
+    extraMetricLabels?: string[];
   },
 ): {
   totalStackedValues: number[];
@@ -394,11 +395,20 @@ export function extractDataTotalValues(
 } {
   const totalStackedValues: number[] = [];
   const thresholdValues: number[] = [];
-  const { stack, percentageThreshold, xAxisCol, legendState } = opts;
+  const {
+    stack,
+    percentageThreshold,
+    xAxisCol,
+    legendState,
+    extraMetricLabels,
+  } = opts;
+  // Metrics that are only part of the query for sorting/limiting purposes are
+  // not rendered as series, so they must not contribute to the stacked total.
+  const excludedKeys = new Set([xAxisCol, ...(extraMetricLabels ?? [])]);
   if (stack) {
     data.forEach(datum => {
       const values = Object.keys(datum).reduce((prev, curr) => {
-        if (curr === xAxisCol) {
+        if (excludedKeys.has(curr)) {
           return prev;
         }
         if (legendState && !legendState[curr]) {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -28,6 +28,7 @@ import { GenericDataType } from '@apache-superset/core/common';
 import {
   calculateLowerLogTick,
   dedupSeries,
+  extractDataTotalValues,
   extractGroupbyLabel,
   extractSeries,
   extractShowValueIndexes,
@@ -700,6 +701,60 @@ describe('extractGroupbyLabel', () => {
       }),
     ).toEqual('');
     expect(extractGroupbyLabel({})).toEqual('');
+  });
+});
+
+describe('extractDataTotalValues', () => {
+  const data = [
+    { __timestamp: '2000-01-01', A: 32, B: 0, Sort: 2 },
+    { __timestamp: '2000-02-01', A: 10, B: 5, Sort: 3 },
+  ];
+
+  test('should sum every non x-axis column when no extra metrics are given', () => {
+    expect(
+      extractDataTotalValues(data, {
+        stack: true,
+        percentageThreshold: 0,
+        xAxisCol: '__timestamp',
+      }).totalStackedValues,
+    ).toEqual([34, 18]);
+  });
+
+  test('should exclude extra (series limit) metrics from the stacked total', () => {
+    expect(
+      extractDataTotalValues(data, {
+        stack: true,
+        percentageThreshold: 0,
+        xAxisCol: '__timestamp',
+        extraMetricLabels: ['Sort'],
+      }).totalStackedValues,
+    ).toEqual([32, 15]);
+  });
+
+  test('should exclude extra metrics and legend-disabled series', () => {
+    const { totalStackedValues, thresholdValues } = extractDataTotalValues(
+      data,
+      {
+        stack: true,
+        percentageThreshold: 50,
+        xAxisCol: '__timestamp',
+        legendState: { A: true, B: false },
+        extraMetricLabels: ['Sort'],
+      },
+    );
+    expect(totalStackedValues).toEqual([32, 10]);
+    expect(thresholdValues).toEqual([16, 5]);
+  });
+
+  test('should return empty arrays when not stacked', () => {
+    expect(
+      extractDataTotalValues(data, {
+        stack: false,
+        percentageThreshold: 0,
+        xAxisCol: '__timestamp',
+        extraMetricLabels: ['Sort'],
+      }),
+    ).toEqual({ totalStackedValues: [], thresholdValues: [] });
   });
 });
 


### PR DESCRIPTION
### SUMMARY
On a stacked Timeseries Bar/Area chart with "Show Total"/"Only Total" enabled, `extractDataTotalValues` (`plugins/plugin-chart-echarts/src/utils/series.ts`) summed every non x-axis column of each data row into the stacked total. This included the `timeseries_limit_metric` ("Sort by" metric), which is added to the query purely for sorting/limiting the x-axis and is correctly excluded from the rendered series/legend by `extractSeries` via `extraMetricLabels`. Since that column never appears as a legend entry, `legendState` could not exclude it either, so its value silently leaked into the displayed total.

This threads `extraMetricLabels` (already computed in `Timeseries/transformProps.ts` for `extractSeries`) into `extractDataTotalValues` and excludes those keys the same way the x-axis column is excluded.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (data-only bug, see reproduction in linked issue)

### TESTING INSTRUCTIONS
1. Create an `echarts_timeseries_bar` chart with 2 metrics `A`, `B`, Stacked, "Only Total" enabled.
2. Set `timeseries_limit_metric` ("Sort Series By") to a metric not among the displayed metrics, e.g. `MIN(some_sequence_column)`.
3. Before the fix, the "Only Total" label includes the sort metric's value (e.g. `32 + 0 + 2 = 34`) instead of the correct sum of only the displayed metrics (`32 + 0 = 32`).
4. Added unit tests in `plugins/plugin-chart-echarts/test/utils/series.test.ts` covering `extractDataTotalValues` with and without `extraMetricLabels`, combined with `legendState` and non-stacked mode.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #42701
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API