### PR TITLE
fix(embedded): resolve guest user permissions (backports #39197)

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -968,6 +968,23 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             .join(self.role_model)
         )
 
+        # Guest users (embedded dashboards) have is_anonymous=False but no
+        # database identity, so querying by user_id returns nothing. Instead,
+        # resolve permissions directly from the roles attached to the guest
+        # token (typically the Public role).
+        if self.is_guest_user():
+            role_ids = [
+                role.id for role in g.user.roles if role and role.id is not None
+            ]
+            if not role_ids:
+                return set()
+            view_menu_names = (
+                base_query.filter(self.role_model.id.in_(role_ids)).filter(
+                    self.permission_model.name == permission_name
+                )
+            ).all()
+            return {s.name for s in view_menu_names}
+
         if not g.user.is_anonymous:
             user_id = get_user_id()
 

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1547,3 +1547,75 @@ def test_validate_child_in_parent_multilayer_null_params(
     assert not sm._validate_child_in_parent_multilayer(
         child_slice_id=1, parent_slice=parent_slice
     )
+
+
+def test_user_view_menu_names_for_guest_user(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that user_view_menu_names resolves permissions from the guest
+    user's roles instead of querying by user_id (which is None for guests).
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    mock_role = mocker.MagicMock(spec=Role)
+    mock_role.id = 99
+
+    mock_guest = mocker.MagicMock()
+    mock_guest.is_anonymous = False
+    mock_guest.roles = [mock_role]
+
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
+    mocker.patch.object(sm, "is_guest_user", return_value=True)
+    # The regression: guest path must NEVER fall through to get_user_id().
+    # Patching it as an error means an accidental fall-through fails loudly.
+    mock_get_user_id = mocker.patch(
+        "superset.security.manager.get_user_id",
+        side_effect=AssertionError("get_user_id must not be called for guest users"),
+    )
+
+    mock_result = [SimpleNamespace(name="[PostgreSQL].[my_table](id:1)")]
+    mock_query = mocker.MagicMock()
+    mock_query.join.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.all.return_value = mock_result
+    mocker.patch.object(sm.session, "query", return_value=mock_query)
+
+    result = sm.user_view_menu_names("datasource_access")
+
+    assert result == {"[PostgreSQL].[my_table](id:1)"}
+    mock_get_user_id.assert_not_called()
+    mock_query.filter.assert_called()
+
+
+def test_user_view_menu_names_for_guest_user_no_roles(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    Test that user_view_menu_names returns empty set when guest user has
+    no roles with valid IDs.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+
+    mock_role = mocker.MagicMock(spec=Role)
+    mock_role.id = None
+
+    mock_guest = mocker.MagicMock()
+    mock_guest.is_anonymous = False
+    mock_guest.roles = [mock_role]
+
+    mock_g = SimpleNamespace(user=mock_guest)
+    mocker.patch("superset.security.manager.g", new=mock_g)
+    mocker.patch.object(sm, "is_guest_user", return_value=True)
+    mock_get_user_id = mocker.patch(
+        "superset.security.manager.get_user_id",
+        side_effect=AssertionError("get_user_id must not be called for guest users"),
+    )
+
+    result = sm.user_view_menu_names("datasource_access")
+
+    assert result == set()
+    mock_get_user_id.assert_not_called()


### PR DESCRIPTION
### SUMMARY

Backports #39197 to `6.2`. Cherry-picked from `041ecbc248` with no adaptation, diff is identical to the original commit.

See #39197 for the rationale.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no UI change.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/security/manager_test.py
```

41 pass, including the 2 tests the original commit adds (`pytest ... -k user_view_menu_names`).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `EMBEDDED_SUPERSET`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
