### PR TITLE
fix(models): guard three more backref cascades for SQLAlchemy 2.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,9 +30,12 @@ filterwarnings =
     always::sqlalchemy.exc.RemovedIn20Warning
     error:Passing a string to Connection.execute\(\) is deprecated:sqlalchemy.exc.RemovedIn20Warning
     error:"Query" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"ReportExecutionLog" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"ReportRecipients" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"SavedQuery" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"SqlaTable" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"SqlMetric" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
+    error:"SSHTunnel" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"TableColumn" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:"TaggedObject" object is being merged into a Session:sqlalchemy.exc.RemovedIn20Warning
     error:The autoload parameter is deprecated:sqlalchemy.exc.RemovedIn20Warning

--- a/superset/databases/ssh_tunnel/models.py
+++ b/superset/databases/ssh_tunnel/models.py
@@ -55,6 +55,10 @@ class SSHTunnel(AuditMixinNullable, ExtraJSONMixin, ImportExportMixin, Model):
             uselist=False,
             cascade="all, delete-orphan",
             lazy="joined",
+            # SQLAlchemy 2.0 behavior: assigning `ssh_tunnel.database` no
+            # longer cascades the SSHTunnel into the Database's session;
+            # callers must add objects to a session explicitly.
+            cascade_backrefs=False,
         ),
         foreign_keys=[database_id],
     )

--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -388,7 +388,15 @@ class ReportRecipients(Model, AuditMixinNullable):
     )
     report_schedule = relationship(
         ReportSchedule,
-        backref=backref("recipients", cascade="all,delete,delete-orphan"),
+        backref=backref(
+            "recipients",
+            cascade="all,delete,delete-orphan",
+            # SQLAlchemy 2.0 behavior: assigning `recipient.report_schedule`
+            # no longer cascades the ReportRecipients into the
+            # ReportSchedule's session; callers must add objects to a
+            # session explicitly.
+            cascade_backrefs=False,
+        ),
         foreign_keys=[report_schedule_id],
     )
 
@@ -424,7 +432,15 @@ class ReportExecutionLog(Model):  # pylint: disable=too-few-public-methods
     )
     report_schedule = relationship(
         ReportSchedule,
-        backref=backref("logs", cascade="all,delete,delete-orphan"),
+        backref=backref(
+            "logs",
+            cascade="all,delete,delete-orphan",
+            # SQLAlchemy 2.0 behavior: assigning `log.report_schedule` no
+            # longer cascades the ReportExecutionLog into the
+            # ReportSchedule's session; callers must add objects to a
+            # session explicitly.
+            cascade_backrefs=False,
+        ),
         foreign_keys=[report_schedule_id],
     )
 


### PR DESCRIPTION
### SUMMARY

Discussion #40273 step 2 (SQLAlchemy 2.0 migration roadmap) added `cascade_backrefs=False` to seven models (`Query`, `SavedQuery`, `SqlaTable`, `SqlMetric`, `TableColumn`, `TaggedObject`, `User`) whose `backref()`-defined reverse relationships were triggering SQLAlchemy's "object is being merged into a Session along the backref cascade path" deprecation warning, locked in via a `pytest.ini` `filterwarnings` error line per model to prevent regression.

A follow-up sweep for step 6 prep found three more models with the exact same pattern that the original sweep missed: `SSHTunnel.database`, `ReportRecipients.report_schedule`, and `ReportExecutionLog.report_schedule`. Same fix, same reasoning: in SQLAlchemy 2.0 this reverse cascade no longer happens automatically, so callers that relied on it implicitly would silently stop persisting these objects. Verified each caller already reaches the objects via an explicit `db.session.add()` or the forward collection assignment (which carries its own `cascade="all, delete-orphan"`, unaffected by `cascade_backrefs`), so nothing here depended on the removed behavior.

### TESTING INSTRUCTIONS

```
SQLALCHEMY_WARN_20=1 pytest tests/unit_tests/databases/ssh_tunnel tests/unit_tests/reports tests/unit_tests/commands/report tests/unit_tests/daos/test_report_dao.py
```
426 tests pass with the three new `pytest.ini` error lines active, confirming none of the exercised code paths still rely on the removed implicit cascade.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
