### PR TITLE
feat(hooks): add configurable post-creation hook for dashboards

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -94,10 +94,10 @@ class Dashboard(BaseSupersetView):
             viewers=get_default_viewers_for_new_asset(g.user.id if g.user else None),
         )
         db.session.add(new_dashboard)
-        db.session.commit()  # pylint: disable=consider-using-transaction
         if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
+            db.session.flush()
             after_create(new_dashboard, "dashboard")
-            db.session.commit()  # pylint: disable=consider-using-transaction
+        db.session.commit()  # pylint: disable=consider-using-transaction
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -97,7 +97,7 @@ class Dashboard(BaseSupersetView):
         db.session.commit()  # pylint: disable=consider-using-transaction
         if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
             after_create(new_dashboard, "dashboard")
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -17,7 +17,7 @@
 import builtins
 from typing import Callable, Union
 
-from flask import g, redirect, Response, url_for
+from flask import current_app, g, redirect, Response, url_for
 from flask_appbuilder import expose
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -95,6 +95,9 @@ class Dashboard(BaseSupersetView):
         )
         db.session.add(new_dashboard)
         db.session.commit()  # pylint: disable=consider-using-transaction
+        if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
+            after_create(new_dashboard, "dashboard")
+            db.session.commit()
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"


### PR DESCRIPTION
### SUMMARY

Adds an `AFTER_ASSET_CREATE` config callback that fires after a new dashboard is persisted. This allows downstream integrations (e.g. auto-categorization, audit logging, notification triggers) to react to asset creation without modifying core views. The hook receives the model instance and the asset type string ("dashboard")


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
