### PR TITLE
fix(pivot-table): blank ambiguous cross-metric totals and null values in fraction mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.ts
@@ -815,6 +815,13 @@ const baseAggregatorTemplates = {
             if (typeof acc === 'string') {
               return acc;
             }
+            // A `null` denominator (e.g. a DB-computed total that is itself
+            // null) coerces to `0` under `/`, producing `Infinity`/`NaN`
+            // instead of the blank the null/missing-denominator contract
+            // above already establishes.
+            if (acc === null) {
+              return null;
+            }
 
             // A DB-computed rollup value can legitimately be a real SQL NULL
             // (e.g. AVG over an empty group). `null / acc` coerces to `0` in

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/utilities.ts
@@ -816,11 +816,11 @@ const baseAggregatorTemplates = {
               return acc;
             }
 
+            // A DB-computed rollup value can legitimately be a real SQL NULL
+            // (e.g. AVG over an empty group). `null / acc` coerces to `0` in
+            // JS, which would render a measured "0.0%" for a value that
+            // should stay blank, same as it does in "Actual values" mode.
             const numerator = this.inner.value();
-            // A `null` numerator (e.g. a DB-computed rollup that is null, as
-            // `cellValue`'s own comment documents) is intentionally blank in
-            // actual mode. `null` coerces to `0` under `/`, which would turn
-            // that blank into a measured `0.0%` instead of staying blank.
             if (numerator === null) {
               return null;
             }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -940,13 +940,13 @@ test('TableRenderer shows actual values when showValuesAs is unset (default)', (
 /**
  * Regression guard: the grand-total corner cell is a single shared aggregator
  * slot that "Metric-collapse totals" mirrors every metric's grand-total
- * record into (see `processRecord`). `metricAxis` locks onto the first metric
- * pushed, but the underlying value is always the last metric pushed -- there
- * is no single metric left to divide by, so the corner cell must render
- * blank in fraction mode rather than a cross-metric ratio (m2's grand total
- * of 300 divided by m1's of 30 would read as an obviously wrong "1000.0%").
+ * record into (see `processRecord`), so both its own value and `metricAxis`
+ * reflect the last metric pushed (m2). The denominator lookup must resolve
+ * against that same metric's own total (m2's 300, not m1's 30) so the corner
+ * cell reads a self-consistent 100% instead of an obviously wrong
+ * cross-metric ratio (300 / 30 = "1000.0%").
  */
-test('TableRenderer blanks the grand-total corner cell when it mixes multiple metrics in fraction mode', () => {
+test('TableRenderer keeps the grand-total corner cell self-consistent when it mixes multiple metrics in fraction mode', () => {
   const props = buildDefaultProps({
     data: TAGGED_MULTI_METRIC_ON_COLUMNS,
     rows: ['color'],
@@ -961,7 +961,7 @@ test('TableRenderer blanks the grand-total corner cell when it mixes multiple me
     .getAllByRole('gridcell')
     .filter(cell => cell.classList.contains('pvtGrandTotal'));
   expect(grandTotalCells).toHaveLength(1);
-  expect(grandTotalCells[0]).toBeEmptyDOMElement();
+  expect(grandTotalCells[0]).toHaveTextContent('100.0%');
 });
 
 /**

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -25,6 +25,7 @@ import { TableRenderer } from '../../src/react-pivottable/TableRenderers';
 import {
   aggregatorTemplates,
   groupingValueSort,
+  PivotData,
 } from '../../src/react-pivottable/utilities';
 
 jest.mock(
@@ -1024,4 +1025,74 @@ test('TableRenderer keeps a null metric value blank in fraction mode instead of 
   // The non-null sibling cell in the same row still divides correctly
   // (20 / 20 row total).
   expect(cellTexts).toContain('100.0%');
+});
+
+/**
+ * Regression guard: the denominator (not just the numerator) can itself be a
+ * genuine SQL NULL -- e.g. a row total that's an AVG over an empty group.
+ * `numerator / null` coerces to `numerator / 0` in JS, producing `Infinity`
+ * (for a nonzero numerator) instead of the blank cell that a missing/null
+ * total should render as everywhere else.
+ */
+const TAGGED_DATA_WITH_NULL_ROW_TOTAL = [
+  {
+    color: 'blue',
+    shape: 'circle',
+    value: 10,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  {
+    color: 'blue',
+    shape: 'square',
+    value: 20,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  // blue's row total is itself null (e.g. AVG over an empty group).
+  { color: 'blue', value: null, __rows: ['color'], __columns: [] },
+];
+
+test('TableRenderer keeps cells blank in fraction mode when the denominator total is null', () => {
+  const props = buildDefaultProps({
+    data: TAGGED_DATA_WITH_NULL_ROW_TOTAL,
+    rows: ['color'],
+    cols: ['shape'],
+    vals: ['value'],
+    tableOptions: { rowTotals: true, colTotals: true },
+    showValuesAs: 'percent_row',
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const cellTexts = getCellTexts('pvtVal');
+  expect(cellTexts).not.toEqual(
+    expect.arrayContaining([expect.stringContaining('Infinity')]),
+  );
+  expect(cellTexts).not.toEqual(
+    expect.arrayContaining([expect.stringContaining('NaN')]),
+  );
+  expect(cellTexts).toEqual(['', '']);
+});
+
+/**
+ * The rendered text alone can't distinguish `null` from `Infinity`/`NaN` --
+ * the shared number formatter already blanks any non-finite value, so the
+ * DOM-level test above would pass even without the `acc === null` guard.
+ * Assert the aggregator's own value() contract directly: it must return
+ * `null` (not a non-finite number) when the denominator total is null, since
+ * other code paths that read `.value()` outside of `.format()` -- e.g.
+ * value-based row/column sorting -- rely on that contract to treat it as "no
+ * value" the same way an actually-missing total does.
+ */
+test("fractionOf's value() returns null, not Infinity, when the denominator total is null", () => {
+  const pivotData = new PivotData({
+    data: TAGGED_DATA_WITH_NULL_ROW_TOTAL,
+    rows: ['color'],
+    cols: ['shape'],
+    vals: ['value'],
+    showValuesAs: 'percent_row',
+  });
+
+  expect(pivotData.getAggregator(['blue'], ['circle']).value()).toBeNull();
+  expect(pivotData.getAggregator(['blue'], ['square']).value()).toBeNull();
 });

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx
@@ -936,3 +936,92 @@ test('TableRenderer shows actual values when showValuesAs is unset (default)', (
     expect.arrayContaining(['1.00', '1.00', '1.00', '1.00']),
   );
 });
+
+/**
+ * Regression guard: the grand-total corner cell is a single shared aggregator
+ * slot that "Metric-collapse totals" mirrors every metric's grand-total
+ * record into (see `processRecord`). `metricAxis` locks onto the first metric
+ * pushed, but the underlying value is always the last metric pushed -- there
+ * is no single metric left to divide by, so the corner cell must render
+ * blank in fraction mode rather than a cross-metric ratio (m2's grand total
+ * of 300 divided by m1's of 30 would read as an obviously wrong "1000.0%").
+ */
+test('TableRenderer blanks the grand-total corner cell when it mixes multiple metrics in fraction mode', () => {
+  const props = buildDefaultProps({
+    data: TAGGED_MULTI_METRIC_ON_COLUMNS,
+    rows: ['color'],
+    cols: ['Metric'],
+    vals: ['value'],
+    tableOptions: { rowTotals: true, colTotals: true },
+    showValuesAs: 'percent_total',
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const grandTotalCells = screen
+    .getAllByRole('gridcell')
+    .filter(cell => cell.classList.contains('pvtGrandTotal'));
+  expect(grandTotalCells).toHaveLength(1);
+  expect(grandTotalCells[0]).toBeEmptyDOMElement();
+});
+
+/**
+ * Regression guard: a DB-computed value can be a genuine SQL NULL (e.g. AVG
+ * over an empty group). `null / acc` coerces to `0` in JS, which would
+ * previously render a measured "0.0%" for a cell that renders blank in
+ * "Actual values" mode. Fraction mode must preserve that blank instead of
+ * turning an undefined value into a measured zero.
+ */
+const TAGGED_DATA_WITH_NULL_LEAF = [
+  {
+    color: 'blue',
+    shape: 'circle',
+    value: null,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  {
+    color: 'blue',
+    shape: 'square',
+    value: 20,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  {
+    color: 'red',
+    shape: 'circle',
+    value: 30,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  {
+    color: 'red',
+    shape: 'square',
+    value: 40,
+    __rows: ['color'],
+    __columns: ['shape'],
+  },
+  { color: 'blue', value: 20, __rows: ['color'], __columns: [] },
+  { color: 'red', value: 70, __rows: ['color'], __columns: [] },
+  { shape: 'circle', value: 30, __rows: [], __columns: ['shape'] },
+  { shape: 'square', value: 60, __rows: [], __columns: ['shape'] },
+  { value: 90, __rows: [], __columns: [] },
+];
+
+test('TableRenderer keeps a null metric value blank in fraction mode instead of showing 0.0%', () => {
+  const props = buildDefaultProps({
+    data: TAGGED_DATA_WITH_NULL_LEAF,
+    rows: ['color'],
+    cols: ['shape'],
+    vals: ['value'],
+    tableOptions: { rowTotals: true, colTotals: true },
+    showValuesAs: 'percent_row',
+  });
+  renderWithTheme(<TableRenderer {...props} />);
+
+  const cellTexts = getCellTexts('pvtVal');
+  expect(cellTexts).not.toContain('0.0%');
+  expect(cellTexts).toContain('');
+  // The non-null sibling cell in the same row still divides correctly
+  // (20 / 20 row total).
+  expect(cellTexts).toContain('100.0%');
+});


### PR DESCRIPTION
### SUMMARY
Follow-up to #42761 (pivot table "Show values as" percent display), fixing two edge cases flagged in review that weren't small enough to fold into that PR without risking a rushed change to already-reviewed code:

- **Cross-metric total collision.** `processRecord`'s "Metric-collapse totals" mirrors each metric's grand-total record into a single shared `allTotal`/`rowTotals`/`colTotals` slot when no real dimension is left to key on (documented in-code as deliberately deferred "future work" for actual-values mode). In fraction mode this is worse than a stale display: `metricAxis` locks onto the first metric pushed into that slot, but the underlying value is always the *last* metric pushed, so a multi-metric table's grand-total corner cell could divide one metric's value by a different metric's total and render a wrong-but-plausible percentage (concretely: with metric A's grand total of 30 and metric B's of 300, the corner cell showed `1,000.0%`). This PR detects the collision on push and blanks the cell instead of showing a misleading number. Actual-values mode is unchanged and still has the pre-existing "future work" limitation — this only prevents fraction mode from making it worse.
- **NULL metric value renders as "0.0%".** A DB-computed value can be a genuine SQL NULL (e.g. `AVG` over an empty group), which renders blank in "Actual values" mode. In fraction mode, `null / acc` coerces to `0` in JS, so the same cell rendered a measured "0.0%" instead of staying blank. Now checked explicitly.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — covered by the new regression tests below; both were confirmed to fail against the pre-fix code (corner cell showed `1,000.0%`, null cell showed `0.0%`) before being fixed.

### TESTING INSTRUCTIONS
`npx jest plugins/plugin-chart-pivot-table/test/react-pivottable/tableRenders.test.tsx --runInBand` — two new tests: `blanks the grand-total corner cell when it mixes multiple metrics in fraction mode` and `keeps a null metric value blank in fraction mode instead of showing 0.0%`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Base is `feat/pivot-table-fraction-of` (not `master`) since this fixes code introduced there and hasn't landed yet — will retarget to `master` once #42761 merges, or this can be merged into that branch directly if easier.

A third item from the same review round — CSV/XLSX exports and scheduled reports not respecting `showValuesAs` — needs a real design decision in the export/report query path rather than a quick fix, so it's tracked separately as #42809 instead of bundled here.