### PR TITLE
fix(export): derive chart_hashes and zip from a single chart list

### DIFF
--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -19,7 +19,7 @@
 import logging
 import uuid as uuid_module
 from typing import Any, Optional, Callable
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator
 
 import yaml
 
@@ -62,9 +62,11 @@ def get_default_position(title: str) -> dict[str, Any]:
     }
 
 
-def append_charts(position: dict[str, Any], charts: set[Slice]) -> dict[str, Any]:
-    # Materialize the set into a list once so chart_hashes and the zip below
-    # iterate the exact same ordering and can never desynchronize.
+def append_charts(
+    position: dict[str, Any], charts: Collection[Slice]
+) -> dict[str, Any]:
+    # Materialize the collection into a list once so chart_hashes and the zip
+    # below iterate the exact same ordering and can never desynchronize.
     chart_list = list(charts)
     chart_hashes = [f"CHART-{str(chart.uuid)}" for chart in chart_list]
 

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -63,7 +63,10 @@ def get_default_position(title: str) -> dict[str, Any]:
 
 
 def append_charts(position: dict[str, Any], charts: set[Slice]) -> dict[str, Any]:
-    chart_hashes = [f"CHART-{str(chart.uuid)}" for chart in charts]
+    # Materialize the set into a list once so chart_hashes and the zip below
+    # iterate the exact same ordering and can never desynchronize.
+    chart_list = list(charts)
+    chart_hashes = [f"CHART-{str(chart.uuid)}" for chart in chart_list]
 
     # if we have ROOT_ID/GRID_ID, append orphan charts to a new row inside the grid
     row_hash = None
@@ -78,7 +81,7 @@ def append_charts(position: dict[str, Any], charts: set[Slice]) -> dict[str, Any
             "parents": ["ROOT_ID", "GRID_ID"],
         }
 
-    for chart_hash, chart in zip(chart_hashes, charts, strict=False):
+    for chart_hash, chart in zip(chart_hashes, chart_list, strict=False):
         position[chart_hash] = {
             "children": [],
             "id": chart_hash,


### PR DESCRIPTION
Follow-up to #36339.

### SUMMARY
`append_charts()` in `superset/commands/dashboard/export.py` built `chart_hashes` by iterating the `charts` set once, then iterated it again a few lines later via `zip(chart_hashes, charts, strict=False)` to populate position metadata. Iterating a `set` twice isn't guaranteed to produce the same order both times, so the two passes could in principle desynchronize and pair a chart hash with the wrong chart. This converts `charts` to a list once at the top of the function and derives both `chart_hashes` and the zip from that single list so the two passes can never get out of sync.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Backend change, not applicable.

### TESTING INSTRUCTIONS
`pytest -q tests/unit_tests/dashboards/export_append_charts_tests.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)