### PR TITLE
fix(import): wrap per-tag tag operation in SAVEPOINT to prevent Session poisoning

### DIFF
--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -318,28 +318,29 @@ def import_tag(
 
     for tag_name in target_tag_names:
         try:
-            tag = existing_tags.get(tag_name)
+            with db_session.begin_nested():
+                tag = existing_tags.get(tag_name)
 
-            # If tag does not exist, create it
-            if tag is None:
-                description = tag_descriptions.get(tag_name, None)
-                tag = Tag(name=tag_name, description=description, type="custom")
-                db_session.add(tag)
-                existing_tags[tag_name] = tag  # Update the existing_tags dictionary
+                # If tag does not exist, create it
+                if tag is None:
+                    description = tag_descriptions.get(tag_name, None)
+                    tag = Tag(name=tag_name, description=description, type="custom")
+                    db_session.add(tag)
+                    existing_tags[tag_name] = tag  # Update the existing_tags dict
 
-            # Ensure the association with the object
-            tagged_object = (
-                db_session.query(TaggedObject)
-                .filter_by(object_id=object_id, object_type=object_type, tag_id=tag.id)
-                .first()
-            )
-            if not tagged_object:
-                new_tagged_object = TaggedObject(
-                    tag_id=tag.id, object_id=object_id, object_type=object_type
+                # Ensure the association with the object
+                tagged_object = (
+                    db_session.query(TaggedObject)
+                    .filter_by(object_id=object_id, object_type=object_type, tag_id=tag.id)
+                    .first()
                 )
-                db_session.add(new_tagged_object)
+                if not tagged_object:
+                    new_tagged_object = TaggedObject(
+                        tag_id=tag.id, object_id=object_id, object_type=object_type
+                    )
+                    db_session.add(new_tagged_object)
 
-            new_tag_ids.append(tag.id)
+                new_tag_ids.append(tag.id)
 
         except SQLAlchemyError as err:
             logger.error(
@@ -349,7 +350,7 @@ def import_tag(
                 object_id,
                 err,
             )
-            continue  # No need for manual rollback, handled by transaction decorator
+            continue  # SAVEPOINT rolled back, session is clean
 
     # Remove old tags not in the new config
     for tag in existing_assocs:


### PR DESCRIPTION
## Summary

Fixes #42912

`import_tag` catches `SQLAlchemyError` after a query-triggered autoflush failure and continues using the same SQLAlchemy `Session` without rolling back or isolating the failed per-tag operation in a SAVEPOINT.

When two concurrent tag imports race on the same `TaggedObject` association (`uix_tagged_object` unique constraint), one transaction commits first and the other receives a real `UniqueViolation`. `import_tag` catches it and `continue`s, but the `Session` remains in SQLAlchemy's pending-rollback state, so the next `Session` operation raises `PendingRollbackError`.

The `@transaction()` decorator on `import_tag` is a no-op when called from `ImportAssetsCommand.run()` (which is already inside a transaction), so the poisoned session is not recovered before reuse.

## Fix

Wrap each per-tag operation in a SAVEPOINT via `db_session.begin_nested()`. On failure the SAVEPOINT is rolled back, the failed tag is skipped, and the `Session` remains usable for subsequent tags — the concurrent import completes without discarding unrelated imports.

## Why this approach

- `begin_nested()` rolls back only the failed per-tag operation, preserving successfully-imported tags
- A full outer `Session.rollback()` would discard the entire import, which the issue explicitly warns against
- Mirrors the pattern used in related Session-recovery fixes (#42675, #38934, #38859)

## Testing

- [ ] Test plan to be added (pending local Superset test environment)