### PR TITLE
feat(database): identify configured database connection errors

### DIFF
--- a/superset/databases/error_provenance.py
+++ b/superset/databases/error_provenance.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Helpers for identifying SQLAlchemy errors from Database model engines.
+
+The listener covers connection failures and errors raised through SQLAlchemy
+Core. Superset executes queries on raw DB-API cursors, so query execution errors
+do not pass through this listener.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+from sqlalchemy.engine import ExceptionContext
+
+_DATABASE_ENGINE_ERROR_MARKER = "_superset_database_engine_error"
+
+
+def is_database_engine_error(exception: BaseException) -> bool:
+    """Return whether SQLAlchemy marked this Database model engine exception.
+
+    A later ``handle_error`` listener may replace the marked exception. Such a
+    replacement has its own provenance and is not marked by this helper.
+    """
+
+    return getattr(exception, _DATABASE_ENGINE_ERROR_MARKER, False) is True
+
+
+def mark_database_engine_error(context: ExceptionContext) -> None:
+    """Mark the SQLAlchemy exception emitted by a Database model engine."""
+
+    exception = context.sqlalchemy_exception
+    if exception is None:
+        exception = context.original_exception
+    with suppress(Exception):
+        setattr(exception, _DATABASE_ENGINE_ERROR_MARKER, True)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -67,6 +67,7 @@ from superset_core.common.models import Database as CoreDatabase
 from superset import db, db_engine_specs, is_feature_enabled
 from superset.commands.database.exceptions import DatabaseInvalidError
 from superset.constants import LRU_CACHE_MAX_SIZE, PASSWORD_MASK
+from superset.databases.error_provenance import mark_database_engine_error
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import MetricType, TimeGrain
 from superset.extensions import (
@@ -720,6 +721,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             engine = create_engine(sqlalchemy_url, **engine_kwargs)
         except Exception as ex:
             raise self.db_engine_spec.get_dbapi_mapped_exception(ex) from ex
+        sqla.event.listen(engine, "handle_error", mark_database_engine_error)
         if cache_key is not None:
             with _ENGINE_CACHE_LOCK:
                 _ENGINE_CACHE[cache_key] = engine

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -31,6 +31,7 @@ from tests.integration_tests.fixtures.birth_names_dashboard import (
 )
 
 import pytest
+from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.types import DateTime  # noqa: F401
 
@@ -150,6 +151,7 @@ class TestDatabaseModel(SupersetTestCase):
         SupersetTestCase.is_module_installed("pyhive"), "pyhive not installed"
     )
     def test_impersonate_user_presto(self, mocked_create_engine):
+        mocked_create_engine.return_value = create_engine("sqlite://", future=True)
         uri = "presto://localhost"
         principal_user = security_manager.find_user(username="gamma")
         extra = """
@@ -201,6 +203,7 @@ class TestDatabaseModel(SupersetTestCase):
     )
     @mock.patch("superset.models.core.create_engine")
     def test_adjust_engine_params_mysql(self, mocked_create_engine):
+        mocked_create_engine.return_value = create_engine("sqlite://", future=True)
         model = Database(
             database_name="test_database1",
             sqlalchemy_uri="mysql://user:password@localhost",
@@ -223,6 +226,7 @@ class TestDatabaseModel(SupersetTestCase):
 
     @mock.patch("superset.models.core.create_engine")
     def test_impersonate_user_trino(self, mocked_create_engine):
+        mocked_create_engine.return_value = create_engine("sqlite://", future=True)
         principal_user = security_manager.find_user(username="gamma")
 
         with override_user(principal_user):
@@ -259,6 +263,7 @@ class TestDatabaseModel(SupersetTestCase):
         SupersetTestCase.is_module_installed("thrift"), "thrift not installed"
     )
     def test_impersonate_user_hive(self, mocked_create_engine):
+        mocked_create_engine.return_value = create_engine("sqlite://", future=True)
         uri = "hive://localhost"
         principal_user = security_manager.find_user(username="gamma")
         extra = """

--- a/tests/unit_tests/databases/error_provenance_test.py
+++ b/tests/unit_tests/databases/error_provenance_test.py
@@ -1,0 +1,250 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
+
+from superset.databases.error_provenance import (
+    is_database_engine_error,
+    mark_database_engine_error,
+)
+from superset.models.core import Database
+
+
+def _database_engine(mocker: MockerFixture, **kwargs: Any) -> Engine:
+    real_create_engine = create_engine
+    mocker.patch(
+        "superset.models.core.create_engine",
+        side_effect=lambda url, **engine_kwargs: real_create_engine(
+            url, **engine_kwargs, **kwargs
+        ),
+    )
+    return Database(
+        database_name="database",
+        sqlalchemy_uri="sqlite://",
+    )._get_sqla_engine(nullpool=False)
+
+
+def test_connect_error_is_marked_without_changing_exception(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    original = sqlite3.OperationalError("connect failed")
+
+    def fail_to_connect() -> None:
+        raise original
+
+    engine = _database_engine(mocker, creator=fail_to_connect)
+    observed: list[BaseException] = []
+
+    def observe(context: Any) -> None:
+        observed.append(context.sqlalchemy_exception)
+
+    event.listen(engine, "handle_error", observe)
+
+    with pytest.raises(OperationalError) as exc_info:
+        engine.connect()
+
+    assert observed == [exc_info.value]
+    assert observed[0] is exc_info.value
+    assert is_database_engine_error(exc_info.value)
+    assert exc_info.value.orig is original
+    assert str(exc_info.value.orig) == "connect failed"
+
+
+def test_sqlalchemy_core_error_is_marked_without_changing_exception(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    engine = _database_engine(mocker)
+    observed: list[BaseException] = []
+
+    def observe(context: Any) -> None:
+        observed.append(context.sqlalchemy_exception)
+
+    event.listen(engine, "handle_error", observe)
+
+    with engine.connect() as connection, pytest.raises(OperationalError) as exc_info:
+        connection.execute(text("SELECT * FROM table_that_does_not_exist"))
+
+    assert observed == [exc_info.value]
+    assert observed[0] is exc_info.value
+    assert is_database_engine_error(exc_info.value)
+    assert isinstance(exc_info.value.orig, sqlite3.OperationalError)
+    assert "table_that_does_not_exist" in str(exc_info.value)
+
+
+def test_raw_dbapi_cursor_error_is_outside_listener_scope(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    database = Database(database_name="database", sqlalchemy_uri="sqlite://")
+    real_create_engine = create_engine
+    mocker.patch(
+        "superset.models.core.create_engine",
+        side_effect=lambda url, **engine_kwargs: real_create_engine(
+            url, **engine_kwargs
+        ),
+    )
+
+    with (
+        database.get_raw_connection() as connection,
+        pytest.raises(sqlite3.OperationalError) as exc_info,
+    ):
+        connection.cursor().execute("SELECT * FROM table_that_does_not_exist")
+
+    assert not is_database_engine_error(exc_info.value)
+
+
+def test_unrelated_and_metadata_engine_errors_are_not_marked() -> None:
+    assert not is_database_engine_error(ValueError("unrelated"))
+
+    metadata_engine = create_engine("sqlite://", future=True)
+    with (
+        metadata_engine.connect() as connection,
+        pytest.raises(OperationalError) as exc_info,
+    ):
+        connection.execute(text("SELECT * FROM table_that_does_not_exist"))
+
+    assert not is_database_engine_error(exc_info.value)
+
+
+def test_public_engine_context_preserves_marker_for_private_engine(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    original = sqlite3.OperationalError("public path connect failed")
+
+    def fail_to_connect() -> None:
+        raise original
+
+    real_create_engine = create_engine
+    mocker.patch(
+        "superset.models.core.create_engine",
+        side_effect=lambda url, **engine_kwargs: real_create_engine(
+            url,
+            **engine_kwargs,
+            creator=fail_to_connect,
+        ),
+    )
+    database = Database(database_name="database", sqlalchemy_uri="sqlite://")
+    mocker.patch.object(
+        database.db_engine_spec,
+        "get_prequeries",
+        return_value=["SELECT 1"],
+    )
+
+    with pytest.raises(OperationalError) as exc_info:
+        with database.get_sqla_engine() as engine:
+            engine.connect()
+
+    assert exc_info.value.orig is original
+    assert is_database_engine_error(exc_info.value)
+
+
+def test_cached_engine_has_one_instance_listener_without_database_closure(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    from superset.models.core import _ENGINE_CACHE
+
+    _ENGINE_CACHE.clear()
+    try:
+        listen = mocker.spy(__import__("sqlalchemy").event, "listen")
+        database = Database(database_name="database", sqlalchemy_uri="sqlite://")
+        database.id = 1
+
+        first = database._get_sqla_engine(nullpool=False)
+        second = database._get_sqla_engine(nullpool=False)
+
+        assert first is second
+        handle_error_calls = [
+            call
+            for call in listen.call_args_list
+            if len(call.args) > 1 and call.args[1] == "handle_error"
+        ]
+        assert len(handle_error_calls) == 1
+        callback = handle_error_calls[0].args[2]
+        assert callback is mark_database_engine_error
+    finally:
+        _ENGINE_CACHE.clear()
+
+
+def test_marker_assignment_failure_does_not_mask_error() -> None:
+    class UnmarkableError(Exception):
+        def __setattr__(self, name: str, value: object) -> None:
+            raise AttributeError(name)
+
+    unmarkable = UnmarkableError("original")
+    context = SimpleNamespace(sqlalchemy_exception=unmarkable)
+
+    mark_database_engine_error(context)
+    assert context.sqlalchemy_exception is unmarkable
+    assert not is_database_engine_error(unmarkable)
+
+
+def test_marker_helper_marks_exception() -> None:
+    exception = RuntimeError("database error")
+    context = SimpleNamespace(sqlalchemy_exception=exception)
+
+    mark_database_engine_error(context)
+
+    assert is_database_engine_error(exception)
+
+
+def test_original_exception_is_marked_when_sqlalchemy_exception_is_none() -> None:
+    exception = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte")
+    context = SimpleNamespace(
+        sqlalchemy_exception=None,
+        original_exception=exception,
+    )
+
+    mark_database_engine_error(context)
+
+    assert is_database_engine_error(exception)
+
+
+def test_later_listener_replacement_is_not_marked(
+    app_context: None,
+    mocker: MockerFixture,
+) -> None:
+    engine = _database_engine(mocker)
+    original: list[BaseException] = []
+
+    def replace(context: Any) -> RuntimeError:
+        original.append(context.sqlalchemy_exception)
+        return RuntimeError("replacement")
+
+    event.listen(engine, "handle_error", replace, retval=True)
+
+    with (
+        engine.connect() as connection,
+        pytest.raises(RuntimeError, match="replacement") as exc_info,
+    ):
+        connection.execute(text("SELECT * FROM table_that_does_not_exist"))
+
+    assert is_database_engine_error(original[0])
+    assert not is_database_engine_error(exc_info.value)

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -26,6 +26,7 @@ from flask import current_app
 from pytest_mock import MockerFixture
 from sqlalchemy import (
     Column,
+    create_engine,
     Integer,
     MetaData,
     select,
@@ -37,6 +38,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import Select
 
 from superset.connectors.sqla.models import SqlaTable, TableColumn
+from superset.databases.error_provenance import mark_database_engine_error
 from superset.errors import SupersetErrorType
 from superset.exceptions import OAuth2Error, OAuth2RedirectError
 from superset.models.core import Database
@@ -573,15 +575,24 @@ def test_get_sqla_engine(mocker: MockerFixture) -> None:
     )
     mocker.patch("superset.models.core.get_username", return_value="alice")
 
-    create_engine = mocker.patch("superset.models.core.create_engine")
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://", future=True),
+    )
+    listen = mocker.spy(__import__("sqlalchemy").event, "listen")
 
     database = Database(database_name="my_db", sqlalchemy_uri="trino://")
     database._get_sqla_engine(nullpool=False)
 
-    create_engine.assert_called_with(
+    create_engine_mock.assert_called_with(
         make_url("trino:///"),
         connect_args={"source": "Apache Superset"},
         future=True,
+    )
+    listen.assert_any_call(
+        create_engine_mock.return_value,
+        "handle_error",
+        mark_database_engine_error,
     )
 
 
@@ -609,17 +620,29 @@ def test_get_sqla_engine_caches_engine_per_url(mocker: MockerFixture) -> None:
         "superset.models.core.security_manager.find_user",
         return_value=None,
     )
-    create_engine = mocker.patch("superset.models.core.create_engine")
-
-    database = Database(database_name="my_db", sqlalchemy_uri="trino://")
-    database.id = 1  # Cache is keyed on id; skipped for unsaved instances.
-    database._get_sqla_engine()
-    database._get_sqla_engine()
-
-    assert create_engine.call_count == 1, (
-        "Database._get_sqla_engine should reuse the engine for the same URL "
-        f"(create_engine called {create_engine.call_count} times)"
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://", future=True),
     )
+    listen = mocker.spy(__import__("sqlalchemy").event, "listen")
+
+    try:
+        database = Database(database_name="my_db", sqlalchemy_uri="trino://")
+        database.id = 1  # Cache is keyed on id; skipped for unsaved instances.
+        database._get_sqla_engine()
+        database._get_sqla_engine()
+
+        assert create_engine_mock.call_count == 1, (
+            "Database._get_sqla_engine should reuse the engine for the same URL "
+            f"(create_engine called {create_engine_mock.call_count} times)"
+        )
+        listen.assert_any_call(
+            create_engine_mock.return_value,
+            "handle_error",
+            mark_database_engine_error,
+        )
+    finally:
+        _ENGINE_CACHE.clear()
 
 
 def test_get_sqla_engine_does_not_cache_unsaved_instances(
@@ -637,12 +660,33 @@ def test_get_sqla_engine_does_not_cache_unsaved_instances(
         "superset.models.core.security_manager.find_user",
         return_value=None,
     )
-    create_engine = mocker.patch("superset.models.core.create_engine")
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://", future=True),
+    )
+    listen = mocker.spy(__import__("sqlalchemy").event, "listen")
 
     Database(database_name="db_a", sqlalchemy_uri="trino://")._get_sqla_engine()
     Database(database_name="db_b", sqlalchemy_uri="trino://")._get_sqla_engine()
 
-    assert create_engine.call_count == 2
+    assert create_engine_mock.call_count == 2
+    handle_error_calls = [
+        call
+        for call in listen.call_args_list
+        if len(call.args) > 1 and call.args[1] == "handle_error"
+    ]
+    assert handle_error_calls == [
+        mocker.call(
+            create_engine_mock.return_value,
+            "handle_error",
+            mark_database_engine_error,
+        ),
+        mocker.call(
+            create_engine_mock.return_value,
+            "handle_error",
+            mark_database_engine_error,
+        ),
+    ]
     assert _ENGINE_CACHE == {}
 
 
@@ -690,7 +734,11 @@ def test_get_sqla_engine_user_impersonation(mocker: MockerFixture) -> None:
     )
     mocker.patch("superset.models.core.get_username", return_value="alice")
 
-    create_engine = mocker.patch("superset.models.core.create_engine")
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://", future=True),
+    )
+    listen = mocker.spy(__import__("sqlalchemy").event, "listen")
 
     database = Database(
         database_name="my_db",
@@ -699,10 +747,15 @@ def test_get_sqla_engine_user_impersonation(mocker: MockerFixture) -> None:
     )
     database._get_sqla_engine(nullpool=False)
 
-    create_engine.assert_called_with(
+    create_engine_mock.assert_called_with(
         make_url("trino:///"),
         connect_args={"user": "alice", "source": "Apache Superset"},
         future=True,
+    )
+    listen.assert_any_call(
+        create_engine_mock.return_value,
+        "handle_error",
+        mark_database_engine_error,
     )
 
 
@@ -746,7 +799,11 @@ def test_get_sqla_engine_user_impersonation_email(mocker: MockerFixture) -> None
     )
     mocker.patch("superset.models.core.get_username", return_value="alice")
 
-    create_engine = mocker.patch("superset.models.core.create_engine")
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://", future=True),
+    )
+    listen = mocker.spy(__import__("sqlalchemy").event, "listen")
 
     database = Database(
         database_name="my_db",
@@ -755,10 +812,15 @@ def test_get_sqla_engine_user_impersonation_email(mocker: MockerFixture) -> None
     )
     database._get_sqla_engine(nullpool=False)
 
-    create_engine.assert_called_with(
+    create_engine_mock.assert_called_with(
         make_url("trino:///"),
         connect_args={"user": "alice.doe", "source": "Apache Superset"},
         future=True,
+    )
+    listen.assert_any_call(
+        create_engine_mock.return_value,
+        "handle_error",
+        mark_database_engine_error,
     )
 
 


### PR DESCRIPTION
### SUMMARY

Identify connection errors from database connections configured in Superset.

Superset uses separate SQLAlchemy engines for:

- its own metadata database; and
- databases added through **Settings → Database Connections**.

A connection error alone does not reliably show which kind of engine produced it. Extensions otherwise have to guess from the exception class or message, which can be identical across databases.

This PR adds a SQLAlchemy `handle_error` listener to every engine created for a configured database. The listener marks the existing exception. It does **not** catch, replace, reclassify, or otherwise change the error.

Python extensions can check it through:

```python
from superset.databases.error_provenance import is_database_engine_error
```

```python
if is_database_engine_error(exception):
    # SQLAlchemy emitted the error from a configured database engine.
    ...
```

This works for connection failures from all SQLAlchemy-backed database engines without parsing driver-specific messages. It also observes errors raised through SQLAlchemy Core.

### Scope and limitation

This API is intended to identify **connection failures** from configured database engines. SQLAlchemy's `handle_error` event also observes SQLAlchemy Core operations, but Superset normally executes queries directly through raw DB-API cursors. Those raw cursor errors bypass the event and are not marked by this PR; `is_database_engine_error()` returns `False` for them. A test records this boundary explicitly.

This PR intentionally does not catch every exception leaving `get_raw_connection()`. That context also contains logging, extension, and other application work, so a broad catch could incorrectly label an unrelated database error as coming from the configured engine. Wrapping or replacing every driver cursor would be invasive and could break driver-specific behavior. Refactoring the engine-spec execution API could cover raw query errors safely, but it is a larger cross-engine behavior change and should be proposed and reviewed separately if needed.

The conservative behavior is therefore: connection errors are identified; raw query errors and anything uncertain remain unidentified.

The listener is installed once, immediately after engine creation and before the engine is cached. Existing exception types, messages, tracebacks, OAuth handling, HTTP responses, and query behavior remain unchanged. If SQLAlchemy does not create a wrapper exception, the listener marks the original exception instead.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this change has no UI impact.

### TESTING INSTRUCTIONS

Run:

```bash
pytest -q tests/unit_tests/databases/error_provenance_test.py
pytest -q tests/unit_tests/models/core_test.py
pytest -q tests/integration_tests/model_tests.py \
  -k 'impersonate_user_presto or adjust_engine_params_mysql or impersonate_user_trino or impersonate_user_hive or test_get_sqla_engine'
```

Validated locally:

- Database error tests: **10 passed**.
- Full `tests/unit_tests/models/core_test.py`: **76 passed**.
- Pre-commit on all changed implementation and test files: **passed**.
- The selected integration tests could not start because the local metadata database lacked the `css_templates` table. The errors occurred during test setup, before the selected test bodies ran.

The tests cover:

- connection errors and SQLAlchemy Core errors;
- the raw DB-API cursor limitation;
- fallback to the original exception when no SQLAlchemy wrapper exists;
- preservation of exception identity, type, message, and original driver error;
- public, private, and cached engine paths;
- exactly one listener per created engine;
- safe behavior when an exception cannot be marked;
- behavior when a later listener replaces an exception;
- existing tests that mock engine creation.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

The implementation uses SQLAlchemy 1.4's `handle_error` event and `ExceptionContext`. These assumptions should be reviewed as part of a future SQLAlchemy major-version upgrade.

If another `handle_error` listener later replaces the marked exception, the replacement is intentionally not marked because it is a different exception.

