### PR TITLE
feat(chart): enable cross-filter on temporal x-axis (bar/label click)

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/index.ts
@@ -49,5 +49,6 @@ export { default as finestTemporalGrainFormatter } from './formatters/finestTemp
 
 export { default as normalizeTimestamp } from './utils/normalizeTimestamp';
 export { default as denormalizeTimestamp } from './utils/denormalizeTimestamp';
+export { default as createTimeRangeFromGranularity } from './utils/createTimeRangeFromGranularity';
 
 export * from './types';

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
@@ -21,7 +21,7 @@ import {
   waitFor,
   cleanup,
 } from '../../../../spec/helpers/testing-library';
-import { AxisType, TimeGranularity } from '@superset-ui/core';
+import { AxisType, DTTM_ALIAS, TimeGranularity } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { ECElementEvent } from 'echarts/types/src/util/types';
@@ -425,7 +425,7 @@ test('uses rendered categorical axis for query event handlers', () => {
   );
 
   expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe(
-    'xAxis.category',
+    'xAxis',
   );
 
   cleanup();
@@ -446,7 +446,7 @@ test('uses rendered categorical axis for query event handlers', () => {
   );
 
   expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe(
-    'yAxis.category',
+    'yAxis',
   );
 });
 
@@ -473,6 +473,7 @@ test('emits cross-filter from horizontal categorical axis label clicks', () => {
     getLatestEchartProps().queryEventHandlers?.[0].handler;
   expect(labelClickHandler).toBeDefined();
   labelClickHandler?.({
+    targetType: 'axisLabel',
     value: 'Product A',
   } as ECElementEvent);
 
@@ -511,7 +512,7 @@ test('does not emit duplicate cross-filter for generic axis label clicks', async
   expect(setDataMaskMock).not.toHaveBeenCalled();
 });
 
-test('does not emit cross-filter when no dimensions and time-based X-axis', async () => {
+test('emits TEMPORAL_RANGE cross-filter from time axis label click on day bucket', () => {
   const setDataMaskMock = jest.fn();
 
   const propsWithTimeXAxis: TimeseriesChartTransformedProps = {
@@ -519,33 +520,430 @@ test('does not emit cross-filter when no dimensions and time-based X-axis', asyn
     emitCrossFilters: true,
     setDataMask: setDataMaskMock,
     groupby: [], // No dimensions
+    formData: {
+      ...defaultFormData,
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.DAY,
+    },
     xAxis: {
-      label: '__timestamp',
-      type: AxisType.Time, // Time-based X-axis (not categorical)
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
     },
   };
 
   render(<EchartsTimeseries {...propsWithTimeXAxis} />);
 
-  const lastCall = mockEchart.mock.calls.at(-1);
-  expect(lastCall).toBeDefined();
-  const [props] = lastCall as [EchartsProps];
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as ECElementEvent);
 
-  // Simulate a click event
-  const clickHandler = props.eventHandlers?.click;
-  if (clickHandler) {
-    clickHandler({
-      componentType: 'series',
-      seriesName: 'Sales',
-      data: [1609459200000, 100], // Timestamp
-      name: '2021-01-01',
-      dataIndex: 0,
-    });
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-01-02T00:00:00',
+    },
+  ]);
+});
 
-    // Wait a bit and verify setDataMask was NOT called
-    await new Promise(resolve => setTimeout(resolve, 400));
-    expect(setDataMaskMock).not.toHaveBeenCalled();
-  }
+test('emits TEMPORAL_RANGE cross-filter from time axis label click on month bucket', () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as ECElementEvent);
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits TEMPORAL_RANGE cross-filter from time axis label click on year bucket', () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.YEAR,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as ECElementEvent);
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2022-01-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket', async () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  await waitFor(
+    () => {
+      expect(setDataMaskMock).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not metric', async () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        orientation: OrientationType.Horizontal,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [129, Date.UTC(2021, 0, 1)],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  await waitFor(
+    () => {
+      expect(setDataMaskMock).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits TEMPORAL_RANGE cross-filter from horizontal time axis label click', () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        orientation: OrientationType.Horizontal,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'yAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as ECElementEvent);
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('warns and skips temporal axis label cross-filter when label value cannot be parsed', () => {
+  const setDataMaskMock = jest.fn();
+  const warn = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: 'not-a-date',
+  } as ECElementEvent);
+
+  expect(setDataMaskMock).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledWith(
+    'Unable to parse time axis label for cross-filtering',
+    'not-a-date',
+  );
+
+  warn.mockRestore();
+});
+
+test('clears temporal X-axis cross-filter when clicking selected bucket again', async () => {
+  const setDataMaskMock = jest.fn();
+  const selectedRange = '2021-01-01T00:00:00 : 2021-02-01T00:00:00';
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      selectedValues={{ ds: selectedRange }}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  await waitFor(
+    () => {
+      expect(setDataMaskMock).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  expect(setDataMaskMock.mock.calls[0][0]).toEqual({
+    extraFormData: {
+      filters: [],
+    },
+    filterState: {
+      label: undefined,
+      value: null,
+      selectedValues: null,
+    },
+  });
+});
+
+test('does not emit temporal X-axis label cross-filter when dimensions are set', () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={['country']}
+      formData={{
+        ...defaultFormData,
+        groupby: ['country'],
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as ECElementEvent);
+
+  expect(setDataMaskMock).not.toHaveBeenCalled();
+});
+
+test('does not emit temporal X-axis cross-filter when dimensions are set', async () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={['country']}
+      labelMap={{
+        Sales: ['US'],
+      }}
+      formData={{
+        ...defaultFormData,
+        groupby: ['country'],
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  await waitFor(
+    () => {
+      expect(setDataMaskMock).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'country',
+      op: 'IN',
+      val: ['US'],
+    },
+  ]);
+  expect(
+    setDataMaskMock.mock.calls[0][0].extraFormData.filters.some(
+      (filter: { op: string }) => filter.op === 'TEMPORAL_RANGE',
+    ),
+  ).toBe(false);
 });
 
 // Test for issue #41102: horizontal bar cross-filter must use the category

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
@@ -21,8 +21,14 @@ import {
   waitFor,
   cleanup,
 } from '../../../../spec/helpers/testing-library';
-import { AxisType, DTTM_ALIAS, TimeGranularity } from '@superset-ui/core';
+import {
+  AxisType,
+  createTimeRangeFromGranularity,
+  DTTM_ALIAS,
+  TimeGranularity,
+} from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
+import { logging } from '@apache-superset/core/utils';
 import type { EChartsCoreOption } from 'echarts/core';
 import type { ECElementEvent } from 'echarts/types/src/util/types';
 import type { ReactNode } from 'react';
@@ -93,11 +99,16 @@ afterAll(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   cleanup();
   mockEchart.mockReset();
   (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
     originalResizeObserver;
 });
+
+const advanceClickTimer = () => {
+  jest.advanceTimersByTime(300);
+};
 
 const defaultFormData: EchartsTimeseriesFormData & {
   vizType: string;
@@ -314,7 +325,8 @@ test('falls back to window resize listener when ResizeObserver is unavailable', 
 });
 
 // Test for issue #25334: Bar chart cross-filter without dimensions
-test('emits cross-filter on X-axis value when no dimensions and categorical X-axis', async () => {
+test('emits cross-filter on X-axis value when no dimensions and categorical X-axis', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   const propsWithCategoricalXAxis: TimeseriesChartTransformedProps = {
@@ -348,13 +360,7 @@ test('emits cross-filter on X-axis value when no dimensions and categorical X-ax
       dataIndex: 0,
     });
 
-    // Wait for the timer (TIMER_DURATION = 300ms)
-    await waitFor(
-      () => {
-        expect(setDataMaskMock).toHaveBeenCalled();
-      },
-      { timeout: 500 },
-    );
+    advanceClickTimer();
 
     // Verify the cross-filter uses the X-axis column and value, not the metric
     const dataMaskCall = setDataMaskMock.mock.calls[0][0];
@@ -368,7 +374,8 @@ test('emits cross-filter on X-axis value when no dimensions and categorical X-ax
   }
 });
 
-test('emits cross-filter on category value for horizontal bar clicks', async () => {
+test('emits cross-filter on category value for horizontal bar clicks', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -397,12 +404,7 @@ test('emits cross-filter on category value for horizontal bar clicks', async () 
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -482,7 +484,8 @@ test('emits cross-filter from horizontal categorical axis label clicks', () => {
   ]);
 });
 
-test('does not emit duplicate cross-filter for generic axis label clicks', async () => {
+test('does not emit duplicate cross-filter for generic axis label clicks', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -504,8 +507,25 @@ test('does not emit duplicate cross-filter for generic axis label clicks', async
     name: 'Product A',
   });
 
-  await new Promise(resolve => setTimeout(resolve, 400));
+  jest.advanceTimersByTime(400);
   expect(setDataMaskMock).not.toHaveBeenCalled();
+});
+
+test('keeps temporal range exclusive ends on whole-second boundaries', () => {
+  const clickedTimestamp = new Date(Date.UTC(2021, 0, 15, 12, 34, 56, 789));
+
+  [TimeGranularity.DAY, TimeGranularity.MONTH, TimeGranularity.YEAR].forEach(
+    grain => {
+      const [, inclusiveEnd] = createTimeRangeFromGranularity(
+        clickedTimestamp,
+        grain,
+        false,
+      );
+      const exclusiveEnd = new Date(inclusiveEnd.getTime() + 1);
+
+      expect(exclusiveEnd.getUTCMilliseconds()).toBe(0);
+    },
+  );
 });
 
 test('emits TEMPORAL_RANGE cross-filter from time axis label click on day bucket', () => {
@@ -628,7 +648,8 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on year bucke
   ]);
 });
 
-test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket', async () => {
+test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -660,12 +681,7 @@ test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -676,7 +692,52 @@ test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket
   ]);
 });
 
-test('uses resolved time grain for temporal point-click cross-filter', async () => {
+test('emits TEMPORAL_RANGE from string-typed time point click value', () => {
+  jest.useFakeTimers();
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: ['2021-01-01T00:00:00Z', 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  advanceClickTimer();
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('uses resolved time grain for temporal point-click cross-filter', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -711,12 +772,7 @@ test('uses resolved time grain for temporal point-click cross-filter', async () 
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -727,7 +783,8 @@ test('uses resolved time grain for temporal point-click cross-filter', async () 
   ]);
 });
 
-test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not metric', async () => {
+test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not metric', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -760,12 +817,7 @@ test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -819,7 +871,7 @@ test('emits TEMPORAL_RANGE cross-filter from horizontal time axis label click', 
 
 test('warns and skips temporal axis label cross-filter when label value cannot be parsed', () => {
   const setDataMaskMock = jest.fn();
-  const warn = jest.spyOn(console, 'warn').mockImplementation();
+  const warn = jest.spyOn(logging, 'warn').mockImplementation();
 
   render(
     <EchartsTimeseries
@@ -850,14 +902,106 @@ test('warns and skips temporal axis label cross-filter when label value cannot b
 
   expect(setDataMaskMock).not.toHaveBeenCalled();
   expect(warn).toHaveBeenCalledWith(
-    'Unable to parse time axis label for cross-filtering',
+    'Unable to parse time axis value for cross-filtering',
     'not-a-date',
   );
 
   warn.mockRestore();
 });
 
-test('clears temporal X-axis cross-filter when clicking selected bucket again', async () => {
+test('logs and skips temporal point-click cross-filter when string value cannot be parsed', () => {
+  jest.useFakeTimers();
+  const setDataMaskMock = jest.fn();
+  const warn = jest.spyOn(logging, 'warn').mockImplementation();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: ['not-a-date', 100],
+    name: 'not-a-date',
+    dataIndex: 0,
+  });
+
+  advanceClickTimer();
+
+  expect(setDataMaskMock).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledWith(
+    'Unable to parse time axis value for cross-filtering',
+    'not-a-date',
+  );
+
+  warn.mockRestore();
+});
+
+test('emits empty temporal X-axis data mask when filter grain is missing', () => {
+  jest.useFakeTimers();
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: undefined,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  advanceClickTimer();
+
+  expect(setDataMaskMock.mock.calls[0][0]).toEqual({
+    extraFormData: {
+      filters: [],
+    },
+    filterState: {
+      label: undefined,
+      value: null,
+      selectedValues: null,
+    },
+  });
+});
+
+test('clears temporal X-axis cross-filter when clicking selected bucket again', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
   const selectedRange = '2021-01-01T00:00:00 : 2021-02-01T00:00:00';
 
@@ -891,12 +1035,7 @@ test('clears temporal X-axis cross-filter when clicking selected bucket again', 
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0]).toEqual({
     extraFormData: {
@@ -944,7 +1083,8 @@ test('does not emit temporal X-axis label cross-filter when dimensions are set',
   expect(setDataMaskMock).not.toHaveBeenCalled();
 });
 
-test('does not emit temporal X-axis cross-filter when dimensions are set', async () => {
+test('does not emit temporal X-axis cross-filter when dimensions are set', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   render(
@@ -979,12 +1119,7 @@ test('does not emit temporal X-axis cross-filter when dimensions are set', async
     dataIndex: 0,
   });
 
-  await waitFor(
-    () => {
-      expect(setDataMaskMock).toHaveBeenCalled();
-    },
-    { timeout: 500 },
-  );
+  advanceClickTimer();
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -1003,7 +1138,8 @@ test('does not emit temporal X-axis cross-filter when dimensions are set', async
 // Test for issue #41102: horizontal bar cross-filter must use the category
 // value, not the metric. For horizontal bars the data tuple is value-first
 // (e.g. [100, 'Product A']), so relying on data[0] emitted the metric value.
-test('emits cross-filter on the category value for a horizontal categorical bar', async () => {
+test('emits cross-filter on the category value for a horizontal categorical bar', () => {
+  jest.useFakeTimers();
   const setDataMaskMock = jest.fn();
 
   const propsWithHorizontalXAxis: TimeseriesChartTransformedProps = {
@@ -1037,12 +1173,7 @@ test('emits cross-filter on the category value for a horizontal categorical bar'
       dataIndex: 0,
     });
 
-    await waitFor(
-      () => {
-        expect(setDataMaskMock).toHaveBeenCalled();
-      },
-      { timeout: 500 },
-    );
+    advanceClickTimer();
 
     // Must filter on the category ('Product A'), not the metric value (100)
     const dataMaskCall = setDataMaskMock.mock.calls[0][0];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.test.tsx
@@ -424,9 +424,7 @@ test('uses rendered categorical axis for query event handlers', () => {
     />,
   );
 
-  expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe(
-    'xAxis',
-  );
+  expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe('xAxis');
 
   cleanup();
   mockEchart.mockReset();
@@ -445,9 +443,7 @@ test('uses rendered categorical axis for query event handlers', () => {
     />,
   );
 
-  expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe(
-    'yAxis',
-  );
+  expect(getLatestEchartProps().queryEventHandlers?.[0].query).toBe('yAxis');
 });
 
 test('emits cross-filter from horizontal categorical axis label clicks', () => {
@@ -475,7 +471,7 @@ test('emits cross-filter from horizontal categorical axis label clicks', () => {
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: 'Product A',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -520,6 +516,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on day bucket
     emitCrossFilters: true,
     setDataMask: setDataMaskMock,
     groupby: [], // No dimensions
+    resolvedTimeGrain: TimeGranularity.DAY,
     formData: {
       ...defaultFormData,
       granularitySqla: 'ds',
@@ -540,7 +537,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on day bucket
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: '2021-01-01',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -560,6 +557,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on month buck
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
       formData={{
         ...defaultFormData,
         granularitySqla: 'ds',
@@ -579,7 +577,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on month buck
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: '2021-01-01',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -599,6 +597,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on year bucke
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
+      resolvedTimeGrain={TimeGranularity.YEAR}
       formData={{
         ...defaultFormData,
         granularitySqla: 'ds',
@@ -618,7 +617,7 @@ test('emits TEMPORAL_RANGE cross-filter from time axis label click on year bucke
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: '2021-01-01',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -638,10 +637,62 @@ test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
       formData={{
         ...defaultFormData,
         granularitySqla: 'ds',
         timeGrainSqla: TimeGranularity.MONTH,
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const clickHandler = getLatestEchartProps().eventHandlers?.click;
+  expect(clickHandler).toBeDefined();
+  clickHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+
+  await waitFor(
+    () => {
+      expect(setDataMaskMock).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('uses resolved time grain for temporal point-click cross-filter', async () => {
+  const setDataMaskMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      setDataMask={setDataMaskMock}
+      groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.DAY,
+        extraFormData: {
+          time_grain_sqla: TimeGranularity.MONTH,
+        },
       }}
       xAxis={{
         label: DTTM_ALIAS,
@@ -685,6 +736,7 @@ test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
       formData={{
         ...defaultFormData,
         orientation: OrientationType.Horizontal,
@@ -733,6 +785,7 @@ test('emits TEMPORAL_RANGE cross-filter from horizontal time axis label click', 
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
       formData={{
         ...defaultFormData,
         orientation: OrientationType.Horizontal,
@@ -753,7 +806,7 @@ test('emits TEMPORAL_RANGE cross-filter from horizontal time axis label click', 
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: '2021-01-01',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock.mock.calls[0][0].extraFormData.filters).toEqual([
     {
@@ -793,7 +846,7 @@ test('warns and skips temporal axis label cross-filter when label value cannot b
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: 'not-a-date',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock).not.toHaveBeenCalled();
   expect(warn).toHaveBeenCalledWith(
@@ -814,7 +867,8 @@ test('clears temporal X-axis cross-filter when clicking selected bucket again', 
       emitCrossFilters
       setDataMask={setDataMaskMock}
       groupby={[]}
-      selectedValues={{ ds: selectedRange }}
+      selectedValues={{ 0: selectedRange }}
+      resolvedTimeGrain={TimeGranularity.MONTH}
       formData={{
         ...defaultFormData,
         granularitySqla: 'ds',
@@ -885,7 +939,7 @@ test('does not emit temporal X-axis label cross-filter when dimensions are set',
   labelClickHandler?.({
     targetType: 'axisLabel',
     value: '2021-01-01',
-  } as ECElementEvent);
+  } as unknown as ECElementEvent);
 
   expect(setDataMaskMock).not.toHaveBeenCalled();
 });
@@ -1000,6 +1054,55 @@ test('emits cross-filter on the category value for a horizontal categorical bar'
       },
     ]);
   }
+});
+
+test('context menu cross-filter is available for a temporal bar point', async () => {
+  const onContextMenuMock = jest.fn();
+
+  render(
+    <EchartsTimeseries
+      {...defaultProps}
+      emitCrossFilters
+      onContextMenu={onContextMenuMock}
+      groupby={[]}
+      resolvedTimeGrain={TimeGranularity.MONTH}
+      formData={{
+        ...defaultFormData,
+        granularitySqla: 'ds',
+        timeGrainSqla: TimeGranularity.DAY,
+        extraFormData: {
+          time_grain_sqla: TimeGranularity.MONTH,
+        },
+      }}
+      xAxis={{
+        label: DTTM_ALIAS,
+        type: AxisType.Time,
+      }}
+    />,
+  );
+
+  const contextMenuHandler = getLatestEchartProps().eventHandlers?.contextmenu;
+  expect(contextMenuHandler).toBeDefined();
+  await contextMenuHandler?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    event: { stop: jest.fn(), event: { clientX: 10, clientY: 20 } },
+  });
+
+  await waitFor(() => {
+    expect(onContextMenuMock).toHaveBeenCalled();
+  });
+
+  const { crossFilter } = onContextMenuMock.mock.calls[0][2];
+  expect(crossFilter.dataMask.extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
 });
 
 // Test for issue #41102: the context-menu ("Add cross-filter") path must also

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -21,11 +21,13 @@ import {
   DTTM_ALIAS,
   BinaryQueryObjectFilterClause,
   AxisType,
+  type TimeGranularity,
   getTimeFormatter,
   getColumnLabel,
   getNumberFormatter,
   LegendState,
   ensureIsArray,
+  createTimeRangeFromGranularity,
 } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
@@ -48,6 +50,29 @@ import { getTemporalXAxisDrillByFilter } from '../utils/xAxisDrillByFilter';
 import { ExtraControls } from '../components/ExtraControls';
 
 const TIMER_DURATION = 300;
+const getTimestampFromTimeAxisLabel = (value: string | number) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    console.warn('Unable to parse time axis label for cross-filtering', value);
+  }
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+};
+
+const formatDateTime = (date: Date) =>
+  [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, '0'),
+    String(date.getUTCDate()).padStart(2, '0'),
+  ].join('-') +
+  'T' +
+  [
+    String(date.getUTCHours()).padStart(2, '0'),
+    String(date.getUTCMinutes()).padStart(2, '0'),
+    String(date.getUTCSeconds()).padStart(2, '0'),
+  ].join(':');
 
 // Percent-change draggable baseline handle geometry, in pixels.
 const BASELINE_HANDLE_WIDTH = 8;
@@ -363,6 +388,70 @@ export default function EchartsTimeseries({
     [selectedValues, xAxis.label],
   );
 
+  const getTimeAxisCrossFilterDataMask = useCallback(
+    (clickedTimestamp: number) => {
+      const filterColumn =
+        xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
+      const grain = formData.timeGrainSqla as TimeGranularity | undefined;
+
+      if (!filterColumn || !grain) {
+        return {
+          dataMask: {
+            extraFormData: {
+              filters: [],
+            },
+            filterState: {
+              label: undefined,
+              value: null,
+              selectedValues: null,
+            },
+          },
+          isCurrentValueSelected: false,
+        };
+      }
+
+      const [start, inclusiveEnd] = createTimeRangeFromGranularity(
+        new Date(clickedTimestamp),
+        grain,
+        false,
+      );
+      const exclusiveEnd = new Date(inclusiveEnd.getTime() + 1);
+      const timeRange = `${formatDateTime(start)} : ${formatDateTime(exclusiveEnd)}`;
+      const selected: string[] = Object.values(selectedValues);
+      const isCurrentValueSelected = selected.includes(timeRange);
+      const values = isCurrentValueSelected ? [] : [timeRange];
+
+      return {
+        dataMask: {
+          extraFormData: {
+            filters:
+              values.length === 0
+                ? []
+                : [
+                    {
+                      col: filterColumn,
+                      op: 'TEMPORAL_RANGE' as const,
+                      val: timeRange,
+                    },
+                  ],
+          },
+          filterState: {
+            label: values.length ? values : undefined,
+            value: values.length ? values : null,
+            selectedValues: values.length ? values : null,
+          },
+        },
+        isCurrentValueSelected,
+      };
+    },
+    [
+      formData.granularitySqla,
+      formData.timeGrainSqla,
+      selectedValues,
+      xAxis.label,
+    ],
+  );
+
   const handleChange = useCallback(
     (value: string) => {
       if (!emitCrossFilters) {
@@ -384,15 +473,26 @@ export default function EchartsTimeseries({
     [emitCrossFilters, setDataMask, getXAxisCrossFilterDataMask],
   );
 
+  const handleTimeAxisChange = useCallback(
+    (clickedTimestamp: number) => {
+      if (!emitCrossFilters) {
+        return;
+      }
+      setDataMask(getTimeAxisCrossFilterDataMask(clickedTimestamp).dataMask);
+    },
+    [emitCrossFilters, setDataMask, getTimeAxisCrossFilterDataMask],
+  );
+
   // Determine if X-axis can be used for cross-filtering (categorical axis without dimensions)
   const canCrossFilterByXAxis =
-    !hasDimensions && xAxis.type === AxisType.Category;
-  const categoryAxisValueIndex =
+    !hasDimensions &&
+    (xAxis.type === AxisType.Category || xAxis.type === AxisType.Time);
+  const xAxisValueIndex =
     formData.orientation === OrientationType.Horizontal ? 1 : 0;
-  const getCategoryAxisValue = useCallback(
+  const getXAxisValue = useCallback(
     (data: unknown, name: unknown) => {
       if (Array.isArray(data)) {
-        const categoryAxisValue = data[categoryAxisValueIndex];
+        const categoryAxisValue = data[xAxisValueIndex];
         if (
           typeof categoryAxisValue === 'string' ||
           typeof categoryAxisValue === 'number'
@@ -405,7 +505,7 @@ export default function EchartsTimeseries({
       }
       return undefined;
     },
-    [categoryAxisValueIndex],
+    [xAxisValueIndex],
   );
 
   const eventHandlers: EventHandlers = {
@@ -423,14 +523,27 @@ export default function EchartsTimeseries({
           // Cross-filter by dimension (original behavior)
           const { seriesName: name } = props;
           handleChange(name);
-        } else if (canCrossFilterByXAxis && props.componentType === 'series') {
+        } else if (
+          canCrossFilterByXAxis &&
+          xAxis.type === AxisType.Category &&
+          props.componentType === 'series'
+        ) {
           // Cross-filter by X-axis value when no dimensions (issue #25334)
-          const categoryAxisValue = getCategoryAxisValue(
+          const categoryAxisValue = getXAxisValue(
             props.data,
             props.name,
           );
           if (categoryAxisValue !== undefined) {
             handleXAxisChange(categoryAxisValue);
+          }
+        } else if (
+          canCrossFilterByXAxis &&
+          xAxis.type === AxisType.Time &&
+          props.componentType === 'series'
+        ) {
+          const timeAxisValue = getXAxisValue(props.data, props.name);
+          if (typeof timeAxisValue === 'number') {
+            handleTimeAxisChange(timeAxisValue);
           }
         }
       }, TIMER_DURATION);
@@ -466,6 +579,7 @@ export default function EchartsTimeseries({
         ];
         const groupBy = ensureIsArray(formData.groupby);
         if (data && xAxis.type === AxisType.Time) {
+          const timeAxisValue = getXAxisValue(data, eventParams.name);
           drillToDetailFilters.push({
             col:
               // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
@@ -474,8 +588,8 @@ export default function EchartsTimeseries({
                 : xAxis.label,
             grain: formData.timeGrainSqla,
             op: '==',
-            val: data[0],
-            formattedVal: xValueFormatter(data[0]),
+            val: timeAxisValue,
+            formattedVal: xValueFormatter(timeAxisValue),
           });
         }
         [
@@ -564,9 +678,10 @@ export default function EchartsTimeseries({
           crossFilter = getCrossFilterDataMask(seriesName);
         } else if (
           canCrossFilterByXAxis &&
+          xAxis.type === AxisType.Category &&
           eventParams.componentType === 'series'
         ) {
-          const categoryAxisValue = getCategoryAxisValue(
+          const categoryAxisValue = getXAxisValue(
             data,
             eventParams.name,
           );
@@ -593,26 +708,34 @@ export default function EchartsTimeseries({
       const { value } = event;
       if (
         canCrossFilterByXAxis &&
+        event.targetType === 'axisLabel' &&
         (typeof value === 'string' || typeof value === 'number')
       ) {
-        handleXAxisChange(value);
+        if (xAxis.type === AxisType.Time) {
+          const timestamp = getTimestampFromTimeAxisLabel(value);
+          if (timestamp !== undefined) {
+            handleTimeAxisChange(timestamp);
+          }
+        } else {
+          handleXAxisChange(value);
+        }
       }
     },
-    [canCrossFilterByXAxis, handleXAxisChange],
+    [canCrossFilterByXAxis, handleTimeAxisChange, handleXAxisChange, xAxis.type],
   );
 
-  const categoryAxis =
+  const renderedXAxis =
     formData.orientation === OrientationType.Horizontal ? 'yAxis' : 'xAxis';
 
   const queryEventHandlers = useMemo(
     () => [
       {
         name: 'click',
-        query: `${categoryAxis}.category`,
+        query: renderedXAxis,
         handler: handleXAxisLabelClick,
       },
     ],
-    [categoryAxis, handleXAxisLabelClick],
+    [renderedXAxis, handleXAxisLabelClick],
   );
 
   const zrEventHandlers: EventHandlers = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -62,17 +62,15 @@ const getTimestampFromTimeAxisLabel = (value: string | number) => {
 };
 
 const formatDateTime = (date: Date) =>
-  [
+  `${[
     date.getUTCFullYear(),
     String(date.getUTCMonth() + 1).padStart(2, '0'),
     String(date.getUTCDate()).padStart(2, '0'),
-  ].join('-') +
-  'T' +
-  [
+  ].join('-')}T${[
     String(date.getUTCHours()).padStart(2, '0'),
     String(date.getUTCMinutes()).padStart(2, '0'),
     String(date.getUTCSeconds()).padStart(2, '0'),
-  ].join(':');
+  ].join(':')}`;
 
 // Percent-change draggable baseline handle geometry, in pixels.
 const BASELINE_HANDLE_WIDTH = 8;
@@ -96,6 +94,7 @@ export default function EchartsTimeseries({
   onFocusedSeries,
   xValueFormatter,
   xAxis,
+  resolvedTimeGrain,
   refs,
   emitCrossFilters,
   coltypeMapping,
@@ -392,7 +391,7 @@ export default function EchartsTimeseries({
     (clickedTimestamp: number) => {
       const filterColumn =
         xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
-      const grain = formData.timeGrainSqla as TimeGranularity | undefined;
+      const grain = resolvedTimeGrain as TimeGranularity | undefined;
 
       if (!filterColumn || !grain) {
         return {
@@ -444,12 +443,7 @@ export default function EchartsTimeseries({
         isCurrentValueSelected,
       };
     },
-    [
-      formData.granularitySqla,
-      formData.timeGrainSqla,
-      selectedValues,
-      xAxis.label,
-    ],
+    [formData.granularitySqla, resolvedTimeGrain, selectedValues, xAxis.label],
   );
 
   const handleChange = useCallback(
@@ -529,10 +523,7 @@ export default function EchartsTimeseries({
           props.componentType === 'series'
         ) {
           // Cross-filter by X-axis value when no dimensions (issue #25334)
-          const categoryAxisValue = getXAxisValue(
-            props.data,
-            props.name,
-          );
+          const categoryAxisValue = getXAxisValue(props.data, props.name);
           if (categoryAxisValue !== undefined) {
             handleXAxisChange(categoryAxisValue);
           }
@@ -580,17 +571,19 @@ export default function EchartsTimeseries({
         const groupBy = ensureIsArray(formData.groupby);
         if (data && xAxis.type === AxisType.Time) {
           const timeAxisValue = getXAxisValue(data, eventParams.name);
-          drillToDetailFilters.push({
-            col:
-              // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
-              xAxis.label === DTTM_ALIAS
-                ? formData.granularitySqla
-                : xAxis.label,
-            grain: formData.timeGrainSqla,
-            op: '==',
-            val: timeAxisValue,
-            formattedVal: xValueFormatter(timeAxisValue),
-          });
+          if (timeAxisValue !== undefined) {
+            drillToDetailFilters.push({
+              col:
+                // if the xAxis is '__timestamp', granularity_sqla will be the column of filter
+                xAxis.label === DTTM_ALIAS
+                  ? formData.granularitySqla
+                  : xAxis.label,
+              grain: resolvedTimeGrain,
+              op: '==',
+              val: timeAxisValue,
+              formattedVal: xValueFormatter(timeAxisValue),
+            });
+          }
         }
         [
           ...(xAxis.type === AxisType.Category && data ? [xAxis.label] : []),
@@ -681,12 +674,18 @@ export default function EchartsTimeseries({
           xAxis.type === AxisType.Category &&
           eventParams.componentType === 'series'
         ) {
-          const categoryAxisValue = getXAxisValue(
-            data,
-            eventParams.name,
-          );
+          const categoryAxisValue = getXAxisValue(data, eventParams.name);
           if (categoryAxisValue !== undefined) {
             crossFilter = getXAxisCrossFilterDataMask(categoryAxisValue);
+          }
+        } else if (
+          canCrossFilterByXAxis &&
+          xAxis.type === AxisType.Time &&
+          eventParams.componentType === 'series'
+        ) {
+          const timeAxisValue = getXAxisValue(data, eventParams.name);
+          if (typeof timeAxisValue === 'number') {
+            crossFilter = getTimeAxisCrossFilterDataMask(timeAxisValue);
           }
         }
 
@@ -721,7 +720,12 @@ export default function EchartsTimeseries({
         }
       }
     },
-    [canCrossFilterByXAxis, handleTimeAxisChange, handleXAxisChange, xAxis.type],
+    [
+      canCrossFilterByXAxis,
+      handleTimeAxisChange,
+      handleXAxisChange,
+      xAxis.type,
+    ],
   );
 
   const renderedXAxis =

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -31,6 +31,7 @@ import {
 } from '@superset-ui/core';
 import { useTheme } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
+import { logging } from '@apache-superset/core/utils';
 import type {
   ECElementEvent,
   ViewRootGroup,
@@ -50,17 +51,19 @@ import { getTemporalXAxisDrillByFilter } from '../utils/xAxisDrillByFilter';
 import { ExtraControls } from '../components/ExtraControls';
 
 const TIMER_DURATION = 300;
-const getTimestampFromTimeAxisLabel = (value: string | number) => {
+const getTimestampFromTimeAxisValue = (value: string | number) => {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : undefined;
   }
   const timestamp = Date.parse(value);
   if (Number.isNaN(timestamp)) {
-    console.warn('Unable to parse time axis label for cross-filtering', value);
+    logging.warn('Unable to parse time axis value for cross-filtering', value);
   }
   return Number.isNaN(timestamp) ? undefined : timestamp;
 };
 
+// Day, month, and year ranges end at 23:59:59.999, so adding 1ms lands on a
+// whole-second next bucket boundary. The formatter intentionally emits seconds.
 const formatDateTime = (date: Date) =>
   `${[
     date.getUTCFullYear(),
@@ -533,8 +536,11 @@ export default function EchartsTimeseries({
           props.componentType === 'series'
         ) {
           const timeAxisValue = getXAxisValue(props.data, props.name);
-          if (typeof timeAxisValue === 'number') {
-            handleTimeAxisChange(timeAxisValue);
+          if (timeAxisValue !== undefined) {
+            const timestamp = getTimestampFromTimeAxisValue(timeAxisValue);
+            if (timestamp !== undefined) {
+              handleTimeAxisChange(timestamp);
+            }
           }
         }
       }, TIMER_DURATION);
@@ -624,9 +630,7 @@ export default function EchartsTimeseries({
           xAxis.label === DTTM_ALIAS ? formData.granularitySqla : xAxis.label;
         if (data && xAxis.type === AxisType.Time && xAxisCol) {
           // For horizontal orientation the [x, value] pair is swapped
-          const xValue = Array.isArray(data)
-            ? data[categoryAxisValueIndex]
-            : data;
+          const xValue = Array.isArray(data) ? data[xAxisValueIndex] : data;
           const xAxisFilter = getTemporalXAxisDrillByFilter(
             xAxisCol,
             xValue,
@@ -637,10 +641,7 @@ export default function EchartsTimeseries({
             xAxisFilters.push(xAxisFilter);
           }
         } else if (xAxis.type === AxisType.Category && xAxisCol) {
-          const categoryAxisValue = getCategoryAxisValue(
-            data,
-            eventParams.name,
-          );
+          const categoryAxisValue = getXAxisValue(data, eventParams.name);
           if (categoryAxisValue !== undefined) {
             // A category axis can still sit on a temporal column when the
             // axis is forced categorical; filter by time bucket in that case
@@ -684,8 +685,11 @@ export default function EchartsTimeseries({
           eventParams.componentType === 'series'
         ) {
           const timeAxisValue = getXAxisValue(data, eventParams.name);
-          if (typeof timeAxisValue === 'number') {
-            crossFilter = getTimeAxisCrossFilterDataMask(timeAxisValue);
+          if (timeAxisValue !== undefined) {
+            const timestamp = getTimestampFromTimeAxisValue(timeAxisValue);
+            if (timestamp !== undefined) {
+              crossFilter = getTimeAxisCrossFilterDataMask(timestamp);
+            }
           }
         }
 
@@ -711,7 +715,7 @@ export default function EchartsTimeseries({
         (typeof value === 'string' || typeof value === 'number')
       ) {
         if (xAxis.type === AxisType.Time) {
-          const timestamp = getTimestampFromTimeAxisLabel(value);
+          const timestamp = getTimestampFromTimeAxisValue(value);
           if (timestamp !== undefined) {
             handleTimeAxisChange(timestamp);
           }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -1245,7 +1245,7 @@ export default function transformProps(
     name: xAxisTitle,
     nameGap: convertInteger(xAxisTitleMargin),
     nameLocation: 'middle',
-    ...(xAxisType === AxisType.Category &&
+    ...((xAxisType === AxisType.Category || xAxisType === AxisType.Time) &&
       groupBy.length === 0 && {
         triggerEvent: true,
       }),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -1587,6 +1587,7 @@ export default function transformProps(
       label: xAxisLabel,
       type: xAxisType,
     },
+    resolvedTimeGrain,
     refs,
     coltypeMapping: dataTypes,
     onLegendScroll,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -120,5 +120,6 @@ export type TimeseriesChartTransformedProps =
         label: string;
         type: AxisType;
       };
+      resolvedTimeGrain?: TimeGranularity;
       onFocusedSeries: (series: string | null) => void;
     };

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/EchartsTimeseries.test.tsx
@@ -16,11 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render } from '@testing-library/react';
-import { AxisType } from '@superset-ui/core';
+import { render, waitFor } from '@testing-library/react';
+import { AxisType, DTTM_ALIAS, TimeGranularity } from '@superset-ui/core';
 import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import { logging } from '@apache-superset/core/utils';
+import type { ECElementEvent } from 'echarts/types/src/util/types';
 import EchartsTimeseries from '../../src/Timeseries/EchartsTimeseries';
-import { TimeseriesChartTransformedProps } from '../../src/Timeseries/types';
+import {
+  OrientationType,
+  TimeseriesChartTransformedProps,
+} from '../../src/Timeseries/types';
+import type { EchartsProps } from '../../src/types';
 
 // Percent-change draggable baseline: this is the one piece of the ECharts
 // rebuilds with zero prior test coverage despite six separate production
@@ -40,12 +46,14 @@ let mockChart: {
   convertFromPixel: jest.Mock;
   getModel: jest.Mock;
 };
+const mockEchart = jest.fn();
 
 jest.mock('../../src/components/Echart', () => {
   const { forwardRef, useImperativeHandle } = jest.requireActual('react');
   return {
     __esModule: true,
-    default: forwardRef((_props: unknown, ref: unknown) => {
+    default: forwardRef((props: unknown, ref: unknown) => {
+      mockEchart(props);
       useImperativeHandle(ref, () => ({
         getEchartInstance: () => mockChart,
       }));
@@ -115,6 +123,17 @@ function renderTimeseries(
   );
 }
 
+function getLatestEchartProps() {
+  const lastCall = mockEchart.mock.calls.at(-1);
+  expect(lastCall).toBeDefined();
+  const [props] = lastCall as [EchartsProps];
+  return props;
+}
+
+function advanceClickTimer() {
+  jest.advanceTimersByTime(300);
+}
+
 // Pulls the graphic descriptor for the draggable baseline handle out of the
 // most recent setOption call, mirroring how ECharts itself would read it.
 function getBaselineGraphic() {
@@ -126,6 +145,7 @@ function getBaselineGraphic() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockEchart.mockReset();
   setupChartMock();
   jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
     cb(0);
@@ -134,6 +154,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  jest.useRealTimers();
   jest.restoreAllMocks();
 });
 
@@ -244,4 +265,401 @@ test('does not touch the chart instance when rebase is disabled', () => {
   renderTimeseries({ formData: { rebasePercentChange: false } as any });
 
   expect(mockChart.setOption).not.toHaveBeenCalled();
+});
+
+test('emits TEMPORAL_RANGE cross-filter from time axis label click on day bucket', () => {
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.DAY,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.DAY,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as unknown as ECElementEvent);
+
+  expect(setDataMask.mock.calls[0][0]).toEqual({
+    extraFormData: {
+      filters: [
+        {
+          col: 'ds',
+          op: 'TEMPORAL_RANGE',
+          val: '2021-01-01T00:00:00 : 2021-01-02T00:00:00',
+        },
+      ],
+    },
+    filterState: {
+      label: ['2021-01-01T00:00:00 : 2021-01-02T00:00:00'],
+      value: ['2021-01-01T00:00:00 : 2021-01-02T00:00:00'],
+      selectedValues: ['2021-01-01T00:00:00 : 2021-01-02T00:00:00'],
+    },
+  });
+});
+
+test('emits upper-exclusive TEMPORAL_RANGE from time point click on month bucket', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('uses resolved time grain for temporal point-click cross-filter', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.DAY,
+      extraFormData: {
+        time_grain_sqla: TimeGranularity.MONTH,
+      },
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits TEMPORAL_RANGE from string-typed time point click value', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: ['2021-01-01T00:00:00Z', 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('emits TEMPORAL_RANGE from horizontal time point click using timestamp, not metric', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      orientation: OrientationType.Horizontal,
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [129, Date.UTC(2021, 0, 1)],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0].extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
+});
+
+test('clears temporal X-axis cross-filter when clicking selected bucket again', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+  const selectedRange = '2021-01-01T00:00:00 : 2021-02-01T00:00:00';
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    selectedValues: { 0: selectedRange },
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0]).toEqual({
+    extraFormData: {
+      filters: [],
+    },
+    filterState: {
+      label: undefined,
+      value: null,
+      selectedValues: null,
+    },
+  });
+});
+
+test('emits empty temporal X-axis data mask when filter grain is missing', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: undefined,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask.mock.calls[0][0]).toEqual({
+    extraFormData: {
+      filters: [],
+    },
+    filterState: {
+      label: undefined,
+      value: null,
+      selectedValues: null,
+    },
+  });
+});
+
+test('warns and skips temporal cross-filter when string value cannot be parsed', () => {
+  jest.useFakeTimers();
+  const setDataMask = jest.fn();
+  const warn = jest.spyOn(logging, 'warn').mockImplementation();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  getLatestEchartProps().eventHandlers?.click?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: ['not-a-date', 100],
+    name: 'not-a-date',
+    dataIndex: 0,
+  });
+  advanceClickTimer();
+
+  expect(setDataMask).not.toHaveBeenCalled();
+  expect(warn).toHaveBeenCalledWith(
+    'Unable to parse time axis value for cross-filtering',
+    'not-a-date',
+  );
+});
+
+test('does not emit temporal X-axis label cross-filter when dimensions are set', () => {
+  const setDataMask = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    setDataMask,
+    groupby: ['country'],
+    formData: {
+      groupby: ['country'],
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.MONTH,
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  const labelClickHandler = getLatestEchartProps().queryEventHandlers?.find(
+    ({ query }) => query === 'xAxis',
+  )?.handler;
+  expect(labelClickHandler).toBeDefined();
+  labelClickHandler?.({
+    targetType: 'axisLabel',
+    value: '2021-01-01',
+  } as unknown as ECElementEvent);
+
+  expect(setDataMask).not.toHaveBeenCalled();
+});
+
+test('context menu cross-filter is available for a temporal bar point', async () => {
+  const onContextMenu = jest.fn();
+
+  renderTimeseries({
+    emitCrossFilters: true,
+    onContextMenu,
+    groupby: [],
+    resolvedTimeGrain: TimeGranularity.MONTH,
+    formData: {
+      granularitySqla: 'ds',
+      timeGrainSqla: TimeGranularity.DAY,
+      extraFormData: {
+        time_grain_sqla: TimeGranularity.MONTH,
+      },
+      vizType: 'echarts_timeseries_line',
+    } as any,
+    xAxis: {
+      label: DTTM_ALIAS,
+      type: AxisType.Time,
+    },
+  });
+
+  await getLatestEchartProps().eventHandlers?.contextmenu?.({
+    componentType: 'series',
+    seriesName: 'Sales',
+    data: [Date.UTC(2021, 0, 1), 100],
+    name: '2021-01-01',
+    event: { stop: jest.fn(), event: { clientX: 10, clientY: 20 } },
+  });
+
+  await waitFor(() => {
+    expect(onContextMenu).toHaveBeenCalled();
+  });
+
+  const { crossFilter } = onContextMenu.mock.calls[0][2];
+  expect(crossFilter.dataMask.extraFormData.filters).toEqual([
+    {
+      col: 'ds',
+      op: 'TEMPORAL_RANGE',
+      val: '2021-01-01T00:00:00 : 2021-02-01T00:00:00',
+    },
+  ]);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2082,6 +2082,39 @@ test('xAxisForceCategorical forces Category axis regardless of Numeric coltype',
   expect(xAxis.triggerEvent).toBe(true);
 });
 
+test('temporal x-axis enables trigger events when no dimensions are set', () => {
+  const ts1 = 1745784000000;
+  const ts2 = 1745870400000;
+  const chartProps = createTestChartProps({
+    formData: {
+      metrics: ['metric'],
+      granularity_sqla: 'ds',
+      x_axis: '__timestamp',
+    },
+    queriesData: [
+      createTestQueryData(
+        [
+          { __timestamp: ts1, metric: 10 },
+          { __timestamp: ts2, metric: 20 },
+        ],
+        {
+          colnames: ['__timestamp', 'metric'],
+          coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+        },
+      ),
+    ],
+  });
+
+  const { echartOptions } = transformProps(chartProps);
+  const xAxis = echartOptions.xAxis as {
+    triggerEvent?: boolean;
+    type: string;
+  };
+
+  expect(xAxis.type).toBe(AxisType.Time);
+  expect(xAxis.triggerEvent).toBe(true);
+});
+
 test('temporal x coltype forced categorical yields a Category axis with date labels', () => {
   // Issue #28204: with a temporal x-axis (e.g. weekly grain) the default Time
   // scale places ticks at "nice" intervals that don't line up with the buckets.

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2362,6 +2362,7 @@ test('tooltip time grain wiring: dashboard-level extraFormData time grain overri
   });
 
   const transformedProps = transformProps(chartProps);
+  expect(transformedProps.resolvedTimeGrain).toBe(TimeGranularity.MONTH);
   const tooltipFormatter = (
     transformedProps.echartOptions as unknown as TooltipFormatterOptions
   ).tooltip.formatter;
@@ -2395,6 +2396,7 @@ test('tooltip time grain wiring: chart-level time grain drives the tooltip when 
   });
 
   const transformedProps = transformProps(chartProps);
+  expect(transformedProps.resolvedTimeGrain).toBe(TimeGranularity.YEAR);
   const tooltipFormatter = (
     transformedProps.echartOptions as unknown as TooltipFormatterOptions
   ).tooltip.formatter;


### PR DESCRIPTION
### SUMMARY

Currently, clicking a bar or an axis label on a time-based (temporal) X-axis
does not trigger cross-filtering when no dimension/groupby is set — unlike the
existing categorical X-axis cross-filter support (#37407, #41111). This PR
extends that same no-dimension cross-filter capability to temporal X-axes.

- Extend `canCrossFilterByXAxis` to support `AxisType.Time` in addition to
  `AxisType.Category`, gated by `!hasDimensions`
- Add temporal `TEMPORAL_RANGE` data mask generation using
  `createTimeRangeFromGranularity` (day/month/year granularities)
- Apply a +1ms adjustment to convert the utility's inclusive end into the
  backend's upper-exclusive bound, per `get_time_filter` semantics in
  `superset/models/helpers.py`
- Add `triggerEvent: true` for temporal X-axis when no dimensions are set,
  enabling axis-label click events
- Register an orientation-aware query event handler (`xAxis`/`yAxis`) guarded
  by `targetType === 'axisLabel'`, covering both categorical and temporal
  label clicks
- Fix a horizontal-orientation point-click bug reading the wrong tuple index
  (metric value instead of axis value) for the temporal cross-filter path,
  using the same orientation-aware extraction already used for the
  categorical path
- Add regression tests covering day/month/year point-click and
  axis-label-click payloads, toggle behavior, horizontal/vertical
  orientation, and no-op behavior when dimensions are set

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavioral fix, no UI changes.

### TESTING INSTRUCTIONS

1. Create a bar chart (`echarts_timeseries_bar`) with no dimension/groupby,
   a temporal X-axis column, and any time grain (day/month/year).
2. Add it to a dashboard alongside a target chart sharing the same temporal
   column, and enable cross-filtering.
3. Click a bar → the target chart filters to the clicked time bucket via a
   `TEMPORAL_RANGE` filter.
4. Click the same bar again → the filter clears (toggle behavior).
5. Click an X-axis label directly → same cross-filter behavior as clicking
   the bar.
6. Repeat steps 1–5 with `orientation: horizontal` — verify the correct time
   bucket is used (not the metric value).
7. Set a groupby/dimension on the chart → clicking bars or labels should NOT
   trigger this temporal cross-filter path (existing dimension-based
   behavior applies instead).

Automated: `npm run test -- EchartsTimeseries.test.tsx transformProps.test.ts`

### ADDITIONAL INFORMATION

- [x] Has associated issue: Related to #31302 (community discussion reporting the same gap)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API