### PR TITLE
fix(dashboard): batch virtualized chart force-render for large-dashboard export

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row/Row.test.tsx
@@ -18,6 +18,7 @@
  */
 import React from 'react';
 import {
+  act,
   fireEvent,
   render,
   RenderResult,
@@ -25,6 +26,10 @@ import {
 } from 'spec/helpers/testing-library';
 
 import { DASHBOARD_GRID_ID } from 'src/dashboard/util/constants';
+import {
+  FORCE_IN_VIEW_EVENT,
+  RESTORE_VIRTUALIZATION_EVENT,
+} from 'src/dashboard/constants';
 import { getMockStore } from 'spec/fixtures/mockStore';
 import { dashboardLayout as mockLayout } from 'spec/fixtures/mockDashboardLayout';
 import { initialState } from 'src/SqlLab/fixtures';
@@ -327,5 +332,59 @@ describe('visibility handling for intersection observers', () => {
     const nonIntersectingEntry = { isIntersecting: false };
     expect(() => callback([nonIntersectingEntry])).not.toThrow();
     expect(callback([nonIntersectingEntry])).toBe(false);
+  });
+
+  test('force-in-view event with no detail disconnects the observers for every row', () => {
+    setup({ isComponentVisible: true });
+
+    act(() => {
+      window.dispatchEvent(new Event(FORCE_IN_VIEW_EVENT));
+    });
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  test('force-in-view event scoped to other rowIds does not disconnect this row', () => {
+    setup({ isComponentVisible: true });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(FORCE_IN_VIEW_EVENT, {
+          detail: { rowIds: ['SOME_OTHER_ROW_ID'] },
+        }),
+      );
+    });
+
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+
+  test('force-in-view event scoped to this rowId disconnects the observers', () => {
+    setup({ isComponentVisible: true });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(FORCE_IN_VIEW_EVENT, {
+          detail: { rowIds: [props.id] },
+        }),
+      );
+    });
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  test('restore-virtualization event re-observes after a force-in-view', () => {
+    setup({ isComponentVisible: true });
+    expect(mockObserve).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      window.dispatchEvent(new Event(FORCE_IN_VIEW_EVENT));
+    });
+    act(() => {
+      window.dispatchEvent(new Event(RESTORE_VIRTUALIZATION_EVENT));
+    });
+
+    // The initial mount observes twice (enabler + disabler); restoring
+    // after a force-in-view re-observes both again.
+    expect(mockObserve).toHaveBeenCalledTimes(4);
   });
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Row/Row.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Row/Row.tsx
@@ -216,7 +216,18 @@ const Row = memo((props: RowProps) => {
       // dispatches these events so off-screen rows render before the capture
       // and lazy loading is restored afterwards. Without this, virtualized
       // charts are exported as loading spinners.
-      const handleForceInView = () => {
+      //
+      // The force event optionally carries a `rowIds` batch in its detail so
+      // large dashboards can be force-rendered a few rows at a time instead
+      // of every row at once (see FORCE_RENDER_BATCH_SIZE in
+      // downloadUtils.ts). No detail means "force every row", preserving the
+      // original single-shot behavior for any other future caller.
+      const handleForceInView = (event: Event) => {
+        const rowIds = (event as CustomEvent<{ rowIds?: string[] }>).detail
+          ?.rowIds;
+        if (rowIds && !rowIds.includes(rowComponent.id as string)) {
+          return;
+        }
         observerEnabler?.disconnect();
         observerDisabler?.disconnect();
         setIsInView(true);
@@ -341,6 +352,7 @@ const Row = memo((props: RowProps) => {
             backgroundStyle.className,
           )}
           data-test={`grid-row-${backgroundStyle.className}`}
+          data-row-id={rowComponent.id}
           ref={containerRef}
           editMode={editMode}
         >

--- a/superset-frontend/src/utils/downloadUtils.test.ts
+++ b/superset-frontend/src/utils/downloadUtils.test.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 import { isFeatureEnabled } from '@superset-ui/core';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
+import {
+  addInfoToast,
+  addWarningToast,
+} from 'src/components/MessageToasts/actions';
 import {
   FORCE_IN_VIEW_EVENT,
   RESTORE_VIRTUALIZATION_EVENT,
@@ -37,7 +40,8 @@ jest.mock('src/dashboard/constants', () => ({
 }));
 
 jest.mock('@apache-superset/core/translation', () => ({
-  t: (str: string) => str,
+  t: (str: string, values?: Record<string, unknown>) =>
+    values ? `${str} ${JSON.stringify(values)}` : str,
 }));
 
 jest.mock('@apache-superset/core/utils', () => ({
@@ -45,10 +49,22 @@ jest.mock('@apache-superset/core/utils', () => ({
 }));
 
 jest.mock('src/components/MessageToasts/actions', () => ({
+  addInfoToast: jest.fn(),
   addWarningToast: jest.fn(),
 }));
 
 const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
+
+function makeRow(id: string, loading = false): HTMLDivElement {
+  const row = document.createElement('div');
+  row.setAttribute('data-row-id', id);
+  if (loading) {
+    const spinner = document.createElement('div');
+    spinner.className = 'loading';
+    row.appendChild(spinner);
+  }
+  return row;
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -106,6 +122,102 @@ test('forceLoadAllCharts warns when charts never finish loading before the timeo
   // Virtualization was active, so the caller must still restore it.
   expect(result).toBe(true);
   expect(addWarningToast).toHaveBeenCalledTimes(1);
+});
+
+test('forceLoadAllCharts dispatches a single force-in-view event when rows fit in one batch', async () => {
+  jest.useFakeTimers();
+  mockIsFeatureEnabled.mockReturnValue(true);
+  const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+  const container = document.createElement('div');
+  container.append(makeRow('a'), makeRow('b'), makeRow('c'));
+
+  const promise = forceLoadAllCharts(container);
+  await jest.advanceTimersByTimeAsync(2000);
+  const result = await promise;
+
+  expect(result).toBe(true);
+  expect(addInfoToast).not.toHaveBeenCalled();
+  const forceEvents = dispatchSpy.mock.calls
+    .map(([event]) => event as Event)
+    .filter(event => event.type === FORCE_IN_VIEW_EVENT);
+  expect(forceEvents).toHaveLength(1);
+  expect((forceEvents[0] as CustomEvent).detail).toBeUndefined();
+});
+
+test('forceLoadAllCharts batches rows in groups rather than forcing everything at once', async () => {
+  jest.useFakeTimers();
+  mockIsFeatureEnabled.mockReturnValue(true);
+  const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+  const container = document.createElement('div');
+  const rowIds = Array.from({ length: 12 }, (_, i) => `row-${i}`);
+  rowIds.forEach(id => container.appendChild(makeRow(id)));
+
+  const onProgress = jest.fn();
+  const promise = forceLoadAllCharts(container, onProgress);
+
+  // 3 sequential batch waits + the final whole-container check, ~1s each
+  // since nothing is ever `.loading`.
+  await jest.advanceTimersByTimeAsync(5000);
+  const result = await promise;
+
+  expect(result).toBe(true);
+  expect(addInfoToast).toHaveBeenCalledTimes(1);
+
+  const forceEvents = dispatchSpy.mock.calls
+    .map(([event]) => event as CustomEvent<{ rowIds: string[] }>)
+    .filter(event => event.type === FORCE_IN_VIEW_EVENT);
+
+  expect(forceEvents).toHaveLength(3);
+  expect(forceEvents[0].detail.rowIds).toEqual(rowIds.slice(0, 5));
+  expect(forceEvents[1].detail.rowIds).toEqual(rowIds.slice(5, 10));
+  expect(forceEvents[2].detail.rowIds).toEqual(rowIds.slice(10, 12));
+
+  expect(onProgress).toHaveBeenNthCalledWith(1, {
+    loadedBatches: 1,
+    totalBatches: 3,
+  });
+  expect(onProgress).toHaveBeenNthCalledWith(2, {
+    loadedBatches: 2,
+    totalBatches: 3,
+  });
+  expect(onProgress).toHaveBeenNthCalledWith(3, {
+    loadedBatches: 3,
+    totalBatches: 3,
+  });
+});
+
+test('forceLoadAllCharts moves on to the next batch even if the current one times out', async () => {
+  jest.useFakeTimers();
+  mockIsFeatureEnabled.mockReturnValue(true);
+  const container = document.createElement('div');
+  // Batch 1 (5 rows): one spinner is slow to clear.
+  const stuck = makeRow('stuck', true);
+  container.appendChild(stuck);
+  for (let i = 1; i < 5; i += 1) {
+    container.appendChild(makeRow(`row-${i}`));
+  }
+  // Batch 2 (1 row): loads fine.
+  container.appendChild(makeRow('row-5'));
+
+  const onProgress = jest.fn();
+  const promise = forceLoadAllCharts(container, onProgress);
+
+  // Batch 1 gives up waiting at the 10s per-batch cap since `stuck` hasn't
+  // cleared yet, but moves on to batch 2 (which has nothing loading and
+  // resolves on its own first poll) instead of blocking the whole export
+  // on one slow chart.
+  await jest.advanceTimersByTimeAsync(12_000);
+  expect(onProgress).toHaveBeenCalledTimes(2);
+
+  // The chart finishes just after its batch gave up on it. The final
+  // whole-container check (a safety net for exactly this) should pick that
+  // up on its next poll rather than needing its own full 60s timeout.
+  stuck.querySelector('.loading')?.remove();
+  await jest.advanceTimersByTimeAsync(1000);
+  const result = await promise;
+
+  expect(result).toBe(true);
+  expect(addWarningToast).not.toHaveBeenCalled();
 });
 
 test('restoreVirtualization dispatches the restore event', () => {

--- a/superset-frontend/src/utils/downloadUtils.test.ts
+++ b/superset-frontend/src/utils/downloadUtils.test.ts
@@ -220,6 +220,27 @@ test('forceLoadAllCharts moves on to the next batch even if the current one time
   expect(addWarningToast).not.toHaveBeenCalled();
 });
 
+test('forceLoadAllCharts caps the total wait across batches to the overall deadline', async () => {
+  jest.useFakeTimers();
+  mockIsFeatureEnabled.mockReturnValue(true);
+  const container = document.createElement('div');
+  // 8 batches of 5 rows, every row permanently `.loading`: with no overall
+  // deadline this would burn a full 10s per batch (80s) plus another 60s on
+  // the final whole-container check (140s total) before giving up.
+  const rowIds = Array.from({ length: 40 }, (_, i) => `row-${i}`);
+  rowIds.forEach(id => container.appendChild(makeRow(id, true)));
+
+  const promise = forceLoadAllCharts(container);
+
+  // Comfortably past the 60s overall budget, but far short of the 140s the
+  // unbounded, per-timeout-summed behavior would have required.
+  await jest.advanceTimersByTimeAsync(65_000);
+  const result = await promise;
+
+  expect(result).toBe(true);
+  expect(addWarningToast).toHaveBeenCalledTimes(1);
+});
+
 test('restoreVirtualization dispatches the restore event', () => {
   const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
 

--- a/superset-frontend/src/utils/downloadUtils.ts
+++ b/superset-frontend/src/utils/downloadUtils.ts
@@ -19,11 +19,32 @@
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
+import {
+  addInfoToast,
+  addWarningToast,
+} from 'src/components/MessageToasts/actions';
 import {
   FORCE_IN_VIEW_EVENT,
   RESTORE_VIRTUALIZATION_EVENT,
 } from 'src/dashboard/constants';
+
+// Rows carry a `data-row-id` attribute (see Row.tsx) so the export path can
+// target a subset of them per batch. How many rows get forced into view at
+// once: large enough that a small dashboard finishes in one batch, small
+// enough that a dashboard with hundreds of rows doesn't fire hundreds of
+// chart queries in the same tick, which is the exact thundering-herd load
+// DASHBOARD_VIRTUALIZATION exists to prevent in the first place.
+const FORCE_RENDER_BATCH_SIZE = 5;
+// Upper bound on how long a single batch is given to finish loading before
+// moving on to the next one. Intentionally shorter than the final,
+// whole-container timeout below: a slow chart in one batch shouldn't stall
+// every later batch, since the final check catches stragglers anyway.
+const BATCH_LOAD_TIMEOUT_MS = 10_000;
+
+export type ForceLoadProgress = {
+  loadedBatches: number;
+  totalBatches: number;
+};
 
 /**
  * Poll until all `.loading` spinners inside a container disappear,
@@ -56,16 +77,91 @@ function waitForChartsToLoad(
 }
 
 /**
- * When DASHBOARD_VIRTUALIZATION is enabled, forces all lazy-loaded
- * charts to render and waits for them to finish loading.
- * Returns true if virtualization was active (caller must restore it).
+ * Poll until none of the given row elements contain a `.loading` spinner.
+ * Scoped to just those rows (rather than the whole container, like
+ * waitForChartsToLoad above) so a chart stuck in an earlier batch doesn't
+ * force every later batch to also burn its full timeout re-checking that
+ * same stale spinner. Resolves (doesn't reject) either way; a straggler
+ * here is still caught by the final whole-container check afterwards.
  */
-export async function forceLoadAllCharts(container: Element): Promise<boolean> {
+function waitForRowsToLoad(rows: Element[], timeoutMs: number): Promise<void> {
+  return new Promise(resolve => {
+    const startTime = Date.now();
+    const check = () => {
+      const stillLoading = rows.some(row => row.querySelector('.loading'));
+      if (!stillLoading || Date.now() - startTime > timeoutMs) {
+        resolve();
+        return;
+      }
+      setTimeout(check, 500);
+    };
+    setTimeout(check, 1000);
+  });
+}
+
+function getRowElements(container: Element): Element[] {
+  return Array.from(container.querySelectorAll('[data-row-id]'));
+}
+
+function getRowId(row: Element): string | null {
+  return row.getAttribute('data-row-id');
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
+
+/**
+ * When DASHBOARD_VIRTUALIZATION is enabled, forces lazy-loaded charts to
+ * render in small batches (rather than all at once) and waits for them to
+ * finish loading. Returns true if virtualization was active (caller must
+ * restore it).
+ */
+export async function forceLoadAllCharts(
+  container: Element,
+  onProgress?: (progress: ForceLoadProgress) => void,
+): Promise<boolean> {
   const useVirtualization = isFeatureEnabled(
     FeatureFlag.DashboardVirtualization,
   );
   if (useVirtualization) {
-    window.dispatchEvent(new Event(FORCE_IN_VIEW_EVENT));
+    const rowElements = getRowElements(container);
+    const rowBatches = rowElements.length
+      ? chunk(rowElements, FORCE_RENDER_BATCH_SIZE)
+      : [];
+
+    if (rowBatches.length <= 1) {
+      // Nothing to batch (no rows found, or everything fits in one batch):
+      // force everything into view in a single pass, same as before batching.
+      window.dispatchEvent(new Event(FORCE_IN_VIEW_EVENT));
+    } else {
+      addInfoToast(
+        t('Preparing %(count)s charts for export. This may take a moment.', {
+          count: rowElements.length,
+        }),
+      );
+      // eslint-disable-next-line no-restricted-syntax -- batches must be
+      // dispatched sequentially so the query burst is actually staggered.
+      for (const [index, batch] of rowBatches.entries()) {
+        const rowIds = batch
+          .map(getRowId)
+          .filter((id): id is string => id !== null);
+        window.dispatchEvent(
+          new CustomEvent(FORCE_IN_VIEW_EVENT, { detail: { rowIds } }),
+        );
+        // eslint-disable-next-line no-await-in-loop -- see above
+        await waitForRowsToLoad(batch, BATCH_LOAD_TIMEOUT_MS);
+        onProgress?.({
+          loadedBatches: index + 1,
+          totalBatches: rowBatches.length,
+        });
+      }
+    }
+
     const allLoaded = await waitForChartsToLoad(container);
     if (!allLoaded) {
       addWarningToast(

--- a/superset-frontend/src/utils/downloadUtils.ts
+++ b/superset-frontend/src/utils/downloadUtils.ts
@@ -40,6 +40,12 @@ const FORCE_RENDER_BATCH_SIZE = 5;
 // whole-container timeout below: a slow chart in one batch shouldn't stall
 // every later batch, since the final check catches stragglers anyway.
 const BATCH_LOAD_TIMEOUT_MS = 10_000;
+// Overall budget for the whole force-load pass (every batch wait plus the
+// final whole-container check combined). Without this, a dashboard with
+// many permanently-stalled batches could burn its full per-batch timeout
+// on each one, plus another full timeout on the final check, keeping the
+// export blocked far longer than any single timeout value suggests.
+const OVERALL_LOAD_TIMEOUT_MS = 60_000;
 
 export type ForceLoadProgress = {
   loadedBatches: number;
@@ -129,6 +135,7 @@ export async function forceLoadAllCharts(
     FeatureFlag.DashboardVirtualization,
   );
   if (useVirtualization) {
+    const deadline = Date.now() + OVERALL_LOAD_TIMEOUT_MS;
     const rowElements = getRowElements(container);
     const rowBatches = rowElements.length
       ? chunk(rowElements, FORCE_RENDER_BATCH_SIZE)
@@ -153,8 +160,15 @@ export async function forceLoadAllCharts(
         window.dispatchEvent(
           new CustomEvent(FORCE_IN_VIEW_EVENT, { detail: { rowIds } }),
         );
+        // Never wait longer than what's left of the overall budget, so a
+        // string of stalled batches can't each burn a full per-batch
+        // timeout and blow past the deadline in aggregate.
+        const remainingMs = Math.max(0, deadline - Date.now());
         // eslint-disable-next-line no-await-in-loop -- see above
-        await waitForRowsToLoad(batch, BATCH_LOAD_TIMEOUT_MS);
+        await waitForRowsToLoad(
+          batch,
+          Math.min(BATCH_LOAD_TIMEOUT_MS, remainingMs),
+        );
         onProgress?.({
           loadedBatches: index + 1,
           totalBatches: rowBatches.length,
@@ -162,7 +176,10 @@ export async function forceLoadAllCharts(
       }
     }
 
-    const allLoaded = await waitForChartsToLoad(container);
+    const allLoaded = await waitForChartsToLoad(
+      container,
+      Math.max(0, deadline - Date.now()),
+    );
     if (!allLoaded) {
       addWarningToast(
         t('Some charts did not finish loading. The export may be incomplete.'),


### PR DESCRIPTION
### SUMMARY

Follow-up to #42561, stacked on top of it (base branch is `upstream-fix-29719-force-render-export`, not `master`, so this diff only shows what's new here).

#42561 fixes the client-side Download as Image/PDF path exporting virtualized dashboard rows as loading spinners, by forcing every row into view before capture. The fix is correct, but it forces *every* row into view in a single instant `window` event with no batching. On a dashboard with hundreds of charts, that reintroduces the exact thundering-herd load `DASHBOARD_VIRTUALIZATION` exists to prevent in the first place, just moved from page-load time to export time, with no concurrency limit and no signal to the user that anything expensive is about to happen.

This adds:

- **Row-level batching.** Rows now carry a `data-row-id` attribute; the export path force-renders them in groups of 5 rather than all at once, waiting (with a bounded 10s per-batch timeout) for each batch before moving to the next. The per-batch wait is scoped to just that batch's own row elements, not the whole container, so a chart stuck in one batch doesn't force every later batch to also burn its full timeout re-checking that same stale spinner (caught this via a failing test, not by inspection, see commit for details). Dashboards small enough to fit in one batch keep the original single-event behavior unchanged. The existing whole-container 60s check after all batches still runs as a final safety net.
- **An upfront info toast** ("Preparing N charts for export. This may take a moment.") when a multi-batch export starts, so the user gets a signal that a large export is underway rather than wondering if the click did nothing. A live per-batch progress bar felt like a bigger UI commitment than this follow-up warranted; `forceLoadAllCharts` now accepts an optional `onProgress` callback as an extensibility hook if that's wanted later.
- **Test coverage for `Row.tsx`'s event handling.** #42561 added the force-in-view/restore-virtualization listeners to `Row.tsx` but never tested them directly, only the dispatching side in `downloadUtils.test.ts`. This adds coverage for the actual consumer: scoped batch targeting (responds only when its own row id is in the event, or when no `rowIds` filter is present at all) and observer re-attachment on restore.
- **Test coverage for the batching logic**: grouping into batches of 5, progress callback sequencing, per-batch timeout isolation (the bug mentioned above), and confirming the existing single-pass/flag-off paths from #42561 are unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — this changes the pacing/signaling of an existing export flow, not its visual output.

### TESTING INSTRUCTIONS

```bash
npx jest src/utils/downloadUtils.test.ts src/dashboard/components/gridComponents/Row/Row.test.tsx
```

Manually: with `DASHBOARD_VIRTUALIZATION` enabled, open a dashboard with more than 5 charts in one tab (enough to span multiple batches), and use Download → Export to Image/PDF. You should see a "Preparing N charts for export" toast, and the export should still contain every chart rendered (not loading spinners), same end result as #42561, just staggered.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
