### PR TITLE
docs(mcp): add update_dashboard to write-tools enumeration

### DIFF
--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -493,11 +493,11 @@ Input format:
 {_feature_availability}Permission Awareness:
 {_instance_info_role_bullet}- ALWAYS check the user's roles BEFORE suggesting write operations (creating datasets,
   charts, or dashboards). SQL execution is a separate permission — see execute_sql below.
-- Write tools (generate_chart, generate_dashboard, update_chart, duplicate_dashboard,
-  create_dataset, create_virtual_dataset, update_dataset_metric, save_sql_query,
-  add_chart_to_existing_dashboard, manage_native_filters, remove_chart_from_dashboard,
-  update_chart_preview, manage_dashboard_owners, manage_dashboard_roles,
-  manage_dashboard_certification) require write
+- Write tools (generate_chart, generate_dashboard, update_chart, update_dashboard,
+  duplicate_dashboard, create_dataset, create_virtual_dataset, update_dataset_metric,
+  save_sql_query, add_chart_to_existing_dashboard, manage_native_filters,
+  remove_chart_from_dashboard, update_chart_preview, manage_dashboard_owners,
+  manage_dashboard_roles, manage_dashboard_certification) require write
   permissions. These tools are only listed for users who have the necessary access.
   If a write tool does not appear in the tool list, the current user lacks write access.
 - execute_sql requires SQL Lab access (execute_sql_query permission), which is separate


### PR DESCRIPTION
Follow-up to #40399.

### SUMMARY

`update_dashboard` (added in #40399) is already listed in the Dashboard Management bullet list in `get_default_instructions` and correctly gates on write access, but the separate "Permission Awareness" paragraph that explicitly enumerates write tools (`generate_chart, generate_dashboard, update_chart, ...`) still didn't mention it. Agents that key off that paragraph specifically to figure out which tools require write access wouldn't know `update_dashboard` needs it.

This just adds `update_dashboard` to that enumeration in `superset/mcp_service/app.py`, right after `update_chart`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, docstring-only change.

### TESTING INSTRUCTIONS

No behavior change. Confirmed pre-commit passes on the changed file:

```
pre-commit run --files superset/mcp_service/app.py
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API