### PR TITLE
fix(datasets): catch TemplateError instead of narrower TemplateSyntaxError in render_dataset_fields

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -30,7 +30,7 @@ from flask_appbuilder.api.schemas import get_item_schema
 from flask_appbuilder.const import API_RESULT_RES_KEY, API_SELECT_COLUMNS_RIS_KEY
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
-from jinja2.exceptions import TemplateSyntaxError
+from jinja2.exceptions import TemplateError
 from marshmallow import ValidationError
 from sqlalchemy.orm.exc import MultipleResultsFound
 
@@ -1835,7 +1835,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
 
             try:
                 data[new_key] = func(data[key])
-            except (TemplateSyntaxError, SupersetSyntaxErrorException) as ex:
+            except (TemplateError, SupersetSyntaxErrorException) as ex:
                 template_exception = SupersetTemplateException(
                     f"Unable to render expression from dataset {item_type}.",
                 )

--- a/tests/unit_tests/datasets/api_tests.py
+++ b/tests/unit_tests/datasets/api_tests.py
@@ -122,6 +122,57 @@ def test_get_dataset_include_rendered_sql_passes_table_to_template_processor(
     mock_get_processor.assert_called_once_with(database=database, table=dataset)
 
 
+def test_get_dataset_include_rendered_sql_handles_undefined_error(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Dataset API: Test that include_rendered_sql returns a typed 422 instead
+    of an unhandled 500 when the template processor raises a raw
+    ``jinja2.exceptions.UndefinedError``.
+
+    Regression test for the bug where an undefined variable accessed via
+    attribute/subscript (e.g. ``{{ foo.bar }}``) raises ``UndefinedError``
+    from ``process_template``, which is not a subclass of
+    ``TemplateSyntaxError`` and so escaped ``render_dataset_fields``'s
+    exception handling unhandled.
+    """
+    from jinja2.exceptions import UndefinedError
+
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.core import Database
+
+    SqlaTable.metadata.create_all(db.session.get_bind())
+
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="sqlite://",
+    )
+    dataset = SqlaTable(
+        table_name="test_render_sql_undefined_table",
+        schema="my_schema",
+        database=database,
+        sql="SELECT 1",
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    mock_processor = MagicMock()
+    mock_processor.process_template.side_effect = UndefinedError("'foo' is undefined")
+
+    with patch(
+        "superset.datasets.api.get_template_processor",
+        return_value=mock_processor,
+    ):
+        response = client.get(
+            f"/api/v1/dataset/{dataset.id}?include_rendered_sql=true",
+        )
+
+    assert response.status_code == 422
+    assert "Unable to render expression from dataset" in response.json["message"]
+
+
 def test_handle_filters_args_returns_request_scoped_filters(
     session: Session,
     client: Any,


### PR DESCRIPTION
### SUMMARY
`DatasetRestApi.render_dataset_fields()` (used by `GET /api/v1/dataset/<id_or_uuid>?include_rendered_sql=true`) caught `(TemplateSyntaxError, SupersetSyntaxErrorException)` when rendering Jinja macros in a dataset's `sql`/`metrics`/`columns` fields, but not the raw `jinja2.exceptions.UndefinedError` that can also propagate from `process_template()`. This widens the catch to `TemplateError` (jinja2's base class covering both), converting the previously-unhandled case into the existing typed 422.

### PROBLEM
`superset/jinja_context.py::BaseTemplateProcessor.process_template()` converts most Jinja errors to typed exceptions, but has a bare-`raise` fallback for `UndefinedError` when an undefined variable is accessed via attribute/subscript syntax (e.g. `{{ foo.bar }}`) rather than a function call — the regex heuristic that maps to `UndefinedTemplateFunctionException` only matches function-call syntax. This is the same gap already fixed at other `process_template()` call sites in this codebase: #42366, #42401, #42714, #42757.

`jinja2.exceptions.UndefinedError`'s MRO is `UndefinedError -> TemplateRuntimeError -> TemplateError -> Exception` — it is **not** a subclass of `TemplateSyntaxError`. So a dataset with a malformed Jinja expression in its `sql`, a metric, or a calculated column (e.g. referencing `{{ some_undefined.attr }}`) would raise a raw `UndefinedError` that escaped both `render_dataset_fields`'s own catch and the calling view method's `except SupersetTemplateException`, surfacing as an opaque 500 instead of the intended typed 4xx.

### FIX
Widened the `except` clause in `render_dataset_fields()` from `(TemplateSyntaxError, SupersetSyntaxErrorException)` to `(TemplateError, SupersetSyntaxErrorException)`, and updated the import accordingly. Additive-only: `SupersetSyntaxErrorException`/`SupersetTemplateException` (Superset's own exception hierarchy) are not `jinja2.exceptions.TemplateError` subclasses, so no currently-working path changes behavior — this only adds coverage for the raw-`UndefinedError`-via-attribute/subscript-access case.

### TESTING INSTRUCTIONS
Added `test_get_dataset_include_rendered_sql_handles_undefined_error` to `tests/unit_tests/datasets/api_tests.py`, mocking `get_template_processor` to raise a raw `jinja2.exceptions.UndefinedError` and asserting `GET /api/v1/dataset/{id}?include_rendered_sql=true` returns 422 (not 500).

- Confirmed the test fails on pre-fix code: `git stash` of `api.py` (test kept) reproduces `assert 500 == 422`, with the raw `UndefinedError` traceback surfacing through Flask's error handler.
- Post-fix: full `tests/unit_tests/datasets/api_tests.py` passes (4/4).
- `ruff check` / `ruff format --check`: pass. `pre-commit run` (mypy, ruff, ruff-format, pylint): all hooks pass. Diffed `mypy superset/datasets/api.py` output before/after — byte-identical (only pre-existing, unrelated errors), zero new errors.

### ADDITIONAL INFORMATION
- [x] Has associated tests
- [x] Confirmed the regression test fails on pre-fix code and passes post-fix

**Tradeoffs**: none — additive-only exception-handling widening, no behavior change to any currently-working path.

Related: #42366, #42401, #42714, #42757 (same `process_template()` bare-raise-fallback bug class, different call sites).