### PR TITLE
fix(deckgl): restore the Fill Color control on the GeoJSON layer

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type {
+  ControlPanelSectionConfig,
+  ControlSetItem,
+} from '@superset-ui/chart-controls';
+import controlPanel from './controlPanel';
+
+const getGeoJsonSettingsSection = () =>
+  controlPanel.controlPanelSections.find(
+    (
+      section: ControlPanelSectionConfig | null,
+    ): section is ControlPanelSectionConfig =>
+      section != null && section.label === 'GeoJson Settings',
+  );
+
+const findControl = (name: string) =>
+  getGeoJsonSettingsSection()
+    ?.controlSetRows.flat()
+    .find(
+      (control: ControlSetItem) =>
+        control &&
+        typeof control === 'object' &&
+        'name' in control &&
+        control.name === name,
+    ) as any;
+
+test('controlPanel should include fill_color_picker control', () => {
+  const control = findControl('fill_color_picker');
+
+  expect(control).toBeDefined();
+  expect(control.config.type).toBe('ColorPickerControl');
+});
+
+test('fill_color_picker should be visible even though the layer has no color_scheme_type control', () => {
+  const controlNames = getGeoJsonSettingsSection()
+    ?.controlSetRows.flat()
+    .filter(
+      (control: ControlSetItem) =>
+        control && typeof control === 'object' && 'name' in control,
+    )
+    .map((control: any) => control.name);
+
+  // The layer intentionally has no color scheme type control, so the shared
+  // fixed-color visibility gate must not be applied to the fill color picker.
+  expect(controlNames).not.toContain('color_scheme_type');
+  expect(
+    findControl('fill_color_picker').config.visibility({ controls: {} }),
+  ).toBe(true);
+});
+
+test('controlPanel should include stroke_color_picker control', () => {
+  const control = findControl('stroke_color_picker');
+
+  expect(control).toBeDefined();
+  expect(control.config.type).toBe('ColorPickerControl');
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/Geojson/controlPanel.ts
@@ -44,6 +44,18 @@ import {
 import { dndGeojsonColumn } from '../../utilities/sharedDndControls';
 import { BLACK_COLOR } from '../../utilities/controls';
 
+// The shared fillColorPicker is only shown when a `color_scheme_type` control is
+// set to "fixed color". The GeoJSON layer has no such control - features carry
+// their own colors and this picker acts as an override (set the opacity to 0 to
+// fall back to the feature's own fillColor) - so the gate is dropped here.
+const geojsonFillColorPicker = {
+  ...fillColorPicker,
+  config: {
+    ...fillColorPicker.config,
+    visibility: () => true,
+  },
+};
+
 const config: ControlPanelConfig = {
   controlPanelSections: [
     {
@@ -71,7 +83,7 @@ const config: ControlPanelConfig = {
     {
       label: t('GeoJson Settings'),
       controlSetRows: [
-        [fillColorPicker, strokeColorPicker],
+        [geojsonFillColorPicker, strokeColorPicker],
         [filled, stroked],
         [extruded],
         [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

Restores the missing Fill Color control on the deck.gl GeoJSON chart, which also fixes the ability to set fill opacity to `0` (falling back to each feature's own`fillColor` property).

Bug: A shared control update (#34017) added a visibility gate (`color_scheme_type`) to `fillColorPicker`. Because the GeoJSON layer didn't adopt `color_scheme_type`,  the gate permanently evaluates to `false`, hiding the picker.
-> Fix: Override the visibility gate specifically for the GeoJSON layer's shared control definition rather than adding an unsupported dropdown.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
_Before:_ the **GeoJson Settings** section shows only **Stroke Color**.   

_After:_ **Fill Color** appears next to **Stroke Color**, and setting its opacity
to 0 restores the GeoJSON feature's own `fillColor`:


<img width="1661" height="1159" alt="geojson_fix" src="https://github.com/user-attachments/assets/1bfaa37f-281b-4660-90d9-607593108751" />


### TESTING INSTRUCTIONS

1. Open a **deck.gl GeoJSON** where features have built-in `fillColor` properties.
1. Go to **GeoJson Settings** and confirm **Fill Color** is present alongside **Stroke Color**.
1. Test setting opacity > 0 (overrides features) and opacity = 0 (falls back to feature properties).
1. Verify the Polygon chart's Fill Color control still behaves correctly based on its Color scheme type.

Sample dataset SQL (Postgres):
```sql
SELECT * FROM (VALUES
  ('red'::text,
   '{"type":"Feature","properties":{"name":"red","fillColor":"#e04836","strokeColor":"#7d1a0d"},"geometry":{"type":"Polygon","coordinates":[[[13.36,52.50],[13.38,52.50],[13.38,52.52],[13.36,52.52],[13.36,52.50]]]}}'::text),
  ('green',
   '{"type":"Feature","properties":{"name":"green","fillColor":"#3fa34d","strokeColor":"#14532d"},"geometry":{"type":"Polygon","coordinates":[[[13.39,52.50],[13.41,52.50],[13.41,52.52],[13.39,52.52],[13.39,52.50]]]}}'),
  ('blue',
   '{"type":"Feature","properties":{"name":"blue","fillColor":"#2f6fdb","strokeColor":"#0b2f6b"},"geometry":{"type":"Polygon","coordinates":[[[13.42,52.50],[13.44,52.50],[13.44,52.52],[13.42,52.52],[13.42,52.50]]]}}'),
  ('magenta-rgba',
   '{"type":"Feature","properties":{"name":"magenta-rgba","fillColor":[214,51,214,200],"strokeColor":[90,20,90,255]},"geometry":{"type":"Polygon","coordinates":[[[13.45,52.50],[13.47,52.50],[13.47,52.52],[13.45,52.52],[13.45,52.50]]]}}'),
  ('no-color',
   '{"type":"Feature","properties":{"name":"no-color"},"geometry":{"type":"Polygon","coordinates":[[[13.36,52.47],[13.38,52.47],[13.38,52.49],[13.36,52.49],[13.36,52.47]]]}}'),
  ('point',
   '{"type":"Feature","properties":{"name":"point","fillColor":"#111111"},"geometry":{"type":"Point","coordinates":[13.415,52.535]}}')
) AS t(name, geojson)

```
Automated:
```bash
cd superset-frontend
npm run test -- plugins/preset-chart-deckgl/src/layers/Geojson
```
Includes a regression test asserting the control's visibility resolves correctly without color_scheme_type)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
