### PR TITLE
fix(tech-debt): measure oxlint metrics against the project's ruleset

### DIFF
--- a/superset-frontend/scripts/oxlint-metrics-uploader.js
+++ b/superset-frontend/scripts/oxlint-metrics-uploader.js
@@ -79,11 +79,18 @@ async function runOxlintAndProcess() {
   try {
     // Run OXC with JSON format
     console.log('Running OXC linter...');
-    const oxlintOutput = execSync('npx oxlint --format json', {
-      encoding: 'utf8',
-      maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large outputs
-      stdio: ['pipe', 'pipe', 'ignore'], // Ignore stderr to avoid error output
-    });
+    // `oxlint.json` is not the `.oxlintrc.json` oxlint auto-discovers, so the
+    // config has to be passed explicitly or the run reports oxlint's defaults
+    // instead of the project's ruleset. Matches the `lint` scripts in
+    // package.json.
+    const oxlintOutput = execSync(
+      'npx oxlint --config oxlint.json --format json',
+      {
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large outputs
+        stdio: ['pipe', 'pipe', 'ignore'], // Ignore stderr to avoid error output
+      },
+    );
 
     const results = JSON.parse(oxlintOutput);
 


### PR DESCRIPTION
### SUMMARY

`superset-frontend/scripts/oxlint-metrics-uploader.js` runs bare `npx oxlint`. The project's
config is named `oxlint.json`, not the `.oxlintrc.json` that oxlint auto-discovers, so the run
falls back to oxlint's **default** ruleset — while every `lint` script in `package.json` passes
`--config oxlint.json` explicitly. The numbers `tech-debt.yml` pushes to the tech-debt
spreadsheet therefore describe a ruleset the project does not use.

Measured on `master` @ `3b164e4` with oxlint 1.76.0:

| | `npx oxlint` (what the uploader runs) | `npx oxlint --config oxlint.json` |
|---|---|---|
| total | **92** | **1470** |
| top rule | `no-unused-vars` — 85 | `prefer-destructuring` — 567 |
| | `erasing-op` 2, `no-control-regex` 2 | `react-hooks/exhaustive-deps` 381 |
| | `no-shadow-restricted-names` 1 | `react/no-unstable-nested-components` 151 |
| | `no-extra-boolean-cast` 1 | `no-console` 135 |
| | `unicorn/no-useless-fallback-in-spread` 1 | `react/jsx-key` 80 |

92% of the reported total is `no-unused-vars`, which `oxlint.json` sets to `off`. Absent from the
series are 381 `react-hooks/exhaustive-deps` and 47 `react-hooks/rules-of-hooks` — correctness
rules, not style.

The fix passes the config explicitly rather than renaming `oxlint.json` to `.oxlintrc.json`. The
rename removes the whole class of bug but churns every script and contributor habit, so it belongs
in its own change if wanted.

**The tracked total will step from ~92 to ~1470 on the first run after this merges. That is a
measurement correction, not a regression** — no new violations are introduced, and no CI gate
changes. The spreadsheet has no way to express a ruleset change, so the changeover date is worth
annotating there; otherwise the step reads as a debt explosion. For the same reason, several
earlier drops in that series coincide with rules leaving the tracker rather than with violations
being fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no UI change.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npx oxlint --format json | jq '.diagnostics | length'                       # 92
npx oxlint --config oxlint.json --format json | jq '.diagnostics | length'  # 1470
```

The second is what the uploader runs after this change. To exercise the script end to end,
`npm run lint-stats` with `SPREADSHEET_ID` and `SERVICE_ACCOUNT_KEY` set; the upload itself needs
the `GSHEET_KEY` secret, so full verification is CI-side.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #42954 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

### AUTHOR'S NOTE

I used Devin to figure out what the contribution guidelines were and where tech debt was being recorded. Devin helped me find the Google Sheets document. At that point I asked Devin to figure out how it was being generated, and it found this flag issue and compared for me the rules that oxlint is meant to be running versus the rules that the project is meant to be running.

It looks to me to be a fairly straightforward issue.

### AI DISCLOSURE

Authored with AI assistance (Devin). Per ASF generative tooling guidance the commit carries a
`Generated-by:` trailer. The change is a single flag on an existing command line; the before/after
counts above were measured locally on this checkout, not asserted by the model. No third-party
copyrighted material is carried in.
