### PR TITLE
feat(soft-delete): enable soft delete by default and purge for real

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,34 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Soft delete is on by default, and purging is live
+
+`SOFT_DELETE` now ships **on** (`DEFAULT_FEATURE_FLAGS`), so deleting a
+dashboard, chart, or dataset archives it rather than removing it. Archived
+objects are hidden from normal listings, recoverable from **Recently Archived**,
+and permanently removed once the retention window elapses.
+`SOFT_DELETE_PURGE_DRY_RUN` also flips to `False`, so the nightly
+`deletion_retention.purge_soft_deleted` task deletes for real instead of only
+logging `would_purge` counts.
+
+**What operators should do before upgrading:**
+
+- **Size the first live purge.** The first real run removes every entity that
+  aged past `SOFT_DELETE_RETENTION_DAYS` (default 30) since soft delete began
+  capturing, which on a busy deployment can be a large batch in one window. To
+  see the size first, set `SOFT_DELETE_PURGE_DRY_RUN = True`, read the
+  `would_purge` counts from one nightly run, then set it back.
+- **Check a replaced `CELERY_CONFIG`.** A deployment that redefines it rather
+  than inheriting must carry both `superset.tasks.deletion_retention` in
+  `imports` and the `deletion_retention.purge_soft_deleted` beat entry;
+  a startup warning now names whichever is absent.
+
+**Both switches are retained.** `SOFT_DELETE = False` restores hard-delete
+behaviour and `SOFT_DELETE_PURGE_DRY_RUN = True` suspends purging, at any time.
+One caveat on turning soft delete back off: objects archived while it was on are
+**resurrected** into normal listings, since the rows were never removed — an
+emergency stop rather than a clean rollback.
+
 ### Scheduled report execution now enforces one application deadline
 
 Scheduled report (not alert) executions are now governed by a single
@@ -454,7 +482,7 @@ The task ships in the default `CeleryConfig` (both the `superset.tasks.version_h
 
 Soft-deleted dashboards, charts, and datasets are now permanently removed after a retention window (default 30 days; `SOFT_DELETE_RETENTION_DAYS`, `0` disables; settable per workspace at runtime via the `deletion-retention set-window` CLI, which takes precedence). The `deletion_retention.purge_soft_deleted` Celery beat task runs daily and removes each aged-out entity together with its M:N join rows, owned children, datasource permission, and version-history shadow rows. After purge an entity is **unrecoverable** — its detail and `/restore` endpoints return 404 and its version history is gone.
 
-The introducing release **defaults to dry-run** (`SOFT_DELETE_PURGE_DRY_RUN=True`): the task logs `would_purge` counts but deletes nothing, so operators can validate against production before activating real purging by setting it to `False`. Note `would_purge` is an **upper bound** — it counts every entity past the retention window without evaluating deletion blockers, so a real run may purge fewer (entities referenced by report schedules or set as a user's welcome dashboard are blocked and reported separately). The task only acts while the temporary `SOFT_DELETE` rollout flag is on.
+Purging is **live by default** (`SOFT_DELETE_PURGE_DRY_RUN=False`), so the retention promise above is real on a stock deployment. Set it to `True` to have the task log `would_purge` counts and delete nothing — the lever is retained, so an operator can return to dry-run at any time. Note `would_purge` is an **upper bound** — it counts every entity past the retention window without evaluating deletion blockers, so a real run may purge fewer (entities referenced by report schedules or set as a user's welcome dashboard are blocked and reported separately). The task only acts while the `SOFT_DELETE` rollout flag is on; it now ships on by default.
 
 Deployments that replace the default `CELERY_CONFIG` must ensure workers register `superset.tasks.deletion_retention` and schedule the `deletion_retention.purge_soft_deleted` task themselves. The shipped Docker development config uses `imports` and includes both entries. While `SOFT_DELETE` is statically enabled, a missing beat entry logs a startup warning; when the override explicitly defines `imports`, a missing purge module is also reported.
 

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -89,9 +89,9 @@
       },
       {
         "name": "SOFT_DELETE",
-        "default": false,
+        "default": true,
         "lifecycle": "development",
-        "description": "Temporary rollout / kill-switch gate for soft delete (default off = legacy hard delete). An emergency stop, not a clean rollback: flipping ON->OFF resurrects already-soft-deleted rows. Removed (along with its two gate points \u2014 BaseDAO.delete routing and the do_orm_execute visibility listener) once soft delete is stable."
+        "description": "Temporary rollout / kill-switch gate for soft delete (off = legacy hard delete). An emergency stop, not a clean rollback: flipping ON->OFF resurrects already-soft-deleted rows. Retained through this release as the move-back lever; removed (along with its two gate points \u2014 BaseDAO.delete routing and the do_orm_execute visibility listener) once post-flip confidence is established."
       },
       {
         "name": "TABLE_V2_TIME_COMPARISON_ENABLED",

--- a/superset-frontend/playwright/components/modals/DeleteConfirmationModal.ts
+++ b/superset-frontend/playwright/components/modals/DeleteConfirmationModal.ts
@@ -19,10 +19,16 @@
 
 import { expect } from '@playwright/test';
 import { Modal, Input } from '../core';
+import { isFeatureEnabled } from '../../helpers/featureFlags';
 
 /**
- * Delete confirmation modal that requires typing "DELETE" to confirm.
- * Used throughout Superset for destructive delete operations.
+ * Delete confirmation modal, used throughout Superset for delete operations.
+ *
+ * The modal has two modes. Destructive mode demands the user type "DELETE"
+ * before the action is enabled. Recoverable mode — what `SOFT_DELETE` turns
+ * on — archives instead of removing, so the action reads "Archive" and the
+ * type-to-confirm friction is deliberately dropped: reduced friction is what
+ * a reversible action earns.
  *
  * Provides primitives for tests to compose deletion flows.
  */
@@ -95,5 +101,41 @@ export class DeleteConfirmationModal extends Modal {
     );
     await expect(confirmButton).toBeEnabled({ timeout: options?.timeout });
     await confirmButton.click(options);
+  }
+
+  /**
+   * Confirms the deletion using whichever interaction the modal is in.
+   *
+   * Which mode is in force is a property of the instance, not of the caller,
+   * so the flag decides rather than the test — the same spec then covers the
+   * hard-delete and archive paths without being rewritten when the default
+   * flips, and keeps covering hard delete for deployments that turn the
+   * toggle back off.
+   *
+   * Neither branch is merely tolerant: the recoverable branch asserts the
+   * confirmation input is genuinely *absent* rather than skipping past it,
+   * so a regression that dropped the typed confirmation from destructive
+   * mode still fails here instead of quietly passing.
+   *
+   * Assumes the modal's mode follows `SOFT_DELETE` alone. That holds
+   * everywhere except a bulk selection containing semantic views, which
+   * stays destructive even with the flag on — such a flow should drive
+   * {@link fillConfirmationInput} and {@link clickDelete} directly.
+   *
+   * @param confirmationText - Text typed in destructive mode
+   *
+   * @example
+   * const deleteModal = new DeleteConfirmationModal(page);
+   * await deleteModal.waitForVisible();
+   * await deleteModal.confirmDeletion();
+   * await deleteModal.waitForHidden();
+   */
+  async confirmDeletion(confirmationText = 'DELETE'): Promise<void> {
+    if (await isFeatureEnabled(this.page, 'SOFT_DELETE')) {
+      await expect(this.confirmationInput.element).toHaveCount(0);
+    } else {
+      await this.fillConfirmationInput(confirmationText);
+    }
+    await this.clickDelete();
   }
 }

--- a/superset-frontend/playwright/tests/chart/chart-list.spec.ts
+++ b/superset-frontend/playwright/tests/chart/chart-list.spec.ts
@@ -76,11 +76,9 @@ test('should delete a chart with confirmation', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();
@@ -237,11 +235,9 @@ test('should bulk delete multiple charts', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();

--- a/superset-frontend/playwright/tests/dashboard/dashboard-list.spec.ts
+++ b/superset-frontend/playwright/tests/dashboard/dashboard-list.spec.ts
@@ -81,11 +81,10 @@ test('should delete a dashboard with confirmation', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button (waits for it to become enabled)
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead. Either
+  // way it waits for the action to become enabled.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();
@@ -191,11 +190,9 @@ test('should bulk delete multiple dashboards', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();

--- a/superset-frontend/playwright/tests/dataset/dataset-list.spec.ts
+++ b/superset-frontend/playwright/tests/dataset/dataset-list.spec.ts
@@ -37,6 +37,7 @@ import {
   ENDPOINTS,
 } from '../../helpers/api/dataset';
 import { createTestDataset } from './dataset-test-helpers';
+import { isFeatureEnabled } from '../../helpers/featureFlags';
 import {
   waitForGet,
   waitForPost,
@@ -120,19 +121,21 @@ test('should delete a dataset with confirmation', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();
 
-  // Verify success toast appears with correct message.
+  // Verify success toast appears with correct message. The copy names what
+  // actually happened, so it tracks the mode: archiving is not deleting, and
+  // a toast saying otherwise would misreport a recoverable action as final.
   const toast = new Toast(page);
   await expect(toast.getSuccess()).toBeVisible();
-  await expect(toast.getMessage()).toContainText('Deleted');
+  await expect(toast.getMessage()).toContainText(
+    (await isFeatureEnabled(page, 'SOFT_DELETE')) ? 'Archived' : 'Deleted',
+  );
 
   // Verify dataset is removed from list (deleted rows are removed from the DOM, so assert count rather than visibility)
   await expect(datasetListPage.getDatasetRow(datasetName)).toHaveCount(0, {
@@ -431,11 +434,9 @@ test('should bulk delete multiple datasets', async ({
   const deleteModal = new DeleteConfirmationModal(page);
   await deleteModal.waitForVisible();
 
-  // Type "DELETE" to confirm
-  await deleteModal.fillConfirmationInput('DELETE');
-
-  // Click the Delete button
-  await deleteModal.clickDelete();
+  // Confirm: types "DELETE" while the modal is destructive, and goes straight
+  // through once SOFT_DELETE makes it a recoverable archive instead.
+  await deleteModal.confirmDeletion();
 
   // Modal should close
   await deleteModal.waitForHidden();

--- a/superset/config.py
+++ b/superset/config.py
@@ -689,13 +689,14 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # can_copy_clipboard) instead of the single can_csv permission
     # @lifecycle: development
     "GRANULAR_EXPORT_CONTROLS": False,
-    # Temporary rollout / kill-switch gate for soft delete (default off = legacy
-    # hard delete). An emergency stop, not a clean rollback: flipping ON->OFF
-    # resurrects already-soft-deleted rows. Removed (along with its two gate
-    # points — BaseDAO.delete routing and the do_orm_execute visibility listener)
-    # once soft delete is stable.
+    # Temporary rollout / kill-switch gate for soft delete (off = legacy hard
+    # delete). An emergency stop, not a clean rollback: flipping ON->OFF
+    # resurrects already-soft-deleted rows. Retained through this release as
+    # the move-back lever; removed (along with its two gate points —
+    # BaseDAO.delete routing and the do_orm_execute visibility listener) once
+    # post-flip confidence is established.
     # @lifecycle: development
-    "SOFT_DELETE": False,
+    "SOFT_DELETE": True,
     # Enable semantic layers and show semantic views alongside datasets
     # @lifecycle: development
     "SEMANTIC_LAYERS": False,
@@ -1003,10 +1004,11 @@ USER_AGENT_FUNC: Callable[[Database, utils.QuerySource | None], str] | None = No
 FEATURE_FLAGS: dict[str, bool] = {}
 
 # Retention policy for soft-deleted dashboards, charts, and datasets. A value of
-# zero disables scheduled purging. Dry-run mode is enabled by default so operators
-# must explicitly opt in to irreversible deletion.
+# zero disables scheduled purging. Purging is live by default, so the retention
+# promise above is real on a stock deployment; set SOFT_DELETE_PURGE_DRY_RUN back
+# to True to have the task log ``would_purge`` counts without deleting anything.
 SOFT_DELETE_RETENTION_DAYS: int = 30
-SOFT_DELETE_PURGE_DRY_RUN: bool = True
+SOFT_DELETE_PURGE_DRY_RUN: bool = False
 
 # A function that receives a dict of all feature flags
 # (DEFAULT_FEATURE_FLAGS merged with FEATURE_FLAGS)

--- a/tests/unit_tests/tasks/test_deletion_retention.py
+++ b/tests/unit_tests/tasks/test_deletion_retention.py
@@ -117,11 +117,20 @@ def test_clock_uses_now_not_utcnow() -> None:
     purge.assert_called_once_with(Slice, now - timedelta(days=30), False)
 
 
-def test_default_config_is_safe() -> None:
+def test_default_config_purges_for_real_after_the_retention_window() -> None:
+    """The shipped defaults make the docs' retention promise true.
+
+    Superseding ``test_default_config_is_safe``: dry-run was the
+    introducing release's posture, deliberately opt-in so operators could
+    validate ``would_purge`` counts against production first. Purging is now
+    live by default, and ``SOFT_DELETE_PURGE_DRY_RUN`` is retained as the
+    operational lever to put it back. Pinned so a default change is a
+    deliberate edit here rather than a silent one.
+    """
     from superset import config
 
     assert config.SOFT_DELETE_RETENTION_DAYS == 30
-    assert config.SOFT_DELETE_PURGE_DRY_RUN is True
+    assert config.SOFT_DELETE_PURGE_DRY_RUN is False
 
 
 def test_default_celery_config_registers_daily_purge() -> None:

--- a/tests/unit_tests/tasks/test_deletion_retention.py
+++ b/tests/unit_tests/tasks/test_deletion_retention.py
@@ -122,7 +122,7 @@ def test_default_config_purges_for_real_after_the_retention_window() -> None:
 
     Superseding ``test_default_config_is_safe``: dry-run was the
     introducing release's posture, deliberately opt-in so operators could
-    validate ``would_purge`` counts against production first. Purging is now
+    validate ``would_purge`` counts against production first. Purging is
     live by default, and ``SOFT_DELETE_PURGE_DRY_RUN`` is retained as the
     operational lever to put it back. Pinned so a default change is a
     deliberate edit here rather than a silent one.


### PR DESCRIPTION
> **Dependencies satisfied.** #42641 and #42642 (the FR-010 preconditions) both merged on 2026-08-05, so this PR is no longer gated by them.

### SUMMARY

Flips the two soft-delete release defaults for general availability:

| Setting | Before | After |
|---|---|---|
| `SOFT_DELETE` | `False` | **`True`** |
| `SOFT_DELETE_PURGE_DRY_RUN` | `True` | **`False`** |

Deleting a dashboard, chart, or dataset now **archives** it rather than removing it — hidden from normal listings, recoverable from **Recently Archived** (#41550), and permanently removed once `SOFT_DELETE_RETENTION_DAYS` (default 30) elapses. The nightly `deletion_retention.purge_soft_deleted` task deletes for real instead of only logging `would_purge` counts, which makes the retention promise in the docs true on a stock deployment.

**Both switches are retained, deliberately.** `SOFT_DELETE = False` restores hard-delete behaviour; `SOFT_DELETE_PURGE_DRY_RUN = True` suspends purging without a redeploy. The hard-delete fallback branch and the tests covering *both* flag states stay in place and keep passing — the way back is only real if it stays exercised. Removing the toggle is deliberately a separate, later change (sc-115600), not part of this one.

**Scope: soft delete only.** The versioning flips (`VERSION_HISTORY`, `ENABLE_VERSIONING_CAPTURE`) are a separate branch. They answer to a different gate — a SIP-210 [VOTE] rather than the internal determination behind this one — so the two are kept independently reviewable, independently shippable, and independently revertible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — configuration defaults. The UI this enables (Recently Archived, restore, permanent delete) shipped in #41550 and is unchanged here.

### TESTING INSTRUCTIONS

Exactly one test in the unit suite changes behaviour under the flip, and it is the deliberate guard: `test_default_config_is_safe` asserted the pre-flip posture. It is superseded by `test_default_config_purges_for_real_after_the_retention_window`, which pins the new defaults and records why dry-run was the introducing release's choice.

Verified before pushing:

- full `tests/unit_tests` run — the flip breaks **only** that one test (the 24 firebolt SQL-dialect failures in that run are a different subsystem, unrelated and pre-existing)
- `tests/unit_tests/{tasks/test_deletion_retention,config_test,views/test_soft_delete_filter,daos/test_base_dao_soft_delete,models/test_soft_delete_mixin}.py` — 66/66
- `tests/integration_tests/deletion_retention/purge_tests.py` — 24/24, including the `dry_run=True` behavioural coverage that proves the retained lever still suppresses deletion
- `pre-commit run` green; `docs/static/feature-flags.json` regenerated by the docs-sync hook

Manual: with default config, delete a chart — it disappears from the list and appears under **Recently Archived**, recoverable. Set `FEATURE_FLAGS = {"SOFT_DELETE": False}` and delete another — it is removed outright, as before.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SOFT_DELETE` (this changes its default; the flag itself is retained)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**`UPDATING.md`** gains a breaking-change entry covering what changes and two things operators should do first:

- **Size the first live purge.** The first real run removes everything that aged past the retention window since soft delete began capturing — on a busy deployment, potentially a large batch in a single window. Set `SOFT_DELETE_PURGE_DRY_RUN = True`, read the `would_purge` counts from one nightly run, then set it back.
- **Check a replaced `CELERY_CONFIG`.** A deployment that redefines rather than inherits it must carry both `superset.tasks.deletion_retention` in `imports` and the beat entry. #42641 adds a startup warning naming whichever is absent — which is why it gated this PR.

It also states the caveat plainly: turning soft delete back **off resurrects** objects archived while it was on, because those rows were never removed. That is an emergency stop, not a clean rollback, and operators should know it before they need it.

**Dependencies:**

- #42641 — beat-schedule startup warning (FR-010 precondition; merged 2026-08-05)
- #42642 — sc-112173 no-op migration fix (FR-010 precondition; merged 2026-08-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
