### PR TITLE
fix(ci): enforce a single Alembic migration head

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -79,6 +79,7 @@ github:
           - lint-check
           - cypress-matrix-required
           - dependency-review
+          - enforce-single-migration-head
           - frontend-build
           - playwright-tests-required
           - pre-commit (current)

--- a/.github/workflows/check-db-migration-confict.yml
+++ b/.github/workflows/check-db-migration-confict.yml
@@ -17,34 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  enforce_single_migration_head:
-    name: Enforce single Alembic migration head
-    runs-on: ubuntu-26.04
-    permissions:
-      contents: read
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup Python
-        uses: ./.github/actions/setup-backend/
-        with:
-          requirements-type: base
-      - name: Assert a single Alembic head
-        env:
-          SUPERSET__SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
-        run: |
-          heads="$(superset db heads)"
-          echo "$heads"
-          head_count=$(printf '%s\n' "$heads" | grep -c .)
-          if [ "$head_count" -ne 1 ]; then
-            echo "::error::superset/migrations resolves to $head_count Alembic heads (expected exactly 1)."
-            echo "Another migration already landed with the same down_revision this branch was cut from."
-            echo "Add a no-op merge revision joining the heads: https://superset.apache.org/docs/contributing/development#merging-db-migrations"
-            exit 1
-          fi
-
   check_db_migration_conflict:
     name: Check DB migration conflict
     runs-on: ubuntu-slim

--- a/.github/workflows/check-db-migration-confict.yml
+++ b/.github/workflows/check-db-migration-confict.yml
@@ -17,6 +17,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  enforce_single_migration_head:
+    name: Enforce single Alembic migration head
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: ./.github/actions/setup-backend/
+        with:
+          requirements-type: base
+      - name: Assert a single Alembic head
+        env:
+          SUPERSET__SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
+        run: |
+          heads="$(superset db heads)"
+          echo "$heads"
+          head_count=$(printf '%s\n' "$heads" | grep -c .)
+          if [ "$head_count" -ne 1 ]; then
+            echo "::error::superset/migrations resolves to $head_count Alembic heads (expected exactly 1)."
+            echo "Another migration already landed with the same down_revision this branch was cut from."
+            echo "Add a no-op merge revision joining the heads: https://superset.apache.org/docs/contributing/development#merging-db-migrations"
+            exit 1
+          fi
+
   check_db_migration_conflict:
     name: Check DB migration conflict
     runs-on: ubuntu-slim

--- a/.github/workflows/enforce-single-migration-head.yml
+++ b/.github/workflows/enforce-single-migration-head.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: Enforce single Alembic migration head
+on:
+  push:
+    branches:
+      - "master"
+      - "[0-9].[0-9]*"
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+
+# No `paths:` filter on purpose: this job is a required status check, and a
+# required check that never runs for a given PR blocks that PR from merging
+# forever. It has to fire on every PR so it always reports a status; whether
+# migrations changed is decided inside the job, not the trigger.
+
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  enforce-single-migration-head:
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check for migration file changes
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            if (context.eventName === 'push') {
+              core.setOutput('changed', 'true');
+              return;
+            }
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const changed = files.some((f) => f.filename.startsWith('superset/migrations/'));
+            core.setOutput('changed', String(changed));
+      - name: Setup Python
+        if: steps.check.outputs.changed == 'true'
+        uses: ./.github/actions/setup-backend/
+        with:
+          requirements-type: base
+      - name: Assert a single Alembic head
+        if: steps.check.outputs.changed == 'true'
+        env:
+          SUPERSET__SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
+        run: |
+          heads="$(superset db heads)"
+          echo "$heads"
+          head_count=$(printf '%s\n' "$heads" | grep -c .)
+          if [ "$head_count" -ne 1 ]; then
+            echo "::error::superset/migrations resolves to $head_count Alembic heads (expected exactly 1)."
+            echo "Another migration already landed with the same down_revision this branch was cut from."
+            echo "Add a no-op merge revision joining the heads: https://superset.apache.org/docs/contributing/development#merging-db-migrations"
+            exit 1
+          fi


### PR DESCRIPTION
### SUMMARY

The existing `Check DB migration conflict` workflow is advisory-only: when a
migration lands on the base branch, it scans other *open* PRs that also
touch `superset/migrations/**` and posts a warning comment asking them to
rebase. It never actually computes whether the merge leaves more than one
Alembic head, and nothing about it blocks a merge.

That gap is exactly how master ended up with two divergent heads
(`4f145192b583` and `c4a1b8e2d739`) this week — two unrelated migrations
branched off the same parent and merged independently, and nothing caught
it until `flask db upgrade` broke and #42878 had to land a manual merge
revision to fix it retroactively.

This adds a new workflow, `enforce-single-migration-head.yml`, that runs
`superset db heads` and fails if the count isn't exactly 1:

- On `pull_request` it checks out the default merge ref (base + this PR
  combined, which is what `actions/checkout` gives you automatically for
  `pull_request`-triggered runs). `flask-migrate`'s `heads` command only
  walks the migration script directory — it never touches a real database —
  so this doesn't need Postgres/Redis services, just a syntactically valid
  `SQLALCHEMY_DATABASE_URI` to let the app instantiate.
- It also runs on `push` to `master`/release branches (so if a required-check
  bypass ever lets a fork through, master itself fails loudly and
  immediately instead of drifting until someone notices a broken upgrade).
- **Deliberately no `paths:` filter on the trigger.** This is registered as
  a required status check below, and a required check that never runs for
  a given PR blocks that PR from merging forever — GitHub has no way to
  mark an "Expected" check satisfied if it never reports. So the workflow
  fires on every PR, and a first step asks the GitHub API whether this PR's
  files touch `superset/migrations/` to decide whether to actually do the
  (cheap, but non-zero) work, while still always reporting a status. Matches
  the pattern `dependency-review.yml` already uses for the same reason.
- Also registers `enforce-single-migration-head` in `.asf.yaml`'s
  `required_status_checks.contexts`, so ASF Infra actually enforces it on
  `master` instead of it just being a check nobody's required to look at.

The existing advisory-comment job is left as-is; it's still useful context
for the "hey, someone else also touched migrations" case, just no longer
the only line of defense.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI workflow only.

### TESTING INSTRUCTIONS

- `zizmor` (GHA security audit, run via pre-commit) passes clean on both
  changed workflow files.
- YAML validated with `yaml.safe_load` for the workflow and `.asf.yaml`.
- Reasoned through against `flask_migrate`/`alembic` internals:
  `ScriptDirectory.from_config(...).get_heads()` (what the `heads` command
  calls) parses migration files directly and never invokes `env.py`, so it
  needs no DB connectivity — consistent with the existing `superset db
  upgrade` invocation pattern already used in `superset-app-cli.yml`, just
  without that job's Postgres/Redis services.
- Confirmed against the repo's existing required contexts (`lint-check`,
  `dependency-review`, `frontend-build`) that `.asf.yaml` contexts match the
  job *id*, not a job-level `name:` override, so this job intentionally has
  no `name:` field to keep the two in sync.
- Once merged, the easiest live test is to open two PRs with migrations
  that branch off the same parent and confirm the second one to update
  fails this check.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)