### PR TITLE
fix(deckgl): normalize legend swatch alpha channel to 0-1 for CSS rgba()

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.test.tsx
@@ -95,6 +95,21 @@ test('clicking a legend item toggles the category without triggering anchor navi
   expect(toggleCategory).toHaveBeenCalledWith('Positive');
 });
 
+test('normalizes the 0-255 deck.gl alpha channel to the 0-1 range CSS rgba() expects', () => {
+  renderWithTheme(
+    <Legend
+      format={null}
+      categories={{
+        Translucent: { enabled: true, color: [255, 0, 0, 128] },
+      }}
+    />,
+  );
+
+  const legendItem = screen.getByRole('button', { name: 'Translucent' });
+  const swatch = legendItem.firstChild as HTMLElement;
+  expect(swatch).toHaveStyle(`background-color: rgba(255, 0, 0, ${128 / 255})`);
+});
+
 test('ctrl+clicking a legend item toggles the category without opening a new tab', () => {
   // Regression proof for #34157: legend items render as real <button>
   // elements (not href="#" anchors), so a ctrl+click has no "open link in

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Legend.tsx
@@ -147,7 +147,13 @@ const Legend = ({
   }
 
   const categories = Object.entries(categoriesObject).map(([k, v]) => {
-    const color = `rgba(${v.color?.join(', ')})`;
+    const [r, g, b, a] = v.color ?? [];
+    // deck.gl colour arrays express alpha as 0-255, but CSS rgba() expects
+    // an alpha channel of 0-1, so it must be normalized before use.
+    const color =
+      a === undefined
+        ? `rgba(${r}, ${g}, ${b})`
+        : `rgba(${r}, ${g}, ${b}, ${a / 255})`;
     // Render the swatch as a real coloured box rather than a colour-tinted
     // text glyph. U+25FC/U+25FB are in Unicode's Emoji set but lack
     // Emoji_Presentation, so Chromium resolves them to a colour-emoji font


### PR DESCRIPTION
Follow-up to #40784.

### SUMMARY

#40784 replaced the deck.gl legend's colour-tinted glyph swatch with a real
CSS box whose `background-color`/`border` come from the category colour. That
colour string is built as `rgba(${v.color?.join(', ')})`, but deck.gl colour
arrays express alpha as 0-255 while CSS `rgba()` expects the alpha channel as
0-1. As a result, any category with a semi-transparent colour rendered its
legend swatch fully opaque instead of translucent.

This normalizes the alpha channel by dividing it by 255 before building the
`rgba()` string, matching what CSS expects.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — the bug only affects the alpha channel of the legend swatch
colour, which isn't visually distinct in a static screenshot without a
side-by-side transparency comparison against the map layer.

### TESTING INSTRUCTIONS

1. Configure a deck.gl chart (Polygon/Scatterplot/Arc/Path) with a categorical
   colour scheme where the underlying colours include an alpha value less
   than 255 (e.g. via a custom color scheme or opacity control).
2. Open the chart and check the legend swatches: before this change, swatches
   for semi-transparent colours rendered fully opaque; after this change they
   render with the correct translucency.
3. Added a unit test in `Legend.test.tsx` asserting the swatch's
   `background-color` divides the input alpha by 255.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)