### PR TITLE
fix(semantic-layer): hydrate the semantic view edit modal from /structure

### DIFF
--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -396,6 +396,22 @@ test('does not toast if the fetch is cancelled while formatting its error', asyn
   expect(props.addDangerToast).not.toHaveBeenCalled();
 });
 
+test('clears structure loading when the semantic view is removed', async () => {
+  mockedGet.mockReturnValue(new Promise(() => {}));
+  const props = createProps();
+  const { rerender } = render(<SemanticViewEditModal {...props} />);
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  rerender(<SemanticViewEditModal {...props} semanticView={null} />);
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+});
+
 test('details tab save still works after viewing structure tabs', async () => {
   mockedPut.mockResolvedValue({});
   const props = createProps();

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -252,6 +252,34 @@ test('hydrates null description and cache timeout from the server', async () => 
   });
 });
 
+test('keeps prop-seeded values when the server omits the editable fields', async () => {
+  // An older backend (deploy skew) returns structure without description /
+  // cache_timeout. Hydration must not blank the form — otherwise a save
+  // right after would silently null the user's persisted description.
+  const { dimensions, metrics } = MOCK_STRUCTURE.result;
+  mockedGet.mockResolvedValue({ json: { result: { dimensions, metrics } } });
+  const props = createProps();
+
+  render(<SemanticViewEditModal {...props} />);
+
+  mockedPut.mockResolvedValue({});
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+  expect(screen.getByDisplayValue('old description')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  await waitFor(() => {
+    expect(mockedPut).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/7',
+      jsonPayload: {
+        description: 'old description',
+        cache_timeout: 60,
+      },
+    });
+  });
+});
+
 test('falls back to the caller prop when the structure fetch fails', async () => {
   mockedGet.mockRejectedValue(new Error('structure failed'));
   mockedGetClientErrorObject.mockResolvedValue({ error: 'boom' });
@@ -402,6 +430,8 @@ test('details tab save still works after viewing structure tabs', async () => {
 
 const LARGE_STRUCTURE = {
   result: {
+    description: 'old description',
+    cache_timeout: 60,
     dimensions: Array.from({ length: 500 }, (_, i) => ({
       name: `dim_${String(i).padStart(3, '0')}`,
       type: 'string',

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -38,6 +38,10 @@ const mockedGetClientErrorObject = getClientErrorObject as jest.Mock;
 
 const MOCK_STRUCTURE = {
   result: {
+    // Matches createProps() so tests that are not about hydration keep
+    // asserting the same values whichever source the form reads from.
+    description: 'old description',
+    cache_timeout: 60,
     dimensions: [
       {
         name: 'order_date',
@@ -156,6 +160,80 @@ test('fetches structure on mount', async () => {
       endpoint: '/api/v1/semantic_view/7/structure',
     });
   });
+});
+
+// sc-107904: the caller passes its own copy of description/cache_timeout, and
+// that copy goes stale as soon as this modal saves — Explore feeds the
+// pre-edit datasource straight back into the store. The modal must therefore
+// hydrate the Details tab from /structure, not from the prop.
+test('hydrates Details from the server, not the stale caller prop', async () => {
+  mockedGet.mockResolvedValue({
+    json: {
+      result: {
+        ...MOCK_STRUCTURE.result,
+        description: 'saved on the server',
+        cache_timeout: 900,
+      },
+    },
+  });
+  const props = createProps();
+
+  render(<SemanticViewEditModal {...props} />);
+
+  await waitFor(() => {
+    expect(screen.getByDisplayValue('saved on the server')).toBeInTheDocument();
+  });
+  expect(screen.queryByDisplayValue('old description')).not.toBeInTheDocument();
+
+  mockedPut.mockResolvedValue({});
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  await waitFor(() => {
+    expect(mockedPut).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/7',
+      jsonPayload: {
+        description: 'saved on the server',
+        cache_timeout: 900,
+      },
+    });
+  });
+});
+
+test('hydrates a description cleared on the server back to empty', async () => {
+  mockedGet.mockResolvedValue({
+    json: {
+      result: {
+        ...MOCK_STRUCTURE.result,
+        description: null,
+        cache_timeout: null,
+      },
+    },
+  });
+  const props = createProps();
+
+  render(<SemanticViewEditModal {...props} />);
+
+  await waitFor(() => {
+    expect(mockedGet).toHaveBeenCalled();
+  });
+  await waitFor(() => {
+    expect(
+      screen.queryByDisplayValue('old description'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+test('falls back to the caller prop when the structure fetch fails', async () => {
+  mockedGet.mockRejectedValue(new Error('structure failed'));
+  mockedGetClientErrorObject.mockResolvedValue({ error: 'boom' });
+  const props = createProps();
+
+  render(<SemanticViewEditModal {...props} />);
+
+  await waitFor(() => {
+    expect(props.addDangerToast).toHaveBeenCalledWith('boom');
+  });
+  expect(screen.getByDisplayValue('old description')).toBeInTheDocument();
 });
 
 test('fetches and displays dimensions tab', async () => {

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { act, render, screen, waitFor } from 'spec/helpers/testing-library';
 import { SupersetClient, getClientErrorObject } from '@superset-ui/core';
 
 import SemanticViewEditModal from './SemanticViewEditModal';
@@ -199,7 +199,29 @@ test('hydrates Details from the server, not the stale caller prop', async () => 
   });
 });
 
-test('hydrates a description cleared on the server back to empty', async () => {
+test('preserves unsaved edits when the parent recreates its props', async () => {
+  const props = createProps();
+  const { rerender } = render(<SemanticViewEditModal {...props} />);
+
+  const description = await screen.findByDisplayValue('old description');
+  await userEvent.clear(description);
+  await userEvent.type(description, 'unsaved edit');
+
+  rerender(
+    <SemanticViewEditModal
+      {...props}
+      semanticView={{
+        ...props.semanticView,
+        description: 'changed parent value',
+        cache_timeout: 120,
+      }}
+    />,
+  );
+
+  expect(screen.getByDisplayValue('unsaved edit')).toBeInTheDocument();
+});
+
+test('hydrates null description and cache timeout from the server', async () => {
   mockedGet.mockResolvedValue({
     json: {
       result: {
@@ -213,13 +235,20 @@ test('hydrates a description cleared on the server back to empty', async () => {
 
   render(<SemanticViewEditModal {...props} />);
 
+  mockedPut.mockResolvedValue({});
   await waitFor(() => {
-    expect(mockedGet).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
   });
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
   await waitFor(() => {
-    expect(
-      screen.queryByDisplayValue('old description'),
-    ).not.toBeInTheDocument();
+    expect(mockedPut).toHaveBeenCalledWith({
+      endpoint: '/api/v1/semantic_view/7',
+      jsonPayload: {
+        description: null,
+        cache_timeout: null,
+      },
+    });
   });
 });
 
@@ -314,6 +343,29 @@ test('handles structure fetch error', async () => {
       'Failed to load structure',
     );
   });
+});
+
+test('does not toast if the fetch is cancelled while formatting its error', async () => {
+  let resolveClientError: (value: { error: string }) => void = () => {};
+  mockedGet.mockRejectedValue(new Error('fetch failed'));
+  mockedGetClientErrorObject.mockImplementation(
+    () =>
+      new Promise(resolve => {
+        resolveClientError = resolve;
+      }),
+  );
+  const props = createProps();
+  const { rerender } = render(<SemanticViewEditModal {...props} />);
+
+  await waitFor(() => {
+    expect(mockedGetClientErrorObject).toHaveBeenCalled();
+  });
+  rerender(<SemanticViewEditModal {...props} show={false} />);
+  await act(async () => {
+    resolveClientError({ error: 'Failed to load structure' });
+  });
+
+  expect(props.addDangerToast).not.toHaveBeenCalled();
 });
 
 test('details tab save still works after viewing structure tabs', async () => {

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
@@ -57,8 +57,10 @@ interface SemanticMetric {
 }
 
 interface SemanticViewStructure {
-  description: string | null;
-  cache_timeout: number | null;
+  // Optional because an older backend may not emit them (deploy skew); the
+  // hydration effect only overwrites the form when they are present.
+  description?: string | null;
+  cache_timeout?: number | null;
   dimensions: SemanticDimension[];
   metrics: SemanticMetric[];
 }
@@ -117,8 +119,10 @@ export default function SemanticViewEditModal({
   );
   const [structureLoading, setStructureLoading] = useState(false);
 
-  // Seeds the form so it is populated while /structure is in flight, and is
-  // what the form falls back to if that request fails.
+  // Seeds the form from the caller's copy — what the form falls back to if
+  // /structure fails (a spinner covers the form while that fetch is in
+  // flight). Keyed to open/identity rather than the semanticView object so a
+  // parent re-render cannot clobber in-progress edits.
   useEffect(() => {
     if (semanticView) {
       setDescription(semanticView.description || '');
@@ -129,6 +133,7 @@ export default function SemanticViewEditModal({
   useEffect(() => {
     if (!show || !semanticView) {
       setStructure(null);
+      setStructureLoading(false);
       return undefined;
     }
 
@@ -142,8 +147,15 @@ export default function SemanticViewEditModal({
         setStructure(json.result);
         // The caller's copy of these fields goes stale the moment this modal
         // saves, so re-open hydrates from the server rather than the prop.
-        setDescription(json.result.description || '');
-        setCacheTimeout(json.result.cache_timeout ?? null);
+        // Only overwrite when the response carries the field: an older
+        // backend that omits it (deploy skew) must not blank the form — while
+        // an explicit null still means "cleared on the server".
+        if ('description' in json.result) {
+          setDescription(json.result.description || '');
+        }
+        if ('cache_timeout' in json.result) {
+          setCacheTimeout(json.result.cache_timeout ?? null);
+        }
       })
       .catch(async error => {
         if (cancelled) return;

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
@@ -124,7 +124,7 @@ export default function SemanticViewEditModal({
       setDescription(semanticView.description || '');
       setCacheTimeout(semanticView.cache_timeout ?? null);
     }
-  }, [semanticView]);
+  }, [show, semanticView?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!show || !semanticView) {
@@ -148,6 +148,7 @@ export default function SemanticViewEditModal({
       .catch(async error => {
         if (cancelled) return;
         const clientError = await getClientErrorObject(error);
+        if (cancelled) return;
         addDangerToast?.(
           clientError.error ||
             t('An error occurred while fetching the semantic view structure'),
@@ -160,7 +161,7 @@ export default function SemanticViewEditModal({
     return () => {
       cancelled = true;
     };
-  }, [show, semanticView]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [show, semanticView?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSave = async () => {
     if (!semanticView) return;

--- a/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
+++ b/superset-frontend/src/features/semanticViews/SemanticViewEditModal.tsx
@@ -57,6 +57,8 @@ interface SemanticMetric {
 }
 
 interface SemanticViewStructure {
+  description: string | null;
+  cache_timeout: number | null;
   dimensions: SemanticDimension[];
   metrics: SemanticMetric[];
 }
@@ -115,6 +117,8 @@ export default function SemanticViewEditModal({
   );
   const [structureLoading, setStructureLoading] = useState(false);
 
+  // Seeds the form so it is populated while /structure is in flight, and is
+  // what the form falls back to if that request fails.
   useEffect(() => {
     if (semanticView) {
       setDescription(semanticView.description || '');
@@ -123,27 +127,39 @@ export default function SemanticViewEditModal({
   }, [semanticView]);
 
   useEffect(() => {
-    if (show && semanticView) {
-      setStructureLoading(true);
-      SupersetClient.get({
-        endpoint: `/api/v1/semantic_view/${semanticView.id}/structure`,
-      })
-        .then(({ json }) => {
-          setStructure(json.result);
-        })
-        .catch(async error => {
-          const clientError = await getClientErrorObject(error);
-          addDangerToast?.(
-            clientError.error ||
-              t('An error occurred while fetching the semantic view structure'),
-          );
-        })
-        .finally(() => {
-          setStructureLoading(false);
-        });
-    } else {
+    if (!show || !semanticView) {
       setStructure(null);
+      return undefined;
     }
+
+    let cancelled = false;
+    setStructureLoading(true);
+    SupersetClient.get({
+      endpoint: `/api/v1/semantic_view/${semanticView.id}/structure`,
+    })
+      .then(({ json }) => {
+        if (cancelled) return;
+        setStructure(json.result);
+        // The caller's copy of these fields goes stale the moment this modal
+        // saves, so re-open hydrates from the server rather than the prop.
+        setDescription(json.result.description || '');
+        setCacheTimeout(json.result.cache_timeout ?? null);
+      })
+      .catch(async error => {
+        if (cancelled) return;
+        const clientError = await getClientErrorObject(error);
+        addDangerToast?.(
+          clientError.error ||
+            t('An error occurred while fetching the semantic view structure'),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setStructureLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [show, semanticView]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSave = async () => {

--- a/superset/semantic_layers/api.py
+++ b/superset/semantic_layers/api.py
@@ -197,7 +197,11 @@ class SemanticViewRestApi(BaseSupersetModelRestApi):
         log_to_statsd=False,
     )
     def structure(self, pk: int) -> Response:
-        """Get the structure (dimensions and metrics) of a semantic view.
+        """Get a semantic view's editable fields and its structure.
+
+        The editable fields (``description``, ``cache_timeout``) are served here
+        because ``SemanticViewRestApi`` exposes no detail route: this is the only
+        read endpoint an editor can hydrate from after a write.
         ---
         get:
           summary: Get semantic view structure
@@ -267,6 +271,8 @@ class SemanticViewRestApi(BaseSupersetModelRestApi):
             200,
             result={
                 "name": view.name,
+                "description": view.description,
+                "cache_timeout": view.cache_timeout,
                 "dimensions": dimensions,
                 "metrics": metrics,
             },

--- a/superset/semantic_layers/api.py
+++ b/superset/semantic_layers/api.py
@@ -196,7 +196,11 @@ class SemanticViewRestApi(BaseSupersetModelRestApi):
         log_to_statsd=False,
     )
     def structure(self, pk: int) -> Response:
-        """Get the structure (dimensions and metrics) of a semantic view.
+        """Get a semantic view's editable fields and its structure.
+
+        The editable fields (``description``, ``cache_timeout``) are served here
+        because ``SemanticViewRestApi`` exposes no detail route: this is the only
+        read endpoint an editor can hydrate from after a write.
         ---
         get:
           summary: Get semantic view structure
@@ -264,6 +268,8 @@ class SemanticViewRestApi(BaseSupersetModelRestApi):
             200,
             result={
                 "name": view.name,
+                "description": view.description,
+                "cache_timeout": view.cache_timeout,
                 "dimensions": dimensions,
                 "metrics": metrics,
             },

--- a/tests/unit_tests/semantic_layers/api_test.py
+++ b/tests/unit_tests/semantic_layers/api_test.py
@@ -2275,6 +2275,8 @@ def test_get_semantic_view_structure(
 
     mock_view = MagicMock()
     mock_view.name = "orders"
+    mock_view.description = "All orders"
+    mock_view.cache_timeout = 600
     mock_view.implementation.get_dimensions.return_value = {mock_dim}
     mock_view.implementation.get_metrics.return_value = {mock_metric}
 
@@ -2288,6 +2290,10 @@ def test_get_semantic_view_structure(
     assert response.status_code == 200
     result = response.json["result"]
     assert result["name"] == "orders"
+    # The edit modal has no detail route to hydrate from, so these must ride
+    # along with the structure or a saved description cannot be read back.
+    assert result["description"] == "All orders"
+    assert result["cache_timeout"] == 600
     assert len(result["dimensions"]) == 1
     assert result["dimensions"][0]["name"] == "order_date"
     assert result["dimensions"][0]["type"] == "timestamp[us]"
@@ -2371,6 +2377,8 @@ def test_get_semantic_view_structure_no_grain(
 
     mock_view = MagicMock()
     mock_view.name = "customers"
+    mock_view.description = None
+    mock_view.cache_timeout = None
     mock_view.implementation.get_dimensions.return_value = {mock_dim}
     mock_view.implementation.get_metrics.return_value = set()
 
@@ -2385,6 +2393,10 @@ def test_get_semantic_view_structure_no_grain(
     result = response.json["result"]
     assert result["dimensions"][0]["grain"] is None
     assert result["metrics"] == []
+    # An unset description must come back as null, not be omitted: the modal
+    # distinguishes "cleared" from "absent" when hydrating.
+    assert result["description"] is None
+    assert result["cache_timeout"] is None
     mock_view.raise_for_access.assert_called_once()
 
 

--- a/tests/unit_tests/semantic_layers/api_test.py
+++ b/tests/unit_tests/semantic_layers/api_test.py
@@ -2114,6 +2114,8 @@ def test_get_semantic_view_structure(
 
     mock_view = MagicMock()
     mock_view.name = "orders"
+    mock_view.description = "All orders"
+    mock_view.cache_timeout = 600
     mock_view.implementation.get_dimensions.return_value = {mock_dim}
     mock_view.implementation.get_metrics.return_value = {mock_metric}
 
@@ -2127,6 +2129,10 @@ def test_get_semantic_view_structure(
     assert response.status_code == 200
     result = response.json["result"]
     assert result["name"] == "orders"
+    # The edit modal has no detail route to hydrate from, so these must ride
+    # along with the structure or a saved description cannot be read back.
+    assert result["description"] == "All orders"
+    assert result["cache_timeout"] == 600
     assert len(result["dimensions"]) == 1
     assert result["dimensions"][0]["name"] == "order_date"
     assert result["dimensions"][0]["type"] == "timestamp[us]"
@@ -2210,6 +2216,8 @@ def test_get_semantic_view_structure_no_grain(
 
     mock_view = MagicMock()
     mock_view.name = "customers"
+    mock_view.description = None
+    mock_view.cache_timeout = None
     mock_view.implementation.get_dimensions.return_value = {mock_dim}
     mock_view.implementation.get_metrics.return_value = set()
 
@@ -2224,6 +2232,10 @@ def test_get_semantic_view_structure_no_grain(
     result = response.json["result"]
     assert result["dimensions"][0]["grain"] is None
     assert result["metrics"] == []
+    # An unset description must come back as null, not be omitted: the modal
+    # distinguishes "cleared" from "absent" when hydrating.
+    assert result["description"] is None
+    assert result["cache_timeout"] is None
     mock_view.raise_for_access.assert_called_once()
 
 


### PR DESCRIPTION
### SUMMARY

Editing a semantic view's **Description** saved correctly but re-opening the Edit datasource modal always showed the field empty, so the user had no way to confirm the save and would reasonably conclude it was lost.

The Details tab read `description`/`cache_timeout` from a prop, and both callers hand the modal their own copy of the datasource. In Explore that copy is never refreshed after a write — `DatasourceControl` passes the *pre-edit* `datasource` straight back into the store via `handleDatasourceSave` — so the prop is stale from the first save onward. There was nothing to fall back to either: `SemanticViewRestApi` omits `"get"` from `include_route_methods`, so `GET /api/v1/semantic_view/<id>` answers **405**, as the bug report observed.

So the modal had no read path to the values it had just written.

This PR serves both editable fields from `/<pk>/structure` — the one read endpoint the modal already calls — and hydrates the form from that response. The prop still seeds the form while the request is in flight and remains the fallback if it fails, so a `/structure` error degrades to today's behaviour rather than to a blank field.

Two notes for reviewers:

- The structure fetch gains a cancellation guard. That is new exposure introduced here, not a pre-existing bug: the response previously only wrote to `structure` state, and now also writes to *form* state, so a response for a superseded view could otherwise clobber what the user is editing.
- The endpoint already returned `name`, so returning model scalars is not a new kind of thing — but the drift is now explicit enough that the docstring has to explain it. The cleaner long-term fix is a real detail route, which would also close the 405; that needs `show_columns` and its own security review, so it is left as a follow-up.

The addition is purely additive. The other two `/structure` consumers (`ColumnSelect.tsx`, `FiltersConfigForm.tsx`) destructure only `dimensions`/`name`/`metrics` and are unaffected — verified by reading them, not by assuming structural typing covers it.

Disclosure: this change was developed with AI assistance (Claude), on behalf of and reviewed by @mikebridge.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Captured on a live local stack running this branch (flask + webpack dev server), driven with Playwright. The semantic view is backed by a minimal in-process demo semantic layer registered from dev config -- Snowflake/Cube/MetricFlow need external services -- but everything on screen is the real application path: real `/api/v1/semantic_view` API, real metadata DB, real Explore page and modal. The bug and the fix live entirely in the modal <-> API layer, which this exercises end to end.

Both captures follow the same flow: open **Edit datasource** on a semantic view in Explore, type a Description, **Save** (the PUT returns 200 and the value persists server-side in both cases), then re-open the modal.

**Before** (component at `preset/master`) -- the save persisted, but re-opening shows Description empty:

| typed & saved | re-opened |
| --- | --- |
| ![before: typed](https://github.com/mikebridge/superset/raw/sc-107904-assets/before-1-typed.png) | ![before: reopened empty](https://github.com/mikebridge/superset/raw/sc-107904-assets/before-2-reopened.png) |

**After** (this branch) -- re-opening shows the saved value:

| typed & saved | re-opened |
| --- | --- |
| ![after: typed](https://github.com/mikebridge/superset/raw/sc-107904-assets/after-1-typed.png) | ![after: reopened populated](https://github.com/mikebridge/superset/raw/sc-107904-assets/after-2-reopened.png) |

### TESTING INSTRUCTIONS

Automated:

```bash
# backend
pytest tests/unit_tests/semantic_layers/            # 392 passed

# frontend
cd superset-frontend
npx jest src/features/semanticViews                                      # 24 passed
npx jest src/explore/components/controls/DatasourceControl src/pages/DatasetList   # 134 passed
```

Controls were run in both directions:

- Reverting `superset/semantic_layers/api.py` fails the two new backend assertions with `KeyError: 'description'`.
- Reverting `SemanticViewEditModal.tsx` fails both new hydration tests.
- Of the three new frontend tests, only two discriminate. `falls back to the caller prop when the structure fetch fails` passes against pre-fix code as well — it pins the fallback contract and should not be read as proving the fix.

Manual, with `SEMANTIC_LAYERS` enabled (this exact flow is what the screenshots above exercise, on the live local stack):

1. Open Explore on a semantic view (`/explore/?datasource_type=semantic_view&datasource_id=<id>`).
2. More menu → **Edit datasource** → **Details** tab → set Description to `roundtrip test` → **Save**.
3. Re-open More → **Edit datasource**.
4. **Expected:** Description shows `roundtrip test`. On `master` it is empty.
5. Repeat from the Datasources list (edit action on a semantic-view row) — that path should behave identically.
6. Confirm `GET /api/v1/semantic_view/<id>/structure` now includes `description` and `cache_timeout`.

QA note: this closes TC28 (SemanticViewEditModal round-trip) for the Snowflake, BigQuery and Cube suites, which need re-running against a real environment.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SEMANTIC_LAYERS`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

