### PR TITLE
fix: verify database access before dataset repointing, and tab ownership before tab-state updates

### DIFF
--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -127,9 +127,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         new_db_connection: Database | None = None
 
         if database_id and database_id != self._model.database.id:
-            if new_db_connection := DatasetDAO.get_database_by_id(database_id):
-                self._properties["database"] = new_db_connection
-            else:
+            if not (new_db_connection := DatasetDAO.get_database_by_id(database_id)):
                 exceptions.append(DatabaseNotFoundValidationError())
         db = new_db_connection or self._model.database
         default_catalog = db.get_default_catalog()
@@ -163,6 +161,19 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             schema,
             catalog,
         )
+
+        # Repointing to a different database connection requires access to
+        # that connection, independent of the caller's editorship of this
+        # dataset -- only persist the change once that's confirmed.
+        if new_db_connection:
+            try:
+                security_manager.raise_for_access(
+                    database=new_db_connection, table=table
+                )
+            except SupersetSecurityException as ex:
+                exceptions.append(DatasetDataAccessIsNotAllowed(ex.error.message))
+            else:
+                self._properties["database"] = new_db_connection
 
         # Validate uniqueness
         if not DatasetDAO.validate_update_uniqueness(

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -96,10 +96,14 @@ class Datasource(BaseSupersetView):
             try:
                 security_manager.raise_for_access(
                     database=new_database,
+                    # Check access against the table/schema/catalog the
+                    # request is repointing to, not the dataset's current
+                    # values -- update_from_object (below) applies whatever
+                    # table_name/schema/catalog the request supplies.
                     table=Table(
-                        orm_datasource.table_name,
-                        orm_datasource.schema,
-                        orm_datasource.catalog,
+                        datasource_dict.get("table_name", orm_datasource.table_name),
+                        datasource_dict.get("schema", orm_datasource.schema),
+                        datasource_dict.get("catalog", orm_datasource.catalog),
                     ),
                 )
             except SupersetSecurityException as ex:

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -83,12 +83,28 @@ class Datasource(BaseSupersetView):
         orm_datasource = DatasourceDAO.get_datasource(
             DatasourceType(datasource_type), datasource_id
         )
-        orm_datasource.database_id = database_id
 
         try:
             security_manager.raise_for_editorship(orm_datasource)
         except SupersetSecurityException as ex:
             raise DatasetForbiddenError() from ex
+
+        if database_id != orm_datasource.database_id:
+            new_database = DatasetDAO.get_database_by_id(database_id)
+            if new_database is None:
+                return json_error_response(_("Database not found."), status=422)
+            try:
+                security_manager.raise_for_access(
+                    database=new_database,
+                    table=Table(
+                        orm_datasource.table_name,
+                        orm_datasource.schema,
+                        orm_datasource.catalog,
+                    ),
+                )
+            except SupersetSecurityException as ex:
+                raise DatasetForbiddenError() from ex
+            orm_datasource.database_id = database_id
 
         duplicates = [
             name

--- a/superset/views/sql_lab/views.py
+++ b/superset/views/sql_lab/views.py
@@ -184,6 +184,12 @@ class TabStateView(BaseSupersetView):
     @has_access_api
     @expose("<int:tab_state_id>/query/<client_id>", methods=("DELETE",))
     def delete_query(self, tab_state_id: int, client_id: str) -> FlaskResponse:
+        tab_user_id = _get_tab_user_id(tab_state_id)
+        if tab_user_id is None:
+            return Response(status=404)
+        if tab_user_id != get_user_id():
+            return Response(status=403)
+
         try:
             # Before deleting the query, ensure it's not tied to any
             # active tab as the last query. If so, replace the query

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -174,6 +174,110 @@ def test_update_dataset_sql_unauthorized_schema(mocker: MockerFixture) -> None:
     )
 
 
+def test_update_dataset_database_id_change_checks_new_database_access(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Changing ``database_id`` alone (with no ``sql`` in the payload) must
+    still be authorised against the new database connection: ownership of
+    the dataset (``raise_for_editorship``) is not enough. When the caller
+    isn't authorised for the new database, the update is rejected and the
+    dataset is not repointed.
+    """
+    mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
+    mock_current_database = mocker.MagicMock()
+    mock_current_database.id = 1
+
+    mock_new_database = mocker.MagicMock()
+    mock_new_database.id = 2
+    mock_new_database.get_default_catalog.return_value = "catalog"
+    mock_new_database.allow_multi_catalog = False
+
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.database = mock_current_database
+    mock_dataset.catalog = "catalog"
+    mock_dataset.schema = "public"
+    mock_dataset.table_name = "test_table"
+    mock_dataset.editors = []  # No editors to avoid computation issues
+
+    mock_dataset_dao.find_by_id.return_value = mock_dataset
+    mock_dataset_dao.get_database_by_id.return_value = mock_new_database
+    mock_dataset_dao.validate_update_uniqueness.return_value = True
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_editorship",
+    )
+    mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
+
+    mock_raise_for_access = mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                error_type=SupersetErrorType.MISSING_OWNERSHIP_ERROR,
+                message="You don't have access to that database",
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    with pytest.raises(DatasetInvalidError) as excinfo:
+        UpdateDatasetCommand(1, {"database_id": 2}).run()
+
+    mock_raise_for_access.assert_called_once()
+    assert mock_raise_for_access.call_args.kwargs["database"] is mock_new_database
+    assert any(
+        "You don't have access to that database" in str(exc)
+        for exc in excinfo.value._exceptions
+    )
+    # The update never runs, so the dataset is never repointed.
+    mock_dataset_dao.update.assert_not_called()
+
+
+def test_update_dataset_database_id_change_allowed_with_access(
+    mocker: MockerFixture,
+) -> None:
+    """
+    When the caller is authorised for the new database, changing
+    ``database_id`` alone succeeds and the dataset is repointed to it.
+    """
+    mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
+    mock_current_database = mocker.MagicMock()
+    mock_current_database.id = 1
+
+    mock_new_database = mocker.MagicMock()
+    mock_new_database.id = 2
+    mock_new_database.get_default_catalog.return_value = "catalog"
+    mock_new_database.allow_multi_catalog = False
+
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.database = mock_current_database
+    mock_dataset.catalog = "catalog"
+    mock_dataset.schema = "public"
+    mock_dataset.table_name = "test_table"
+    mock_dataset.editors = []  # No editors to avoid computation issues
+
+    mock_dataset_dao.find_by_id.return_value = mock_dataset
+    mock_dataset_dao.get_database_by_id.return_value = mock_new_database
+    mock_dataset_dao.validate_update_uniqueness.return_value = True
+    mock_dataset_dao.update.return_value = mock_dataset
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_editorship",
+    )
+    mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
+    mock_raise_for_access = mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
+    )
+
+    result = UpdateDatasetCommand(1, {"database_id": 2}).run()
+
+    mock_raise_for_access.assert_called_once()
+    assert mock_raise_for_access.call_args.kwargs["database"] is mock_new_database
+    assert result == mock_dataset
+    _, update_kwargs = mock_dataset_dao.update.call_args
+    assert update_kwargs["attributes"]["database"] is mock_new_database
+
+
 @pytest.mark.parametrize(
     ("payload, exception, error_msg"),
     [

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -313,29 +313,40 @@ def test_save_non_editor_with_editors_field_is_rejected(
 
 
 @patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
 @patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
 @patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
-def test_save_repoints_database_id_without_checking_new_database_access(
+def test_save_rejects_repoint_to_database_without_access(
     mock_get_datasource: MagicMock,
     mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
     mock_db: MagicMock,
 ) -> None:
     """
     ``save`` lets a dataset editor supply a different ``database.id`` in the
-    request body. The ORM object's ``database_id`` is reassigned to the
-    caller-supplied value before (and independent of) the only permission
-    check performed, ``raise_for_editorship``, which verifies ownership of
-    the *dataset* being edited but never checks whether the caller has
-    access to the *new* database being pointed at.
+    request body. Ownership of the *dataset* being edited
+    (``raise_for_editorship``) is not sufficient to repoint it to a new
+    database -- the caller must also be authorised for the *new* database,
+    checked via ``raise_for_access`` before ``database_id`` is reassigned.
     """
     mock_orm = MagicMock()
     mock_orm.database_id = 1
+    mock_orm.table_name = "my_table"
+    mock_orm.schema = "public"
+    mock_orm.catalog = None
     mock_orm.data = {"id": 1}
     mock_get_datasource.return_value = mock_orm
-    # Caller owns the dataset, so the only check performed here passes.
+    # Caller owns the dataset, so that check passes...
     mock_security_manager.raise_for_editorship.return_value = None
 
+    mock_new_database = MagicMock()
+    mock_get_database_by_id.return_value = mock_new_database
+    # ...but the caller is not authorised for the new database.
+    mock_security_manager.raise_for_access.side_effect = _security_exception()
+
     from flask import Flask
+
+    from superset.commands.dataset.exceptions import DatasetForbiddenError
 
     raw_save = _get_view_func("save")
     app = Flask(__name__)
@@ -355,14 +366,73 @@ def test_save_repoints_database_id_without_checking_new_database_access(
             )
         },
     ):
-        raw_save(_view_self())
+        with pytest.raises(DatasetForbiddenError):
+            raw_save(_view_self())
 
-    # The ORM object was repointed to the caller-supplied database id.
-    assert mock_orm.database_id == 999
     # Ownership of the dataset was checked...
     mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
-    # ...but nothing checked whether the caller may access database 999.
-    mock_security_manager.raise_for_access.assert_not_called()
+    # ...and access to the new database was checked too.
+    mock_security_manager.raise_for_access.assert_called_once()
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is mock_new_database
+    assert call_kwargs["table"].table == "my_table"
+    assert call_kwargs["table"].schema == "public"
+    # The ORM object was NOT repointed since access was denied.
+    assert mock_orm.database_id == 1
+
+
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_allows_repoint_to_database_with_access(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    When the caller is authorised for the new database, ``save`` proceeds
+    to repoint ``database_id``.
+    """
+    mock_orm = MagicMock()
+    mock_orm.database_id = 1
+    mock_orm.table_name = "my_table"
+    mock_orm.schema = "public"
+    mock_orm.catalog = None
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    mock_new_database = MagicMock()
+    mock_get_database_by_id.return_value = mock_new_database
+    mock_security_manager.raise_for_access.return_value = None
+
+    from flask import Flask
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 999},
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        raw_save(_view_self())
+
+    mock_security_manager.raise_for_access.assert_called_once()
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is mock_new_database
+    assert call_kwargs["table"].table == "my_table"
+    assert mock_orm.database_id == 999
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -312,6 +312,59 @@ def test_save_non_editor_with_editors_field_is_rejected(
     mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
 
 
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_repoints_database_id_without_checking_new_database_access(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    ``save`` lets a dataset editor supply a different ``database.id`` in the
+    request body. The ORM object's ``database_id`` is reassigned to the
+    caller-supplied value before (and independent of) the only permission
+    check performed, ``raise_for_editorship``, which verifies ownership of
+    the *dataset* being edited but never checks whether the caller has
+    access to the *new* database being pointed at.
+    """
+    mock_orm = MagicMock()
+    mock_orm.database_id = 1
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    # Caller owns the dataset, so the only check performed here passes.
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    from flask import Flask
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    # database id 999 stands in for a database the caller
+                    # has no explicit grant on.
+                    "database": {"id": 999},
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        raw_save(_view_self())
+
+    # The ORM object was repointed to the caller-supplied database id.
+    assert mock_orm.database_id == 999
+    # Ownership of the dataset was checked...
+    mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
+    # ...but nothing checked whether the caller may access database 999.
+    mock_security_manager.raise_for_access.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Datasource.samples
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -435,6 +435,67 @@ def test_save_allows_repoint_to_database_with_access(
     assert mock_orm.database_id == 999
 
 
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_checks_access_against_requested_table_not_stale_one(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    A request that repoints ``database.id`` can also change
+    ``table_name``/``schema``/``catalog`` in the same payload --
+    ``update_from_object`` applies those requested values afterwards.
+    The access check must therefore be evaluated against the *requested*
+    table, not the dataset's current (stale) one, or a caller could pass
+    the check using a table they're authorised for while actually
+    repointing to one they are not.
+    """
+    mock_orm = MagicMock()
+    mock_orm.database_id = 1
+    mock_orm.table_name = "authorised_table"
+    mock_orm.schema = "public"
+    mock_orm.catalog = None
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    mock_new_database = MagicMock()
+    mock_get_database_by_id.return_value = mock_new_database
+    mock_security_manager.raise_for_access.return_value = None
+
+    from flask import Flask
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 999},
+                    "table_name": "secret_table",
+                    "schema": "finance",
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        raw_save(_view_self())
+
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is mock_new_database
+    # The check ran against the requested table, not the dataset's old one.
+    assert call_kwargs["table"].table == "secret_table"
+    assert call_kwargs["table"].schema == "finance"
+
+
 # ---------------------------------------------------------------------------
 # Datasource.samples
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/views/test_sql_lab_tab_state_views.py
+++ b/tests/unit_tests/views/test_sql_lab_tab_state_views.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Behavioral tests for ``superset.views.sql_lab.views.TabStateView``.
+
+These tests call the undecorated view methods directly (via
+``__wrapped__``, which ``flask_appbuilder.has_access_api`` preserves through
+``functools.update_wrapper``) so that the business logic of each method can
+be exercised against an in-memory database without needing a fully
+authenticated HTTP session. Only the ownership-check logic inside the view
+methods themselves is under test here.
+"""
+
+from sqlalchemy.orm.session import Session
+
+from superset.models.sql_lab import Query, TabState
+from superset.views.sql_lab.views import TabStateView
+
+
+def _create_tab_state_and_query(
+    session: Session,
+    *,
+    owner_id: int,
+    latest_query_client_id: str,
+) -> tuple[TabState, Query]:
+    tab_state = TabState(
+        user_id=owner_id,
+        label="unrelated tab",
+        active=True,
+        database_id=1,
+        latest_query_id=latest_query_client_id,
+    )
+    session.add(tab_state)
+    session.flush()
+
+    query = Query(
+        client_id=latest_query_client_id,
+        database_id=1,
+        user_id=owner_id,
+        sql_editor_id=str(tab_state.id),
+        sql="SELECT 1",
+    )
+    session.add(query)
+    session.flush()
+
+    return tab_state, query
+
+
+def test_delete_query_updates_another_users_tab_state_pointer(
+    session: Session, mocker
+) -> None:
+    """
+    ``delete_query`` scopes the ``Query`` row deletion to
+    ``Query.user_id == get_user_id()``, but the preceding update of the
+    owning ``TabState.latest_query_id`` pointer (used to keep the tab's
+    "last run query" reference consistent) is filtered only by
+    ``TabState.id`` and the current value of ``latest_query_id`` -- not by
+    the tab's ``user_id``. A caller who is not the tab's owner can still
+    trigger that update as long as they supply the tab's id and the
+    client_id currently stored in ``latest_query_id``.
+    """
+    TabState.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+
+    owner_id = 2
+    other_user_id = 1
+
+    tab_state, query = _create_tab_state_and_query(
+        session, owner_id=owner_id, latest_query_client_id="owner-query-1"
+    )
+    session.commit()
+
+    # Act as a different, unrelated user.
+    mocker.patch("superset.views.sql_lab.views.get_user_id", return_value=other_user_id)
+
+    view = TabStateView()
+    response = TabStateView.delete_query.__wrapped__(
+        view, tab_state.id, "owner-query-1"
+    )
+
+    assert response.status_code == 200
+
+    session.expire_all()
+    refreshed_tab_state = session.query(TabState).filter_by(id=tab_state.id).one()
+    # The pointer was mutated even though `other_user_id` does not own the
+    # tab and no ownership check was performed before the update.
+    assert refreshed_tab_state.latest_query_id != "owner-query-1"
+
+    # The Query row deletion is correctly scoped to the caller's own user_id,
+    # so the owner's Query row is left in place -- only the TabState update
+    # is unguarded.
+    still_present = session.query(Query).filter_by(client_id="owner-query-1").first()
+    assert still_present is not None
+    assert still_present.id == query.id
+
+
+def test_put_rejects_update_from_non_owning_user(session: Session, mocker) -> None:
+    """
+    Sibling method ``put`` performs the ownership check that ``delete_query``
+    omits: it looks up the tab's owner via ``_get_tab_user_id`` and returns
+    403 before touching the row when the caller does not own the tab. This
+    is included for contrast with ``delete_query`` above -- the guard exists
+    elsewhere in this class, it's just missing on the ``delete_query`` path.
+    """
+    TabState.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+
+    owner_id = 2
+    other_user_id = 1
+
+    tab_state, _query = _create_tab_state_and_query(
+        session, owner_id=owner_id, latest_query_client_id="owner-query-1"
+    )
+    session.commit()
+
+    mocker.patch("superset.views.sql_lab.views.get_user_id", return_value=other_user_id)
+
+    view = TabStateView()
+    response = TabStateView.put.__wrapped__(view, tab_state.id)
+
+    assert response.status_code == 403

--- a/tests/unit_tests/views/test_sql_lab_tab_state_views.py
+++ b/tests/unit_tests/views/test_sql_lab_tab_state_views.py
@@ -60,18 +60,16 @@ def _create_tab_state_and_query(
     return tab_state, query
 
 
-def test_delete_query_updates_another_users_tab_state_pointer(
+def test_delete_query_rejects_update_from_non_owning_user(
     session: Session, mocker
 ) -> None:
     """
-    ``delete_query`` scopes the ``Query`` row deletion to
-    ``Query.user_id == get_user_id()``, but the preceding update of the
-    owning ``TabState.latest_query_id`` pointer (used to keep the tab's
-    "last run query" reference consistent) is filtered only by
-    ``TabState.id`` and the current value of ``latest_query_id`` -- not by
-    the tab's ``user_id``. A caller who is not the tab's owner can still
-    trigger that update as long as they supply the tab's id and the
-    client_id currently stored in ``latest_query_id``.
+    ``delete_query`` checks tab ownership via ``_get_tab_user_id`` before
+    touching the owning ``TabState.latest_query_id`` pointer (used to keep
+    the tab's "last run query" reference consistent), matching every other
+    mutating method on this view. A caller who is not the tab's owner is
+    rejected before either the ``TabState`` update or the ``Query`` row
+    deletion happens.
     """
     TabState.metadata.create_all(session.get_bind())  # pylint: disable=no-member
 
@@ -91,17 +89,15 @@ def test_delete_query_updates_another_users_tab_state_pointer(
         view, tab_state.id, "owner-query-1"
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 403
 
     session.expire_all()
     refreshed_tab_state = session.query(TabState).filter_by(id=tab_state.id).one()
-    # The pointer was mutated even though `other_user_id` does not own the
-    # tab and no ownership check was performed before the update.
-    assert refreshed_tab_state.latest_query_id != "owner-query-1"
+    # The pointer is untouched -- the ownership check rejects the request
+    # before the TabState update runs.
+    assert refreshed_tab_state.latest_query_id == "owner-query-1"
 
-    # The Query row deletion is correctly scoped to the caller's own user_id,
-    # so the owner's Query row is left in place -- only the TabState update
-    # is unguarded.
+    # The owner's Query row is left in place too.
     still_present = session.query(Query).filter_by(client_id="owner-query-1").first()
     assert still_present is not None
     assert still_present.id == query.id


### PR DESCRIPTION
### SUMMARY

Two unrelated but similarly-shaped fixes: each adds a missing check that a sibling code path in the same class already performs.

- Both the legacy `Datasource.save` view and `UpdateDatasetCommand` let an editor change a dataset's `database_id` to any value while only checking ownership of the dataset itself, not access to the target database connection. Editorship of a dataset doesn't imply access to every database connection in the deployment. Both now route the `database_id` change through `security_manager.raise_for_access` with the resolved `Database` object before persisting it, mirroring the check `CreateDatasetCommand` already performs when attaching a new dataset to a database. Access denial leaves `database_id` unchanged.
- `TabStateView.delete_query` updated the tab's `latest_query_id` pointer without first checking that the caller owns the tab, unlike every other mutating method on `TabStateView`/`TableSchemaView`. Added the same ownership guard used by `put`/`activate`/`migrate_query`/etc.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/views/test_sql_lab_tab_state_views.py
pytest tests/unit_tests/views/datasource/views_test.py
pytest tests/unit_tests/commands/dataset/update_test.py
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API