### PR TITLE
fix(sqllab): wrap process_template() in QueryEstimationCommand to prevent raw UndefinedError leak

### DIFF
--- a/superset/commands/sql_lab/estimate.py
+++ b/superset/commands/sql_lab/estimate.py
@@ -21,6 +21,7 @@ from typing import Any, TypedDict
 
 from flask import current_app as app
 from flask_babel import gettext as __
+from jinja2.exceptions import TemplateError
 
 from superset import db, is_feature_enabled, security_manager
 from superset.commands.base import BaseCommand
@@ -150,7 +151,17 @@ class QueryEstimationCommand(BaseCommand):
         sql = self._sql
         if self._template_params:
             template_processor = get_template_processor(self._database)
-            sql = template_processor.process_template(sql, **self._template_params)
+            try:
+                sql = template_processor.process_template(sql, **self._template_params)
+            except TemplateError as ex:
+                raise SupersetErrorException(
+                    SupersetError(
+                        message=str(ex),
+                        error_type=SupersetErrorType.GENERIC_COMMAND_ERROR,
+                        level=ErrorLevel.ERROR,
+                    ),
+                    status=400,
+                ) from ex
 
         # Apply the same SQL security controls used by the execution path
         # (sql_lab.execute_sql_statements) so cost estimation cannot be used to

--- a/tests/unit_tests/commands/sql_lab/test_estimate.py
+++ b/tests/unit_tests/commands/sql_lab/test_estimate.py
@@ -377,3 +377,41 @@ def test_apply_sql_security_propagates_engine_schema_gate(
 
     # RLS injection must not happen once the schema gate has rejected the query.
     mock_apply_rls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# process_template() error handling: raw jinja2 errors must not leak from run()
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.estimate.get_template_processor")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.db")
+def test_run_wraps_raw_jinja_undefined_error(
+    mock_db: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_template_processor: MagicMock,
+) -> None:
+    """A raw jinja2 ``UndefinedError`` from ``process_template()`` (the
+    bare-raise fallback in ``BaseTemplateProcessor.process_template`` for
+    undefined attribute/subscript access, e.g. ``{{ foo.bar }}``) must not
+    leak past ``run()`` -- it should surface as a typed
+    ``SupersetErrorException``, matching the ``ExecuteSqlCommand`` sibling's
+    broad-catch pattern in ``commands/sql_lab/execute.py``."""
+    from jinja2.exceptions import UndefinedError
+
+    mock_database = MagicMock()
+    mock_db.session.query.return_value.get.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    mock_get_template_processor.return_value.process_template.side_effect = (
+        UndefinedError("'foo' is undefined")
+    )
+
+    command = QueryEstimationCommand(
+        _make_params(sql="SELECT {{ foo.bar }}", template_params={"x": 1})
+    )
+    with pytest.raises(SupersetErrorException) as exc_info:
+        command.run()
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_COMMAND_ERROR


### PR DESCRIPTION
### SUMMARY
`QueryEstimationCommand.run()` (`superset/commands/sql_lab/estimate.py`, the command behind SQL Lab's "estimate query cost" feature) calls `template_processor.process_template()` with no try/except around it. `process_template()` (`superset/jinja_context.py`) normally converts Jinja errors into typed Superset exceptions (`SupersetSyntaxErrorException`, `SupersetTemplateException`, `UndefinedTemplateFunctionException`) — but it has one bare-`raise` fallback for `jinja2.exceptions.UndefinedError` when an undefined template variable is accessed via attribute/subscript (e.g. `{{ foo.bar }}`) rather than called as a function. That raw exception propagates past `estimate.py`'s unguarded call site, past the API layer (`superset/sqllab/api.py::estimate_query_cost`, `/api/v1/sqllab/estimate/`), which also has no try/except around `command.run()`, and lands on Flask's global catch-all handler — an opaque 500 instead of a typed 4xx, for what's just a malformed Jinja template typed into the SQL Lab editor.

The sibling command in the same package, `ExecuteSqlCommand.run()` (`superset/commands/sql_lab/execute.py`), already guards against this class of leak by wrapping its whole body and converting any non-Superset exception into a typed one. `estimate.py` had no equivalent guard for this call site.

Same bug class as apache/superset#42366, #42401, #42426, #42442, #42714 — a prior daily-cleanup pipeline that's been converting these raw-exception leaks into properly typed/statused Superset exceptions across the codebase.

### FIX
Wraps only the `process_template()` call in `except TemplateError` (jinja2's own base exception, not Superset's), converting the leak into `SupersetErrorException(status=400)`. This is additive-only: `SupersetSyntaxErrorException`/`SupersetTemplateException` are Superset's own exception hierarchy, not `TemplateError` subclasses, so their existing (already-correct) propagation paths are untouched.

### TESTING INSTRUCTIONS
- New regression test `test_run_wraps_raw_jinja_undefined_error` in `tests/unit_tests/commands/sql_lab/test_estimate.py`: mocks `get_template_processor().process_template` to raise a raw `jinja2.exceptions.UndefinedError`, calls `QueryEstimationCommand.run()`, asserts a `SupersetErrorException` with `status == 400` is raised instead.
- Confirmed the test fails on pre-fix code (raw `UndefinedError` propagates uncaught) and passes post-fix.
- Manual repro: in SQL Lab, estimate the cost of a query with a template like `SELECT {{ foo.bar }}` where `foo` is not defined in the Jinja context — pre-fix this 500s with a generic error; post-fix it returns a 400 with the Jinja error message.
- `ruff check` / `ruff format --check` clean on both changed files (pinned 0.9.7 via `uvx`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Tradeoffs**: additive-only — no existing failure-mode semantics change. The one previously-uncaught path (raw `UndefinedError` for undefined attribute/subscript access in an estimate-time template) now returns a typed 400 instead of an opaque 500; no other paths are touched.

**Correction for accuracy**: the `except TemplateError` clause is slightly broader than the illustrative example above suggests. `SparkTemplateProcessor`/`TrinoTemplateProcessor` (`jinja_context.py`) override `process_template()` entirely with no internal try/except of their own, so for those two engines *any* `TemplateError` (not just the attribute/subscript `UndefinedError` case) was previously leaking raw and is now also caught and converted to a typed 400. This is strictly the same failure mode at the same call site (raw 500-leak → typed 400), just triggered by more `TemplateError` subtypes/engines than the one example covers — not a new or different behavior change.

