### PR TITLE
fix(versioning): pin shadow-row reads and restore to (id, uuid)

### DIFF
--- a/superset/daos/version.py
+++ b/superset/daos/version.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from superset.versioning.queries import (
     current_live_transaction_id,
     current_live_version_uuid,
+    current_version_info,
     current_version_number,
     derive_version_uuid,
     derive_version_uuid as _derive_version_uuid,  # noqa: F401
@@ -62,7 +63,9 @@ class VersionDAO:
 
     # --- read side (queries.py) -------------------------------------------
     find_active_by_uuid = staticmethod(find_active_by_uuid)
+    derive_version_uuid = staticmethod(derive_version_uuid)
     current_version_number = staticmethod(current_version_number)
+    current_version_info = staticmethod(current_version_info)
     current_live_transaction_id = staticmethod(current_live_transaction_id)
     current_live_version_uuid = staticmethod(current_live_version_uuid)
     list_change_records_batch = staticmethod(list_change_records_batch)

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -109,16 +109,19 @@ def current_entity_version_info(
         entity_uuid = db.session.scalar(
             sa.select(model_cls.uuid).where(model_cls.id == entity_id)
         )
+    if entity_uuid is None:
+        return EntityVersionInfo()
+    version, transaction_id = VersionDAO.current_version_info(
+        model_cls, entity_id, entity_uuid
+    )
     version_uuid = (
-        VersionDAO.current_live_version_uuid(model_cls, entity_id, entity_uuid)
-        if entity_uuid is not None
+        VersionDAO.derive_version_uuid(entity_uuid, transaction_id)
+        if transaction_id is not None
         else None
     )
     return EntityVersionInfo(
-        version=VersionDAO.current_version_number(model_cls, entity_id, entity_uuid),
-        transaction_id=VersionDAO.current_live_transaction_id(
-            model_cls, entity_id, entity_uuid
-        ),
+        version=version,
+        transaction_id=transaction_id,
         version_uuid=str(version_uuid) if version_uuid else None,
     )
 

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -115,8 +115,10 @@ def current_entity_version_info(
         else None
     )
     return EntityVersionInfo(
-        version=VersionDAO.current_version_number(model_cls, entity_id),
-        transaction_id=VersionDAO.current_live_transaction_id(model_cls, entity_id),
+        version=VersionDAO.current_version_number(model_cls, entity_id, entity_uuid),
+        transaction_id=VersionDAO.current_live_transaction_id(
+            model_cls, entity_id, entity_uuid
+        ),
         version_uuid=str(version_uuid) if version_uuid else None,
     )
 

--- a/superset/versioning/baseline/collection.py
+++ b/superset/versioning/baseline/collection.py
@@ -124,7 +124,7 @@ def version_table_for(obj: Any) -> Any:
 
 
 def shadow_row_count(session: Session, obj: Any, version_table: Any) -> int | None:
-    """Return number of shadow rows for *obj.id* in *version_table*, or
+    """Return the number of shadow rows for *obj* in *version_table*, or
     ``None`` when the version table is missing (migration not yet applied)
     or the count query raised unexpectedly.
     """
@@ -139,7 +139,10 @@ def shadow_row_count(session: Session, obj: Any, version_table: Any) -> int | No
                 .execute(
                     sa.select(sa.func.count())
                     .select_from(version_table)
-                    .where(version_table.c.id == obj.id)
+                    .where(
+                        version_table.c.id == obj.id,
+                        version_table.c.uuid == obj.uuid,
+                    )
                 )
                 .scalar()
             )

--- a/superset/versioning/factory.py
+++ b/superset/versioning/factory.py
@@ -31,6 +31,7 @@ from sqlalchemy_continuum.utils import versioned_column_properties
 
 from superset.utils import json
 from superset.versioning.diff import DASHBOARD_JSON_METADATA_AUDIT_KEYS
+from superset.versioning.queries import identity_filter
 
 logger = logging.getLogger(__name__)
 
@@ -293,7 +294,14 @@ class SkipUnmodifiedPlugin(Plugin):
 
         select_stmt = (
             sa.select(*[ver_table.c[c] for c in col_keys])
-            .where(ver_table.c.id == target.id)
+            # Pinned to (id, uuid) for the same reason the read paths are: a
+            # freed id can resolve a predecessor's still-open shadow row. That
+            # would compare this save against a stranger's values — and where
+            # an entity was deleted and recreated identically, they match, so
+            # a genuine edit would be misread as a no-op and never captured.
+            .where(
+                identity_filter(ver_table.c, target.id, getattr(target, "uuid", None))
+            )
             .where(ver_table.c.end_transaction_id.is_(None))
             .order_by(ver_table.c.transaction_id.desc())
             .limit(1)

--- a/superset/versioning/factory.py
+++ b/superset/versioning/factory.py
@@ -31,7 +31,6 @@ from sqlalchemy_continuum.utils import versioned_column_properties
 
 from superset.utils import json
 from superset.versioning.diff import DASHBOARD_JSON_METADATA_AUDIT_KEYS
-from superset.versioning.queries import identity_filter
 
 logger = logging.getLogger(__name__)
 
@@ -294,14 +293,7 @@ class SkipUnmodifiedPlugin(Plugin):
 
         select_stmt = (
             sa.select(*[ver_table.c[c] for c in col_keys])
-            # Pinned to (id, uuid) for the same reason the read paths are: a
-            # freed id can resolve a predecessor's still-open shadow row. That
-            # would compare this save against a stranger's values — and where
-            # an entity was deleted and recreated identically, they match, so
-            # a genuine edit would be misread as a no-op and never captured.
-            .where(
-                identity_filter(ver_table.c, target.id, getattr(target, "uuid", None))
-            )
+            .where(ver_table.c.id == target.id)
             .where(ver_table.c.end_transaction_id.is_(None))
             .order_by(ver_table.c.transaction_id.desc())
             .limit(1)

--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -40,7 +40,10 @@ from flask_appbuilder import Model
 from sqlalchemy_continuum import version_class
 
 from superset.extensions import db
-from superset.versioning.baseline import CONTINUUM_BOOKKEEPING_COLUMNS
+from superset.versioning.baseline import (
+    CONTINUUM_BOOKKEEPING_COLUMNS,
+    OPERATION_DELETE,
+)
 from superset.versioning.db_errors import is_missing_table_error
 
 logger = logging.getLogger(__name__)
@@ -173,18 +176,31 @@ def identity_filter(columns: Any, entity_id: int, entity_uuid: UUID) -> Any:
     return sa.and_(columns.id == entity_id, columns.uuid == entity_uuid)
 
 
-def _get_version_count(
+def current_version_info(
     model_cls: type[Model], entity_id: int, entity_uuid: UUID
-) -> int:
-    """Return the number of historical version rows for the entity."""
+) -> tuple[int | None, int | None]:
+    """Return the version number and live transaction from one query."""
     ver_cls = version_class(model_cls)
-    return (
-        db.session.query(sa.func.count())
-        .select_from(ver_cls)
+    count, transaction_id = (
+        db.session.query(
+            sa.func.count(),
+            sa.func.max(
+                sa.case(
+                    (
+                        sa.and_(
+                            ver_cls.end_transaction_id.is_(None),
+                            ver_cls.operation_type != OPERATION_DELETE,
+                        ),
+                        ver_cls.transaction_id,
+                    )
+                )
+            ),
+        )
         .filter(identity_filter(ver_cls, entity_id, entity_uuid))
-        .scalar()
-        or 0
+        .one()
     )
+    version_number = count - 1 if count > 0 else None
+    return version_number, transaction_id
 
 
 def current_version_number(
@@ -202,8 +218,10 @@ def current_version_number(
     can refer to different rows before and after a prune cycle. Use
     :func:`current_live_transaction_id` for a stable identifier.
     """
-    count = _get_version_count(model_cls, entity_id, entity_uuid)
-    return count - 1 if count > 0 else None
+    version_number, _transaction_id = current_version_info(
+        model_cls, entity_id, entity_uuid
+    )
+    return version_number
 
 
 def current_live_transaction_id(
@@ -213,16 +231,10 @@ def current_live_transaction_id(
     *entity_id* — stable across retention pruning, unlike the index
     returned by :func:`current_version_number`.
     """
-    ver_cls = version_class(model_cls)
-    row = (
-        db.session.query(ver_cls.transaction_id)
-        .filter(identity_filter(ver_cls, entity_id, entity_uuid))
-        .filter(ver_cls.end_transaction_id.is_(None))
-        .order_by(ver_cls.transaction_id.desc())
-        .limit(1)
-        .first()
+    _version_number, transaction_id = current_version_info(
+        model_cls, entity_id, entity_uuid
     )
-    return row[0] if row else None
+    return transaction_id
 
 
 def current_live_version_uuid(

--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -168,33 +168,13 @@ def find_active_by_uuid(model_cls: type[Model], entity_uuid: UUID) -> Any | None
     )
 
 
-def identity_filter(columns: Any, entity_id: int, entity_uuid: UUID | None) -> Any:
-    """Predicate pinning a shadow-row query to the entity it came from.
-
-    *columns* supplies the ``id`` and ``uuid`` columns, so it accepts either
-    the Continuum version class (ORM queries) or a version table's ``.c``
-    collection (Core ``select()`` queries) — both read paths need the same
-    pinning, and a single predicate keeps them from drifting apart.
-
-    The integer id alone is not an identity: a hard delete frees the id and
-    the database may hand it to a different entity — guaranteed on SQLite
-    ROWID tables, and reachable wherever a sequence is reset. Matching on the
-    id alone lets a successor inherit its predecessor's version history, and
-    lets a restore write the predecessor's content over it. The shadow tables
-    carry ``uuid``, so pinning both makes a reused id match nothing rather
-    than match a stranger. Mirrors ``_identity_predicates`` in the purge
-    cascade, where the same defect was fixed on the soft-delete side.
-
-    Falls back to the id alone when no uuid is available, preserving the
-    previous behaviour for callers that cannot supply one.
-    """
-    if entity_uuid is None:
-        return columns.id == entity_id
+def identity_filter(columns: Any, entity_id: int, entity_uuid: UUID) -> Any:
+    """Build an ``(id, uuid)`` predicate for ORM or Core version columns."""
     return sa.and_(columns.id == entity_id, columns.uuid == entity_uuid)
 
 
 def _get_version_count(
-    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID
 ) -> int:
     """Return the number of historical version rows for the entity."""
     ver_cls = version_class(model_cls)
@@ -208,7 +188,7 @@ def _get_version_count(
 
 
 def current_version_number(
-    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID
 ) -> int | None:
     """Return the 0-based ``version_number`` of the live row for *entity_id*
     — equivalent to the index of the most recent entry that
@@ -227,7 +207,7 @@ def current_version_number(
 
 
 def current_live_transaction_id(
-    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID
 ) -> int | None:
     """Return the Continuum ``transaction_id`` of the live row for
     *entity_id* — stable across retention pruning, unlike the index
@@ -383,7 +363,7 @@ def list_versions(
             *_user_select_cols(user_tbl),
         )
         .select_from(_version_with_tx_user_join(ver_tbl, tx_tbl, user_tbl))
-        .where(identity_filter(ver_tbl.c, entity.id, getattr(entity, "uuid", None)))
+        .where(identity_filter(ver_tbl.c, entity.id, entity_uuid))
         .order_by(*_baseline_first_ordering(ver_tbl))
     )
     rows = db.session.execute(stmt).mappings().all()
@@ -454,7 +434,7 @@ def resolve_version(
     ver_cls = version_class(model_cls)
     tx_ids = (
         db.session.query(ver_cls.transaction_id)
-        .filter(identity_filter(ver_cls, entity.id, getattr(entity, "uuid", None)))
+        .filter(identity_filter(ver_cls, entity.id, entity_uuid))
         .order_by(
             (ver_cls.operation_type != 0).asc(),
             ver_cls.transaction_id.asc(),
@@ -534,7 +514,7 @@ def get_version(
         # to a wider one addresses the wrong row. Pinned there but not here,
         # a recycled id would surface a predecessor's snapshot under the
         # successor's version uuid.
-        .where(identity_filter(ver_tbl.c, entity.id, getattr(entity, "uuid", None)))
+        .where(identity_filter(ver_tbl.c, entity.id, entity_uuid))
         .order_by(*_baseline_first_ordering(ver_tbl))
         .offset(version_num)
         .limit(1)

--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -168,19 +168,43 @@ def find_active_by_uuid(model_cls: type[Model], entity_uuid: UUID) -> Any | None
     )
 
 
-def _get_version_count(model_cls: type[Model], entity_id: int) -> int:
-    """Return the number of historical version rows for *entity_id*."""
+def _identity_filter(ver_cls: Any, entity_id: int, entity_uuid: UUID | None) -> Any:
+    """Predicate pinning a shadow-row query to the entity it came from.
+
+    The integer id alone is not an identity: a hard delete frees the id and
+    the database may hand it to a different entity — guaranteed on SQLite
+    ROWID tables, and reachable wherever a sequence is reset. Matching on the
+    id alone lets a successor inherit its predecessor's version history, and
+    lets a restore write the predecessor's content over it. The shadow tables
+    carry ``uuid``, so pinning both makes a reused id match nothing rather
+    than match a stranger. Mirrors ``_identity_predicates`` in the purge
+    cascade, where the same defect was fixed on the soft-delete side.
+
+    Falls back to the id alone when no uuid is available, preserving the
+    previous behaviour for callers that cannot supply one.
+    """
+    if entity_uuid is None:
+        return ver_cls.id == entity_id
+    return sa.and_(ver_cls.id == entity_id, ver_cls.uuid == entity_uuid)
+
+
+def _get_version_count(
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+) -> int:
+    """Return the number of historical version rows for the entity."""
     ver_cls = version_class(model_cls)
     return (
         db.session.query(sa.func.count())
         .select_from(ver_cls)
-        .filter(ver_cls.id == entity_id)
+        .filter(_identity_filter(ver_cls, entity_id, entity_uuid))
         .scalar()
         or 0
     )
 
 
-def current_version_number(model_cls: type[Model], entity_id: int) -> int | None:
+def current_version_number(
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+) -> int | None:
     """Return the 0-based ``version_number`` of the live row for *entity_id*
     — equivalent to the index of the most recent entry that
     :func:`list_versions` would return, or ``None`` when the entity has no
@@ -193,11 +217,13 @@ def current_version_number(model_cls: type[Model], entity_id: int) -> int | None
     can refer to different rows before and after a prune cycle. Use
     :func:`current_live_transaction_id` for a stable identifier.
     """
-    count = _get_version_count(model_cls, entity_id)
+    count = _get_version_count(model_cls, entity_id, entity_uuid)
     return count - 1 if count > 0 else None
 
 
-def current_live_transaction_id(model_cls: type[Model], entity_id: int) -> int | None:
+def current_live_transaction_id(
+    model_cls: type[Model], entity_id: int, entity_uuid: UUID | None = None
+) -> int | None:
     """Return the Continuum ``transaction_id`` of the live row for
     *entity_id* — stable across retention pruning, unlike the index
     returned by :func:`current_version_number`.
@@ -205,7 +231,7 @@ def current_live_transaction_id(model_cls: type[Model], entity_id: int) -> int |
     ver_cls = version_class(model_cls)
     row = (
         db.session.query(ver_cls.transaction_id)
-        .filter(ver_cls.id == entity_id)
+        .filter(_identity_filter(ver_cls, entity_id, entity_uuid))
         .filter(ver_cls.end_transaction_id.is_(None))
         .order_by(ver_cls.transaction_id.desc())
         .limit(1)
@@ -219,7 +245,7 @@ def current_live_version_uuid(
 ) -> UUID | None:
     """Return the deterministic ``version_uuid`` of the live row, or
     ``None`` when the entity has no version rows yet."""
-    tx_id = current_live_transaction_id(model_cls, entity_id)
+    tx_id = current_live_transaction_id(model_cls, entity_id, entity_uuid)
     if tx_id is None:
         return None
     return derive_version_uuid(entity_uuid, tx_id)
@@ -423,7 +449,7 @@ def resolve_version(
     ver_cls = version_class(model_cls)
     tx_ids = (
         db.session.query(ver_cls.transaction_id)
-        .filter(ver_cls.id == entity.id)
+        .filter(_identity_filter(ver_cls, entity.id, getattr(entity, "uuid", None)))
         .order_by(
             (ver_cls.operation_type != 0).asc(),
             ver_cls.transaction_id.asc(),

--- a/superset/versioning/queries.py
+++ b/superset/versioning/queries.py
@@ -168,8 +168,13 @@ def find_active_by_uuid(model_cls: type[Model], entity_uuid: UUID) -> Any | None
     )
 
 
-def _identity_filter(ver_cls: Any, entity_id: int, entity_uuid: UUID | None) -> Any:
+def identity_filter(columns: Any, entity_id: int, entity_uuid: UUID | None) -> Any:
     """Predicate pinning a shadow-row query to the entity it came from.
+
+    *columns* supplies the ``id`` and ``uuid`` columns, so it accepts either
+    the Continuum version class (ORM queries) or a version table's ``.c``
+    collection (Core ``select()`` queries) — both read paths need the same
+    pinning, and a single predicate keeps them from drifting apart.
 
     The integer id alone is not an identity: a hard delete frees the id and
     the database may hand it to a different entity — guaranteed on SQLite
@@ -184,8 +189,8 @@ def _identity_filter(ver_cls: Any, entity_id: int, entity_uuid: UUID | None) -> 
     previous behaviour for callers that cannot supply one.
     """
     if entity_uuid is None:
-        return ver_cls.id == entity_id
-    return sa.and_(ver_cls.id == entity_id, ver_cls.uuid == entity_uuid)
+        return columns.id == entity_id
+    return sa.and_(columns.id == entity_id, columns.uuid == entity_uuid)
 
 
 def _get_version_count(
@@ -196,7 +201,7 @@ def _get_version_count(
     return (
         db.session.query(sa.func.count())
         .select_from(ver_cls)
-        .filter(_identity_filter(ver_cls, entity_id, entity_uuid))
+        .filter(identity_filter(ver_cls, entity_id, entity_uuid))
         .scalar()
         or 0
     )
@@ -231,7 +236,7 @@ def current_live_transaction_id(
     ver_cls = version_class(model_cls)
     row = (
         db.session.query(ver_cls.transaction_id)
-        .filter(_identity_filter(ver_cls, entity_id, entity_uuid))
+        .filter(identity_filter(ver_cls, entity_id, entity_uuid))
         .filter(ver_cls.end_transaction_id.is_(None))
         .order_by(ver_cls.transaction_id.desc())
         .limit(1)
@@ -378,7 +383,7 @@ def list_versions(
             *_user_select_cols(user_tbl),
         )
         .select_from(_version_with_tx_user_join(ver_tbl, tx_tbl, user_tbl))
-        .where(ver_tbl.c.id == entity.id)
+        .where(identity_filter(ver_tbl.c, entity.id, getattr(entity, "uuid", None)))
         .order_by(*_baseline_first_ordering(ver_tbl))
     )
     rows = db.session.execute(stmt).mappings().all()
@@ -449,7 +454,7 @@ def resolve_version(
     ver_cls = version_class(model_cls)
     tx_ids = (
         db.session.query(ver_cls.transaction_id)
-        .filter(_identity_filter(ver_cls, entity.id, getattr(entity, "uuid", None)))
+        .filter(identity_filter(ver_cls, entity.id, getattr(entity, "uuid", None)))
         .order_by(
             (ver_cls.operation_type != 0).asc(),
             ver_cls.transaction_id.asc(),
@@ -524,7 +529,12 @@ def get_version(
             *_user_select_cols(user_tbl),
         )
         .select_from(_version_with_tx_user_join(ver_tbl, tx_tbl, user_tbl))
-        .where(ver_tbl.c.id == entity.id)
+        # Must pin identically to the count ``resolve_version_uuid`` derived
+        # ``version_num`` from: an offset counted over one row set and applied
+        # to a wider one addresses the wrong row. Pinned there but not here,
+        # a recycled id would surface a predecessor's snapshot under the
+        # successor's version uuid.
+        .where(identity_filter(ver_tbl.c, entity.id, getattr(entity, "uuid", None)))
         .order_by(*_baseline_first_ordering(ver_tbl))
         .offset(version_num)
         .limit(1)

--- a/superset/versioning/restore.py
+++ b/superset/versioning/restore.py
@@ -135,7 +135,11 @@ def restore_version(
     target_version = (
         db.session.query(ver_cls)
         .filter(
+            # Pin to (id, uuid): a hard delete frees the integer id, so
+            # matching on it alone can resolve a *predecessor's* version row
+            # and restore its content over the current entity.
             ver_cls.id == entity.id,
+            ver_cls.uuid == entity.uuid,
             ver_cls.transaction_id == transaction_id,
         )
         .one_or_none()

--- a/tests/integration_tests/charts/version_restore_tests.py
+++ b/tests/integration_tests/charts/version_restore_tests.py
@@ -236,7 +236,7 @@ class TestChartRestoreApi(SupersetTestCase):
         ver_cls = version_class(Slice)
         first_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == chart_id)
+            .filter(ver_cls.id == chart_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.asc())
             .limit(1)
             .scalar()
@@ -342,7 +342,7 @@ class TestChartRestoreApi(SupersetTestCase):
         assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == chart.id)
+            .filter(ver_cls.id == chart.id, ver_cls.uuid == chart.uuid)
             .order_by(ver_cls.transaction_id.asc())
             .limit(1)
             .scalar()
@@ -402,7 +402,7 @@ class TestChartRestoreApi(SupersetTestCase):
         assert boys_uuid is not None
         boys_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == boys.id)
+            .filter(ver_cls.id == boys.id, ver_cls.uuid == boys_uuid)
             .order_by(ver_cls.transaction_id.asc())
             .limit(1)
             .scalar()
@@ -438,7 +438,7 @@ class TestChartRestoreApi(SupersetTestCase):
         assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == chart_id)
+            .filter(ver_cls.id == chart_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.asc())
             .limit(1)
             .scalar()
@@ -451,7 +451,7 @@ class TestChartRestoreApi(SupersetTestCase):
 
         latest_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == chart_id)
+            .filter(ver_cls.id == chart_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.desc())
             .limit(1)
             .scalar()

--- a/tests/integration_tests/charts/version_restore_tests.py
+++ b/tests/integration_tests/charts/version_restore_tests.py
@@ -44,7 +44,7 @@ def _get_version_rows(chart: Slice) -> list[Any]:
     ver_cls = version_class(Slice)
     return (
         db.session.query(ver_cls)
-        .filter(ver_cls.id == chart.id)
+        .filter(ver_cls.id == chart.id, ver_cls.uuid == chart.uuid)
         .order_by(ver_cls.transaction_id.asc())
         .all()
     )
@@ -289,7 +289,15 @@ class TestChartRestoreApi(SupersetTestCase):
         original_name = chart.slice_name
 
         ver_cls = version_class(Slice)
-        count_before = db.session.query(ver_cls).filter(ver_cls.id == chart_id).count()
+        # Pin to (id, uuid), as the API's version lookup does. A shared test
+        # database recycles integer ids across the suite, so an id-only count
+        # picks up shadow rows belonging to hard-deleted predecessors and
+        # over-states this chart's history.
+        count_before = (
+            db.session.query(ver_cls)
+            .filter(ver_cls.id == chart_id, ver_cls.uuid == chart.uuid)
+            .count()
+        )
         expected_old = count_before - 1 if count_before > 0 else None
 
         self.login(ADMIN_USERNAME)

--- a/tests/integration_tests/dashboards/version_restore_tests.py
+++ b/tests/integration_tests/dashboards/version_restore_tests.py
@@ -107,7 +107,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
                 ver_cls.dashboard_title,
                 ver_cls.end_transaction_id,
             )
-            .filter(ver_cls.id == dashboard_id)
+            .filter(ver_cls.id == dashboard_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.asc())
             .all()
         )
@@ -168,7 +168,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         ver_cls = version_class(Dashboard)
         target_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == dashboard_id)
+            .filter(ver_cls.id == dashboard_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.desc())
             .limit(1)
             .scalar()
@@ -231,7 +231,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         assert entity_uuid is not None
         target_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == dashboard_id)
+            .filter(ver_cls.id == dashboard_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.desc())
             .limit(1)
             .scalar()
@@ -290,7 +290,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         assert entity_uuid is not None
         target_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == dashboard_id)
+            .filter(ver_cls.id == dashboard_id, ver_cls.uuid == entity_uuid)
             .order_by(ver_cls.transaction_id.desc())
             .limit(1)
             .scalar()
@@ -350,7 +350,7 @@ class TestDashboardRestoreApi(SupersetTestCase):
         assert entity_uuid is not None
         first_tx = (
             db.session.query(ver_cls.transaction_id)
-            .filter(ver_cls.id == dashboard.id)
+            .filter(ver_cls.id == dashboard.id, ver_cls.uuid == dashboard.uuid)
             .order_by(ver_cls.transaction_id.asc())
             .limit(1)
             .scalar()

--- a/tests/integration_tests/dashboards/version_restore_tests.py
+++ b/tests/integration_tests/dashboards/version_restore_tests.py
@@ -45,7 +45,7 @@ def _get_version_rows(dashboard: Dashboard) -> list[Any]:
     ver_cls = version_class(Dashboard)
     return (
         db.session.query(ver_cls)
-        .filter(ver_cls.id == dashboard.id)
+        .filter(ver_cls.id == dashboard.id, ver_cls.uuid == dashboard.uuid)
         .order_by(ver_cls.transaction_id.asc())
         .all()
     )
@@ -398,8 +398,14 @@ class TestDashboardRestoreApi(SupersetTestCase):
         original_title = dashboard.dashboard_title
 
         ver_cls = version_class(Dashboard)
+        # Pin to (id, uuid), as the API's version lookup does. A shared test
+        # database recycles integer ids across the suite, so an id-only count
+        # picks up shadow rows belonging to hard-deleted predecessors and
+        # over-states this dashboard's history.
         count_before = (
-            db.session.query(ver_cls).filter(ver_cls.id == dashboard_id).count()
+            db.session.query(ver_cls)
+            .filter(ver_cls.id == dashboard_id, ver_cls.uuid == dashboard.uuid)
+            .count()
         )
         expected_old = count_before - 1 if count_before > 0 else None
 

--- a/tests/integration_tests/versioning/id_reuse_tests.py
+++ b/tests/integration_tests/versioning/id_reuse_tests.py
@@ -40,6 +40,7 @@ import sqlalchemy as sa
 from superset import db
 from superset.daos.version import VersionDAO
 from superset.models.slice import Slice
+from superset.versioning.queries import get_version, list_versions
 from superset.versioning.restore import restore_version
 from tests.integration_tests.test_app import app
 
@@ -216,3 +217,49 @@ def test_shadow_rows_for_both_entities_share_the_id(recycled_id_charts) -> None:
         f"successor's shadow rows missing under the recycled id; found {uuids}"
     )
     assert sa.inspect(db.session.bind).has_table("slices_version")
+
+
+def test_list_versions_excludes_the_predecessors_rows(recycled_id_charts) -> None:
+    """The history listing must contain the successor's versions only.
+
+    ``list_versions`` selects the shadow rows with its own Core query rather
+    than going through the counting helper, so pinning the count alone left
+    this path — the one behind the version-history panel — still listing a
+    stranger's versions.
+    """
+    _entity_id, _predecessor_uuid, successor = recycled_id_charts
+
+    versions = list_versions(Slice, successor.uuid, entity=successor)
+
+    assert versions is not None, "successor is active, so its history resolves"
+    assert len(versions) == 1, (
+        "successor should list only its own INSERT; got "
+        f"{len(versions)} entries: {[v['transaction_id'] for v in versions]}"
+    )
+
+
+def test_get_version_returns_the_successors_own_snapshot(recycled_id_charts) -> None:
+    """A version snapshot must carry the content of the entity asked about.
+
+    ``version_number`` is resolved from a pinned count but applied to the
+    snapshot query as an OFFSET. While that query matched on the id alone the
+    offset was counted over one row set and applied to a wider one, so the row
+    it addressed could be a predecessor's — returning that entity's content
+    labelled with the successor's version uuid.
+    """
+    _entity_id, _predecessor_uuid, successor = recycled_id_charts
+
+    versions = list_versions(Slice, successor.uuid, entity=successor)
+    assert versions, "fixture should leave the successor one version"
+
+    snapshot = get_version(
+        Slice, successor.uuid, versions[0]["version_uuid"], entity=successor
+    )
+
+    assert snapshot is not None, "the successor's own version must resolve"
+    assert snapshot["slice_name"] == "id_reuse_successor", (
+        f"snapshot returned another entity's content: got {snapshot['slice_name']!r}"
+    )
+    assert snapshot["uuid"] == str(successor.uuid), (
+        f"snapshot belongs to a different entity: {snapshot['uuid']}"
+    )

--- a/tests/integration_tests/versioning/id_reuse_tests.py
+++ b/tests/integration_tests/versioning/id_reuse_tests.py
@@ -33,9 +33,13 @@ paths.
 from __future__ import annotations
 
 import uuid as uuid_module
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TypeAlias
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy_continuum import version_class, versioning_manager
 
 from superset import db
 from superset.daos.version import VersionDAO
@@ -43,6 +47,8 @@ from superset.models.slice import Slice
 from superset.versioning.queries import get_version, list_versions
 from superset.versioning.restore import restore_version
 from tests.integration_tests.test_app import app
+
+RecycledIdCharts: TypeAlias = tuple[int, uuid_module.UUID, Slice]
 
 
 def _make_chart(name: str, chart_uuid: uuid_module.UUID) -> Slice:
@@ -58,8 +64,19 @@ def _make_chart(name: str, chart_uuid: uuid_module.UUID) -> Slice:
     return chart
 
 
+@contextmanager
+def _capture_disabled() -> Iterator[None]:
+    """Temporarily disable Continuum writes without reordering listeners."""
+    previous = versioning_manager.options["versioning"]
+    versioning_manager.options["versioning"] = False
+    try:
+        yield
+    finally:
+        versioning_manager.options["versioning"] = previous
+
+
 @pytest.fixture
-def recycled_id_charts():
+def recycled_id_charts() -> Iterator[RecycledIdCharts]:
     """Create a chart, capture history, hard-delete it, then create a second
     chart that lands on the freed id.
 
@@ -100,7 +117,7 @@ def recycled_id_charts():
 
 
 def test_successor_under_recycled_id_has_no_inherited_history(
-    recycled_id_charts,
+    recycled_id_charts: RecycledIdCharts,
 ) -> None:
     """The successor's version count must reflect its own writes only.
 
@@ -128,7 +145,9 @@ def test_successor_under_recycled_id_has_no_inherited_history(
     )
 
 
-def test_live_transaction_id_is_not_the_predecessors(recycled_id_charts) -> None:
+def test_live_transaction_id_is_not_the_predecessors(
+    recycled_id_charts: RecycledIdCharts,
+) -> None:
     """The live transaction resolved for the successor must be its own.
 
     ``current_live_version_uuid`` derives the client-visible version uuid from
@@ -157,7 +176,9 @@ def test_live_transaction_id_is_not_the_predecessors(recycled_id_charts) -> None
     assert VersionDAO.current_live_transaction_id(Slice, entity_id) == successor_tx
 
 
-def test_restore_refuses_a_predecessors_transaction(recycled_id_charts) -> None:
+def test_restore_refuses_a_predecessors_transaction(
+    recycled_id_charts: RecycledIdCharts,
+) -> None:
     """Restoring the successor to a transaction that belongs to the
     predecessor must fail rather than overwrite it with a stranger's content.
 
@@ -165,7 +186,7 @@ def test_restore_refuses_a_predecessors_transaction(recycled_id_charts) -> None:
     history, but restore *writes*.
     """
     entity_id, predecessor_uuid, successor = recycled_id_charts
-    from superset.versioning.queries import version_class
+    assert successor.uuid is not None
 
     # The predecessor has no *live* row (it was hard-deleted), so take any of
     # its surviving shadow transactions directly — that is exactly what an
@@ -193,13 +214,14 @@ def test_restore_refuses_a_predecessors_transaction(recycled_id_charts) -> None:
     )
 
 
-def test_shadow_rows_for_both_entities_share_the_id(recycled_id_charts) -> None:
+def test_shadow_rows_for_both_entities_share_the_id(
+    recycled_id_charts: RecycledIdCharts,
+) -> None:
     """Guard the guard: prove the fixture really did recycle the id and that
     both entities' shadow rows coexist under it, so the tests above are not
     passing vacuously.
     """
     entity_id, predecessor_uuid, successor = recycled_id_charts
-    from superset.versioning.queries import version_class
 
     ver_cls = version_class(Slice)
     uuids = {
@@ -219,7 +241,9 @@ def test_shadow_rows_for_both_entities_share_the_id(recycled_id_charts) -> None:
     assert sa.inspect(db.session.bind).has_table("slices_version")
 
 
-def test_list_versions_excludes_the_predecessors_rows(recycled_id_charts) -> None:
+def test_list_versions_excludes_the_predecessors_rows(
+    recycled_id_charts: RecycledIdCharts,
+) -> None:
     """The history listing must contain the successor's versions only.
 
     ``list_versions`` selects the shadow rows with its own Core query rather
@@ -228,6 +252,7 @@ def test_list_versions_excludes_the_predecessors_rows(recycled_id_charts) -> Non
     stranger's versions.
     """
     _entity_id, _predecessor_uuid, successor = recycled_id_charts
+    assert successor.uuid is not None
 
     versions = list_versions(Slice, successor.uuid, entity=successor)
 
@@ -238,7 +263,9 @@ def test_list_versions_excludes_the_predecessors_rows(recycled_id_charts) -> Non
     )
 
 
-def test_get_version_returns_the_successors_own_snapshot(recycled_id_charts) -> None:
+def test_get_version_returns_the_successors_own_snapshot(
+    recycled_id_charts: RecycledIdCharts,
+) -> None:
     """A version snapshot must carry the content of the entity asked about.
 
     ``version_number`` is resolved from a pinned count but applied to the
@@ -248,6 +275,7 @@ def test_get_version_returns_the_successors_own_snapshot(recycled_id_charts) -> 
     labelled with the successor's version uuid.
     """
     _entity_id, _predecessor_uuid, successor = recycled_id_charts
+    assert successor.uuid is not None
 
     versions = list_versions(Slice, successor.uuid, entity=successor)
     assert versions, "fixture should leave the successor one version"
@@ -263,3 +291,48 @@ def test_get_version_returns_the_successors_own_snapshot(recycled_id_charts) -> 
     assert snapshot["uuid"] == str(successor.uuid), (
         f"snapshot belongs to a different entity: {snapshot['uuid']}"
     )
+
+
+def _assert_reused_id_gets_its_own_baseline_when_capture_resumes() -> None:
+    """A predecessor's shadow rows must not suppress a successor baseline."""
+    predecessor_uuid = uuid_module.uuid4()
+    predecessor = _make_chart("baseline_predecessor", predecessor_uuid)
+    entity_id = predecessor.id
+    predecessor.slice_name = "baseline_predecessor_v2"
+    db.session.commit()
+    db.session.delete(predecessor)
+    db.session.commit()
+
+    successor_uuid = uuid_module.uuid4()
+    with _capture_disabled():
+        successor = _make_chart("baseline_successor", successor_uuid)
+
+    if successor.id != entity_id:
+        db.session.delete(successor)
+        db.session.commit()
+        pytest.skip(f"backend did not recycle the id ({entity_id} -> {successor.id})")
+
+    successor.slice_name = "baseline_successor_v2"
+    db.session.commit()
+
+    ver_cls = version_class(Slice)
+    rows = (
+        db.session.query(ver_cls)
+        .filter(ver_cls.id == entity_id, ver_cls.uuid == successor_uuid)
+        .order_by(ver_cls.transaction_id.asc())
+        .all()
+    )
+    assert [row.operation_type for row in rows] == [0, 1]
+    assert [row.slice_name for row in rows] == [
+        "baseline_successor",
+        "baseline_successor_v2",
+    ]
+
+    db.session.delete(successor)
+    db.session.commit()
+
+
+def test_reused_id_gets_its_own_baseline_when_capture_resumes() -> None:
+    """Exercise the capture transition inside the integration app context."""
+    with app.app_context():
+        _assert_reused_id_gets_its_own_baseline_when_capture_resumes()

--- a/tests/integration_tests/versioning/id_reuse_tests.py
+++ b/tests/integration_tests/versioning/id_reuse_tests.py
@@ -77,8 +77,7 @@ def _capture_disabled() -> Iterator[None]:
 
 @pytest.fixture
 def recycled_id_charts() -> Iterator[RecycledIdCharts]:
-    """Create a chart, capture history, hard-delete it, then create a second
-    chart that lands on the freed id.
+    """Create two charts whose durable identities share a recycled integer id.
 
     Yields ``(entity_id, predecessor_uuid, successor)`` or skips when the
     backend did not actually recycle the id — the assertions are only
@@ -110,10 +109,12 @@ def recycled_id_charts() -> Iterator[RecycledIdCharts]:
                 "tables only"
             )
 
-        yield entity_id, predecessor_uuid, successor
-
-        db.session.delete(successor)
-        db.session.commit()
+        try:
+            yield entity_id, predecessor_uuid, successor
+        finally:
+            db.session.rollback()
+            db.session.delete(successor)
+            db.session.commit()
 
 
 def test_successor_under_recycled_id_has_no_inherited_history(
@@ -126,9 +127,12 @@ def test_successor_under_recycled_id_has_no_inherited_history(
     freshly created chart reported the deleted chart's history as its own.
     """
     entity_id, _predecessor_uuid, successor = recycled_id_charts
+    assert successor.uuid is not None
+    ver_cls = version_class(Slice)
 
     version = VersionDAO.current_version_number(Slice, entity_id, successor.uuid)
-    id_only_version = VersionDAO.current_version_number(Slice, entity_id)
+    id_only_count = db.session.query(ver_cls).filter(ver_cls.id == entity_id).count()
+    id_only_version = id_only_count - 1 if id_only_count else None
 
     # The successor has exactly one version of its own (its INSERT).
     assert version == 0, (
@@ -155,6 +159,8 @@ def test_live_transaction_id_is_not_the_predecessors(
     version the caller can never legitimately hold.
     """
     entity_id, predecessor_uuid, successor = recycled_id_charts
+    assert successor.uuid is not None
+    ver_cls = version_class(Slice)
 
     successor_tx = VersionDAO.current_live_transaction_id(
         Slice, entity_id, successor.uuid
@@ -172,15 +178,21 @@ def test_live_transaction_id_is_not_the_predecessors(
         "a hard-deleted predecessor has no live version row; got "
         f"{predecessor_tx} (successor's is {successor_tx})"
     )
-    # Control: the id-only lookup cannot make that distinction.
-    assert VersionDAO.current_live_transaction_id(Slice, entity_id) == successor_tx
+    # Control: an explicit id-only query cannot make that distinction.
+    id_only_tx = (
+        db.session.query(ver_cls.transaction_id)
+        .filter(ver_cls.id == entity_id, ver_cls.end_transaction_id.is_(None))
+        .order_by(ver_cls.transaction_id.desc())
+        .limit(1)
+        .scalar()
+    )
+    assert id_only_tx == successor_tx
 
 
 def test_restore_refuses_a_predecessors_transaction(
     recycled_id_charts: RecycledIdCharts,
 ) -> None:
-    """Restoring the successor to a transaction that belongs to the
-    predecessor must fail rather than overwrite it with a stranger's content.
+    """Refuse to restore a successor from its predecessor's transaction.
 
     This is the destructive half of the defect: the read side merely misreports
     history, but restore *writes*.
@@ -217,9 +229,10 @@ def test_restore_refuses_a_predecessors_transaction(
 def test_shadow_rows_for_both_entities_share_the_id(
     recycled_id_charts: RecycledIdCharts,
 ) -> None:
-    """Guard the guard: prove the fixture really did recycle the id and that
-    both entities' shadow rows coexist under it, so the tests above are not
-    passing vacuously.
+    """Prove both entities' shadow rows coexist under the recycled id.
+
+    This guards against the behavioral tests passing without exercising the
+    collision they are intended to cover.
     """
     entity_id, predecessor_uuid, successor = recycled_id_charts
 
@@ -312,24 +325,26 @@ def _assert_reused_id_gets_its_own_baseline_when_capture_resumes() -> None:
         db.session.commit()
         pytest.skip(f"backend did not recycle the id ({entity_id} -> {successor.id})")
 
-    successor.slice_name = "baseline_successor_v2"
-    db.session.commit()
+    try:
+        successor.slice_name = "baseline_successor_v2"
+        db.session.commit()
 
-    ver_cls = version_class(Slice)
-    rows = (
-        db.session.query(ver_cls)
-        .filter(ver_cls.id == entity_id, ver_cls.uuid == successor_uuid)
-        .order_by(ver_cls.transaction_id.asc())
-        .all()
-    )
-    assert [row.operation_type for row in rows] == [0, 1]
-    assert [row.slice_name for row in rows] == [
-        "baseline_successor",
-        "baseline_successor_v2",
-    ]
-
-    db.session.delete(successor)
-    db.session.commit()
+        ver_cls = version_class(Slice)
+        rows = (
+            db.session.query(ver_cls)
+            .filter(ver_cls.id == entity_id, ver_cls.uuid == successor_uuid)
+            .order_by(ver_cls.transaction_id.asc())
+            .all()
+        )
+        assert [row.operation_type for row in rows] == [0, 1]
+        assert [row.slice_name for row in rows] == [
+            "baseline_successor",
+            "baseline_successor_v2",
+        ]
+    finally:
+        db.session.rollback()
+        db.session.delete(successor)
+        db.session.commit()
 
 
 def test_reused_id_gets_its_own_baseline_when_capture_resumes() -> None:

--- a/tests/integration_tests/versioning/id_reuse_tests.py
+++ b/tests/integration_tests/versioning/id_reuse_tests.py
@@ -1,0 +1,218 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Version reads and restore must not resolve a *predecessor's* shadow rows.
+
+A hard delete frees the entity's integer id and the database may hand it to
+the next row inserted — guaranteed on SQLite ROWID tables, and reachable
+elsewhere whenever a sequence is reset. Matching shadow rows on the id alone
+therefore lets a successor entity inherit the deleted predecessor's version
+history, and lets a restore write the predecessor's content over it.
+
+These tests recreate an entity under a recycled id and assert the successor
+has no history and cannot be restored to its predecessor's version. The same
+defect was found and fixed twice on the soft-delete side (``_purge_one``'s
+identity guard, and ``_identity_predicates`` on the purge cascade's locked
+claim); this pins the equivalent guarantee for the versioning read/restore
+paths.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+
+import pytest
+import sqlalchemy as sa
+
+from superset import db
+from superset.daos.version import VersionDAO
+from superset.models.slice import Slice
+from superset.versioning.restore import restore_version
+from tests.integration_tests.test_app import app
+
+
+def _make_chart(name: str, chart_uuid: uuid_module.UUID) -> Slice:
+    chart = Slice(
+        slice_name=name,
+        datasource_type="table",
+        datasource_id=1,
+        viz_type="table",
+        uuid=chart_uuid,
+    )
+    db.session.add(chart)
+    db.session.commit()
+    return chart
+
+
+@pytest.fixture
+def recycled_id_charts():
+    """Create a chart, capture history, hard-delete it, then create a second
+    chart that lands on the freed id.
+
+    Yields ``(entity_id, predecessor_uuid, successor)`` or skips when the
+    backend did not actually recycle the id — the assertions are only
+    meaningful when it did, and forcing reuse portably is not possible.
+    """
+    with app.app_context():
+        predecessor_uuid = uuid_module.uuid4()
+        predecessor = _make_chart("id_reuse_predecessor", predecessor_uuid)
+        entity_id = predecessor.id
+
+        # Give the predecessor a second version so history is non-trivial.
+        predecessor.slice_name = "id_reuse_predecessor_v2"
+        db.session.commit()
+
+        # Hard delete — frees the id. The shadow rows deliberately survive:
+        # that persistence is the whole point of the version tables, and it
+        # is what makes the successor's inheritance possible.
+        db.session.delete(predecessor)
+        db.session.commit()
+
+        successor_uuid = uuid_module.uuid4()
+        successor = _make_chart("id_reuse_successor", successor_uuid)
+        if successor.id != entity_id:
+            db.session.delete(successor)
+            db.session.commit()
+            pytest.skip(
+                f"backend did not recycle the id ({entity_id} -> "
+                f"{successor.id}); reuse is deterministic on SQLite ROWID "
+                "tables only"
+            )
+
+        yield entity_id, predecessor_uuid, successor
+
+        db.session.delete(successor)
+        db.session.commit()
+
+
+def test_successor_under_recycled_id_has_no_inherited_history(
+    recycled_id_charts,
+) -> None:
+    """The successor's version count must reflect its own writes only.
+
+    Before the ``(id, uuid)`` fix, ``current_version_number`` counted every
+    shadow row carrying the integer id — including the predecessor's — so a
+    freshly created chart reported the deleted chart's history as its own.
+    """
+    entity_id, _predecessor_uuid, successor = recycled_id_charts
+
+    version = VersionDAO.current_version_number(Slice, entity_id, successor.uuid)
+    id_only_version = VersionDAO.current_version_number(Slice, entity_id)
+
+    # The successor has exactly one version of its own (its INSERT).
+    assert version == 0, (
+        f"successor should report only its own single version; got {version}"
+    )
+    # Control: the id-only lookup still sees the predecessor's rows, which is
+    # precisely the inheritance the uuid pin removes. If this ever equals the
+    # uuid-pinned result the fixture stopped exercising id reuse.
+    assert id_only_version is not None
+    assert id_only_version > version, (
+        "expected the id-only lookup to over-count via the predecessor's "
+        f"rows (id_only={id_only_version}, pinned={version}); the fixture "
+        "may no longer be recycling the id"
+    )
+
+
+def test_live_transaction_id_is_not_the_predecessors(recycled_id_charts) -> None:
+    """The live transaction resolved for the successor must be its own.
+
+    ``current_live_version_uuid`` derives the client-visible version uuid from
+    this transaction id, so a predecessor's id here produces an ETag naming a
+    version the caller can never legitimately hold.
+    """
+    entity_id, predecessor_uuid, successor = recycled_id_charts
+
+    successor_tx = VersionDAO.current_live_transaction_id(
+        Slice, entity_id, successor.uuid
+    )
+    # Asking about the hard-deleted predecessor must not answer with the
+    # successor's transaction. Without the uuid pin the query cannot tell the
+    # two apart and returns the newest live row under the id — the
+    # successor's — as though the predecessor were still current.
+    predecessor_tx = VersionDAO.current_live_transaction_id(
+        Slice, entity_id, predecessor_uuid
+    )
+
+    assert successor_tx is not None, "successor should have a live transaction"
+    assert predecessor_tx is None, (
+        "a hard-deleted predecessor has no live version row; got "
+        f"{predecessor_tx} (successor's is {successor_tx})"
+    )
+    # Control: the id-only lookup cannot make that distinction.
+    assert VersionDAO.current_live_transaction_id(Slice, entity_id) == successor_tx
+
+
+def test_restore_refuses_a_predecessors_transaction(recycled_id_charts) -> None:
+    """Restoring the successor to a transaction that belongs to the
+    predecessor must fail rather than overwrite it with a stranger's content.
+
+    This is the destructive half of the defect: the read side merely misreports
+    history, but restore *writes*.
+    """
+    entity_id, predecessor_uuid, successor = recycled_id_charts
+    from superset.versioning.queries import version_class
+
+    # The predecessor has no *live* row (it was hard-deleted), so take any of
+    # its surviving shadow transactions directly — that is exactly what an
+    # attacker-or-accident supplies to the restore endpoint.
+    ver_cls = version_class(Slice)
+    predecessor_tx = (
+        db.session.query(ver_cls.transaction_id)
+        .filter(ver_cls.id == entity_id, ver_cls.uuid == predecessor_uuid)
+        .order_by(ver_cls.transaction_id.asc())
+        .limit(1)
+        .scalar()
+    )
+    assert predecessor_tx is not None, "fixture should leave predecessor history"
+
+    original_name = successor.slice_name
+    result = restore_version(Slice, successor.uuid, predecessor_tx, entity=successor)
+
+    assert result is None, (
+        "restore resolved a version row belonging to a hard-deleted "
+        "predecessor under the same id"
+    )
+    db.session.refresh(successor)
+    assert successor.slice_name == original_name, (
+        "successor's content was overwritten from the predecessor's version"
+    )
+
+
+def test_shadow_rows_for_both_entities_share_the_id(recycled_id_charts) -> None:
+    """Guard the guard: prove the fixture really did recycle the id and that
+    both entities' shadow rows coexist under it, so the tests above are not
+    passing vacuously.
+    """
+    entity_id, predecessor_uuid, successor = recycled_id_charts
+    from superset.versioning.queries import version_class
+
+    ver_cls = version_class(Slice)
+    uuids = {
+        row[0]
+        for row in db.session.query(ver_cls.uuid)
+        .filter(ver_cls.id == entity_id)
+        .distinct()
+        .all()
+    }
+
+    assert predecessor_uuid in uuids, (
+        f"predecessor's shadow rows missing under the recycled id; found {uuids}"
+    )
+    assert successor.uuid in uuids, (
+        f"successor's shadow rows missing under the recycled id; found {uuids}"
+    )
+    assert sa.inspect(db.session.bind).has_table("slices_version")

--- a/tests/unit_tests/versioning/test_collection.py
+++ b/tests/unit_tests/versioning/test_collection.py
@@ -23,6 +23,7 @@ or the metric fails nothing."""
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 from sqlalchemy.exc import OperationalError
 
@@ -37,7 +38,7 @@ def _session_raising(error: Exception) -> MagicMock:
 
 def _probe(session: MagicMock) -> Any:
     return collection.shadow_row_count(
-        session, SimpleNamespace(id=7), version_table=MagicMock()
+        session, SimpleNamespace(id=7, uuid=uuid4()), version_table=MagicMock()
     )
 
 


### PR DESCRIPTION
### SUMMARY

Version shadow-row reads and restore previously matched entities by reusable integer id alone. After a hard delete, a new entity can receive that id and accidentally inherit the predecessor history; restore could then write predecessor content over the successor.

The shadow tables already carry UUIDs. All entity-history operations now require and filter by the complete `(id, uuid)` identity:

| Location | Change |
|---|---|
| `versioning/queries.py` | Shared `identity_filter` requires both identifiers |
| `_get_version_count` / `current_version_number` | Counts only rows belonging to the entity UUID |
| `current_live_transaction_id` / `current_live_version_uuid` | Resolves the live transaction only for the complete identity |
| `list_versions` | Excludes predecessor history |
| `resolve_version` / `get_version` | Resolves and returns snapshots only from the requested entity |
| `current_entity_version_info` | Threads the entity UUID through version metadata reads |
| `restore_version` | Refuses transactions belonging to a predecessor |
| `baseline.shadow_row_count` | Does not let predecessor rows suppress a successor baseline after capture resumes |

The integer-id-only fallback was removed from the production helpers. Tests use explicit id-only control queries solely to prove the collision exists.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend correctness fix with no UI surface.

### TESTING INSTRUCTIONS

Run:

```bash
pytest tests/integration_tests/versioning/id_reuse_tests.py
```

The seven behavioral tests cover:

1. successor version counts exclude predecessor rows
2. live transaction lookup respects UUID identity
3. restore refuses a predecessor transaction
4. the fixture proves both UUID histories coexist under the recycled id
5. history listing excludes predecessor rows
6. snapshot lookup returns successor content
7. capture resumption creates the successor baseline despite predecessor history

Also verified locally:

```bash
pytest -q tests/integration_tests/versioning/id_reuse_tests.py tests/unit_tests/versioning/test_collection.py tests/unit_tests/versioning/test_queries.py
```

Result: 13 passed.

Affected-file pre-commit and the Python review pass. The full repository pre-commit suite passes with `oxfmt-frontend` skipped because that all-files hook rewrites unrelated frontend files outside this Python-only PR.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Rollout relevance:** this should land before broad `ENABLE_VERSIONING_CAPTURE` enablement. Retention purges can make integer-id reuse more frequent, so history identity must be UUID-pinned before capture becomes the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)