### PR TITLE
fix(sqllab): wrap process_template() in format_sql to prevent raw UndefinedError leak

### DIFF
--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -23,6 +23,7 @@ from flask import current_app as app, request, Response
 from flask_appbuilder import permission_name
 from flask_appbuilder.api import expose, protect, rison as parse_rison, safe
 from flask_appbuilder.models.sqla.interface import SQLAInterface
+from jinja2.exceptions import TemplateError
 from marshmallow import ValidationError
 from werkzeug.utils import secure_filename
 
@@ -37,6 +38,8 @@ from superset.commands.sql_lab.streaming_export_command import (
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
 from superset.daos.database import DatabaseDAO
 from superset.daos.query import QueryDAO
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetErrorException
 from superset.extensions import event_logger, security_manager
 from superset.jinja_context import get_template_processor
 from superset.models.sql_lab import Query
@@ -266,6 +269,15 @@ class SqlLabRestApi(BaseSupersetApi):
                                 "Invalid template parameter %s. Skipping processing",
                                 str(template_params),
                             )
+                        except TemplateError as ex:
+                            raise SupersetErrorException(
+                                SupersetError(
+                                    message=str(ex),
+                                    error_type=SupersetErrorType.GENERIC_COMMAND_ERROR,
+                                    level=ErrorLevel.ERROR,
+                                ),
+                                status=400,
+                            ) from ex
 
             result = SQLScript(sql, model.get("engine", database_engine)).format()
             return self.response(200, result=result)

--- a/tests/integration_tests/sql_lab/api_tests.py
+++ b/tests/integration_tests/sql_lab/api_tests.py
@@ -336,6 +336,29 @@ class TestSqlLabApi(SupersetTestCase):
         assert "{{tbl}}" not in resp_data["result"]
         assert resp_data["result"] == expected
 
+    def test_format_sql_request_with_undefined_jinja_attribute(self):
+        self.login(ADMIN_USERNAME)
+        example_db = get_example_database()
+
+        # Attribute access on an undefined Jinja variable (``tbl`` is not in the
+        # template params) raises a jinja2 ``UndefinedError`` from within
+        # ``process_template``. This should surface as a typed 400, not an opaque
+        # 500 from the global exception handler. A non-empty ``template_params``
+        # dict is required so the endpoint actually invokes ``process_template``.
+        data = {
+            "sql": "select * from {{ tbl.name }}",
+            "database_id": example_db.id,
+            "template_params": json.dumps({"unrelated": "value"}),
+        }
+        rv = self.client.post(
+            "/api/v1/sqllab/format_sql/",
+            json=data,
+        )
+        resp_data = json.loads(rv.data.decode("utf-8"))
+        assert rv.status_code == 400
+        assert "tbl" in resp_data["errors"][0]["message"]
+        assert "undefined" in resp_data["errors"][0]["message"]
+
     @mock.patch("superset.commands.sql_lab.results.results_backend_use_msgpack", False)
     def test_execute_required_params(self):
         self.login(ADMIN_USERNAME)


### PR DESCRIPTION
### SUMMARY
`SqlLabRestApi.format_sql()` (POST `/api/v1/sqllab/format_sql/`, SQL Lab's "Format SQL" button) calls `process_template()` with no catch for jinja2 exceptions. When an undefined Jinja variable is accessed via attribute/subscript (e.g. `{{ tbl.name }}`, not a bare `{{ tbl }}`), `BaseTemplateProcessor.process_template()`'s bare-raise fallback re-raises the raw `jinja2.exceptions.UndefinedError` instead of converting it to a Superset exception. Since neither of `format_sql()`'s existing `except` clauses (`json.JSONDecodeError`, and the outer `ValidationError`) catches it, the raw exception escapes to Flask's global `@app.errorhandler(Exception)` catch-all as an opaque 500 (`GENERIC_BACKEND_ERROR`) instead of a typed, user-actionable 4xx.

This is the same bug class fixed at 6 other `process_template()` call sites in this series: #42366, #42401, #42714, #42757, #42802, #42851. `superset/sqllab/api.py` had not previously been touched by any of them.

### BEFORE/AFTER
**Before:** posting SQL with an undefined-attribute Jinja reference to `/api/v1/sqllab/format_sql/` returns a `500 GENERIC_BACKEND_ERROR` with a raw traceback-derived message.

**After:** the same request returns a `400` with a typed `SupersetErrorException` (`GENERIC_COMMAND_ERROR`) whose message names the undefined variable.

### FIX
Added `except TemplateError as ex: raise SupersetErrorException(SupersetError(message=str(ex), error_type=GENERIC_COMMAND_ERROR, level=ERROR), status=400) from ex` after the existing `except json.JSONDecodeError` clause, mirroring `QueryEstimationCommand.run()` (#42757) exactly. `SupersetErrorException` is handled by the global `@app.errorhandler(SupersetErrorException)`, the same mechanism `estimate_query_cost()` (a few lines above, same file) already relies on for its own `SupersetErrorException` — consistent with this file's existing pattern, not a new one. Additive-only; no existing behavior changes for well-formed templates.

### TESTING INSTRUCTIONS
1. `POST /api/v1/sqllab/format_sql/` with `sql: "select * from {{ tbl.name }}"`, `template_params: "{}"` (or any non-empty dict that doesn't define `tbl`), and a valid `database_id`.
2. Before this fix: `500` with a raw jinja2 traceback message.
3. After this fix: `400` with a structured error body naming `tbl` as undefined.

New regression test: `test_format_sql_request_with_undefined_jinja_attribute` in `tests/integration_tests/sql_lab/api_tests.py`, right after the existing `test_format_sql_request_with_jinja`. Confirmed it fails on pre-fix code (`git stash` on the source fix, raw `UndefinedError` traceback, `assert rv.status_code == 400` fails with `500`) and passes post-fix.

### ADDITIONAL INFORMATION
- [x] Has associated issue: matches the bug class from #42366
- [x] Required feature flags: N/A
- [ ] Changes UI
- [ ] Includes DB migration
- [ ] Confirm bespoke/custom deployment/upgrade steps required to prepare and deploy this change

**Tradeoffs:** none — this is an additive `except` clause converting an unhandled 500 into a typed 400; no existing success-path behavior changes.

Related: #42366, #42401, #42714, #42757, #42802, #42851 (same bug class, other `process_template()` call sites).
