### PR TITLE
docs: document CACHE_REDIS_SOCKET_TIMEOUT/CONNECT_TIMEOUT config keys

### DIFF
--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -301,6 +301,24 @@ DISTRIBUTED_COORDINATION_CONFIG = {
 }
 ```
 
+By default, connections opened for `DISTRIBUTED_COORDINATION_CONFIG` (as well as
+`GLOBAL_ASYNC_QUERIES_CACHE_BACKEND`, which uses the same `RedisCache`/`RedisSentinelCache`
+backend) have no socket timeout. This can be overridden with `CACHE_REDIS_SOCKET_TIMEOUT` and
+`CACHE_REDIS_SOCKET_CONNECT_TIMEOUT`, both in seconds:
+
+```python
+DISTRIBUTED_COORDINATION_CONFIG = {
+    "CACHE_TYPE": "RedisCache",
+    "CACHE_REDIS_HOST": "localhost",
+    "CACHE_REDIS_PORT": 6379,
+    "CACHE_REDIS_SOCKET_TIMEOUT": 5,  # seconds
+    "CACHE_REDIS_SOCKET_CONNECT_TIMEOUT": 5,  # seconds
+}
+```
+
+These apply to `RedisSentinelCache` connections as well, covering both the sentinel-node
+connections and the resolved master connection.
+
 ### Distributed Lock TTL
 
 You can configure the default lock TTL (time-to-live) in seconds. Locks automatically expire after


### PR DESCRIPTION
### SUMMARY
Follow-up docs for #41813 (redis-py 5.3.1 -> 8.0.1 bump). That PR adds two new `CacheConfig` keys, `CACHE_REDIS_SOCKET_TIMEOUT` and `CACHE_REDIS_SOCKET_CONNECT_TIMEOUT`, so operators can opt into a socket timeout on the `RedisCache`/`RedisSentinelCache` connections used by `DISTRIBUTED_COORDINATION_CONFIG` and `GLOBAL_ASYNC_QUERIES_CACHE_BACKEND` (redis-py 8 changed the library default from "no timeout" to 5s, which #41813 pins back to the old no-timeout behavior unless these are set). `UPDATING.md` covers the upgrade-time behavior change, but the config reference docs never mentioned the new keys, so this adds them to the "Distributed Coordination Backend" section of the caching docs, next to the existing `CACHE_REDIS_*` examples for that same backend.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
- Read the updated section in `docs/admin_docs/configuration/cache.mdx` under "Distributed Coordination Backend" > "Configuration".
- `pre-commit run --files docs/admin_docs/configuration/cache.mdx` passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API