### PR TITLE
fix(app-root): prevent double-prefixed logout link under SUPERSET_APP_ROOT

### DIFF
--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -26,6 +26,7 @@ import {
 } from 'spec/helpers/testing-library';
 import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { isEmbedded } from 'src/dashboard/util/isEmbedded';
+import * as getBootstrapData from 'src/utils/getBootstrapData';
 import RightMenu from './RightMenu';
 import { GlobalMenuDataOptions, RightMenuProps } from './types';
 
@@ -475,4 +476,37 @@ test('hides logout button when embedded and flag is enabled', async () => {
 
   userEvent.hover(await screen.findByText(/Settings/i));
   expect(screen.queryByText('Logout')).not.toBeInTheDocument();
+});
+
+test('Logout link href is single-prefixed under subdirectory deployment', async () => {
+  // The logout URL is built by Flask-AppBuilder's get_url_for_logout, which
+  // is SCRIPT_NAME-aware and already returns `/superset/logout/` under
+  // app_root. Prefixing it again in the frontend produced
+  // `/superset/superset/logout/` (see #40576).
+  const applicationRootSpy = jest
+    .spyOn(getBootstrapData, 'applicationRoot')
+    .mockReturnValue('/superset');
+
+  try {
+    const props = createProps();
+    // Mirror the SCRIPT_NAME-prefixed value the backend would emit under
+    // APPLICATION_ROOT=/superset.
+    props.navbarRight.user_logout_url = '/superset/logout/';
+    resetUseSelectorMock();
+    render(<RightMenu {...props} />, {
+      useRedux: true,
+      useQueryParams: true,
+      useRouter: true,
+      useTheme: true,
+    });
+
+    userEvent.hover(await screen.findByText(/Settings/i));
+    const logoutLink = await screen.findByText('Logout');
+    expect(logoutLink.closest('a')).toHaveAttribute(
+      'href',
+      '/superset/logout/',
+    );
+  } finally {
+    applicationRootSpy.mockRestore();
+  }
 });

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -507,9 +507,7 @@ const RightMenu = ({
           userItems.push({
             key: 'logout',
             label: (
-              <Typography.Link
-                href={ensureAppRoot(navbarRight.user_logout_url)}
-              >
+              <Typography.Link href={navbarRight.user_logout_url}>
                 {t('Logout')}
               </Typography.Link>
             ),


### PR DESCRIPTION
### SUMMARY

Backport of the `RightMenu.tsx` hunk of #38033 to the `6.2` release branch, plus the regression test added in #39925.

`navbarRight.user_logout_url` comes from Flask-AppBuilder's `get_url_for_logout`, which resolves through Flask's `url_for` and is therefore already `SCRIPT_NAME`-aware. On `6.2` it is still wrapped in `ensureAppRoot()`, which prefixes the application root a second time, so the Logout menu item points outside the mount point and 404s under a sub-path deployment.

This is the asymmetry that makes the bug easy to miss: `menu_data` emits `user_info_url` as the *relative* literal `/user_info/` (so it does need prefixing), while `user_logout_url` arrives already rooted. Both were being wrapped identically, so exactly one of them doubled.

```python
# superset/views/base.py
"user_info_url": (None if is_feature_enabled("MENU_HIDE_USER_INFO") else "/user_info/"),
"user_logout_url": appbuilder.get_url_for_logout,   # already SCRIPT_NAME-prefixed
```

This was reported as #40576 and closed as fixed on `master`, but the fix never reached a release branch. Evaluating the shipped `ensureAppRoot` body on each ref against the value the backend actually emits (`APPLICATION_ROOT=/app-superset`):

```
origin/6.1     Logout href -> /app-superset/app-superset/logout/   (broken)
origin/6.2     Logout href -> /app-superset/app-superset/logout/   (broken)
origin/master  Logout href -> /app-superset/logout/                (ok)
```

6.1.0 already shipped this, and `6.2` would ship it again without this backport.

`master` additionally carries an idempotence guard inside `ensureAppRoot()` itself. That is deliberately **not** backported here — the one-line `RightMenu.tsx` change is sufficient and is the smaller risk on a release branch.

Happy to open the equivalent PR against `6.1` if maintainers want it there too.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before (`APPLICATION_ROOT=/app-superset`), Settings → Logout:

```
href="/app-superset/app-superset/logout/"   -> 404
```

After:

```
href="/app-superset/logout/"                -> logs out
```

### TESTING INSTRUCTIONS

Automated — this PR ports the regression test #39925 added on `master`, where it passes. It asserts the Logout `href` stays single-prefixed when the backend supplies an already-rooted URL, so it fails against `6.2`'s current `ensureAppRoot()` wrapping:

```bash
cd superset-frontend
npm run test -- src/features/home/RightMenu.test.tsx -t "single-prefixed"
```

Manual:

1. Run Superset with `SUPERSET_APP_ROOT=/app-superset` (or `APPLICATION_ROOT`) behind a proxy that routes only `/app-superset/*`.
2. Log in, open the Settings menu, and inspect the Logout item's `href`.
3. It should be `/app-superset/logout/`, not `/app-superset/app-superset/logout/`, and clicking it should log you out rather than 404.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40576 (fixed on `master` by #38033; this backports it to `6.2`)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
