### PR TITLE
fix(deps): revert simple-zstd from 2.1.0 back to 1.4.2, again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,13 @@ updates:
       # as a single manual upgrade anyway. TODO: remove when Babel 8 support is viable.
       - dependency-name: "@babel/*"
         update-types: ["version-update:semver-major"]
+      # v2.0.0 renamed ZSTDDecompress to decompress and made it async, breaking
+      # the webpack dev proxy (see #38662, #39138, #39139). Dependabot reopened
+      # the same bump in #39369 after the first revert, so pin it here instead
+      # of relying on a package.json comment (package.json is JSON and can't
+      # hold comments). Remove this once the proxy code is updated to await
+      # the async decompress() API.
+      - dependency-name: "simple-zstd"
     directory: "/superset-frontend/"
     schedule:
       interval: "daily"

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -148,7 +148,7 @@
         "redux-undo": "^1.0.0-beta9-9-7",
         "rison": "^0.1.1",
         "scroll-into-view-if-needed": "^3.1.0",
-        "simple-zstd": "^2.1.0",
+        "simple-zstd": "^1.4.2",
         "stream-browserify": "^3.0.0",
         "tinycolor2": "^1.6.0",
         "urijs": "^1.19.8",
@@ -19252,6 +19252,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplex-maker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/duplex-maker/-/duplex-maker-1.0.0.tgz",
+      "integrity": "sha512-KoHuzggxg7f+vvjqOHfXxaQYI1POzBm+ah0eec7YDssZmbt6QFBI8d1nl5GQwAgR2f+VQCPvyvZtmWWqWuFtlA==",
+      "license": "MIT"
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -19289,6 +19295,54 @@
       "license": "MIT"
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
@@ -19448,7 +19502,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -32332,7 +32385,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -33363,6 +33415,17 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -33913,6 +33976,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/process-streams": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/process-streams/-/process-streams-1.0.3.tgz",
+      "integrity": "sha512-xkIaM5vYnyekB88WyET78YEqXiaJRy0xcvIdE22n+myhvBT7LlLmX6iAtq7jDvVH8CUx2rqQsd32JdRyJMV3NA==",
+      "funding": [
+        "https://www.paypal.com/donate/?hosted_button_id=GB656ZSAEQEXN",
+        "https://de.liberapay.com/nils.knappmeier/"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplex-maker": "^1.0.0"
       }
     },
     "node_modules/proggy": {
@@ -37965,17 +38041,24 @@
       "license": "MIT"
     },
     "node_modules/simple-zstd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/simple-zstd/-/simple-zstd-2.1.0.tgz",
-      "integrity": "sha512-pYzmKWl167db0EHoczlsSpmyjvZ7OinXciHicDEtlHjSKZlo1hPz6tXSyOfS84QIrbWPYT0XW9tx24YtGdQ6cA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/simple-zstd/-/simple-zstd-1.4.2.tgz",
+      "integrity": "sha512-kGYEvT33M5XfyQvvW4wxl3eKcWbdbCc1V7OZzuElnaXft0qbVzoIIXHXiCm3JCUki+MZKKmvjl8p2VGLJc5Y/A==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
         "is-zst": "^1.0.0",
-        "tmp-promise": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
+        "peek-stream": "^1.1.3",
+        "process-streams": "^1.0.1",
+        "through2": "^4.0.2"
+      }
+    },
+    "node_modules/simple-zstd/node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/sirv": {
@@ -38938,6 +39021,12 @@
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
       }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.21.1",
@@ -40363,18 +40452,10 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/tmp-promise": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
-      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tmp": "^0.2.0"
       }
     },
     "node_modules/tmpl": {
@@ -43033,7 +43114,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -225,7 +225,7 @@
     "redux-undo": "^1.0.0-beta9-9-7",
     "rison": "^0.1.1",
     "scroll-into-view-if-needed": "^3.1.0",
-    "simple-zstd": "^2.1.0",
+    "simple-zstd": "^1.4.2",
     "stream-browserify": "^3.0.0",
     "tinycolor2": "^1.6.0",
     "urijs": "^1.19.8",

--- a/superset-frontend/webpack.proxy-config.js
+++ b/superset-frontend/webpack.proxy-config.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 const zlib = require('zlib');
-const { decompress: zstdDecompress } = require('simple-zstd');
+const { ZSTDDecompress } = require('simple-zstd');
 
 const yargs = require('yargs');
 const { hideBin } = require('yargs/helpers');
@@ -117,13 +117,13 @@ function copyHeaders(originalResponse, response) {
  * Manipulate HTML server response to replace asset files with
  * local webpack-dev-server build.
  */
-async function processHTML(proxyResponse, response) {
+function processHTML(proxyResponse, response) {
   let body = Buffer.from([]);
   let originalResponse = proxyResponse;
+  let uncompress;
   const responseEncoding = originalResponse.headers['content-encoding'];
 
   // decode GZIP response
-  let uncompress;
   if (responseEncoding === 'gzip') {
     uncompress = zlib.createGunzip();
   } else if (responseEncoding === 'br') {
@@ -131,7 +131,7 @@ async function processHTML(proxyResponse, response) {
   } else if (responseEncoding === 'deflate') {
     uncompress = zlib.createInflate();
   } else if (responseEncoding === 'zstd') {
-    uncompress = await zstdDecompress();
+    uncompress = ZSTDDecompress();
   }
   if (uncompress) {
     originalResponse.pipe(uncompress);
@@ -178,15 +178,7 @@ module.exports = newManifest => {
           // For HTML responses, flush headers before processing starts
           // processHTML sets up async handlers that will call response.end()
           response.flushHeaders();
-          processHTML(proxyResponse, response).catch(e => {
-            // eslint-disable-next-line no-console
-            console.error(`Error requesting ${request.path} from proxy:`, e);
-            if (!response.writableEnded) {
-              response.end(
-                `Error requesting ${request.path} from proxy: ${e.message}`,
-              );
-            }
-          });
+          processHTML(proxyResponse, response);
         } else {
           const isCSV = (proxyResponse.headers['content-type'] || '').includes(
             'text/csv',


### PR DESCRIPTION
### SUMMARY

Reverts the `simple-zstd` 1.4.2 → 2.1.0 bump for the second time, and this time adds a dependabot ignore rule so it doesn't come back a third time.

**History:**
- #38662 bumped `simple-zstd` from 1.4.2 to 2.1.0 (dependabot). 2.0.0 is a breaking release: `ZSTDDecompress` was renamed to `decompress` and made async (returns `Promise<stream>` instead of a stream).
- #39138 attempted an in-place fix (`await`-ing the new async `decompress()` in `webpack.proxy-config.js`), but `npm run dev-server` was still freezing when navigating between pages.
- #39139 reverted the bump back to 1.4.2 to restore a working dev proxy.
- #39369 was dependabot reopening the exact same 1.4.2 → 2.1.0 bump. This time it shipped with the `webpack.proxy-config.js` async fix baked in and merged, reintroducing the same underlying breakage that #39139 had reverted.

This PR reverts both `superset-frontend/package.json`/`package-lock.json` (`simple-zstd` back to `^1.4.2`) and `superset-frontend/webpack.proxy-config.js` (back to the synchronous `ZSTDDecompress()` API), matching the state #39139 restored.

**Preventing a third bump:** the previous revert had no mechanism to stop dependabot from proposing the same upgrade again, which is exactly what happened in #39369. `package.json` is parsed as strict JSON, so it has no comment syntax to leave a "don't bump this" note on the dependency line — and even a non-standard `"//"` key would do nothing functional, since dependabot only reads ignore rules from `.github/dependabot.yml`, not from `package.json`. This PR adds a `dependency-name: "simple-zstd"` entry to the existing `ignore` list in `.github/dependabot.yml` (following the same pattern already used there for `@deck.gl/*`, `@babel/*`, etc.), with a comment explaining why and what needs to happen before it can be removed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Run `npm ci` in `superset-frontend/`
2. Start the Superset backend
3. Run `npm run dev-server`
4. Navigate between pages — no freezing or proxy errors
5. Confirm dependabot no longer proposes a `simple-zstd` version bump (enforced via `.github/dependabot.yml`, not directly testable locally)

### ADDITIONAL INFORMATION

- [x] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API