### PR TITLE
feat(hooks):  add configurable post-creation hook for dashboards

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -94,10 +94,10 @@ class Dashboard(BaseSupersetView):
             viewers=get_default_viewers_for_new_asset(g.user.id if g.user else None),
         )
         db.session.add(new_dashboard)
-        db.session.commit()  # pylint: disable=consider-using-transaction
         if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
+            db.session.flush()
             after_create(new_dashboard, "dashboard")
-            db.session.commit()  # pylint: disable=consider-using-transaction
+        db.session.commit()  # pylint: disable=consider-using-transaction
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -97,7 +97,7 @@ class Dashboard(BaseSupersetView):
         db.session.commit()  # pylint: disable=consider-using-transaction
         if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
             after_create(new_dashboard, "dashboard")
-            db.session.commit()
+            db.session.commit()  # pylint: disable=consider-using-transaction
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -17,7 +17,7 @@
 import builtins
 from typing import Callable, Union
 
-from flask import g, redirect, Response, url_for
+from flask import current_app, g, redirect, Response, url_for
 from flask_appbuilder import expose
 from flask_appbuilder.actions import action
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -95,6 +95,9 @@ class Dashboard(BaseSupersetView):
         )
         db.session.add(new_dashboard)
         db.session.commit()  # pylint: disable=consider-using-transaction
+        if after_create := current_app.config.get("AFTER_ASSET_CREATE"):
+            after_create(new_dashboard, "dashboard")
+            db.session.commit()
         return redirect(
             url_for(
                 "Superset.dashboard", dashboard_id_or_slug=new_dashboard.id, edit="true"

--- a/tests/integration_tests/dashboard_tests.py
+++ b/tests/integration_tests/dashboard_tests.py
@@ -19,6 +19,7 @@
 
 import re
 from random import random
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -129,6 +130,27 @@ class TestDashboard(SupersetTestCase):
         created_dashboard = db.session.query(Dashboard).get(created_dashboard_id)
         db.session.delete(created_dashboard)
         db.session.commit()
+
+    def test_new_dashboard_calls_after_asset_create_hook(self):
+        self.login(ADMIN_USERNAME)
+        mock_hook = MagicMock()
+        app = self.app
+        app.config["AFTER_ASSET_CREATE"] = mock_hook
+        try:
+            url = "/dashboard/new/"
+            self.client.get(url, follow_redirects=False)
+
+            mock_hook.assert_called_once()
+            call_args = mock_hook.call_args
+            assert isinstance(call_args[0][0], Dashboard)
+            assert call_args[0][1] == "dashboard"
+
+            # Cleanup
+            created_dashboard = call_args[0][0]
+            db.session.delete(created_dashboard)
+            db.session.commit()
+        finally:
+            del app.config["AFTER_ASSET_CREATE"]
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     @pytest.mark.usefixtures("public_role_like_gamma")


### PR DESCRIPTION
### SUMMARY
Adds an `AFTER_ASSET_CREATE` config callback that fires after a new dashboard is persisted. This allows downstream integrations (e.g. auto-categorization, audit logging, notification triggers) to react to asset creation without modifying core views. The hook receives the model instance and the asset type string ("dashboard").

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
