### PR TITLE
feat(build): reinstate `no-restricted-imports` lint rule for `lodash`

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -276,6 +276,19 @@
           "test*WithInitialValues"
         ]
       }
+    ],
+
+    // === ESLint rules ===
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "lodash",
+            "message": "Please use tree-shakeable lodash-es instead"
+          }
+        ]
+      }
     ]
   },
   "overrides": [

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -18,7 +18,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 import { ParentSize } from '@visx/responsive';
 import { t } from '@apache-superset/core/translation';
 import {

--- a/superset-frontend/src/components/DynamicPlugins/index.tsx
+++ b/superset-frontend/src/components/DynamicPlugins/index.tsx
@@ -123,6 +123,7 @@ const pluginApi = makeApi<{}, { result: Plugin[] }>({
 
 const sharedModules = {
   react: () => import('react'),
+  // oxlint-disable-next-line no-restricted-imports
   lodash: () => import('lodash'),
   'react-dom': () => import('react-dom'),
   '@superset-ui/chart-controls': () => import('@superset-ui/chart-controls'),

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -18,7 +18,7 @@
  */
 import { FC, Fragment, useCallback, useEffect, useState } from 'react';
 
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
   ensureIsArray,

--- a/superset-frontend/src/utils/softDeleteCopy.ts
+++ b/superset-frontend/src/utils/softDeleteCopy.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { escape } from 'lodash';
+import { escape } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import getBootstrapData from 'src/utils/getBootstrapData';


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(build): reinstate `no-restricted-imports` lint rule for `lodash`

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Couldn't help but realize that there are remaining `lodash` usage after a recent migration to `lodash-es` for better tree-shaking benefit. To prevent this in future, I've reinstated the lint rule in more performant Oxlint.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
