### PR TITLE
fix(native-filters): preserve user selection on data reload when value is still valid

### DIFF
--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -452,7 +452,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
 
   useEffect(() => {
     if (
-      filterState.value?.every((value?: any) =>
+      filterState.value &&
+      filterState.value.every((value?: any) =>
         data.some(row => row[col] === value),
       )
     )


### PR DESCRIPTION
### SUMMARY
When a parent filter changes (e.g. time range), the select filter plugin re-evaluates whether to reset to the first item. The early return that was meant to preserve a valid selection was gated on optional chaining (`filterState.value?.every(...)`) which returns undefined for null values, causing it to silently fall through and reset the filter to the default even when the user's selection was still present in the new data.

Make the null check explicit (`filterState.value && filterState.value.every(...)`) so the early return reliably fires whenever the current value is still valid in the reloaded data, regardless of how the selection was made.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
