### PR TITLE
fix(i18n-es): correct fuzzy-matcher strandings in Spanish catalog

### DIFF
--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -532,9 +532,9 @@ msgstr "No se pudo agregar la(s) %s vista(s) semántica(s)"
 msgid "%s semantic view(s) failed to add: %s"
 msgstr "Error al agregar %s vista(s) semántica(s): %s"
 
-#, fuzzy, python-format
+#, python-format
 msgid "%s tab selected"
-msgstr "%s seleccionado"
+msgstr "Pestaña %s seleccionada"
 
 #, python-format
 msgid "%s updated"
@@ -1075,13 +1075,11 @@ msgstr ""
 "          Estos valores intermedios pueden basarse en el tiempo o en la "
 "categoría."
 
-#, fuzzy
 msgid "A-Z"
-msgstr "clave a-z"
+msgstr "A-Z"
 
-#, fuzzy
 msgid "AND"
-msgstr "aleatorio"
+msgstr "Y"
 
 #, fuzzy
 msgid "API Key Created"
@@ -2727,9 +2725,8 @@ msgstr "Básico"
 msgid "Basic conditional formatting"
 msgstr "Formato condicional básico"
 
-#, fuzzy
 msgid "Basic information about the chart"
-msgstr "Información básica"
+msgstr "Información básica sobre el gráfico"
 
 #, python-format
 msgid "Batch editing %d filters:"
@@ -2753,9 +2750,8 @@ msgstr "Número grande con línea de tendencia"
 msgid "Bins"
 msgstr "Contenedores"
 
-#, fuzzy
 msgid "Blanks"
-msgstr "BOOLEANO"
+msgstr "En blanco"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: fr, ru]
 #, fuzzy, python-format
@@ -3799,9 +3795,8 @@ msgstr "Haz clic para ordenar de forma descendente"
 msgid "Client ID"
 msgstr "Anchura de la línea"
 
-#, fuzzy
 msgid "Client Secret"
-msgstr "Selección de columna"
+msgstr "Secreto de cliente"
 
 msgid "Close"
 msgstr "Cerrar"
@@ -4281,9 +4276,8 @@ msgstr "La conexión ha fallado; revisa la configuración de tu conexión"
 msgid "Connection looks good!"
 msgstr ""
 
-#, fuzzy
 msgid "Contains"
-msgstr "Continuo"
+msgstr "Contiene"
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: de, sr,
 # sr_Latn]
@@ -4932,9 +4926,8 @@ msgstr "Datos"
 msgid "Data Connections"
 msgstr "Conexiones de la base de datos"
 
-#, fuzzy
 msgid "Data Export Options"
-msgstr "Opciones del gráfico"
+msgstr "Opciones de exportación de datos"
 
 msgid "Data Table"
 msgstr "Tabla de datos"
@@ -5458,9 +5451,9 @@ msgstr[1] "Retrasado (se omitieron %s actualizaciones)"
 msgid "Delete"
 msgstr "Eliminar"
 
-#, fuzzy, python-format
+#, python-format
 msgid "Delete %s"
-msgstr "Se ha eliminado%s"
+msgstr "Eliminar %s"
 
 #, python-format
 msgid "Delete %s?"
@@ -5627,7 +5620,7 @@ msgstr[1] "Se han eliminado%(num)d conjuntos de datos"
 
 #, python-format
 msgid "Deleted %s"
-msgstr "Se ha eliminado%s"
+msgstr "Se ha eliminado %s"
 
 #, python-format
 msgid "Deleted %s item(s)"
@@ -6234,9 +6227,8 @@ msgstr "Función de agregación dinámica"
 msgid "Dynamic Section Label"
 msgstr "Direccional"
 
-#, fuzzy
 msgid "Dynamic group by"
-msgstr "NO AGRUPADO POR"
+msgstr "Agrupación dinámica"
 
 #, fuzzy
 msgid "Dynamic section description"
@@ -6444,9 +6436,8 @@ msgstr ""
 msgid "Either the username or the password is wrong."
 msgstr "El nombre de usuario o la contraseña son incorrectos."
 
-#, fuzzy
 msgid "Elapsed"
-msgstr "Volver a cargar"
+msgstr "Transcurrido"
 
 msgid "Elevation"
 msgstr "Elevación"
@@ -6611,9 +6602,8 @@ msgstr "Fecha final excluida del rango de tiempo"
 msgid "End date must be after start date"
 msgstr "La fecha final debe ser posterior a la fecha inicial"
 
-#, fuzzy
 msgid "Ends With"
-msgstr "Anchura del borde"
+msgstr "Termina con"
 
 #, python-format
 msgid "Ends with (ILIKE %x)"
@@ -6719,9 +6709,8 @@ msgstr "Tamaños de fecha iguales"
 msgid "Equal to (=)"
 msgstr "Igual a (=)"
 
-#, fuzzy
 msgid "Equals"
-msgstr "Secuencial"
+msgstr "Igual a"
 
 msgid "Error"
 msgstr "Error"
@@ -6982,13 +6971,11 @@ msgstr "Explorar el conjunto de resultados en la vista de exploración de datos"
 msgid "Export"
 msgstr "Exportar"
 
-#, fuzzy
 msgid "Export All Data"
-msgstr "Borrar todos los datos"
+msgstr "Exportar todos los datos"
 
-#, fuzzy
 msgid "Export Current View"
-msgstr "Invertir página actual"
+msgstr "Exportar la vista actual"
 
 msgid "Export Data to Excel"
 msgstr ""
@@ -6996,9 +6983,8 @@ msgstr ""
 msgid "Export Images to Excel"
 msgstr ""
 
-#, fuzzy
 msgid "Export YAML"
-msgstr "Nombre del informe"
+msgstr "Exportar YAML"
 
 #, fuzzy
 msgid "Export as Example"
@@ -7339,16 +7325,14 @@ msgstr ""
 "Usando CSV como alternativa; la biblioteca de exportación a Excel no está"
 " disponible."
 
-#, fuzzy
 msgid "False"
-msgstr "Es falso"
+msgstr "Falso"
 
 msgid "Favorite"
 msgstr "Favorito"
 
-#, fuzzy
 msgid "Feature Not Enabled"
-msgstr "El túnel SSH no está habilitado"
+msgstr "Función no habilitada"
 
 msgid "Featured"
 msgstr "Destacado"
@@ -7922,9 +7906,8 @@ msgstr "Tamaño de la cuadrícula"
 msgid "Grid view"
 msgstr "Tamaño de la cuadrícula"
 
-#, fuzzy
 msgid "Group"
-msgstr "Agrupar por"
+msgstr "Grupo"
 
 msgid "Group By"
 msgstr "Agrupar por"
@@ -8232,9 +8215,8 @@ msgstr "En"
 msgid "In Progress"
 msgstr "Progreso"
 
-#, fuzzy
 msgid "In Range"
-msgstr "Intervalo de tiempo"
+msgstr "En el intervalo"
 
 msgid ""
 "In order to connect to non-public sheets you need to either provide a "
@@ -10084,9 +10066,8 @@ msgstr "No se han conservado los ajustes del formulario"
 msgid "No global filters are currently added"
 msgstr "Actualmente no se han añadido filtros globales"
 
-#, fuzzy
 msgid "No groups"
-msgstr "NO AGRUPADO POR"
+msgstr "Sin grupos"
 
 #, fuzzy
 msgid "No groups yet"
@@ -10226,9 +10207,8 @@ msgstr "Normalizar nombres de columnas"
 msgid "Normalized"
 msgstr "Normalizado"
 
-#, fuzzy
 msgid "Not Contains"
-msgstr "Denunciar un contenido"
+msgstr "No contiene"
 
 #, fuzzy
 msgid "Not Equal"
@@ -10402,9 +10382,8 @@ msgstr "OCT"
 msgid "OK"
 msgstr "OK"
 
-#, fuzzy
 msgid "OR"
-msgstr "o"
+msgstr "O"
 
 #. do-not-translate
 msgid "OVERWRITE"
@@ -10878,9 +10857,8 @@ msgstr "Establecer intervalo de actualización automática"
 msgid "Pending"
 msgstr "pendiente"
 
-#, fuzzy
 msgid "Per user caching"
-msgstr "Porcentaje de cambio"
+msgstr "Caché por usuario"
 
 msgid "Percent Change"
 msgstr "Porcentaje de cambio"
@@ -11607,9 +11585,8 @@ msgstr "Consulta la"
 msgid "Referenced columns not available in DataFrame."
 msgstr "Las columnas referenciadas no están disponibles en el marco de datos."
 
-#, fuzzy
 msgid "Referrer"
-msgstr "Actualizar"
+msgstr "Referrer"
 
 msgid "Refetch results"
 msgstr "Volver a obtener resultados"
@@ -11709,9 +11686,8 @@ msgstr "Eliminar"
 msgid "Remove System Dark Theme"
 msgstr "Eliminar tema oscuro del sistema"
 
-#, fuzzy
 msgid "Remove System Default Theme"
-msgstr "Actualizar los valores predeterminados"
+msgstr "Eliminar tema predeterminado del sistema"
 
 msgid "Remove cross-filter"
 msgstr "Eliminar filtro cruzado"
@@ -12310,9 +12286,8 @@ msgstr "Los parámetros del túnel SSH no son válidos."
 msgid "SSH Tunneling is not enabled"
 msgstr "El túnel SSH no está habilitado"
 
-#, fuzzy
 msgid "SSL"
-msgstr "sql"
+msgstr "SSL"
 
 msgid "SSL Mode \"require\" will be used."
 msgstr "Se utilizará el modo SSL «requerido»."
@@ -12638,9 +12613,8 @@ msgstr "Seguridad adicional"
 msgid "Security"
 msgstr "Seguridad"
 
-#, fuzzy
 msgid "See "
-msgstr "series"
+msgstr "Ver "
 
 #, python-format
 msgid "See all %(tableName)s"
@@ -12668,9 +12642,8 @@ msgstr "Selecciona %s o escribe para buscar %s"
 msgid "Select ..."
 msgstr "Seleccionar …"
 
-#, fuzzy
 msgid "Select All"
-msgstr "Deseleccionar todo"
+msgstr "Seleccionar todo"
 
 #, fuzzy
 msgid "Select Database and Schema"
@@ -12787,9 +12760,8 @@ msgstr "Selecciona un tipo de visualización"
 msgid "Select aggregate options"
 msgstr "Selecciona las opciones de agregación"
 
-#, fuzzy
 msgid "Select all"
-msgstr "Deseleccionar todo"
+msgstr "Seleccionar todo"
 
 msgid "Select all data"
 msgstr "Seleccionar todos los datos"
@@ -13732,9 +13704,8 @@ msgstr "Muestra una lista de todas las series disponibles en ese momento"
 msgid "Shows or hides markers for the time series"
 msgstr "Muestra u oculta marcadores para la serie temporal"
 
-#, fuzzy
 msgid "Sign in"
-msgstr "No está en"
+msgstr "Iniciar sesión"
 
 #, fuzzy
 msgid "Sign in with"
@@ -14158,13 +14129,11 @@ msgstr ""
 msgid "Started"
 msgstr "Iniciado"
 
-#, fuzzy
 msgid "Starts With"
-msgstr "Anchura del gráfico"
+msgstr "Empieza con"
 
-#, fuzzy
 msgid "Starts with (ILIKE x%)"
-msgstr "Anchura del gráfico"
+msgstr "Empieza con (ILIKE x%)"
 
 msgid "State"
 msgstr "Estado"
@@ -17085,9 +17054,8 @@ msgstr "Activar alerta si..."
 msgid "Trigger now"
 msgstr ""
 
-#, fuzzy
 msgid "True"
-msgstr "MAR"
+msgstr "Verdadero"
 
 msgid "Truncate Axis"
 msgstr ""
@@ -17248,17 +17216,14 @@ msgstr ""
 "estén configurados: «bigquery.readsessions.create», "
 "«bigquery.readsessions.getData»."
 
-#, fuzzy
 msgid ""
 "Unable to connect. Verify that the following roles are set on the service"
 " account: \"Cloud Datastore Viewer\", \"Cloud Datastore User\", \"Cloud "
 "Datastore Creator\""
 msgstr ""
-"No se ha podido conectar. Comprueba si los siguientes roles están "
-"configurados en la cuenta de servicio: «BigQuery Data Viewer», «BigQuery "
-"Metadata Viewer», «BigQuery Job User»; y que los siguientes permisos "
-"estén configurados: «bigquery.readsessions.create», "
-"«bigquery.readsessions.getData»."
+"No se ha podido conectar. Comprueba que los siguientes roles estén "
+"configurados en la cuenta de servicio: «Cloud Datastore Viewer», «Cloud "
+"Datastore User», «Cloud Datastore Creator»"
 
 msgid "Unable to create chart without a query id."
 msgstr "No se puede crear un gráfico sin un ID de consulta."
@@ -17800,9 +17765,8 @@ msgstr "Valor"
 msgid "Value Aggregation"
 msgstr "Agregación"
 
-#, fuzzy
 msgid "Value Columns"
-msgstr "Columnas de la tabla"
+msgstr "Columnas de valores"
 
 msgid "Value Domain"
 msgstr "Dominio del valor"
@@ -19142,9 +19106,8 @@ msgstr "Su sesión ha finalizado. Por favor, inicie sesión de nuevo."
 msgid "Your user information"
 msgstr "Información general"
 
-#, fuzzy
 msgid "Z-A"
-msgstr "clave z-a"
+msgstr "Z-A"
 
 msgid "ZIP file contains multiple file types"
 msgstr "El archivo ZIP contiene varios tipos de archivos"
@@ -20139,9 +20102,8 @@ msgstr "Hora/fecha"
 msgid "timestamp"
 msgstr "Mostrar marca de tiempo"
 
-#, fuzzy
 msgid "to"
-msgstr "arriba"
+msgstr "a"
 
 msgid "top"
 msgstr "arriba"


### PR DESCRIPTION
### SUMMARY

39 entries in the Spanish catalog carry a translation that renders a **different string
than the English `msgid`**. Several render the opposite of the source:

| `msgid` | Spanish shown to users | What it actually says |
| --- | --- | --- |
| `Select all` | `Deseleccionar todo` | **Deselect all** |
| `Data Export Options` | `Opciones del gráfico` | **Chart options** |
| `Export All Data` | `Borrar todos los datos` | **Delete all data** |
| `Sign in` | `No está en` | **Not in** |
| `Not Contains` | `Denunciar un contenido` | **Report content** |
| `Equals` | `Secuencial` | Sequential |
| `True` | `MAR` | Tue |
| `Client Secret` | `Selección de columna` | Column select |

`Select all` is the label on the button whose handler is `handleSelectAll()`
(`Select.tsx:654`) — so a user clicking a control that reads **"Deselect all"** selects
every option. `Sign in` renders twice on the login page, as the card title *and* the
submit button.

These are legacy strandings. The old `pybabel update` fuzzy matcher copied a translation
from a similar-looking `msgid`; where it guessed wrong, the copied Spanish stayed behind.
`babel_update.sh` has since moved to `--no-fuzzy-matching`, so this is cleanup of damage
already done rather than an ongoing source of new breakage.

They are live in the UI: both the frontend and backend builds compile with `--use-fuzzy`,
so a `#, fuzzy` entry is displayed, not withheld. This is also why `msgfmt` never caught
them — it skips format checking on fuzzy entries.

**This is the follow-up to #42728**, which fixed the 75 entries whose format *placeholders*
didn't match. That defect class had a mechanical proof (`msgfmt`). This one does not: the
placeholders here are fine, so the errors are only visible to someone who reads both
languages.

#### How these were found, and where the method fails

A script made the class tractable, and it is worth stating how it works so the change is
auditable rather than "trust me":

> The fuzzy matcher *copies* a translation from another entry. When it guesses wrong, the
> copied Spanish usually still sits on the entry it was correctly translating. So a fuzzy
> entry whose `msgstr` is byte-identical to another entry's, where the two `msgid`s are
> textually dissimilar, is a stranding suspect.

**The detector under-reports, and this is a structural property, not a tuning problem.**
When a *legitimate* synonym shares the stranded translation, the pair scores as similar and
never surfaces. Three entries in this PR were missed that way:

| Missed entry | Masked by |
| --- | --- |
| `Select all` → "Deseleccionar todo" | `Deselect all` → "Deseleccionar todo" (correct) |
| `Data Export Options` → "Opciones del gráfico" | `Chart Options` → "Opciones del gráfico" (correct) |
| `Revoke` → "Eliminar" | `Remove` → "Eliminar" (correct) |

The first two were caught only by opening the running UI and looking. The third is left for
a follow-up. So: the detector is a lead generator, not a proof, and this PR is **not** a
claim that the catalog is clean.

**Every entry here was confirmed by reading its call site**, which changed several of the
translations. Entries with no reachable call site were left alone rather than guessed at
(e.g. `beta`, whose only occurrences are in test files).

#### Scope notes

- **The ag-Grid table filter menu is corrected as a whole.** Three entries surfaced
  individually, then turned out to sit in one dropdown (`AgGridTable/index.tsx:556-587`)
  where most neighbours were also stranded. Fixing 3 of 13 in the same menu would have
  been incoherent. Note this table is behind `AG_GRID_TABLE_ENABLED`; `Select all` and
  `Select All` are **not** flag-gated and render in the core `Select` component.
- **Every shared `msgid` was checked for other call sites** before being touched — `to`,
  `Group`, `Select All`, `Select all`.
- **The Datastore connection error** listed the *BigQuery* roles and permissions instead
  of the Datastore ones (`db_engine_specs/datastore.py`).
- **`Referrer` is deliberately left untranslated.** It is `Log.referrer` — the HTTP Referer
  URL — in an admin audit view, and this catalog already keeps protocol terms as-is
  (`URL`, `JSON`, `dttm`, `Host`). It replaces "Actualizar" (*Refresh*), which was wrong.
- **`Feature Not Enabled` → "Función no habilitada"**: *funcionalidad* is arguably the more
  precise Spanish, but this catalog uses *función* for the software sense throughout
  (`función de desglose`, `función experimental`) and *funcionalidad* appears nowhere in
  its 4,871 entries. Consistency was chosen over precision; happy to switch.
- Entries carrying the `# Machine-translated via backfill_po.py` comment are **out of
  scope** — those are AI drafts awaiting review, a different workflow.

38 `#, fuzzy` flags are cleared, since the corrected entries are now confirmed
translations. `Deleted %s` was already un-fuzzy — confirmed, and wrong.

Deliberately **not** included, to keep this reviewable: two recently-added features
(API keys, semantic layers/views) shipped with almost entirely stranded catalogs and want
their own PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Captured on a local instance running `apache/superset:f65b424`, this PR's base commit.

| | Before | After |
| --- | --- | --- |
| **Login page** | `Sign in` renders as "No está en" (*Not in*) on both the card title and the submit button | "Iniciar sesión" |
| **Explore → export menu** | "Opciones del gráfico" → "Borrar todos los datos" / "Invertir página actual" | "Opciones de exportación de datos" → "Exportar todos los datos" / "Exportar la vista actual" |
| **Multi-select bulk actions** | "Deseleccionar todo (66)" with 0 selected — the control that selects all | "Seleccionar todo (66)" |

Login before
<img width="1493" height="812" alt="01-login" src="https://github.com/user-attachments/assets/57f8cce9-7a96-4f52-a52e-ec9340c34f17" />
Login After
<img width="1503" height="818" alt="01-login" src="https://github.com/user-attachments/assets/bbfc0eeb-78d0-4eb4-ae23-377d3ba09338" />
Export Menu Before
<img width="1503" height="818" alt="02-export-menu" src="https://github.com/user-attachments/assets/99b97df2-f737-467e-9f1a-75811e307420" />
Export Menu after
<img width="1503" height="818" alt="02-export-menu" src="https://github.com/user-attachments/assets/8a7c2536-5905-43bc-a7e4-0ab89abe3e55" />
Select all before
<img width="1503" height="818" alt="03-select-all" src="https://github.com/user-attachments/assets/bec03af2-f467-44e0-becb-4d402abf2978" />
Select all after
<img width="1503" height="818" alt="03-select-all" src="https://github.com/user-attachments/assets/515f41fa-4bba-4bf6-9fc9-f5123b349375" />




### TESTING INSTRUCTIONS

The catalog compiles cleanly and no new format errors are introduced:

```bash
msgfmt -c --statistics -o /dev/null superset/translations/es/LC_MESSAGES/messages.po
# 3931 translated, 978 fuzzy, 197 untranslated  (was 3893 / 1016 / 197)
```

To confirm none of the newly-confirmed entries hides a format defect, blanket-clear the
fuzzy flags and recompile — `msgfmt` only format-checks non-fuzzy entries:

```bash
sed -E 's/^#,(.*)fuzzy(.*)$/#,\1\2/' \
  superset/translations/es/LC_MESSAGES/messages.po > /tmp/t.po
msgfmt -c -o /dev/null /tmp/t.po
```

This reports **4 fatal errors both before and after this change** — all pre-existing, in
`%s column`, `%s item`, `Added to 1 dashboard` and `%(suggestion)s instead of …`. Anything
above 4 would mean new breakage.

To see the strings in the UI, run with the locale set to `es`, then:

- **Login page** — card title and submit button
- **Explore → any chart → ⋮ → Data Export Options** — the submenu and its two children
- **Any multi-select** (e.g. Explore → Filters → a string column → operator `IN`) — the
  bulk-action bar at the bottom of the dropdown
- **Settings → Action Log** — the `Referrer` column
- **A table chart's column filter menu** (requires `AG_GRID_TABLE_ENABLED`) — operators,
  `Blanks`, `AND`/`OR`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
