### PR TITLE
docs(exploring-data): document CSV/XLSX download in drill modals

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -352,6 +352,13 @@ The **Custom** time range picker accepts natural language expressions alongside 
 
 These expressions are evaluated at query time, so saved charts always display data relative to the current date.
 
+### Downloading Drill to Detail and Drill By Results
+
+The **Drill to detail** and **Drill by** modals, available from a chart's context menu, show the row-level
+data behind a chart (or behind a specific data point, when one is selected). Use the **Download** button in
+the modal's toolbar to export the rows currently displayed in the table as CSV or Excel (XLSX), without
+leaving the modal.
+
 :::resources
 
 - [Chart Walkthroughs](https://docs.preset.io/docs/chart-walkthroughs) - Detailed guides for most chart types

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -356,8 +356,8 @@ These expressions are evaluated at query time, so saved charts always display da
 
 The **Drill to detail** and **Drill by** modals, available from a chart's context menu, show the row-level
 data behind a chart (or behind a specific data point, when one is selected). Use the **Download** button in
-the modal's toolbar to export the rows currently displayed in the table as CSV or Excel (XLSX), without
-leaving the modal.
+the modal's toolbar to export the underlying result set as CSV or Excel (XLSX) without leaving the modal —
+the export isn't limited to the page currently visible in the table.
 
 :::resources
 


### PR DESCRIPTION
### SUMMARY
#42051 added a Download button (CSV/XLSX) to the Drill to Detail and Drill By modals, but this user-facing feature wasn't mentioned in the docs. This adds a short section to the exploring-data tutorial covering it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Docs-only change, no UI screenshots.

### TESTING INSTRUCTIONS
- Read `docs/docs/using-superset/exploring-data.mdx` and confirm the new "Downloading Drill to Detail and Drill By Results" section renders correctly.
- Optionally run the docs site locally (`cd docs && npm start`) and check the page.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #42051.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>