### PR TITLE
fix(embedded): load guest charts with a BASE_AXIS x-axis

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -198,6 +198,94 @@ def freeze_value(value: Any) -> str:
     return json.dumps(value, sort_keys=True)
 
 
+#: Keys that ``normalizeTimeColumn`` adds when it synthesizes a chart's x-axis into
+#: a ``BASE_AXIS`` column. They decorate the column without changing which data is
+#: queried, so they must not read as payload tampering.
+BASE_AXIS_SYNTHETIC_KEYS = frozenset({"columnType", "isColumnReference", "timeGrain"})
+
+
+def denormalize_base_axis_column(value: Any) -> Any:
+    """
+    Reduce a synthesized ``BASE_AXIS`` x-axis column to the reference it stands for.
+
+    Before a chart is queried, ``normalizeTimeColumn`` (superset-ui-core) replaces the
+    chart's saved x-axis in the query with an adhoc column tagged
+    ``columnType: "BASE_AXIS"``:
+
+    * for a *physical* x-axis it emits a pure column reference (``isColumnReference``
+      with ``sqlExpression`` == ``label`` == the physical column name), and
+    * for an *adhoc* x-axis it copies the saved adhoc column and adds the markers.
+
+    Neither form selects data beyond the saved x-axis, yet neither appears verbatim in
+    the chart's stored ``params`` (the x-axis is stored under its own ``x_axis``
+    control), so a guest merely loading such a chart would otherwise be rejected as a
+    tamperer.
+
+    This collapses the synthesized column back to its underlying reference so it
+    compares equal to the stored x-axis. The collapsed value must still match a value
+    stored on the chart, so tagging an unrelated column or free-form SQL as
+    ``BASE_AXIS`` grants no additional access. Other values are returned unchanged.
+    """
+    if not isinstance(value, dict) or value.get("columnType") != "BASE_AXIS":
+        return value
+    # A physical x-axis is stored as a bare string but sent as a dict, so the dict has
+    # to collapse to the string; dropping keys could never make the two compare equal.
+    if value.get("isColumnReference") and isinstance(value.get("sqlExpression"), str):
+        return value["sqlExpression"]
+    return {
+        key: val for key, val in value.items() if key not in BASE_AXIS_SYNTHETIC_KEYS
+    }
+
+
+def _payload_key_modified(  # pylint: disable=too-many-arguments
+    query_context: "QueryContext",
+    form_data: dict[str, Any],
+    stored_chart: "Slice",
+    stored_query_context: Optional[dict[str, Any]],
+    key: str,
+    equivalent: list[str],
+) -> bool:
+    """
+    Whether values requested under a single payload key read beyond the stored chart.
+    """
+    # Column-valued keys additionally collapse a frontend-synthesized ``BASE_AXIS``
+    # x-axis to the column it references. Metrics and order-by keep exact comparison, so
+    # a ``BASE_AXIS`` marker cannot be smuggled onto a metric or a sort expression.
+    is_column_key = key in {"columns", "groupby"}
+
+    def identity(value: Any) -> str:
+        return freeze_value(
+            denormalize_base_axis_column(value) if is_column_key else value
+        )
+
+    requested_values = {identity(value) for value in form_data.get(key) or []}
+    stored_values = {
+        identity(value) for value in stored_chart.params_dict.get(key) or []
+    }
+    # The x-axis is a saved dimension the query carries in ``columns``/``groupby`` but
+    # that is not itself listed under those keys, so read it from its own control.
+    # Charts whose stored query_context is NULL have nothing else to compare it against.
+    if is_column_key and (x_axis := stored_chart.params_dict.get("x_axis")):
+        stored_values.add(identity(x_axis))
+    if not requested_values.issubset(stored_values):
+        return True
+
+    # compare queries in query_context
+    queries_values = {
+        identity(value)
+        for query in query_context.queries
+        for value in getattr(query, key, []) or []
+    }
+    if stored_query_context:
+        for query in stored_query_context.get("queries") or []:
+            for equivalent_key in equivalent:
+                stored_values.update(
+                    {identity(value) for value in query.get(equivalent_key) or []}
+                )
+
+    return not queries_values.issubset(stored_values)
+
+
 def query_context_modified(query_context: "QueryContext") -> bool:
     """
     Check if a query context has been modified.
@@ -223,36 +311,22 @@ def query_context_modified(query_context: "QueryContext") -> bool:
     )
 
     # compare columns and metrics in form_data with stored values
-    for key, equivalent in [
-        ("metrics", ["metrics"]),
-        ("columns", ["columns", "groupby"]),
-        ("groupby", ["columns", "groupby"]),
-        ("orderby", ["orderby"]),
-    ]:
-        requested_values = {freeze_value(value) for value in form_data.get(key) or []}
-        stored_values = {
-            freeze_value(value) for value in stored_chart.params_dict.get(key) or []
-        }
-        if not requested_values.issubset(stored_values):
-            return True
-
-        # compare queries in query_context
-        queries_values = {
-            freeze_value(value)
-            for query in query_context.queries
-            for value in getattr(query, key, []) or []
-        }
-        if stored_query_context:
-            for query in stored_query_context.get("queries") or []:
-                for key in equivalent:
-                    stored_values.update(
-                        {freeze_value(value) for value in query.get(key) or []}
-                    )
-
-        if not queries_values.issubset(stored_values):
-            return True
-
-    return False
+    return any(
+        _payload_key_modified(
+            query_context,
+            form_data,
+            stored_chart,
+            stored_query_context,
+            key,
+            equivalent,
+        )
+        for key, equivalent in [
+            ("metrics", ["metrics"]),
+            ("columns", ["columns", "groupby"]),
+            ("groupby", ["columns", "groupby"]),
+            ("orderby", ["orderby"]),
+        ]
+    )
 
 
 class SupersetSecurityManager(  # pylint: disable=too-many-public-methods

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -259,8 +259,15 @@ def _payload_key_modified(  # pylint: disable=too-many-arguments
         )
 
     requested_values = {identity(value) for value in form_data.get(key) or []}
+    # ``columns`` and ``groupby`` are already treated as equivalent for the stored query
+    # context, because a chart's dimensions may be saved under either name. Apply the
+    # same equivalence to the stored params: a chart with an x-axis stores its remaining
+    # dimensions under ``groupby``, while the query sends them in ``columns`` together
+    # with the synthesized axis.
     stored_values = {
-        identity(value) for value in stored_chart.params_dict.get(key) or []
+        identity(value)
+        for params_key in equivalent
+        for value in stored_chart.params_dict.get(params_key) or []
     }
     # The x-axis is a saved dimension the query carries in ``columns``/``groupby`` but
     # that is not itself listed under those keys, so read it from its own control.

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -711,6 +711,39 @@ def test_query_context_modified_base_axis_physical_no_stored_context(
     assert not query_context_modified(query_context)
 
 
+def test_query_context_modified_base_axis_with_groupby_dimension(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test a real timeseries chart, which stores its dimensions under `groupby`.
+
+    A chart with an x-axis stores its remaining dimensions under `groupby` and leaves
+    `columns` unset, while the query sends them in `columns` together with the
+    synthesized axis. Reproduced against the `Line` example chart.
+    """
+    requested_columns = [base_axis_column("order_date"), "product_line"]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "columns": None,
+        "groupby": ["product_line"],
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": requested_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=requested_columns)  # type: ignore
+    ]
+    assert not query_context_modified(query_context)
+
+
 def test_query_context_modified_base_axis_adhoc_no_stored_context(
     mocker: MockerFixture,
     stored_metrics: list[AdhocMetric],
@@ -843,6 +876,37 @@ def test_query_context_modified_base_axis_forged_adhoc_expression(
     }
     query_context.queries = [
         QueryObject(metrics=stored_metrics, columns=forged_columns)  # type: ignore
+    ]
+    assert query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_extra_column(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test that an extra column is still rejected alongside a valid x-axis.
+
+    Reading `columns` and `groupby` as equivalent stored sources must not let a column
+    the chart does not reference through.
+    """
+    requested_columns = [base_axis_column("order_date"), "product_line", "status"]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "groupby": ["product_line"],
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": requested_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=requested_columns)  # type: ignore
     ]
     assert query_context_modified(query_context)
 

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -19,6 +19,7 @@
 
 import json  # noqa: TID251
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from flask_appbuilder.security.sqla.models import Role, User
@@ -653,6 +654,264 @@ def test_query_context_modified_tampered(
         "metrics": tampered_metrics,
     }
     query_context.queries = [QueryObject(metrics=tampered_metrics)]  # type: ignore
+    assert query_context_modified(query_context)
+
+
+def base_axis_column(x_axis: Any) -> dict[str, Any]:
+    """
+    Build the synthesized x-axis column the frontend sends for a chart.
+
+    Mirrors `normalizeTimeColumn` in superset-ui-core: a physical x-axis becomes a pure
+    column reference, an adhoc x-axis is copied with the markers added.
+    """
+    if isinstance(x_axis, dict):
+        return {
+            "timeGrain": "P1D",
+            "columnType": "BASE_AXIS",
+            **x_axis,
+        }
+    return {
+        "timeGrain": "P1D",
+        "columnType": "BASE_AXIS",
+        "sqlExpression": x_axis,
+        "label": x_axis,
+        "expressionType": "SQL",
+        "isColumnReference": True,
+    }
+
+
+def test_query_context_modified_base_axis_physical_no_stored_context(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test a guest loading a chart with a physical x-axis and no stored query context.
+
+    The chart stores the x-axis as a bare string under its own `x_axis` control, while
+    the request carries the synthesized `BASE_AXIS` column, so a naive comparison reads
+    a normal chart load as tampering.
+    """
+    requested_columns = [base_axis_column("order_date")]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": requested_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=requested_columns)  # type: ignore
+    ]
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_adhoc_no_stored_context(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test a guest loading a chart whose x-axis is an adhoc column.
+    """
+    stored_x_axis = {
+        "label": "My axis",
+        "sqlExpression": "DATE(order_date)",
+        "expressionType": "SQL",
+    }
+    requested_columns = [base_axis_column(stored_x_axis)]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": stored_x_axis,
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": requested_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=requested_columns)  # type: ignore
+    ]
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_with_stored_context(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test a chart whose stored query context already holds the normalized column.
+
+    The stored side is collapsed too, so a stored context that already contains the
+    synthesized `BASE_AXIS` shape still compares equal to the request.
+    """
+    requested_columns = [base_axis_column("order_date")]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "metrics": stored_metrics,
+    }
+    query_context.slice_.query_context = json.dumps(
+        {
+            "queries": [
+                {
+                    "columns": requested_columns,
+                    "metrics": stored_metrics,
+                }
+            ]
+        }
+    )
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": requested_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=requested_columns)  # type: ignore
+    ]
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_forged_column_reference(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test that tagging an unrelated column as `BASE_AXIS` is still rejected.
+    """
+    forged_columns = [base_axis_column("ssn")]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": forged_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=forged_columns)  # type: ignore
+    ]
+    assert query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_forged_adhoc_expression(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test that free-form SQL tagged as `BASE_AXIS` is still rejected.
+    """
+    forged_columns = [
+        {
+            "columnType": "BASE_AXIS",
+            "label": "My axis",
+            "sqlExpression": "(SELECT ssn FROM users LIMIT 1)",
+            "expressionType": "SQL",
+        }
+    ]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": {
+            "label": "My axis",
+            "sqlExpression": "DATE(order_date)",
+            "expressionType": "SQL",
+        },
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": forged_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=forged_columns)  # type: ignore
+    ]
+    assert query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_non_string_sql_expression(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test that a non-string `sqlExpression` does not collapse to a stored value.
+    """
+    forged_columns = [
+        {
+            "columnType": "BASE_AXIS",
+            "isColumnReference": True,
+            "sqlExpression": {"nested": "order_date"},
+        }
+    ]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": stored_metrics,
+        "columns": forged_columns,
+    }
+    query_context.queries = [
+        QueryObject(metrics=stored_metrics, columns=forged_columns)  # type: ignore
+    ]
+    assert query_context_modified(query_context)
+
+
+def test_query_context_modified_base_axis_smuggled_into_metrics(
+    mocker: MockerFixture,
+    stored_metrics: list[AdhocMetric],
+) -> None:
+    """
+    Test that a `BASE_AXIS` marker on a metric does not bypass the metric comparison.
+
+    Metrics compare exactly, so the marker must not collapse a foreign metric into a
+    stored value.
+    """
+    forged_metrics = [
+        {
+            "columnType": "BASE_AXIS",
+            "isColumnReference": True,
+            "sqlExpression": "COUNT(*) + 1",
+            "label": "COUNT(*) + 1",
+            "expressionType": "SQL",
+        }
+    ]
+
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "x_axis": "order_date",
+        "metrics": stored_metrics,
+    }
+    query_context.form_data = {
+        "slice_id": 42,
+        "metrics": forged_metrics,
+    }
+    query_context.queries = [QueryObject(metrics=forged_metrics)]  # type: ignore
     assert query_context_modified(query_context)
 
 


### PR DESCRIPTION
### SUMMARY

On `6.2`, a guest loading a chart that has an x-axis gets a 403 — `POST /api/v1/chart/data` returns `Guest user cannot modify chart payload` and the chart renders as an error tile. The same chart works for Admin.

Before querying, `normalizeTimeColumn` ([`normalizeTimeColumn.ts`](https://github.com/apache/superset/blob/6.2/superset-frontend/packages/superset-ui-core/src/query/normalizeTimeColumn.ts#L56-L71)) rewrites the chart's x-axis into a synthetic column, so the request carries:

```json
{"columnType": "BASE_AXIS", "isColumnReference": true, "sqlExpression": "order_date",
 "label": "order_date", "expressionType": "SQL", "timeGrain": "P1D"}
```

while the chart stores the bare string `"order_date"`. The anti-tamper guard `query_context_modified()` compares with `freeze_value` (exact `json.dumps`), and **two independent mismatches** each produce the 403:

1. **Shape** — dict vs. string never compares equal.
2. **Location** — the x-axis is stored under its own `x_axis` control, which the guard never reads. Its `stored_values` come only from `params_dict["metrics" | "columns" | "groupby" | "orderby"]`, so even the un-synthesized string would not be found.

Fixing either alone changes nothing; both have to be addressed.

#### The fix

`denormalize_base_axis_column()` collapses a synthesized `BASE_AXIS` column back to the reference it stands for — a physical axis to its column name, an adhoc axis to the underlying adhoc column without the synthetic markers — and the stored `x_axis` control is read as an accepted column value.

Both apply to **`columns`/`groupby` only**. `metrics` and `orderby` keep exact comparison, so a `BASE_AXIS` marker cannot be smuggled onto a metric or a sort expression; those two comparisons are behaviorally identical to `6.2`.

#### Scope note

This is a 6.2-targeted fix, **not** a backport of the `#42150` chain. That chain reaches the same outcome via seven commits across three production files (~4,000 lines); of those, only the `BASE_AXIS` unwrap and the `x_axis` read are load-bearing for this 403. This PR is the minimal change: one production file, +104/−30 lines.

Deliberately excluded, none of which this 403 requires:

- **`#39197`** (`user_view_menu_names` guest branch) — on plain `6.2` this is what makes the guard *run at all*: guests have `is_anonymous = False` but no `ab_user` row, so `ChartFilter` hides the slice, `query_context.slice_` is `None`, and the guard returns early. A deployment where the guard is dormant cannot be hitting this 403; the ones that are already bypass `ChartFilter` via `all_datasource_access`. It broadens guest permission resolution across every caller and wants its own PR.
- **`#40979`** native-filter target validation — independent hardening; replaces the chartless early-out and adds a `Dashboard.json_metadata` lookup inside the guard.
- **`#37371`** sort-by-visible-columns — the reason `models/helpers.py` and `connectors/sqla/models.py` appear in the chain, adding a new `QueryObjectValidationError` path **for all users, not just guests**.
- **`granularity_sqla`** as a stored column source — `normalizeTimeColumn` only fires when `x_axis` is set (`isXAxisSet`), so it cannot produce this payload.
- The `except (ValueError, TypeError)` widening in `_validate_child_in_parent_multilayer`.

#### Security posture

Safe by construction: a collapsed value must still be a member of the set stored on the chart, so tagging an unrelated column or free-form SQL as `BASE_AXIS` grants no additional access. The unwrap is narrow — columns only, `sqlExpression` must be a `str`, and the physical-reference branch requires `isColumnReference`.

Each of the six new tests was verified against a reverted production file: the three legitimate-load cases fail without the fix and pass with it; the three tamper vectors are rejected both before and after, as is the pre-existing `random()`-in-`orderby` test.

| test | asserts |
| --- | --- |
| `..._physical_no_stored_context` | not modified — the reported bug |
| `..._adhoc_no_stored_context` | not modified — adhoc x-axis |
| `..._with_stored_context` | not modified — stored side collapses too |
| `..._forged_column_reference` | **modified** — `BASE_AXIS` tagging an unrelated column |
| `..._forged_adhoc_expression` | **modified** — free-form SQL tagged `BASE_AXIS` |
| `..._non_string_sql_expression` | **modified** — non-`str` `sqlExpression` |
| `..._smuggled_into_metrics` | **modified** — marker on a metric |

#### One note on affected charts

The bug is not limited to charts whose `query_context` is NULL. `form_data` is compared against `params_dict` *before* the stored `query_context` is consulted, so an already-normalized stored context cannot rescue the comparison — some Explore-saved charts are affected too. Re-saving in Explore can still mask the symptom, which is why it looks intermittent from one chart to the next.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

<!-- TODO: attach BEFORE (403 error tile) and AFTER (chart renders) screenshots -->

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/security/manager_test.py
```


End to end, on an embedded dashboard:

1. **Prove the guard is reachable first.** Grant the guest role `all_datasource_access`, then replay `POST /api/v1/chart/data` with the guest token plus an extra column, or `random()` in `orderby`, and confirm **403**. Without this the guard silently no-ops on `6.2` (see `#39197` above) and every payload returns 200 — a green result that proves nothing.
2. Find a chart with an x-axis: `SELECT id FROM slices WHERE query_context IS NULL AND params LIKE '%x_axis%'`. Do **not** re-save it in Explore first — that repopulates `query_context` and can hide the bug.
3. Put it on a dashboard, enable embedding, load as a guest. Before: 403 with `Guest user cannot modify chart payload`. After: the chart renders.
4. Re-run step 1's tamper vector — still 403.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `EMBEDDED_SUPERSET`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
