### PR TITLE
fix(sqllab): render the template before estimating a query's cost

### DIFF
--- a/superset/commands/sql_lab/estimate.py
+++ b/superset/commands/sql_lab/estimate.py
@@ -31,6 +31,7 @@ from superset.exceptions import (
     SupersetDisallowedSQLTableException,
     SupersetDMLNotAllowedException,
     SupersetErrorException,
+    SupersetTemplatedQueryNotEstimableException,
     SupersetTimeoutException,
 )
 from superset.jinja_context import get_template_processor
@@ -148,9 +149,20 @@ class QueryEstimationCommand(BaseCommand):
     ) -> list[dict[str, Any]]:
         self.validate()
 
+        template_processor = get_template_processor(self._database)
+        # A templated query has no single execution plan: it expands using
+        # values only available at run time (a dashboard's time range, the
+        # current user, a URL parameter), and different expansions can produce
+        # different plans. Estimating one of them -- here, the emptiest one,
+        # with no such context to expand from -- would report the plan of a
+        # different query than the one that runs. Refusing before the SQL
+        # reaches `SQLScript` also replaces the parse error the raw `{%` would
+        # otherwise trigger, which reads as a typo in a valid query.
+        if template_processor.has_template(self._sql):
+            raise SupersetTemplatedQueryNotEstimableException()
+
         sql = self._sql
         if self._template_params:
-            template_processor = get_template_processor(self._database)
             try:
                 sql = template_processor.process_template(sql, **self._template_params)
             except TemplateError as ex:

--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -494,6 +494,26 @@ class SupersetDMLNotAllowedException(SupersetErrorException):
         super().__init__(error)
 
 
+class SupersetTemplatedQueryNotEstimableException(SupersetErrorException):
+    """
+    Cost estimation requested for a query that still contains a template
+    """
+
+    status = 400
+
+    def __init__(self) -> None:
+        error = SupersetError(
+            message=_(
+                "The cost of a query using Jinja templating cannot be estimated, "
+                "because the template is only expanded when the query runs. "
+                "Replace the template with literal values to estimate one case."
+            ),
+            error_type=SupersetErrorType.GENERIC_COMMAND_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+        super().__init__(error)
+
+
 class SupersetInvalidCTASException(SupersetErrorException):
     def __init__(self) -> None:
         error = SupersetError(

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -797,6 +797,28 @@ class BaseTemplateProcessor:
         """
         return self._context.copy()
 
+    def has_template(self, sql: str) -> bool:
+        """Whether the SQL contains anything for ``process_template`` to expand
+
+        Lexed rather than parsed, so that a comment -- which leaves no trace in
+        a parsed template -- still counts, and using this processor's own
+        environment, so that any customized delimiters are honored. Lexing
+        evaluates nothing.
+
+        >>> has_template("SELECT '{{ current_username() }}'")
+        True
+        >>> has_template("SELECT '{{1,2},{3,4}}'::int[]")
+        False
+        """
+        try:
+            kinds = {kind for _, kind, _ in self.env.lex(sql)}
+        except TemplateSyntaxError:
+            # Jinja does not recognize this as one of its own constructs, so
+            # there is nothing here it would expand.
+            return False
+
+        return kinds > {"data"}
+
     def process_template(self, sql: str, **kwargs: Any) -> str:
         """Processes a sql template
 
@@ -931,6 +953,12 @@ class JinjaTemplateProcessor(BaseTemplateProcessor):
 
 
 class NoOpTemplateProcessor(BaseTemplateProcessor):
+    def has_template(self, sql: str) -> bool:
+        """
+        Nothing is ever expanded, so there is never a template
+        """
+        return False
+
     def process_template(self, sql: str, **kwargs: Any) -> str:
         """
         Makes processing a template a noop

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -807,17 +807,25 @@ class BaseTemplateProcessor:
 
         >>> has_template("SELECT '{{ current_username() }}'")
         True
+        >>> has_template("{{ dataset(1) }}")
+        True
         >>> has_template("SELECT '{{1,2},{3,4}}'::int[]")
         False
         """
         try:
+            # The whole stream is consumed before deciding, rather than stopping
+            # at the first non-`data` token: `'{{1,2},{3,4}}'` opens like a
+            # template and only turns out not to be one further along, where the
+            # lexer gives up.
             kinds = {kind for _, kind, _ in self.env.lex(sql)}
         except TemplateSyntaxError:
             # Jinja does not recognize this as one of its own constructs, so
             # there is nothing here it would expand.
             return False
 
-        return kinds > {"data"}
+        # SQL that is nothing but a template produces no `data` token at all, so
+        # this asks for any other kind rather than for `data` plus another.
+        return bool(kinds - {"data"})
 
     def process_template(self, sql: str, **kwargs: Any) -> str:
         """Processes a sql template

--- a/tests/unit_tests/commands/sql_lab/test_estimate.py
+++ b/tests/unit_tests/commands/sql_lab/test_estimate.py
@@ -26,7 +26,11 @@ from superset.commands.sql_lab.estimate import (
     QueryEstimationCommand,
 )
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetErrorException, SupersetSecurityException
+from superset.exceptions import (
+    SupersetErrorException,
+    SupersetSecurityException,
+    SupersetTemplatedQueryNotEstimableException,
+)
 
 
 def _make_params(**kwargs: object) -> EstimateQueryCostType:
@@ -397,21 +401,128 @@ def test_run_wraps_raw_jinja_undefined_error(
     undefined attribute/subscript access, e.g. ``{{ foo.bar }}``) must not
     leak past ``run()`` -- it should surface as a typed
     ``SupersetErrorException``, matching the ``ExecuteSqlCommand`` sibling's
-    broad-catch pattern in ``commands/sql_lab/execute.py``."""
+    broad-catch pattern in ``commands/sql_lab/execute.py``.
+
+    ``has_template`` is stubbed to False so that the templating gate lets the
+    SQL through and this test covers the wrapping alone. The gate reaches
+    ``process_template()`` for SQL that Jinja cannot lex, where ``from_string``
+    then raises for itself.
+    """
     from jinja2.exceptions import UndefinedError
 
     mock_database = MagicMock()
     mock_db.session.query.return_value.get.return_value = mock_database
     mock_security_manager.raise_for_access.return_value = None
+    mock_get_template_processor.return_value.has_template.return_value = False
     mock_get_template_processor.return_value.process_template.side_effect = (
         UndefinedError("'foo' is undefined")
     )
 
     command = QueryEstimationCommand(
-        _make_params(sql="SELECT {{ foo.bar }}", template_params={"x": 1})
+        _make_params(sql="SELECT 1", template_params={"x": 1})
     )
     with pytest.raises(SupersetErrorException) as exc_info:
         command.run()
 
+    mock_get_template_processor.return_value.process_template.assert_called_once()
     assert exc_info.value.status == 400
     assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_COMMAND_ERROR
+
+
+# ---------------------------------------------------------------------------
+# A templated query is refused rather than estimated for one expansion of it
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.estimate.app")
+@patch("superset.commands.sql_lab.estimate.get_template_processor")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.db")
+def test_run_refuses_a_templated_query(
+    mock_db: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_template_processor: MagicMock,
+    mock_app: MagicMock,
+) -> None:
+    """A query the template processor reports as templated is refused, and the
+    engine is never asked for a cost.
+
+    The refusal is not a syntax error: leaving the raw ``{%`` to ``SQLScript``
+    reports a parse failure, which reads as a typo in a query that is valid.
+    """
+    mock_app.config = {"DISALLOWED_SQL_FUNCTIONS": {}, "DISALLOWED_SQL_TABLES": {}}
+    mock_database = MagicMock()
+    mock_db.session.query.return_value.get.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    mock_get_template_processor.return_value.has_template.return_value = True
+
+    command = QueryEstimationCommand(_make_params(sql="{% set a = 1 %}SELECT {{ a }}"))
+    with pytest.raises(SupersetTemplatedQueryNotEstimableException) as exc_info:
+        command.run()
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.error.error_type != SupersetErrorType.SYNTAX_ERROR
+    mock_database.db_engine_spec.estimate_query_cost.assert_not_called()
+
+
+@patch("superset.commands.sql_lab.estimate.app")
+@patch("superset.commands.sql_lab.estimate.get_template_processor")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.db")
+def test_run_refuses_a_templated_query_with_template_params(
+    mock_db: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_template_processor: MagicMock,
+    mock_app: MagicMock,
+) -> None:
+    """Supplying ``template_params`` does not pin down a context function such
+    as ``get_time_filter()``, so it does not make the estimate representative
+    and the query is refused all the same."""
+    mock_app.config = {"DISALLOWED_SQL_FUNCTIONS": {}, "DISALLOWED_SQL_TABLES": {}}
+    mock_db.session.query.return_value.get.return_value = MagicMock()
+    mock_security_manager.raise_for_access.return_value = None
+    mock_get_template_processor.return_value.has_template.return_value = True
+
+    command = QueryEstimationCommand(
+        _make_params(
+            sql="SELECT {{ get_time_filter('ds') }}",
+            template_params={"unrelated": 1},
+        )
+    )
+    with pytest.raises(SupersetTemplatedQueryNotEstimableException):
+        command.run()
+
+    mock_get_template_processor.return_value.process_template.assert_not_called()
+
+
+@patch("superset.commands.sql_lab.estimate.app")
+@patch("superset.commands.sql_lab.estimate.get_template_processor")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.db")
+def test_run_estimates_an_untemplated_query(
+    mock_db: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_template_processor: MagicMock,
+    mock_app: MagicMock,
+) -> None:
+    """SQL with no template still reaches the engine unchanged."""
+    mock_app.config = {
+        "DISALLOWED_SQL_FUNCTIONS": {},
+        "DISALLOWED_SQL_TABLES": {},
+        "SQLLAB_QUERY_COST_ESTIMATE_TIMEOUT": 10,
+        "QUERY_COST_FORMATTERS_BY_ENGINE": {},
+    }
+    mock_database = MagicMock()
+    mock_database.db_engine_spec.engine = "postgresql"
+    mock_database.allow_dml = False
+    mock_database.db_engine_spec.query_cost_formatter.return_value = [{"Cost": "1"}]
+    mock_db.session.query.return_value.get.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    mock_get_template_processor.return_value.has_template.return_value = False
+
+    command = QueryEstimationCommand(_make_params(sql="SELECT 1"))
+
+    assert command.run() == [{"Cost": "1"}]
+    assert (
+        mock_database.db_engine_spec.estimate_query_cost.call_args.args[3] == "SELECT 1"
+    )

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -2151,6 +2151,8 @@ def test_get_rendered_sql_filter_values_index_error_on_empty_list() -> None:
         # A comment leaves no trace in a parsed template, but still has to be
         # expanded away before the SQL is SQL.
         pytest.param("SELECT 1 {# a comment #}", True, id="comment"),
+        # A whole query that is one macro lexes without a `data` token at all.
+        pytest.param("{{ dataset(1) }}", True, id="template_only"),
         # Merely containing braces is not templating: Jinja cannot lex either of
         # these, so there is nothing here it would expand.
         pytest.param("SELECT '{{1,2},{3,4}}'::int[]", False, id="postgres_array"),

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -2140,3 +2140,43 @@ def test_get_rendered_sql_filter_values_index_error_on_empty_list() -> None:
         match=r"Virtual dataset template error: list object has no element 0",
     ):
         table.get_rendered_sql(processor)
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        pytest.param("SELECT 1", False, id="plain"),
+        pytest.param("SELECT '{{ current_username() }}'", True, id="expression"),
+        pytest.param("{% set a = 1 %}SELECT {{ a }}", True, id="statement"),
+        # A comment leaves no trace in a parsed template, but still has to be
+        # expanded away before the SQL is SQL.
+        pytest.param("SELECT 1 {# a comment #}", True, id="comment"),
+        # Merely containing braces is not templating: Jinja cannot lex either of
+        # these, so there is nothing here it would expand.
+        pytest.param("SELECT '{{1,2},{3,4}}'::int[]", False, id="postgres_array"),
+        pytest.param("""SELECT '{"a": 1}'::json""", False, id="json_literal"),
+    ],
+)
+def test_has_template(sql: str, expected: bool) -> None:
+    """
+    Test the ``has_template`` method.
+    """
+    database = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
+    processor = get_template_processor(database=database)
+
+    assert processor.has_template(sql) is expected
+
+
+@with_feature_flags(ENABLE_TEMPLATE_PROCESSING=False)
+def test_has_template_when_processing_is_disabled() -> None:
+    """
+    Test that ``has_template`` reports no template when nothing is expanded.
+
+    With ``ENABLE_TEMPLATE_PROCESSING`` off, ``get_template_processor`` returns
+    a ``NoOpTemplateProcessor``: the braces are never expanded, so they are not
+    a template, they are just part of the SQL.
+    """
+    database = Database(id=1, database_name="my_database", sqlalchemy_uri="sqlite://")
+    processor = get_template_processor(database=database)
+
+    assert processor.has_template("SELECT '{{ current_username() }}'") is False


### PR DESCRIPTION
### SUMMARY

Four places in this codebase render Jinja before handing SQL onward. Three of them render unconditionally:

- `SqlQueryRenderImpl.render`, on the SQL Lab execution path
- `validate_sql`
- `process_jinja_sql`, as called from `QueryEstimationCommand.validate()` — this command's own authorization step

The fourth, `QueryEstimationCommand.run()`, gated it on `template_params` being non-empty. This removes that gate, so the four agree.

The gate mattered because a query needs no declared parameter to need rendering: `get_time_filter()`, `current_username()` and `url_param()` take none, and SQL Lab posts an empty `template_params` for an estimate. Such a query skipped rendering entirely, the raw `{%` reached `SQLScript()`, and the estimate failed with `Error parsing near '{%'` — surfaced as **Issue 1003, "perhaps there was a misspelling or a typo"** — for SQL that runs fine when you press Run. A query whose parameters are all supplied renders and estimates exactly as before. It also lets a custom template processor expand its own syntax here, which the gate skipped whenever `template_params` was empty.

**Scope.** This is a narrow path: it needs `ESTIMATE_QUERY_COST` and `ENABLE_TEMPLATE_PROCESSING` (both default off), plus `cost_estimate_enabled` in the database's `extra`, on one of the engines that implements cost estimation. So this is a consistency fix rather than a widely-hit bug — and the blast radius is equally narrow.

#### The error message, added in review

An unprovided parameter is the one thing that survives rendering: `DebugUndefined` leaves it in place rather than raising, and in some positions the leftover then fails to parse (`SELECT * FROM {{ tbl }}`). That error keeps its type and its `sql`/`line`/`column` payload, but names the cause instead of implying a typo — the same shape as the `TemplateError` conversion above it in `run()`, and as the `JSONDecodeError` conversion added in #43888 below it.

Telling the two cases apart goes through a new `BaseTemplateProcessor.has_template()`. It lexes with the processor's own environment, so customized delimiters are honored, and it counts only *closed* constructs — an array literal such as `'{{1,2},{3,4}}'` opens like a template and is abandoned unterminated, so it is not mistaken for one. A processor whose `process_template` expands a syntax of its own answers for that syntax too; `CustomPrestoTemplateProcessor` and its `$DATE(...)` is the in-repo example, and gets the override. Detection getting it wrong only costs the better wording, since the parse error is raised either way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not a UI change — the same modal, with different text in it. Estimating

```sql
SELECT 1 AS n
{% set tf = get_time_filter(strftime="%Y-%m-%d") %}
{% if tf.from_expr %} WHERE 1 = 1 {% endif %}
```

reported `Error parsing near '{%' at line 2:2` before, and returns a cost estimate after.

### TESTING INSTRUCTIONS

1. Enable `ESTIMATE_QUERY_COST` and `ENABLE_TEMPLATE_PROCESSING` in `FEATURE_FLAGS`.
2. Add `"cost_estimate_enabled": true` to a Postgres database's `extra`.
3. In SQL Lab against that database, run the query above — it succeeds.
4. Click **Estimate cost**. Before this change: `Error parsing near '{%' at line 2:2`. After: a cost estimate.
5. `SELECT '{{ ds }}'` with `{"ds": "2026-08-20"}` in the query's parameters still estimates, as before.
6. `SELECT * FROM {{ tbl }}` with no parameters names the missing parameter instead of reporting a typo.
7. Plain SQL, and SQL that merely looks templated (`SELECT '{{1,2},{3,4}}'::int[]`), are unaffected.

Unit tests: `pytest tests/unit_tests/commands/sql_lab/test_estimate.py tests/unit_tests/jinja_context_test.py`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
