### PR TITLE
docs: document color picker for conditional formatting rule colors

### DIFF
--- a/docs/docs/using-superset/creating-your-first-dashboard.mdx
+++ b/docs/docs/using-superset/creating-your-first-dashboard.mdx
@@ -303,6 +303,10 @@ Conditional formatting rules highlight cells based on their values. Rules can be
 
 Each rule has a **"Use gradient"** toggle: enabled applies a varying opacity (lighter = further from threshold), disabled applies a solid fill at full opacity regardless of value.
 
+Each rule's color is set with a full color picker rather than a fixed dropdown of presets. Pick any custom color, or use the **Colors** preset swatches, which reference theme tokens (success, warning, error, and their background variants) so a rule's color updates automatically if the active theme changes, including switching between light and dark mode.
+
+When a rule targets a column with an active time comparison, a **Trend colors** preset also appears, letting you color cells green for an increase and red for a decrease (or the reverse).
+
 #### HTML Rendering in Table Cells
 
 Table chart cells can render raw HTML, enabling rich formatting such as hyperlinks, colored badges, and icons directly in the data. Enable this per-column in the chart's **Column Configuration** panel by toggling **Render HTML**.


### PR DESCRIPTION
### SUMMARY
#42053 replaces the preset color-scheme dropdown in table chart conditional formatting with a full color picker, backed by theme tokens (with light/dark theme switching support) and a trend-colors preset for time-comparison columns. This adds coverage for that in the using-superset docs, in the existing Conditional Formatting section.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
Read the new paragraphs under **Table Chart Features → Conditional Formatting** in `docs/docs/using-superset/creating-your-first-dashboard.mdx`, or view the Netlify deploy preview once it builds.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #42053.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>