### PR TITLE
fix(trino): emit OFFSET before LIMIT for paginated queries

### DIFF
--- a/superset/db_engine_specs/base.py
+++ b/superset/db_engine_specs/base.py
@@ -541,6 +541,16 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
     # pagination via another mechanism (e.g. Elasticsearch's cursor API).
     supports_offset = True
 
+    # Whether the engine's SQL grammar requires OFFSET to appear *before* LIMIT
+    # (Presto and Trino), unlike the ANSI ``LIMIT ... OFFSET`` ordering. Most
+    # SQLAlchemy dialects for these engines emit the clauses in the correct
+    # order, but some drivers (notably PyHive's Presto/Trino dialects) inherit
+    # the ANSI ordering, which Presto and Trino reject with a syntax error
+    # (``mismatched input 'OFFSET'``). When True, Superset normalizes compiled
+    # SQL so OFFSET precedes LIMIT, making paginated queries (e.g. Drill to
+    # Detail page 2+) valid regardless of the installed driver.
+    offset_before_limit = False
+
     # Whether ORDER BY clause can use aliases created in SELECT
     # that are the same as a source column
     allows_alias_to_source_column = True
@@ -1548,6 +1558,48 @@ class BaseEngineSpec:  # pylint: disable=too-many-public-methods
             # SQL with a malformed LIMIT clause (e.g. LIMIT without a value) is
             # not parseable in sqlglot 30+, which now requires an expression arg.
             return None
+
+    @classmethod
+    def apply_offset_before_limit(cls, sql: str) -> str:
+        """
+        Reorder a trailing ``LIMIT ... OFFSET ...`` into ``OFFSET ... LIMIT ...``
+        for engines whose grammar requires OFFSET to precede LIMIT.
+
+        This is a no-op unless ``offset_before_limit`` is set (Presto/Trino) and
+        the compiled SQL is actually in the invalid ANSI order. Some drivers
+        (e.g. PyHive's Presto/Trino dialects) emit ``LIMIT ... OFFSET ...``,
+        which Presto and Trino reject with ``mismatched input 'OFFSET'``.
+        Re-rendering through sqlglot's dialect-aware generator puts the clauses
+        in the order the engine expects, so paginated queries stay valid no
+        matter which SQLAlchemy driver is installed.
+
+        :param sql: A single compiled SQL statement
+        :return: The statement with OFFSET before LIMIT when required
+        """
+        if not cls.offset_before_limit:
+            return sql
+
+        # Cheap textual gate: only re-render when both keywords are present and
+        # the last LIMIT precedes the last OFFSET (the invalid ordering).
+        # Drivers that already emit OFFSET first (e.g. the official ``trino``
+        # package) are left untouched, avoiding a needless reparse/reformat. A
+        # false positive here only triggers a harmless order-preserving
+        # reparse, never wrong SQL.
+        limit_matches = list(re.finditer(r"\bLIMIT\b", sql, re.IGNORECASE))
+        offset_matches = list(re.finditer(r"\bOFFSET\b", sql, re.IGNORECASE))
+        if (
+            not limit_matches
+            or not offset_matches
+            or limit_matches[-1].start() > offset_matches[-1].start()
+        ):
+            return sql
+
+        try:
+            return SQLScript(sql, engine=cls.engine).format()
+        except SupersetParseError:
+            # If the statement can't be reparsed, leave it as-is rather than
+            # risk mangling it; the original error surfaces at execution time.
+            return sql
 
     @classmethod
     def get_cte_query(cls, sql: str) -> str | None:

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -167,6 +167,13 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     supports_dynamic_schema = True
     supports_catalog = supports_dynamic_catalog = supports_cross_catalog_queries = True
 
+    # Presto and Trino require OFFSET to appear before LIMIT in the SQL grammar.
+    # Superset normalizes compiled SQL accordingly so pagination works even when
+    # the connection resolves to a driver whose dialect emits the ANSI
+    # ``LIMIT ... OFFSET`` ordering (e.g. PyHive). See
+    # ``BaseEngineSpec.apply_offset_before_limit``.
+    offset_before_limit = True
+
     encrypted_extra_sensitive_fields = {
         "$.auth_params.password": "Password",
         "$.auth_params.token": "JWT Token",

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1031,6 +1031,12 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             script = SQLScript(sql, self.db_engine_spec.engine).optimize()
             sql = script.format()
 
+        # Presto/Trino require OFFSET before LIMIT; normalize the compiled SQL
+        # so pagination stays valid regardless of the installed driver's dialect
+        # (e.g. PyHive emits the ANSI ``LIMIT ... OFFSET`` order these engines
+        # reject). No-op for engines that don't need it.
+        sql = self.db_engine_spec.apply_offset_before_limit(sql)
+
         return sql
 
     def select_star(  # pylint: disable=too-many-arguments

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -1729,3 +1729,54 @@ def test_unmask_encrypted_extra() -> None:
             "auth_params": {"username": "alice", "password": "old-password"},
         }
     )
+
+
+def test_apply_offset_before_limit_reorders_ansi_ordering() -> None:
+    """
+    Trino requires OFFSET before LIMIT. Some SQLAlchemy drivers (e.g. PyHive)
+    compile paginated queries in the ANSI ``LIMIT ... OFFSET`` order, which
+    Trino rejects with ``mismatched input 'OFFSET'``. The engine spec must
+    normalize such SQL so OFFSET precedes LIMIT.
+    """
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    ansi_sql = "SELECT a, b\nFROM t\nLIMIT 50 OFFSET 50"
+    result = TrinoEngineSpec.apply_offset_before_limit(ansi_sql)
+
+    upper = result.upper()
+    assert "OFFSET" in upper
+    assert "LIMIT" in upper
+    assert upper.rfind("OFFSET") < upper.rfind("LIMIT"), (
+        f"OFFSET must precede LIMIT for Trino, got: {result!r}"
+    )
+
+
+def test_apply_offset_before_limit_leaves_correct_order_untouched() -> None:
+    """
+    When a driver already emits ``OFFSET ... LIMIT`` (e.g. the official trino
+    package), the SQL is left byte-for-byte unchanged — no needless reparse.
+    """
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    valid_sql = "SELECT a, b\nFROM t\nOFFSET 50\nLIMIT 50"
+    assert TrinoEngineSpec.apply_offset_before_limit(valid_sql) == valid_sql
+
+
+def test_apply_offset_before_limit_limit_only_untouched() -> None:
+    """A query with LIMIT but no OFFSET (e.g. page 1) is not rewritten."""
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    limit_only = "SELECT a, b\nFROM t\nLIMIT 50"
+    assert TrinoEngineSpec.apply_offset_before_limit(limit_only) == limit_only
+
+
+def test_apply_offset_before_limit_noop_for_ansi_engines() -> None:
+    """
+    Engines that don't set ``offset_before_limit`` (the default) never touch the
+    SQL, even when it is in ANSI ``LIMIT ... OFFSET`` order (valid for them).
+    """
+    from superset.db_engine_specs.base import BaseEngineSpec
+
+    ansi_sql = "SELECT a, b FROM t LIMIT 50 OFFSET 50"
+    assert BaseEngineSpec.offset_before_limit is False
+    assert BaseEngineSpec.apply_offset_before_limit(ansi_sql) == ansi_sql

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -2085,3 +2085,51 @@ def test_prequery_listener_mutation_race_deterministic(
     assert not t_b.is_alive(), "thread B deadlocked"
 
     assert not errors, f"deterministic interleaving raised: {errors!r}"
+
+
+def test_compile_sqla_query_offset_before_limit_for_trino(
+    mocker: MockerFixture,
+) -> None:
+    """
+    ``compile_sqla_query`` must emit OFFSET before LIMIT for Trino/Presto even
+    when the underlying SQLAlchemy driver compiles paginated queries in the
+    ANSI ``LIMIT ... OFFSET`` order (as PyHive's Presto/Trino dialects do).
+
+    We drive a Trino ``Database`` but back it with a SQLite engine, whose
+    dialect emits ANSI ordering — standing in for a driver that lacks the
+    OFFSET-before-LIMIT override. The fix must reorder the compiled SQL so it
+    is valid Trino.
+    """
+    from contextlib import contextmanager
+
+    from sqlalchemy import create_engine
+
+    from superset.models.core import Database
+
+    database = Database(
+        database_name="trino_db",
+        sqlalchemy_uri="trino://user@localhost:8080/catalog",
+    )
+    # SQLite compiles `LIMIT x OFFSET y` (ANSI order), mimicking PyHive.
+    ansi_engine = create_engine("sqlite://")
+
+    @contextmanager
+    def _get_engine(catalog=None, schema=None, **kwargs):
+        yield ansi_engine
+
+    mocker.patch.object(database, "get_sqla_engine", new=_get_engine)
+
+    # Sanity: the engine spec resolves to Trino, which requires the reorder.
+    assert database.db_engine_spec.offset_before_limit is True
+
+    tbl = SqlalchemyTable("t", MetaData(), Column("a", Integer))
+    qry = select(tbl.c.a).limit(50).offset(50)
+
+    sql = database.compile_sqla_query(qry)
+
+    upper = sql.upper()
+    assert "OFFSET" in upper
+    assert "LIMIT" in upper
+    assert upper.rfind("OFFSET") < upper.rfind("LIMIT"), (
+        f"OFFSET must precede LIMIT for Trino, got: {sql!r}"
+    )


### PR DESCRIPTION
### SUMMARY

Drill to Detail pagination fails on **Trino/Presto**: navigating to page 2 of the results produces a query that Trino rejects with a syntax error:

```
line 7:11: mismatched input 'OFFSET'. Expecting: <EOF>
```

This was reported when using Trino as the query engine. The same query runs fine in SQL Lab, because SQL Lab never emits an `OFFSET` — only the automated pagination path does.

**Problem**

Superset builds paginated queries with SQLAlchemy's dialect-aware construction (`qry.limit(row_limit).offset(row_offset)` in `models/helpers.py`) and compiles them in `Database.compile_sqla_query`. In SQLAlchemy the *compiled* clause order is decided entirely by the driver's dialect (`limit_clause`), not by the order the methods are called.

Trino and Presto require `OFFSET` to appear **before** `LIMIT` (unlike the ANSI `LIMIT ... OFFSET` ordering). Whether Superset emits valid SQL therefore depends on which driver the connection resolves to:

- The official `trino` package and the legacy `sqlalchemy-trino` package both override `limit_clause` to emit `OFFSET ... LIMIT` → correct.
- **PyHive's** Presto/Trino dialects (`PrestoCompiler` / `TrinoCompiler`) do **not** override `limit_clause`; they inherit SQLAlchemy's ANSI `LIMIT ... OFFSET` → **rejected by Presto/Trino**.

So any connection that resolves to a PyHive dialect — including any vanilla `presto://` connection on stock Superset — produces invalid SQL as soon as an offset is applied (Drill to Detail page 2+, server-side pagination, etc.).

Verified directly:

```python
>>> from sqlalchemy import table, column, select
>>> from pyhive.sqlalchemy_presto import PrestoDialect
>>> q = select([table('t', column('a')).c.a]).limit(50).offset(50)
>>> str(q.compile(dialect=PrestoDialect(), compile_kwargs={'literal_binds': True}))
'SELECT "t"."a" FROM "t" LIMIT 50 OFFSET 50'   # ← invalid for Presto/Trino
```

**Fix**

Guarantee the ordering in Superset rather than depending on the driver:

- Add an `offset_before_limit` engine-spec flag (default `False`, set to `True` on `PrestoBaseEngineSpec`, inherited by both Presto and Trino).
- Add `BaseEngineSpec.apply_offset_before_limit(sql)`, which re-renders the statement through sqlglot's dialect-aware generator (which orders `OFFSET` before `LIMIT` for these dialects). A cheap textual gate means it only runs when the flag is set **and** the SQL is actually in the invalid order, so drivers that already emit `OFFSET` first are left byte-for-byte untouched.
- Call it once at the end of `Database.compile_sqla_query`, the single choke point where datasource queries are turned into SQL.

This fixes every automated-offset path (Drill to Detail, samples, server pagination) for Presto and Trino, independent of the installed SQLAlchemy driver.

### BEFORE/AFTER

This is a query-generation fix, so the meaningful before/after is the SQL Superset dispatches for Drill to Detail **page 2** (`row_limit=50`, `row_offset=50`) when the connection resolves to a driver that emits ANSI ordering (e.g. PyHive). Output below is the actual compiled SQL, reproduced end to end.

**Before** — invalid for Trino/Presto (fails with `line N: mismatched input 'OFFSET'. Expecting: <EOF>`):

```sql
SELECT "cleaned_sales_data"."order_number", "cleaned_sales_data"."sales"
FROM "cleaned_sales_data"
LIMIT 50 OFFSET 50
```

**After** — valid; page 2 loads:

```sql
SELECT
  "cleaned_sales_data"."order_number",
  "cleaned_sales_data"."sales"
FROM "cleaned_sales_data"
OFFSET 50
LIMIT 50
```

<sub>UI screenshots aren't included because reproducing the failure in the browser requires a live Trino/Presto cluster connected via the PyHive dialect; the SQL above is the exact statement that changes.</sub>

### TESTING INSTRUCTIONS

1. Connect a Trino (or Presto) database whose connection uses a driver that emits ANSI `LIMIT ... OFFSET` (e.g. PyHive).
2. Open any chart → Drill to Detail → go to page 2 of the results.
3. Before this change the query fails with `mismatched input 'OFFSET'`; after it, the page loads.

Automated coverage added:

- `tests/unit_tests/db_engine_specs/test_trino.py` — `apply_offset_before_limit` reorders ANSI ordering, leaves already-correct/limit-only SQL untouched, and is a no-op for engines that don't set the flag.
- `tests/unit_tests/models/core_test.py` — end-to-end through `compile_sqla_query`, driving a Trino `Database` backed by a dialect that emits ANSI ordering and asserting the compiled SQL puts `OFFSET` before `LIMIT`.

```
pytest tests/unit_tests/db_engine_specs/test_trino.py tests/unit_tests/db_engine_specs/test_presto.py \
       tests/unit_tests/db_engine_specs/test_base.py tests/unit_tests/models/core_test.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

