### PR TITLE
fix(migrations): merge divergent Alembic heads into a single chain

### DIFF
--- a/superset/migrations/versions/2026-08-06_00-01_d7cecc48bd55_merge_databend_sslmode_with_pivot_.py
+++ b/superset/migrations/versions/2026-08-06_00-01_d7cecc48bd55_merge_databend_sslmode_with_pivot_.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""merge databend sslmode migration with pivot-table-percent-display restore
+
+Revision ID: d7cecc48bd55
+Revises: ('c4a1b8e2d739', '4f145192b583')
+Create Date: 2026-08-06 00:01:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d7cecc48bd55"
+down_revision = ("c4a1b8e2d739", "4f145192b583")
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### SUMMARY
Master currently has two Alembic migration heads (`4f145192b583` and `c4a1b8e2d739`), which breaks `flask db upgrade` / `superset db upgrade` on any fresh install or existing deployment picking up both changes.

The two heads were introduced by unrelated PRs that both branched off the same parent revision (`1a27941d5352`) and merged to master independently, so neither author's migration graph reflected the other's new head at merge time:

- `4f145192b583` — added restoring pivot-table percent-display (merges with an earlier report-retry/compare-chart merge head)
- `c4a1b8e2d739` — migrates Databend connections to an explicit `sslmode`

This PR adds a standard no-op Alembic merge revision joining both heads back into a single linear chain, following the same pattern as prior merge migrations in this repo (empty `upgrade`/`downgrade`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — migration-only change.

### TESTING INSTRUCTIONS
1. `flask db heads` on master (before this PR) reports two heads: `4f145192b583` and `c4a1b8e2d739`.
2. With this PR applied, `flask db heads` reports a single head: `d7cecc48bd55`.
3. `flask db upgrade` runs cleanly through the merged chain (the merge revision is a no-op, so both prior migrations' `upgrade()`/`downgrade()` are unaffected).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided (no-op merge revision; no schema or data changes, negligible runtime)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API