### PR TITLE
fix(explore): stop the viz switcher from overflowing the control panel

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/index.tsx
@@ -95,7 +95,7 @@ const VizTypeControl = ({
     <>
       <div
         css={(theme: SupersetTheme) => css`
-          min-width: ${theme.sizeUnit * 72}px;
+          min-width: min(${theme.sizeUnit * 72}px, 100%);
           max-width: fit-content;
         `}
       >


### PR DESCRIPTION
### SUMMARY

The wrapper around `FastVizSwitcher` sets a hard `min-width` floor of `theme.sizeUnit * 72` (288px). That floor does not account for the control panel's own horizontal inset, nor for the gutter taken by its vertical scrollbar — so the panel gains a **horizontal scrollbar as soon as it scrolls vertically**, which it does on most charts.

Measured on the Explore control panel at its default width:

| | |
|---|---|
| `.ant-tabs-content-holder` client width | **305px** (320px minus the 15px scrollbar gutter) |
| wrapper `min-width` | **288px**, placed 24px from the left edge |
| total required | **312px** → 7px of overflow |

`min()` keeps 288px as the *preferred* floor and gives it up only when the container cannot offer that much. Nothing changes where there is room.

```diff
-          min-width: ${theme.sizeUnit * 72}px;
+          min-width: min(${theme.sizeUnit * 72}px, 100%);
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

![Explore control panel, before and after](https://raw.githubusercontent.com/verdier/superset/assets/pr-42911/pr42911-before-after.png)

Explore control panel at its default width, scrolled vertically, same chart and same window in both shots. On `master` the panel carries a horizontal scrollbar and the last viz tile is clipped on the right edge; with this change `scrollWidth - clientWidth` goes from 7px to 0px, the scrollbar is gone and every tile is fully visible.

### TESTING INSTRUCTIONS

1. Open any chart in Explore and make the control panel tall enough to scroll vertically.
2. Observe the horizontal scrollbar under the controls, and that the panel can be scrolled ~7px sideways.
3. With this change, the horizontal scrollbar is gone.

Verified in the browser by measuring the container before and after: overflow **7px → 0px**. The wrapper settles at 265px and every tile stays legible — the active tile keeps its label, the others keep their icons.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
