### PR TITLE
fix(tests): drop removed subtransactions= kwarg from Session.begin()

### DIFF
--- a/tests/integration_tests/datasource_tests.py
+++ b/tests/integration_tests/datasource_tests.py
@@ -107,9 +107,6 @@ def create_and_cleanup_table(table=None):
 
 
 class TestDatasource(SupersetTestCase):
-    def setUp(self):
-        db.session.begin(subtransactions=True)
-
     def tearDown(self):
         db.session.rollback()
         super().tearDown()


### PR DESCRIPTION
### SUMMARY

`TestDatasource.setUp` (`tests/integration_tests/datasource_tests.py`) explicitly opened a transaction with `db.session.begin(subtransactions=True)` before each test, relying on `tearDown`'s `rollback()` to isolate them.

`subtransactions=` was already deprecated in SQLAlchemy 1.4 and is removed outright in 2.0 (`TypeError: scoped_session.begin() got an unexpected keyword argument 'subtransactions'`). It surfaced while investigating discussion #40273's SQLAlchemy 2.0 bump, but it's a standalone fix independent of that work — `Session` autobegins on first use under both 1.4 and 2.0, so the explicit `begin()` call is unnecessary either way, and `tearDown`'s `rollback()` still correctly discards whatever the test did without it.

### TESTING INSTRUCTIONS

Ran the full file locally against sqlite (with Redis up for the two cache-dependent tests):

```
pytest tests/integration_tests/datasource_tests.py -v
# 31 passed
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API