### PR TITLE
style(frontend): apply oxfmt to existing files

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/index.tsx
@@ -34,8 +34,9 @@ export const DropdownButton = ({
   const { type: buttonType } = rest;
   // divider implementation for default (non-primary) buttons
   const defaultBtnCss = css`
-    ${(!buttonType || buttonType === 'default') &&
-    `.ant-dropdown-trigger {
+    ${
+      (!buttonType || buttonType === 'default') &&
+      `.ant-dropdown-trigger {
       position: relative;
       &:before {
         content: '';
@@ -48,7 +49,8 @@ export const DropdownButton = ({
       .anticon {
         vertical-align: middle;
       }
-    }`}
+    }`
+    }
   `;
   const button = (
     <Dropdown.Button
@@ -58,13 +60,13 @@ export const DropdownButton = ({
         defaultBtnCss,
         css`
           .ant-btn {
-            height: ${styleConfig?.controlHeight ??
-            theme.buttonControlHeightSM ??
-            30}px;
+            height: ${
+              styleConfig?.controlHeight ?? theme.buttonControlHeightSM ?? 30
+            }px;
             box-shadow: ${styleConfig?.boxShadow ?? 'none'};
-            font-size: ${styleConfig?.fontSize ??
-            theme.buttonFontSize ??
-            theme.fontSizeSM}px;
+            font-size: ${
+              styleConfig?.fontSize ?? theme.buttonFontSize ?? theme.fontSizeSM
+            }px;
             font-weight: ${styleConfig?.fontWeight ?? theme.fontWeightStrong};
           }
         `,

--- a/superset-frontend/packages/superset-ui-core/src/components/DynamicEditableTitle/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DynamicEditableTitle/index.tsx
@@ -221,18 +221,22 @@ export const DynamicEditableTitle = memo(
             onPressEnter={handleKeyPress}
             placeholder={placeholder}
             css={css`
-              ${!canEdit &&
-              `&[disabled] {
+              ${
+                !canEdit &&
+                `&[disabled] {
                   cursor: default;
                 }
-              `}
+              `
+              }
               font-size: ${theme.fontSizeXL}px;
               transition: auto;
-              ${inputWidth &&
-              inputWidth > 0 &&
-              css`
-                width: ${inputWidth}px;
-              `}
+              ${
+                inputWidth &&
+                inputWidth > 0 &&
+                css`
+                  width: ${inputWidth}px;
+                `
+              }
             `}
             disabled={!canEdit}
           />

--- a/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/EmptyState/index.tsx
@@ -171,9 +171,11 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
       {image && <ImageContainer image={image} size={size} />}
       <div
         css={(theme: SupersetTheme) => css`
-          max-width: ${containerSize === 'large'
-            ? theme.sizeUnit * 150
-            : theme.sizeUnit * 100}px;
+          max-width: ${
+            containerSize === 'large'
+              ? theme.sizeUnit * 150
+              : theme.sizeUnit * 100
+          }px;
         `}
       >
         {title && <Title size={effectiveTextSize}>{title}</Title>}

--- a/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Modal/Modal.tsx
@@ -73,14 +73,16 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
     const closeButtonWidth = theme.sizeUnit * 14;
 
     return css`
-      ${responsive &&
-      css`
-        max-width: ${maxWidth ?? '900px'};
-        padding-left: ${theme.sizeUnit * 3}px;
-        padding-right: ${theme.sizeUnit * 3}px;
-        padding-bottom: 0;
-        top: 0;
-      `}
+      ${
+        responsive &&
+        css`
+          max-width: ${maxWidth ?? '900px'};
+          padding-left: ${theme.sizeUnit * 3}px;
+          padding-right: ${theme.sizeUnit * 3}px;
+          padding-bottom: 0;
+          top: 0;
+        `
+      }
 
       .ant-modal-container {
         background-color: ${theme.colorBgContainer};
@@ -168,40 +170,46 @@ export const StyledModal = styled(BaseModal)<StyledModalProps>`
         padding: 0;
       }
 
-      ${draggable &&
-      css`
-        .ant-modal-header {
-          padding: 0;
+      ${
+        draggable &&
+        css`
+          .ant-modal-header {
+            padding: 0;
 
-          .draggable-trigger {
-            cursor: move;
-            padding: ${theme.sizeUnit * 4}px ${closeButtonWidth}px
-              ${theme.sizeUnit * 4}px ${theme.sizeUnit * 4}px;
-            width: 100%;
-          }
-        }
-      `}
-
-      ${resizable &&
-      css`
-        .resizable {
-          pointer-events: all;
-
-          .resizable-wrapper {
-            height: 100%;
-          }
-
-          .ant-modal-container {
-            height: 100%;
-
-            .ant-modal-body {
-              height: ${hideFooter
-                ? `calc(100% - ${MODAL_HEADER_HEIGHT}px)`
-                : `calc(100% - ${MODAL_HEADER_HEIGHT}px - ${MODAL_FOOTER_HEIGHT}px)`};
+            .draggable-trigger {
+              cursor: move;
+              padding: ${theme.sizeUnit * 4}px ${closeButtonWidth}px
+                ${theme.sizeUnit * 4}px ${theme.sizeUnit * 4}px;
+              width: 100%;
             }
           }
-        }
-      `}
+        `
+      }
+
+      ${
+        resizable &&
+        css`
+          .resizable {
+            pointer-events: all;
+
+            .resizable-wrapper {
+              height: 100%;
+            }
+
+            .ant-modal-container {
+              height: 100%;
+
+              .ant-modal-body {
+                height: ${
+                  hideFooter
+                    ? `calc(100% - ${MODAL_HEADER_HEIGHT}px)`
+                    : `calc(100% - ${MODAL_HEADER_HEIGHT}px - ${MODAL_FOOTER_HEIGHT}px)`
+                };
+              }
+            }
+          }
+        `
+      }
     `;
   }}
 `;

--- a/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Tabs/Tabs.tsx
@@ -51,8 +51,10 @@ const StyledTabs = ({
       .ant-tabs-body-holder {
         overflow: ${allowOverflow ? 'visible' : 'auto'};
         ${fullHeight && 'height: 100%;'}
-        ${contentHeight &&
-        `height: ${typeof contentHeight === 'number' ? `${contentHeight}px` : contentHeight};`}
+        ${
+          contentHeight &&
+          `height: ${typeof contentHeight === 'number' ? `${contentHeight}px` : contentHeight};`
+        }
         ${contentPadding}
       }
       .ant-tabs-body {
@@ -66,9 +68,11 @@ const StyledTabs = ({
         margin: 0;
       }
       .ant-tabs-nav-wrap {
-        ${!(tabBarStyle && 'paddingLeft' in tabBarStyle)
-          ? `padding: 0 ${theme.sizeUnit * 4}px;`
-          : ''}
+        ${
+          !(tabBarStyle && 'paddingLeft' in tabBarStyle)
+            ? `padding: 0 ${theme.sizeUnit * 4}px;`
+            : ''
+        }
       }
       .ant-tabs-tab {
         flex: 1 1 auto;

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -1150,13 +1150,15 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             text-align: ${sharedStyle.textAlign};
             white-space: ${value instanceof Date ? 'nowrap' : undefined};
             position: relative;
-            font-weight: ${color
-              ? `${theme.fontWeightBold}`
-              : `${theme.fontWeightNormal}`};
+            font-weight: ${
+              color ? `${theme.fontWeightBold}` : `${theme.fontWeightNormal}`
+            };
             background: ${backgroundColor || undefined};
-            padding-left: ${column.isChildColumn
-              ? `${theme.sizeUnit * 5}px`
-              : `${theme.sizeUnit}px`};
+            padding-left: ${
+              column.isChildColumn
+                ? `${theme.sizeUnit * 5}px`
+                : `${theme.sizeUnit}px`
+            };
           `;
 
           const cellBarStyles = css`
@@ -1164,10 +1166,11 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             height: 100%;
             display: block;
             top: 0;
-            ${valueRange &&
-            typeof value === 'number' &&
-            valueRangeFlag &&
-            `
+            ${
+              valueRange &&
+              typeof value === 'number' &&
+              valueRangeFlag &&
+              `
                 width: ${`${cellWidth({
                   value: value as number,
                   valueRange,
@@ -1186,15 +1189,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                     theme,
                   })
                 };
-              `}
+              `
+            }
           `;
 
           let arrowStyles = css`
-            color: ${basicColorFormatters &&
-            basicColorFormatters[row.index][originKey]?.arrowColor ===
-              ColorSchemeEnum.Green
-              ? theme.colorSuccess
-              : theme.colorError};
+            color: ${
+              basicColorFormatters &&
+              basicColorFormatters[row.index][originKey]?.arrowColor ===
+                ColorSchemeEnum.Green
+                ? theme.colorSuccess
+                : theme.colorError
+            };
             margin-right: ${theme.sizeUnit}px;
           `;
 
@@ -1203,10 +1209,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             basicColorColumnFormatters?.length > 0
           ) {
             arrowStyles = css`
-              color: ${basicColorColumnFormatters[row.index][column.key]
-                ?.arrowColor === ColorSchemeEnum.Green
-                ? theme.colorSuccess
-                : theme.colorError};
+              color: ${
+                basicColorColumnFormatters[row.index][column.key]
+                  ?.arrowColor === ColorSchemeEnum.Green
+                  ? theme.colorSuccess
+                  : theme.colorError
+              };
               margin-right: ${theme.sizeUnit}px;
             `;
           }

--- a/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
+++ b/superset-frontend/src/SqlLab/components/TableExploreTree/TreeNodeRenderer.tsx
@@ -370,9 +370,9 @@ const TreeNodeRenderer: React.FC<TreeNodeRendererProps> = ({
                     <Icons.SortAscendingOutlined
                       iconSize="m"
                       css={css`
-                        color: ${sortedTables[data.id]
-                          ? theme.colorPrimary
-                          : 'inherit'};
+                        color: ${
+                          sortedTables[data.id] ? theme.colorPrimary : 'inherit'
+                        };
                       `}
                     />
                   }

--- a/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.styles.ts
+++ b/superset-frontend/src/components/Datasource/FoldersEditor/TreeItem.styles.ts
@@ -188,17 +188,21 @@ export const EmptyFolderDropZone = styled.div<{
     margin-left: ${depth * FOLDER_INDENTATION_WIDTH + ITEM_INDENTATION_WIDTH}px;
     padding: ${theme.paddingLG}px;
     border: 2px dashed
-      ${isOver
-        ? isForbidden
-          ? theme.colorError
-          : theme.colorPrimary
-        : 'transparent'};
+      ${
+        isOver
+          ? isForbidden
+            ? theme.colorError
+            : theme.colorPrimary
+          : 'transparent'
+      };
     border-radius: ${theme.borderRadius}px;
-    background: ${isOver
-      ? isForbidden
-        ? theme.colorErrorBg
-        : theme.colorPrimaryBg
-      : 'transparent'};
+    background: ${
+      isOver
+        ? isForbidden
+          ? theme.colorErrorBg
+          : theme.colorPrimaryBg
+        : 'transparent'
+    };
     text-align: center;
     transition: all 0.2s ease-in-out;
     cursor: ${isOver && isForbidden ? 'not-allowed' : 'default'};

--- a/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
+++ b/superset-frontend/src/components/ListView/Filters/CompactSelectPanel.tsx
@@ -106,9 +106,9 @@ const OptionItem = styled.li<{ $active: boolean }>`
     transition: background 0.15s;
 
     &:hover {
-      background: ${$active
-        ? theme.colorPrimaryBgHover
-        : theme.colorFillTertiary};
+      background: ${
+        $active ? theme.colorPrimaryBgHover : theme.colorFillTertiary
+      };
       outline: 2px solid ${theme.colorPrimary};
       outline-offset: -2px;
     }

--- a/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
+++ b/superset-frontend/src/dashboard/components/AutoRefreshStatus/StatusIndicatorDot.tsx
@@ -144,12 +144,14 @@ export const StatusIndicatorDot: FC<StatusIndicatorDotProps> = ({
         background-color ${theme.motionDurationMid} ease-in-out,
         border-color ${theme.motionDurationMid} ease-in-out;
       border: ${statusConfig.needsBorder ? '1px solid' : 'none'};
-      border-color: ${statusConfig.needsBorder
-        ? statusConfig.outlineColor
-        : 'transparent'};
-      box-shadow: ${statusConfig.needsBorder
-        ? 'none'
-        : `0 0 0 2px ${theme.colorBgContainer}`};
+      border-color: ${
+        statusConfig.needsBorder ? statusConfig.outlineColor : 'transparent'
+      };
+      box-shadow: ${
+        statusConfig.needsBorder
+          ? 'none'
+          : `0 0 0 2px ${theme.colorBgContainer}`
+      };
       margin-left: ${theme.marginXS}px;
       margin-right: ${theme.marginXS}px;
       cursor: help;

--- a/superset-frontend/src/dashboard/components/dnd/DragHandle.tsx
+++ b/superset-frontend/src/dashboard/components/dnd/DragHandle.tsx
@@ -30,10 +30,12 @@ const DragHandleContainer = styled.div<{ position: 'left' | 'top' }>`
     height: ${theme.sizeUnit * 5}px;
     overflow: hidden;
     cursor: move;
-    ${position === 'top' &&
-    css`
-      transform: rotate(90deg);
-    `}
+    ${
+      position === 'top' &&
+      css`
+        transform: rotate(90deg);
+      `
+    }
     & path {
       fill: ${theme.colorIcon};
     }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/ActionButtons/index.tsx
@@ -46,32 +46,36 @@ const ButtonsContainer = styled.div<{ isVertical: boolean }>`
   ${({ theme, isVertical }) => css`
     display: flex;
 
-    ${isVertical
-      ? css`
-          flex-direction: column;
-          align-items: center;
-          position: sticky;
-          z-index: 100;
-          bottom: 0;
-          padding: ${theme.sizeUnit * 4}px;
-          padding-top: ${theme.sizeUnit * 6}px;
-          background: linear-gradient(
-            ${tinycolor(theme.colorBgLayout).setAlpha(0).toRgbString()},
-            ${theme.colorBgContainer} 20%
-          );
-        `
-      : css`
-          align-items: center;
-          margin-left: auto;
-        `}
+    ${
+      isVertical
+        ? css`
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            z-index: 100;
+            bottom: 0;
+            padding: ${theme.sizeUnit * 4}px;
+            padding-top: ${theme.sizeUnit * 6}px;
+            background: linear-gradient(
+              ${tinycolor(theme.colorBgLayout).setAlpha(0).toRgbString()},
+              ${theme.colorBgContainer} 20%
+            );
+          `
+        : css`
+            align-items: center;
+            margin-left: auto;
+          `
+    }
   `}
 `;
 
 const applyButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
-  ${isVertical &&
-  css`
-    margin-bottom: ${theme.sizeUnit * 3}px;
-  `}
+  ${
+    isVertical &&
+    css`
+      margin-bottom: ${theme.sizeUnit * 3}px;
+    `
+  }
 `;
 
 const clearAllButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
@@ -88,11 +92,13 @@ const clearAllButtonStyle = (theme: SupersetTheme, isVertical: boolean) => css`
       color: ${theme.colorTextDisabled};
     }
 
-    ${!isVertical &&
-    css`
-      text-transform: capitalize;
-      font-weight: ${theme.fontWeightNormal};
-    `}
+    ${
+      !isVertical &&
+      css`
+        text-transform: capitalize;
+        font-weight: ${theme.fontWeightNormal};
+      `
+    }
   }
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilter.tsx
@@ -63,14 +63,16 @@ const CrossFilter = (props: {
     <div
       key={`${filter.name}${filter.emitterId}`}
       css={css`
-        ${orientation === FilterBarOrientation.Vertical
-          ? `
+        ${
+          orientation === FilterBarOrientation.Vertical
+            ? `
             display: block;
             margin-bottom: ${theme.sizeUnit * 4}px;
           `
-          : `
+            : `
             display: flex;
-          `}
+          `
+        }
       `}
     >
       <CrossFilterTitle
@@ -89,21 +91,23 @@ const CrossFilter = (props: {
         <div
           data-test="cross-filters-divider"
           css={css`
-            ${orientation === FilterBarOrientation.Horizontal
-              ? `
+            ${
+              orientation === FilterBarOrientation.Horizontal
+                ? `
                 width: 1px;
                 height: 22px;
                 margin-left: ${theme.sizeUnit * 4}px;
                 margin-right: ${theme.sizeUnit}px;
                 flex-shrink: 0;
               `
-              : `
+                : `
                 width: 100%;
                 height: 1px;
                 display: block;
                 margin-bottom: ${theme.sizeUnit * 4}px;
                 margin-top: ${theme.sizeUnit * 4}px;
-            `}
+            `
+            }
             background: ${theme.colorSplit};
           `}
         />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTag.tsx
@@ -67,13 +67,15 @@ const CrossFilterTag = (props: {
   return (
     <StyledTag
       css={css`
-        ${orientation === FilterBarOrientation.Vertical
-          ? `
+        ${
+          orientation === FilterBarOrientation.Vertical
+            ? `
             margin-top: ${theme.sizeUnit * 2}px;
           `
-          : `
+            : `
             margin-left: ${theme.sizeUnit * 2}px;
-          `}
+          `
+        }
       `}
       closable
       onClose={() => removeCrossFilter(filter.emitterId)}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/CrossFilterTitle.tsx
@@ -63,9 +63,11 @@ const CrossFilterChartTitle = (props: {
       <Tooltip title={titleIsTruncated ? title : null}>
         <span
           css={css`
-            max-width: ${orientation === FilterBarOrientation.Vertical
-              ? `${theme.sizeUnit * 45}px`
-              : `${theme.sizeUnit * 15}px`};
+            max-width: ${
+              orientation === FilterBarOrientation.Vertical
+                ? `${theme.sizeUnit * 45}px`
+                : `${theme.sizeUnit * 15}px`
+            };
             line-height: 1.4;
             ${ellipsisCss}
           `}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/UrlFilterTag.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/UrlFilters/UrlFilterTag.tsx
@@ -64,9 +64,11 @@ const UrlFilterTag = (props: {
   return (
     <StyledTag
       css={css`
-        ${orientation === FilterBarOrientation.Vertical
-          ? `margin-top: ${theme.sizeUnit * 2}px;`
-          : `margin-left: ${theme.sizeUnit * 2}px;`}
+        ${
+          orientation === FilterBarOrientation.Vertical
+            ? `margin-top: ${theme.sizeUnit * 2}px;`
+            : `margin-left: ${theme.sizeUnit * 2}px;`
+        }
       `}
       closable
       onClose={() => onRemove(filter)}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1998,10 +1998,12 @@ const FiltersConfigForm = (
                                             iconSize="xl"
                                             iconColor={theme.colorPrimary}
                                             css={css`
-                                              margin-left: ${theme.sizeUnit *
-                                              2}px;
-                                              margin-top: ${theme.sizeUnit *
-                                              1.5}px;
+                                              margin-left: ${
+                                                theme.sizeUnit * 2
+                                              }px;
+                                              margin-top: ${
+                                                theme.sizeUnit * 1.5
+                                              }px;
                                             `}
                                             onClick={() => refreshHandler(true)}
                                           />

--- a/superset-frontend/src/explore/components/controls/VerticalRadioControl.tsx
+++ b/superset-frontend/src/explore/components/controls/VerticalRadioControl.tsx
@@ -86,9 +86,11 @@ export default function VerticalRadioControl({
                       css={css`
                         margin-left: 4px;
                         font-size: 12px;
-                        color: ${disabled
-                          ? theme.colorTextDisabled
-                          : theme.colorTextTertiary};
+                        color: ${
+                          disabled
+                            ? theme.colorTextDisabled
+                            : theme.colorTextTertiary
+                        };
                         cursor: help;
                       `}
                     />

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTile.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTile.tsx
@@ -97,30 +97,34 @@ export const VizTile = ({
           white-space: nowrap;
           overflow: hidden;
           max-width: fit-content;
-          ${!isActive &&
-          css`
-            flex-shrink: 0;
-            width: ${theme.sizeUnit * 6}px;
-            background-color: transparent;
-            transition: none;
-            &:hover svg path {
-              fill: ${theme.colorPrimary};
-              transition: fill ${theme.motionDurationMid} ease-out;
-            }
-          `}
+          ${
+            !isActive &&
+            css`
+              flex-shrink: 0;
+              width: ${theme.sizeUnit * 6}px;
+              background-color: transparent;
+              transition: none;
+              &:hover svg path {
+                fill: ${theme.colorPrimary};
+                transition: fill ${theme.motionDurationMid} ease-out;
+              }
+            `
+          }
 
-          ${isActive &&
-          css`
-            width: 100%;
-            background-color: ${theme.colorBgLayout};
-            transition:
-              width ${TILE_TRANSITION_TIME} ease-out,
-              background-color ${TILE_TRANSITION_TIME} ease-out;
-            cursor: default;
-            svg path {
-              fill: ${theme.colorPrimary};
-            }
-          `}
+          ${
+            isActive &&
+            css`
+              width: 100%;
+              background-color: ${theme.colorBgLayout};
+              transition:
+                width ${TILE_TRANSITION_TIME} ease-out,
+                background-color ${TILE_TRANSITION_TIME} ease-out;
+              cursor: default;
+              svg path {
+                fill: ${theme.colorPrimary};
+              }
+            `
+          }
         `}
       >
         <span

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -104,10 +104,12 @@ const StyledMenuItem = styled.div<{ disabled?: boolean }>`
       color: ${!disabled && theme.colorPrimary};
       cursor: ${!disabled ? 'pointer' : 'not-allowed'};
     }
-    ${disabled &&
-    css`
-      color: ${theme.colorTextDisabled};
-    `}
+    ${
+      disabled &&
+      css`
+        color: ${theme.colorTextDisabled};
+      `
+    }
   `}
 `;
 


### PR DESCRIPTION
### SUMMARY

Apply the repository-pinned oxfmt 0.61.0 formatter to 20 existing frontend files that drifted from its output. This restores a clean `pre-commit run --all-files` baseline. There are no behavioral or dependency changes.

It appears that the PR that transitioned from 0.60.0 to 0.61.0 but without running pre-commit with the new rules:

- https://github.com/apache/superset/pull/42434 (transition to oxfmt)
- https://github.com/apache/superset/pull/42746 (bumped 0.60.0 to 0.61.0)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; formatting-only change.

### TESTING INSTRUCTIONS

```bash
export PATH="$HOME/venv/superset/bin:$PATH"
cd superset-frontend && npm ci && cd ..
pre-commit run --all-files
```

All hooks pass, including oxfmt, oxlint, frontend type-checking, stylelint, MyPy, Ruff, and Pylint.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
