### PR TITLE
experiment: test model_class= fix for FSA 3.x break (DO NOT MERGE)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,15 +60,11 @@ dependencies = [
     "flask-login>=0.6.0, < 1.0",
     "flask-migrate>=4.1.0, <5.0",
     "flask-session>=0.4.0, <1.0",
-    # Pinned explicitly below 3.0: 3.0.5 resolves without conflict and
-    # supports both SQLAlchemy 1.4 and 2.0, but real CI runs surfaced a
-    # structural incompatibility with Superset's current session/app-context
-    # handling across Celery task boundaries (see PR #42542) -- widespread
-    # "NoneType has no attribute X" failures and MySQL lock-wait timeouts,
-    # not just a connection-pool quirk. Needs dedicated investigation, not a
-    # driver-compat-prep bump; revisit alongside the actual SQLAlchemy 2.0
-    # core bump (discussion #40273, step 6).
-    "flask-sqlalchemy>=2.5.1, <3.0",
+    # EXPERIMENTAL: testing whether passing model_class= explicitly when
+    # constructing SQLA() (see superset/extensions/__init__.py) resolves the
+    # PR #42542 regression before committing to a real bump. Do not merge
+    # this pin change as-is.
+    "flask-sqlalchemy>=3.0.5, <3.1",
     "flask-wtf>=1.3.0, <2.0",
     "geopy",
     "greenlet<=3.5.4, >=3.5.4",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -148,7 +148,7 @@ flask-migrate==4.1.0
     # via apache-superset (pyproject.toml)
 flask-session==0.8.0
     # via apache-superset (pyproject.toml)
-flask-sqlalchemy==2.5.1
+flask-sqlalchemy==3.0.5
     # via
     #   apache-superset (pyproject.toml)
     #   flask-appbuilder

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -309,7 +309,7 @@ flask-session==0.8.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
-flask-sqlalchemy==2.5.1
+flask-sqlalchemy==3.0.5
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -154,7 +154,9 @@ async_query_manager: AsyncQueryManager = LocalProxy(
 cache_manager = CacheManager()
 celery_app = celery.Celery()
 csrf = CSRFProtect()
-db = get_sqla_class()()
+from flask_appbuilder.models.sqla import Model as _FABModel  # noqa: E402
+
+db = get_sqla_class()(model_class=_FABModel)
 
 # make_versioned() MUST be called immediately after db is constructed and before
 # any versioned model class is defined.  Continuum patches the SQLAlchemy


### PR DESCRIPTION
### SUMMARY

**Investigation only, do not merge.** Testing a theory for the flask-sqlalchemy 3.x break reverted in #42542.

Root cause theory: Flask-AppBuilder's FSA-3.x compatibility shim (`flask_appbuilder/models/sqla/base.py`) doesn't wire `model_class=` through when it constructs `SQLA()`, unlike its FSA-2.x shim (`base_legacy.py`), which explicitly rebinds Superset's models onto FAB's own `declarative_base()` via `create_session()`/`get_bind()` overrides. Under FSA 3.x, Superset's models (all subclassing `flask_appbuilder.Model`) and `db.session`'s bind resolution end up looking at two disconnected declarative registries.

This branch tests whether the fix is entirely Superset-side: passing `model_class=flask_appbuilder.models.sqla.Model` explicitly when constructing `db = get_sqla_class()()` in `superset/extensions/__init__.py`. Confirmed locally that this unifies `db.Model` with `flask_appbuilder.Model` (`db.Model is FABModel` is `True`). Local pytest against sqlite doesn't reproduce the original break either way (matches #42542's own finding that this only ever surfaced under real CI), so this PR exists purely to get a CI signal on `test-sqlite`/`test-mysql`.

Full context: discussion #40273, step 6.

### TESTING INSTRUCTIONS

N/A, investigation only.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
