### PR TITLE
fix(sqla): don't mislabel DB errors as ColumnNotFoundException in adhoc_column_to_sqla

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -84,7 +84,6 @@ from superset.exceptions import (
     ColumnNotFoundException,
     DatasetInvalidPermissionEvaluationException,
     QueryObjectValidationError,
-    SupersetGenericDBErrorException,
     SupersetParseError,
     SupersetSecurityException,
     SupersetSyntaxErrorException,
@@ -1858,42 +1857,43 @@ class SqlaTable(
 
             sqla_column = literal_column(expression)
             if has_timegrain or force_type_check:
-                try:
-                    # probe adhoc column type
-                    # Most databases populate cursor.description from query-plan
-                    # metadata, so WHERE FALSE (zero rows, no table scan) is
-                    # preferred — it avoids hitting row-read limits enforced by
-                    # engines like ClickHouse (max_rows_to_read).
-                    # A small number of drivers (Druid, Pinot) instead build
-                    # cursor.description by inspecting the first returned row;
-                    # for those we fall back to LIMIT 1.
-                    tbl, _unused_cte = self.get_from_clause(template_processor)
-                    if self.db_engine_spec.type_probe_needs_row:
-                        qry = sa.select(sqla_column).limit(1).select_from(tbl)
-                    else:
-                        qry = sa.select(sqla_column).where(sa.false()).select_from(tbl)
-                    sql = self.database.compile_sqla_query(
-                        qry,
-                        catalog=self.catalog,
-                        schema=self.schema,
-                    )
-                    col_desc = get_columns_description(
-                        self.database,
-                        self.catalog,
-                        self.schema or None,
-                        sql,
-                    )
-                    if not col_desc:
-                        raise SupersetGenericDBErrorException("Column not found")
-                    is_dttm = col_desc[0]["is_dttm"]  # type: ignore
-                    # ResultSet already resolves the generic type from the
-                    # driver's cursor.description; reuse it so callers can
-                    # coerce filter values correctly (e.g. numeric IN-lists
-                    # stay unquoted for numeric adhoc expressions like
-                    # CAST(... AS BIGINT)).
-                    generic_type = col_desc[0].get("type_generic")
-                except SupersetGenericDBErrorException as ex:
-                    raise ColumnNotFoundException(message=str(ex)) from ex
+                # probe adhoc column type
+                # Most databases populate cursor.description from query-plan
+                # metadata, so WHERE FALSE (zero rows, no table scan) is
+                # preferred — it avoids hitting row-read limits enforced by
+                # engines like ClickHouse (max_rows_to_read).
+                # A small number of drivers (Druid, Pinot) instead build
+                # cursor.description by inspecting the first returned row;
+                # for those we fall back to LIMIT 1.
+                tbl, _unused_cte = self.get_from_clause(template_processor)
+                if self.db_engine_spec.type_probe_needs_row:
+                    qry = sa.select(sqla_column).limit(1).select_from(tbl)
+                else:
+                    qry = sa.select(sqla_column).where(sa.false()).select_from(tbl)
+                sql = self.database.compile_sqla_query(
+                    qry,
+                    catalog=self.catalog,
+                    schema=self.schema,
+                )
+                # A real DB/connectivity failure during the probe surfaces as a
+                # SupersetGenericDBErrorException from get_columns_description and
+                # is allowed to propagate unchanged; only a genuine empty result
+                # (the column truly isn't there) is a ColumnNotFoundException.
+                col_desc = get_columns_description(
+                    self.database,
+                    self.catalog,
+                    self.schema or None,
+                    sql,
+                )
+                if not col_desc:
+                    raise ColumnNotFoundException(message="Column not found")
+                is_dttm = col_desc[0]["is_dttm"]  # type: ignore
+                # ResultSet already resolves the generic type from the
+                # driver's cursor.description; reuse it so callers can
+                # coerce filter values correctly (e.g. numeric IN-lists
+                # stay unquoted for numeric adhoc expressions like
+                # CAST(... AS BIGINT)).
+                generic_type = col_desc[0].get("type_generic")
 
         if is_dttm and has_timegrain:
             sqla_column = self.db_engine_spec.get_timestamp_expr(

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -2899,6 +2899,51 @@ def test_adhoc_column_type_probe_uses_where_false(database: Database) -> None:
     )
 
 
+def test_adhoc_column_type_probe_propagates_db_error(database: Database) -> None:
+    """
+    Regression test for SUPERSET-PYTHON-WE6.
+
+    A real DB/connectivity failure during the type-probe (surfaced by
+    get_columns_description as a SupersetGenericDBErrorException) must propagate
+    unchanged. It must NOT be relabeled as ColumnNotFoundException, which would
+    cause the calling adhoc-filter code in models/helpers.py to silently drop
+    the filter as if the column didn't exist.
+    """
+    from unittest.mock import patch
+
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+    from superset.exceptions import (
+        ColumnNotFoundException,
+        SupersetGenericDBErrorException,
+    )
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a", type="INTEGER")],
+    )
+
+    adhoc_col: AdhocColumn = {
+        "sqlExpression": "round(a / 50) * 50 / 1000",
+        "label": "Duration",
+        "columnType": "BASE_AXIS",
+        "timeGrain": "P1D",
+    }
+
+    db_error_message = "SSL error: unexpected eof while reading"
+
+    with patch(
+        "superset.connectors.sqla.models.get_columns_description",
+        side_effect=SupersetGenericDBErrorException(db_error_message),
+    ):
+        with pytest.raises(SupersetGenericDBErrorException) as excinfo:
+            table.adhoc_column_to_sqla(adhoc_col, force_type_check=True)
+
+    assert db_error_message in str(excinfo.value)
+    assert not isinstance(excinfo.value, ColumnNotFoundException)
+
+
 def test_adhoc_column_type_probe_uses_limit_1_for_row_dependent_engines(
     database: Database,
 ) -> None:


### PR DESCRIPTION
### SUMMARY

Fixes Sentry [SUPERSET-PYTHON-WE6](https://preset-inc.sentry.io/issues/SUPERSET-PYTHON-WE6) (3677 events / 28 users, still firing) — Shortcut [SC-116904](https://app.shortcut.com/preset/story/116904).

**Root cause:** `SqlaTable.adhoc_column_to_sqla()` (in `superset/connectors/sqla/models.py`) wrapped the entire adhoc-column type-probe in a `try/except SupersetGenericDBErrorException` that relabeled *every* such error as `ColumnNotFoundException`:

```python
if not col_desc:
    raise SupersetGenericDBErrorException("Column not found")
...
except SupersetGenericDBErrorException as ex:
    raise ColumnNotFoundException(message=str(ex)) from ex
```

But `get_columns_description()` (in `superset/connectors/sqla/utils.py`) wraps **any** exception thrown while executing the probe query — real DB/connectivity failures like SSL EOF, timeouts, and dropped connections — in a `SupersetGenericDBErrorException`. So the `except` above caught two very different things and mislabeled both as "column not found":

1. the deliberate zero-columns sentinel raised two lines above, and
2. genuine transient DB errors that escaped `get_columns_description()`.

**Why this matters beyond Sentry noise:** `ColumnNotFoundException` is caught in `superset/models/helpers.py` (`where_clause`'s adhoc-filter handling), where the column is treated as non-existent and the filter is **silently dropped from the query**. A transient SSL/connection blip during the type-probe therefore produced *wrong query results* (a missing filter) rather than a surfaced DB error.

**Fix:** removed the blanket `try/except SupersetGenericDBErrorException` wrapper around the probe and changed the genuine zero-columns case to raise `ColumnNotFoundException("Column not found")` directly. Now only a true empty probe result maps to `ColumnNotFoundException`; a real DB failure from `get_columns_description()` propagates unchanged with its original message. The now-unused `SupersetGenericDBErrorException` import was removed from `models.py` (verified it is not referenced anywhere else in the file). The `get_from_clause`/`compile_sqla_query` calls above are unchanged.

### TRADEOFFS

DB/connectivity errors during the adhoc-column type-probe now surface as `SupersetGenericDBErrorException` (a 400 `GENERIC_DB_ENGINE_ERROR`) instead of being silently converted into a dropped filter. This is an intentional failure-mode change: the user will see a database error where before they'd have silently gotten results with the adhoc filter missing. This matches how DB errors are handled everywhere else in this code path — surfacing a transient DB error is strictly better than silently returning wrong data — but it is a visible behavior change and is flagged here explicitly.

`adhoc_column_to_sqla` has other callers (`models/helpers.py`: groupby, orderby, select construction) that don't catch `ColumnNotFoundException` today. For those, a probe DB error changes from a 404 `ColumnNotFoundException` ("Column not found") to a 400 `SupersetGenericDBErrorException` with the real DB message — still surfaced as an error either way, not a new silent failure, but the specific exception type/status code a caller might see does change.

### TESTING INSTRUCTIONS

Added a regression test and confirmed the genuine not-found path is unchanged.

```
$ pytest tests/unit_tests/models/helpers_test.py -k adhoc_column -x -q
.................                                                        [100%]
17 passed, 132 deselected, 1 warning in 2.37s

$ pytest tests/unit_tests/models/helpers_test.py \
    -k "propagates_db_error or without_comment_safe_retry_hook" -v
tests/unit_tests/models/helpers_test.py::test_adhoc_column_type_probe_propagates_db_error PASSED
tests/unit_tests/models/helpers_test.py::test_adhoc_column_type_probe_raises_without_comment_safe_retry_hook PASSED
```

- New test `test_adhoc_column_type_probe_propagates_db_error` mocks `get_columns_description` with `side_effect=SupersetGenericDBErrorException("SSL error: unexpected eof while reading")` and asserts `adhoc_column_to_sqla(..., force_type_check=True)` raises `SupersetGenericDBErrorException` with that message and **not** `ColumnNotFoundException`.
- Existing `test_adhoc_column_type_probe_raises_without_comment_safe_retry_hook` confirms the genuine empty-result case still raises `ColumnNotFoundException` — no regression.

Lint (repo-pinned ruff 0.9.7):
```
$ ruff check superset/connectors/sqla/models.py tests/unit_tests/models/helpers_test.py
All checks passed!
$ ruff format --check superset/connectors/sqla/models.py tests/unit_tests/models/helpers_test.py
2 files already formatted
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Sentry SUPERSET-PYTHON-WE6 / Shortcut SC-116904
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

