### PR TITLE
fix(native-filters): allow X-clear on defaultToFirstItem filters with required warning

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -65,7 +65,9 @@ const FilterControl = ({
     isFilterInScope(filter) &&
     checkIsMissingRequiredValue(filter, filter.dataMask?.filterState);
   const validateStatus = isMissingRequiredValue ? 'error' : undefined;
-  const isRequired = !!filter.controlValues?.enableEmptyFilter;
+  const isRequired =
+    !!filter.controlValues?.enableEmptyFilter ||
+    !!filter.controlValues?.defaultToFirstItem;
   const inverseSelection = !!filter.controlValues?.inverseSelection;
 
   const {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -48,7 +48,9 @@ export const checkIsMissingRequiredValue = (
   filter: FilterElement,
   filterState?: FilterState,
 ) => {
-  const isRequired = !!filter.controlValues?.enableEmptyFilter;
+  const isRequired =
+    !!filter.controlValues?.enableEmptyFilter ||
+    !!filter.controlValues?.defaultToFirstItem;
 
   if (!isRequired) return false;
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -158,6 +158,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   const [initialColtypeMap] = useState(coltypeMap);
   const [search, setSearch] = useState('');
   const prevDataRef = useRef(data);
+  const userClearedRef = useRef(false);
   const [dataMask, dispatchDataMask] = useImmerReducer(reducer, {
     extraFormData: {},
     filterState,
@@ -289,8 +290,10 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       const values = value === null ? [null] : ensureIsArray(value);
 
       if (values.length === 0) {
+        userClearedRef.current = true;
         updateDataMask(null);
       } else {
+        userClearedRef.current = false;
         updateDataMask(values);
       }
     },
@@ -380,6 +383,12 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       return;
     }
 
+    // Reset userClearedRef when clearAllTrigger fires so auto-select
+    // can re-apply if the filter is re-initialised after a global clear
+    if (clearAllTrigger) {
+      userClearedRef.current = false;
+    }
+
     if (filterState.value !== undefined) {
       // Set the filter state value if it is defined
       updateDataMask(filterState.value);
@@ -390,7 +399,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     // Skip default values when clearAllTrigger is active to prevent
     // defaults from being applied during Clear All operation
     if (!clearAllTrigger) {
-      if (defaultToFirstItem) {
+      if (defaultToFirstItem && !userClearedRef.current) {
         // Set to first item if defaultToFirstItem is true
         const firstItem: SelectValue = data[0]
           ? (groupby.map(col => data[0][col]) as string[])
@@ -451,6 +460,7 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     if (
       !clearAllTrigger &&
       defaultToFirstItem &&
+      !userClearedRef.current &&
       Object.keys(formData?.extraFormData || {}).length &&
       filterState.value !== undefined &&
       firstItem !== null &&


### PR DESCRIPTION
### SUMMARY
When "Select first filter value by default" is enabled, the filter value can now be cleared via the X button. Clearing shows the same red required-style validation warning as "Filter value is required", rather than silently re-auto-selecting the first item.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
