### PR TITLE
Add pre-filter option to Time Grain dashboard control

### DIFF
--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -91,10 +91,6 @@ export default function PluginFilterTimegrain(
     [durationMap, setDataMask],
   );
 
-  useEffect(() => {
-    handleChange(filterState.value ?? []);
-  }, [JSON.stringify(filterState.value)]);
-
   const formItemData: FormItemProps = {};
   if (filterState.validateMessage) {
     formItemData.extra = (
@@ -124,8 +120,8 @@ export default function PluginFilterTimegrain(
     }
 
     const allowedSet = new Set(allowlist);
-    return allOptions.filter(option => allowedSet.has(option.value));
-  }, [data, dashboardTimeGrainAllowlist, formData.timeGrains]);
+    return allOptions.filter(option => allowedSet.has(option.value) || value.includes(option.value));
+  }, [data, dashboardTimeGrainAllowlist, formData.timeGrains, JSON.stringify(value)]);
 
   const validValue = useMemo(() => {
     if (options.length === 0) return [];
@@ -145,6 +141,7 @@ export default function PluginFilterTimegrain(
 
     hasInitRef.current = true;
 
+    if (value.length > 0) return;
     if (target.length > 0) {
       handleChange(target);
     }

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t } from '@apache-superset/core/translation';
+import { t, tn } from '@apache-superset/core/translation';
 import {
   ensureIsArray,
   ExtraFormData,
   TimeGranularity,
 } from '@superset-ui/core';
-import { tn } from '@apache-superset/core/translation';
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ReactReduxContext } from 'react-redux';
 import {
   FormItem,
@@ -57,6 +56,7 @@ export default function PluginFilterTimegrain(
     reduxContext?.store?.getState?.()?.dashboardInfo?.metadata
       ?.time_grain_allowlist;
 
+  const [value, setValue] = useState<string[]>(defaultValue ?? []);
   const durationMap = useMemo(
     () =>
       data.reduce(
@@ -69,16 +69,50 @@ export default function PluginFilterTimegrain(
     [JSON.stringify(data)],
   );
 
+  const handleChange = useCallback(
+    (values: string[] | string | undefined | null) => {
+      const resultValue: string[] = ensureIsArray<string>(values);
+      const [timeGrain] = resultValue;
+      const label = timeGrain ? durationMap[timeGrain] : undefined;
+
+      const extraFormData: ExtraFormData = {};
+      if (timeGrain) {
+        extraFormData.time_grain_sqla = timeGrain as TimeGranularity;
+      }
+      setValue(resultValue);
+      setDataMask({
+        extraFormData,
+        filterState: {
+          label,
+          value: resultValue.length ? resultValue : null,
+        },
+      });
+    },
+    [durationMap, setDataMask],
+  );
+
+  useEffect(() => {
+    handleChange(filterState.value ?? []);
+  }, [JSON.stringify(filterState.value)]);
+
+  const formItemData: FormItemProps = {};
+  if (filterState.validateMessage) {
+    formItemData.extra = (
+      <StatusMessage status={filterState.validateStatus}>
+        {filterState.validateMessage}
+      </StatusMessage>
+    );
+  }
+
   const options = useMemo(() => {
-    const allOptions = (data || []).map(
-      (row: { name: string; duration: string }) => {
+    const allOptions = (data || [])
+      .map((row: { name: string; duration: string }) => {
         const { name, duration } = row;
         return {
           label: name,
           value: duration,
         };
-      },
-    );
+      });
 
     const allowlist =
       dashboardTimeGrainAllowlist?.length > 0
@@ -93,33 +127,11 @@ export default function PluginFilterTimegrain(
     return allOptions.filter(option => allowedSet.has(option.value));
   }, [data, dashboardTimeGrainAllowlist, formData.timeGrains]);
 
-  const rawValue = ensureIsArray<string>(filterState.value);
   const validValue = useMemo(() => {
     if (options.length === 0) return [];
     const optionValues = new Set(options.map(o => o.value));
-    return rawValue.filter(v => optionValues.has(v));
-  }, [rawValue, options]);
-
-  const handleChange = useCallback(
-    (values: string[] | string | undefined | null) => {
-      const resultValue: string[] = ensureIsArray<string>(values);
-      const [timeGrain] = resultValue;
-      const label = timeGrain ? durationMap[timeGrain] : undefined;
-
-      const extraFormData: ExtraFormData = {};
-      if (timeGrain) {
-        extraFormData.time_grain_sqla = timeGrain as TimeGranularity;
-      }
-      setDataMask({
-        extraFormData,
-        filterState: {
-          label,
-          value: resultValue.length ? resultValue : null,
-        },
-      });
-    },
-    [durationMap, setDataMask],
-  );
+    return value.filter(v => optionValues.has(v));
+  }, [value, options]);
 
   const hasInitRef = useRef(false);
   useEffect(() => {
@@ -137,15 +149,6 @@ export default function PluginFilterTimegrain(
       handleChange(target);
     }
   }, [options, defaultValue, handleChange]);
-
-  const formItemData: FormItemProps = {};
-  if (filterState.validateMessage) {
-    formItemData.extra = (
-      <StatusMessage status={filterState.validateStatus}>
-        {filterState.validateMessage}
-      </StatusMessage>
-    );
-  }
 
   const placeholderText =
     options.length === 0

--- a/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/TimeGrain/TimeGrainFilterPlugin.tsx
@@ -16,13 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { t, tn } from '@apache-superset/core/translation';
+import { t } from '@apache-superset/core/translation';
 import {
   ensureIsArray,
   ExtraFormData,
   TimeGranularity,
 } from '@superset-ui/core';
-import { useEffect, useMemo, useState } from 'react';
+import { tn } from '@apache-superset/core/translation';
+import React, { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { ReactReduxContext } from 'react-redux';
 import {
   FormItem,
   type FormItemProps,
@@ -50,7 +52,11 @@ export default function PluginFilterTimegrain(
   } = props;
   const { defaultValue } = formData;
 
-  const [value, setValue] = useState<string[]>(defaultValue ?? []);
+  const reduxContext = useContext(ReactReduxContext);
+  const dashboardTimeGrainAllowlist: string[] | undefined =
+    reduxContext?.store?.getState?.()?.dashboardInfo?.metadata
+      ?.time_grain_allowlist;
+
   const durationMap = useMemo(
     () =>
       data.reduce(
@@ -63,34 +69,74 @@ export default function PluginFilterTimegrain(
     [JSON.stringify(data)],
   );
 
-  const handleChange = (values: string[] | string | undefined | null) => {
-    const resultValue: string[] = ensureIsArray<string>(values);
-    const [timeGrain] = resultValue;
-    const label = timeGrain ? durationMap[timeGrain] : undefined;
-
-    const extraFormData: ExtraFormData = {};
-    if (timeGrain) {
-      extraFormData.time_grain_sqla = timeGrain as TimeGranularity;
-    }
-    setValue(resultValue);
-    setDataMask({
-      extraFormData,
-      filterState: {
-        label,
-        value: resultValue.length ? resultValue : null,
+  const options = useMemo(() => {
+    const allOptions = (data || []).map(
+      (row: { name: string; duration: string }) => {
+        const { name, duration } = row;
+        return {
+          label: name,
+          value: duration,
+        };
       },
-    });
-  };
+    );
 
-  useEffect(() => {
-    handleChange(defaultValue ?? []);
-    // I think after Config Modal update some filter it re-creates default value for all other filters
-    // so we can process it like this `JSON.stringify` or start to use `Immer`
-  }, [JSON.stringify(defaultValue)]);
+    const allowlist =
+      dashboardTimeGrainAllowlist?.length > 0
+        ? dashboardTimeGrainAllowlist
+        : formData.timeGrains;
 
+    if (!allowlist || allowlist.length === 0) {
+      return allOptions;
+    }
+
+    const allowedSet = new Set(allowlist);
+    return allOptions.filter(option => allowedSet.has(option.value));
+  }, [data, dashboardTimeGrainAllowlist, formData.timeGrains]);
+
+  const rawValue = ensureIsArray<string>(filterState.value);
+  const validValue = useMemo(() => {
+    if (options.length === 0) return [];
+    const optionValues = new Set(options.map(o => o.value));
+    return rawValue.filter(v => optionValues.has(v));
+  }, [rawValue, options]);
+
+  const handleChange = useCallback(
+    (values: string[] | string | undefined | null) => {
+      const resultValue: string[] = ensureIsArray<string>(values);
+      const [timeGrain] = resultValue;
+      const label = timeGrain ? durationMap[timeGrain] : undefined;
+
+      const extraFormData: ExtraFormData = {};
+      if (timeGrain) {
+        extraFormData.time_grain_sqla = timeGrain as TimeGranularity;
+      }
+      setDataMask({
+        extraFormData,
+        filterState: {
+          label,
+          value: resultValue.length ? resultValue : null,
+        },
+      });
+    },
+    [durationMap, setDataMask],
+  );
+
+  const hasInitRef = useRef(false);
   useEffect(() => {
-    handleChange(filterState.value ?? []);
-  }, [JSON.stringify(filterState.value)]);
+    if (hasInitRef.current) return;
+    if (options.length === 0) return;
+
+    const optionValues = new Set(options.map(o => o.value));
+    const target = ensureIsArray<string>(defaultValue).filter(v =>
+      optionValues.has(v),
+    );
+
+    hasInitRef.current = true;
+
+    if (target.length > 0) {
+      handleChange(target);
+    }
+  }, [options, defaultValue, handleChange]);
 
   const formItemData: FormItemProps = {};
   if (filterState.validateMessage) {
@@ -100,23 +146,6 @@ export default function PluginFilterTimegrain(
       </StatusMessage>
     );
   }
-
-  const options = (data || [])
-    .map((row: { name: string; duration: string }) => {
-      const { name, duration } = row;
-      return {
-        label: name,
-        value: duration,
-      };
-    })
-    // Apply allowlist filter if timeGrains is configured, but keep current selection visible
-    .filter(option => {
-      const allowlist = formData.timeGrains;
-      if (!allowlist || allowlist.length === 0) {
-        return true;
-      }
-      return allowlist.includes(option.value) || value.includes(option.value);
-    });
 
   const placeholderText =
     options.length === 0
@@ -129,7 +158,7 @@ export default function PluginFilterTimegrain(
         <Select
           name={formData.nativeFilterId}
           allowClear
-          value={value}
+          value={validValue}
           placeholder={placeholderText}
           // @ts-expect-error
           onChange={handleChange}

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -228,6 +228,7 @@ class DashboardJSONMetadataSchema(Schema):
     remote_id = fields.Integer()
     filter_bar_orientation = fields.Str(allow_none=True)
     native_filter_migration = fields.Dict()
+    time_grain_allowlist = fields.List(fields.Str(), allow_none=True)
 
     @pre_load
     def remove_show_native_filters(  # pylint: disable=unused-argument


### PR DESCRIPTION
  **Title:** feat(dashboard): add per-dashboard time grain allowlist via `time_grain_allowlist` in JSON metadata

**Description:**

This MR introduces the ability to restrict available time grains at the **dashboard level** by adding a `time_grain_allowlist` field to the dashboard JSON metadata. When set, all Time Grain native filters on that dashboard will only display the specified time grains, regardless of what the underlying datasource provides.

### Motivation

Currently, Superset allows global time grain restrictions via `TIME_GRAIN_DENYLIST` in `superset_config.py`, but there is no way to limit time grains **per dashboard**. Users have requested the ability to show different time grain options on different dashboards (e.g., hourly/monthly on Dashboard A, monthly/yearly on Dashboard B) without manually editing each filter's settings.

### Changes

#### 1. Backend — `superset/dashboards/schemas.py`
- Added `time_grain_allowlist` to `DashboardJSONMetadataSchema` as a `List(Str)` field with `allow_none=True`.
- This allows the dashboard API (`PUT /api/v1/dashboard/{id}`) to accept and validate the new field in `json_metadata` without throwing `"Unknown field."`.

#### 2. Frontend — `TimeGrainFilterPlugin.tsx`
- Reads `dashboardInfo.metadata.time_grain_allowlist` from the Redux store via `ReactReduxContext` (safe for plugin context where `useSelector` may fail).
- Filters `options` based on the dashboard allowlist. Priority:
  1. Dashboard `time_grain_allowlist`
  2. Filter-level `timeGrains` (existing behavior)
  3. All datasource time grains (fallback)
- Uses `useRef` (`hasInitRef`) to apply `defaultValue` exactly once after `options` are ready, preventing race conditions and "Cannot load filter" errors on initial render.
- `validValue` is computed directly from `filterState.value` intersected with `options`, ensuring the `Select` component never receives a value that does not exist in its option list.

### Usage

Edit a dashboard → **Edit properties** → **Advanced** → **JSON Metadata**:

```json
{
  "time_grain_allowlist": ["PT1H", "P1M"],
  "native_filter_configuration": [ ... ]
}
```

All Time Grain filters on this dashboard will now show only **Hour** and **Month**.

### Supported values

| Value | Label |
|-------|-------|
| `PT1S` | Second |
| `PT1M` | Minute |
| `PT5M` | 5 Minutes |
| `PT10M` | 10 Minutes |
| `PT15M` | 15 Minutes |
| `PT30M` | 30 Minutes |
| `PT1H` | Hour |
| `P1D` | Day |
| `P1W` | Week |
| `P1W/1970-01-05T00:00:00Z` | Week starting Monday |
| `1969-12-29T00:00:00Z/P1W` | Week ending Sunday |
| `P1M` | Month |
| `P3M` | Quarter |
| `P1Y` | Year |

### Backward compatibility
- If `time_grain_allowlist` is absent from dashboard metadata, behavior is unchanged.
- If present but empty `[]`, all time grains are shown (same as no restriction).

### Testing
- [x] Verify `PUT /api/v1/dashboard/{id}` accepts `json_metadata` with `time_grain_allowlist`.
- [ ] Verify Time Grain filter shows only allowed grains when `time_grain_allowlist` is set.
- [ ] Verify filter works normally when `time_grain_allowlist` is absent.
- [ ] Verify no "Cannot load filter" error on first dashboard load with default value.