### PR TITLE
feat(versioning): enable version history and capture by default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -52,6 +52,33 @@ One caveat on turning soft delete back off: objects archived while it was on are
 **resurrected** into normal listings, since the rows were never removed — an
 emergency stop rather than a clean rollback.
 
+### Version history is on by default
+
+`VERSION_HISTORY` and `ENABLE_VERSIONING_CAPTURE` now both ship **on**. Every
+save of a chart, dashboard, or dataset writes version rows, and the version
+history panel appears on Explore and Dashboard pages. The two flip together
+deliberately: a panel with capture off renders an empty "No history yet" that
+misrepresents the entity as unchanged.
+
+**What operators should expect:**
+
+- **Storage growth.** Capture writes shadow rows per save, so the metadata
+  database grows with edit volume. The `version_history.prune_old_versions`
+  beat task removes rows whose transaction is older than
+  `SUPERSET_VERSION_HISTORY_RETENTION_DAYS` (default 30). A deployment that
+  replaces `CELERY_CONFIG` rather than inheriting it must carry both the
+  `superset.tasks.version_history_retention` import and the beat entry; a
+  startup warning names whichever is absent.
+- **`PUT` responses change shape.** Entity updates now return populated
+  `old_version_uuid` / `new_version_uuid` fields and an `ETag` header, which
+  were null or absent while capture was off.
+
+`ENABLE_VERSIONING_CAPTURE` is **retained permanently** as an operational
+kill-switch — not removed with the rollout toggles. Setting it to a falsy value
+stops capture within a restart, without a revert-and-redeploy. Unlike the
+soft-delete toggle, turning it off is a clean stop: existing version rows remain
+readable and no entity state is altered.
+
 ### Scheduled report execution now enforces one application deadline
 
 Scheduled report (not alert) executions are now governed by a single
@@ -481,7 +508,7 @@ Entity version history (the `version_transaction` / `*_version` shadow tables th
 |---|---|---|
 | `SUPERSET_VERSION_HISTORY_RETENTION_DAYS` | `30` | Version rows whose owning `version_transaction.issued_at` is older than this many days are pruned. Each entity's live row (`end_transaction_id IS NULL`) is always preserved, as are the live rows of its children and associations; closed historical rows (including the baseline) age out. Set to `0` or a negative value to disable pruning. |
 
-The task ships in the default `CeleryConfig` (both the `superset.tasks.version_history_retention` import and the beat entry). A deployment that overrides `CELERY_CONFIG` without the beat entry logs a startup warning. When the override explicitly defines `imports`, a missing retention module is also reported; an absent `imports` setting is not diagnosed because Celery may register tasks through `include`, autodiscovery, or worker startup imports. Retention only prunes whatever history exists — capture itself is gated separately by `ENABLE_VERSIONING_CAPTURE` (ships off).
+The task ships in the default `CeleryConfig` (both the `superset.tasks.version_history_retention` import and the beat entry). A deployment that overrides `CELERY_CONFIG` without the beat entry logs a startup warning. When the override explicitly defines `imports`, a missing retention module is also reported; an absent `imports` setting is not diagnosed because Celery may register tasks through `include`, autodiscovery, or worker startup imports. Retention only prunes whatever history exists — capture itself is gated separately by `ENABLE_VERSIONING_CAPTURE`, which now ships on.
 
 ### Deletion retention (soft-deleted entities are eventually purged)
 

--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -107,9 +107,9 @@
       },
       {
         "name": "VERSION_HISTORY",
-        "default": false,
+        "default": true,
         "lifecycle": "development",
-        "description": "Enables the version history panel on Explore and Dashboard pages. History only accrues while ``ENABLE_VERSIONING_CAPTURE`` is also on; with capture off the panel renders but stays empty."
+        "description": "Enables the version history panel on Explore and Dashboard pages. History only accrues while ``ENABLE_VERSIONING_CAPTURE`` is also on; with capture off the panel renders but stays empty, so the two ship with matching defaults and should be changed together."
       }
     ],
     "testing": [

--- a/superset/config.py
+++ b/superset/config.py
@@ -723,9 +723,10 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     "TAGGING_SYSTEM": False,
     # Enables the version history panel on Explore and Dashboard pages.
     # History only accrues while ``ENABLE_VERSIONING_CAPTURE`` is also on;
-    # with capture off the panel renders but stays empty.
+    # with capture off the panel renders but stays empty, so the two ship
+    # with matching defaults and should be changed together.
     # @lifecycle: development
-    "VERSION_HISTORY": False,
+    "VERSION_HISTORY": True,
     # =================================================================
     # IN TESTING
     # =================================================================
@@ -1668,19 +1669,19 @@ DATETIME_FORMAT_DETECTION_SAMPLE_SIZE = 1000
 # The limit for the Superset Meta DB when the feature flag ENABLE_SUPERSET_META_DB is on
 SUPERSET_META_DB_LIMIT: int | None = 1000
 
-# Master switch for entity-version-history capture. Ships defaulted ``False``
-# so the versioning infrastructure (schema + Continuum wiring) lands inert:
-# no save writes shadow rows or a ``version_transaction``/``version_changes``
-# record, while the /versions/ endpoints stay available read-only (returning
-# empty). Set to ``True`` in ``superset_config.py`` (or via the env var of the
-# same name) to enable the before-flush listeners that drive capture.
-# Capture is activated by flipping this default to on once validated in
-# production. It is an operational escape hatch — for use when a
-# versioning-induced regression needs a 30-second recovery instead of
-# revert-and-redeploy — not a feature flag, and remains as the permanent
-# kill-switch.
+# Master switch for entity-version-history capture. Capture is enabled by
+# default, so saves write shadow rows and a ``version_transaction`` /
+# ``version_changes`` record. Set this to a falsy value in
+# ``superset_config.py`` (or via the environment variable of the same name) to
+# disable the before-flush listeners while keeping the /versions/ endpoints
+# available read-only.
+# Capture ships on. It is an operational escape hatch — set the environment
+# variable to a falsy value when a versioning-induced regression needs a
+# 30-second recovery instead of revert-and-redeploy — not a feature flag,
+# and it remains permanently as the kill-switch rather than being removed
+# with the rollout toggles.
 ENABLE_VERSIONING_CAPTURE: bool = utils.parse_boolean_string(
-    os.environ.get("ENABLE_VERSIONING_CAPTURE", "false")
+    os.environ.get("ENABLE_VERSIONING_CAPTURE", "true")
 )
 
 # Retention window (days) for entity version history. Version rows

--- a/tests/unit_tests/commands/importers/v1/assets_test.py
+++ b/tests/unit_tests/commands/importers/v1/assets_test.py
@@ -578,6 +578,11 @@ def test_import_removes_dashboard_charts(
     expected_number_of_charts = len(charts_config_2)
 
     ImportAssetsCommand._import(base_configs)
+    # Commit between imports, as production does: ``run()`` carries
+    # ``@transaction()``, so two imports are two transactions. Without this the
+    # add and the remove of one association share a Continuum transaction and
+    # collide on ``dashboard_slices_version``'s composite key.
+    db.session.commit()
     ImportAssetsCommand._import(new_configs)
     dashboard_ids = db.session.scalars(
         select(dashboard_slices.c.dashboard_id).distinct()

--- a/tests/unit_tests/dashboards/commands/importers/v1/import_command_test.py
+++ b/tests/unit_tests/dashboards/commands/importers/v1/import_command_test.py
@@ -67,6 +67,13 @@ def test_dashboard_import_with_overwrite_replaces_charts(
         **copy.deepcopy(dashboards_config_1),
     }
     ImportDashboardsCommand._import(initial_configs, overwrite=True)
+    # Commit between imports, as production does: ``run()`` carries
+    # ``@transaction()``, so two imports are two transactions. Calling the
+    # private ``_import`` twice without committing puts both in one Continuum
+    # transaction, where adding and removing the same association collides on
+    # ``dashboard_slices_version``'s (dashboard_id, slice_id, transaction_id)
+    # key — an artifact of the test's shortcut, not a reachable state.
+    db.session.commit()
 
     # Verify initial state: 2 charts associated with the dashboard
     initial_chart_ids = db.session.scalars(select(dashboard_slices.c.slice_id)).all()


### PR DESCRIPTION
> **Dependency satisfied.** #42797 (shadow-row reads pinned to `(id, uuid)`) merged on 2026-08-05, so this PR is no longer gated by it.

### SUMMARY

Flips the two versioning release defaults for general availability:

| Setting | Before | After |
|---|---|---|
| `VERSION_HISTORY` | `False` | **`True`** |
| `ENABLE_VERSIONING_CAPTURE` | `false` | **`true`** (env-var default) |

Every save of a chart, dashboard, or dataset now writes version rows, and the version history panel (#41551) appears on Explore and Dashboard pages.

**The two flip together deliberately** (they are not independently useful). The panel reads what capture writes, so panel-on with capture-off renders an empty *"No history yet"* — which misrepresents an edited entity as unchanged. That is the one combination worse than either switch being off.

**`ENABLE_VERSIONING_CAPTURE` is retained permanently** as an operational kill-switch, not removed with the rollout toggles. Setting it falsy stops capture within a restart, no revert-and-redeploy. Unlike the soft-delete toggle, turning it off is a **clean stop**: existing version rows stay readable and no entity state is altered.

**Scope: versioning only.** The soft-delete flips are #42800. FR-009 permits the two shipping in different releases, so they are kept independently reviewable, shippable, and revertible.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — configuration defaults. The UI this enables shipped in #41551 and is unchanged here.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/versioning tests/unit_tests/config_test.py tests/unit_tests/initialization_test.py` — 164/164
- `pytest tests/integration_tests/versioning` — 84 passed, 4 skipped
- `pre-commit run` green; `docs/static/feature-flags.json` regenerated by the docs-sync hook

Manual: with default config, edit a chart twice and open **Version history** on Explore — both saves appear. Set `ENABLE_VERSIONING_CAPTURE=false` and restart; further saves write no rows and the panel stops accruing, while previously captured history remains readable.

Worth noting for reviewers: no test in the suite asserted the *old* defaults, so nothing needed superseding here. (The soft-delete counterpart, #42800, had exactly one such guard.)

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `VERSION_HISTORY` and `ENABLE_VERSIONING_CAPTURE` (this changes their defaults; both are retained, the latter permanently)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**`UPDATING.md`** gains an entry covering what operators should expect:

- **Storage growth.** Capture writes shadow rows per save, so the metadata database grows with edit volume. `version_history.prune_old_versions` bounds it at `SUPERSET_VERSION_HISTORY_RETENTION_DAYS` (default 30). A deployment that replaces `CELERY_CONFIG` rather than inheriting must carry both the `superset.tasks.version_history_retention` import and the beat entry — #42641 adds a startup warning naming whichever is absent.
- **`PUT` response shape changes.** Entity updates now return populated `old_version_uuid` / `new_version_uuid` and an `ETag` header, which were null or absent while capture was off.

**Why #42797 gated this.** Capture-on by default widens exactly the window that PR closed: version reads and restore matched shadow rows on the reusable integer id alone, so an entity created under a recycled id inherited its predecessor's history and could be overwritten by a restore. Purge frequency rises as soft delete graduates, and id reuse is deterministic on SQLite ROWID tables — so the defect gets more reachable precisely as these defaults roll out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

