### PR TITLE
fix(sql-lab): raise SupersetTemplateException instead of raw UndefinedError in SQLExecutor.execute_async

### DIFF
--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -66,6 +66,7 @@ from typing import Any, NoReturn, TYPE_CHECKING
 
 from flask import current_app as app, g, has_app_context
 from flask_babel import gettext as __
+from jinja2.exceptions import TemplateError
 
 from superset import db
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
@@ -75,6 +76,7 @@ from superset.exceptions import (
     SupersetErrorException,
     SupersetParseError,
     SupersetSecurityException,
+    SupersetTemplateException,
     SupersetTimeoutException,
 )
 from superset.extensions import cache_manager
@@ -751,6 +753,7 @@ class SQLExecutor:
         :param sql: SQL string potentially containing Jinja2 templates
         :param template_params: Parameters to pass to the template
         :returns: Rendered SQL string
+        :raises SupersetTemplateException: if the template fails to render
         """
         if template_params is None:
             return sql
@@ -758,7 +761,10 @@ class SQLExecutor:
         from superset.jinja_context import get_template_processor
 
         tp = get_template_processor(database=self.database)
-        return tp.process_template(sql, **template_params)
+        try:
+            return tp.process_template(sql, **template_params)
+        except TemplateError as ex:
+            raise SupersetTemplateException(str(ex)) from ex
 
     def _apply_limit_to_script(self, script: SQLScript, opts: QueryOptions) -> None:
         """

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -44,6 +44,7 @@ from superset_core.queries.types import (
 )
 
 from superset.models.core import Database
+from tests.unit_tests.conftest import with_feature_flags
 
 # Note: database, database_with_dml, mock_db_session fixtures and
 # mock_query_execution helper are imported from conftest.py
@@ -787,6 +788,42 @@ def test_execute_async_dml_without_permission_raises(
 
     with pytest.raises(SupersetSecurityException, match="DML queries are not allowed"):
         database.execute_async("INSERT INTO users (name) VALUES ('test')")
+
+
+@with_feature_flags(ENABLE_TEMPLATE_PROCESSING=True)
+def test_execute_async_undefined_template_var_raises_superset_template_exception(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """A Jinja template referencing an undefined variable (not called as a
+    function) must not leak a raw ``jinja2.exceptions.UndefinedError`` out of
+    ``execute_async`` - it should surface as ``SupersetTemplateException``."""
+    from superset.exceptions import SupersetTemplateException
+
+    mocker.patch.dict(
+        current_app.config, {"SQL_QUERY_MUTATOR": None, "SQLLAB_TIMEOUT": 30}
+    )
+
+    options = QueryOptions(template_params={"foo": "bar"})
+
+    with pytest.raises(SupersetTemplateException):
+        database.execute_async("SELECT {{ missing_var[0] }}", options=options)
+
+
+@with_feature_flags(ENABLE_TEMPLATE_PROCESSING=True)
+def test_execute_sync_undefined_template_var_returns_failed_result(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """The sync ``execute`` path's broad ``except Exception`` still catches the
+    template rendering failure and returns a FAILED ``QueryResult``, unchanged
+    by the ``_render_sql_template`` fix."""
+    mocker.patch.dict(
+        current_app.config, {"SQL_QUERY_MUTATOR": None, "SQLLAB_TIMEOUT": 30}
+    )
+
+    options = QueryOptions(template_params={"foo": "bar"})
+    result = database.execute("SELECT {{ missing_var[0] }}", options=options)
+
+    assert result.status == QueryStatus.FAILED
 
 
 def test_async_handle_get_status(


### PR DESCRIPTION
### SUMMARY
`SQLExecutor._render_sql_template()` (`superset/sql/execution/executor.py`) called `tp.process_template()` with no `try/except` at all. `process_template()` can leak a raw `jinja2.exceptions.UndefinedError` for a template referencing an undefined variable that isn't called as a function. `execute()` happens to be safe because its whole body is wrapped in a broad `except Exception`, but `execute_async()` has no such guard — the raw exception propagated straight out of the public `Database.execute_async()` API contract.

### PROBLEM
`superset/jinja_context.py::BaseTemplateProcessor.process_template()` converts most Jinja rendering failures into typed exceptions, but has a bare-`raise` fallback for `UndefinedError` when the undefined variable is accessed via attribute/subscript syntax rather than a function call. This is the same gap already fixed at other `process_template()` call sites in this codebase: #42366, #42401, #42714, #42757, #42802 — this PR fixes it at a new call site.

`_render_sql_template()` is shared by both `SQLExecutor.execute()` and `SQLExecutor.execute_async()`. `execute()`'s entire body (including the `_prepare_sql()` call that reaches `_render_sql_template()`) is wrapped in `try: ... except Exception as ex: return self._create_error_result(...)`, so any exception raised there already degrades gracefully into a `QueryResult(status=FAILED)` — not a bug. `execute_async()` has no equivalent guard around its `_prepare_sql()` call; confirmed empirically that `database.execute_async("SELECT {{ missing_var[0] }}", options=QueryOptions(template_params={"foo": "bar"}))` raised a bare `jinja2.exceptions.UndefinedError` on `master`, not any `SupersetException`. This also breaks the method's own established contract: `execute_async()` already raises typed `SupersetSecurityException` for other prep-time failures (e.g. disallowed DML), so callers reasonably expect prep-time errors to always be Superset exceptions.

### FIX
Wrapped the `process_template()` call inside `_render_sql_template()` in `try/except TemplateError as ex: raise SupersetTemplateException(str(ex)) from ex`. Reused the existing `SupersetTemplateException` (status 422) rather than inventing a new exception class — it's already the established general-purpose Superset exception for Jinja template rendering failures elsewhere in this codebase (`jinja_context.py` itself raises it for `RecursionError`, and it's caught in `superset/datasets/api.py` and `superset/commands/database/validate_sql.py`).

Additive-only: no behavior change to the sync `execute()` path (its broad `except Exception` still catches the now-typed exception and returns the same `QueryResult(FAILED)` shape — only the error message text improves).

### TESTING INSTRUCTIONS
Added two tests to `tests/unit_tests/sql/execution/test_executor.py`:
- `test_execute_async_undefined_template_var_raises_superset_template_exception` — asserts `execute_async()` with a template referencing an undefined variable raises `SupersetTemplateException`, not a raw `jinja2.exceptions.UndefinedError`.
- `test_execute_sync_undefined_template_var_returns_failed_result` — guard that the sync `execute()` path's error-handling contract (returns `QueryResult(status=FAILED)`) is unchanged.

- Confirmed the regression test fails on pre-fix code: checked out the pre-fix version of `executor.py` (test kept), reran — the async test fails with the raw `jinja2.exceptions.UndefinedError` escaping uncaught.
- Post-fix: full `tests/unit_tests/sql/execution/test_executor.py` passes (82/82).
- `ruff check` / `ruff format --check`: pass on both changed files.

### ADDITIONAL INFORMATION
- [x] Has associated tests
- [x] Confirmed the regression test fails on pre-fix code and passes post-fix

**Tradeoffs**: none — additive-only exception-handling fix, no behavior change to any currently-working path.

Related: #42366, #42401, #42714, #42757, #42802 (same `process_template()` bare-raise-fallback bug class, different call sites).