### PR TITLE
fix(mcp): give each concurrent tool call its own SQLAlchemy session

### DIFF
--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import asyncio
 import json
 import logging
 import os
@@ -33,6 +34,14 @@ except ImportError:
     def get_sqla_class() -> Any:
         return SQLAlchemy
 
+
+# The identity ``flask-sqlalchemy`` scopes ``db.session`` on by default (same
+# import guard as the library itself), kept as the fallback of
+# _session_scope_ident() below for everything running off the event loop.
+try:
+    from greenlet import getcurrent as _greenlet_ident
+except ImportError:
+    from threading import get_ident as _greenlet_ident
 
 from flask_caching.backends.base import BaseCache
 from flask_migrate import Migrate
@@ -145,6 +154,28 @@ class ProfilingExtension:  # pylint: disable=too-few-public-methods
         app.wsgi_app = SupersetProfiler(app.wsgi_app, self.interval)
 
 
+def _session_scope_ident() -> Any:
+    """Identify the owner of the current ``db.session``.
+
+    ``flask-sqlalchemy`` scopes the session on ``greenlet.getcurrent()``, which
+    does not tell asyncio tasks apart: they all run in the same greenlet on the
+    event loop thread. Concurrent MCP tool calls therefore share a single
+    session, and the first Flask app context to be torn down removes it from
+    under the calls still in flight — every one of them is left holding
+    detached instances.
+
+    Scoping on the running task gives each call its own session, and mirrors
+    what the thread pool already does for sync tool calls. Off the event loop
+    the greenlet identity is kept, so the WSGI web tier, Celery workers and the
+    MCP thread pool behave exactly as before.
+    """
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:  # no running event loop
+        return _greenlet_ident()
+    return task if task is not None else _greenlet_ident()
+
+
 APP_DIR = os.path.join(os.path.dirname(__file__), os.path.pardir)
 appbuilder = AppBuilder(update_perms=False)
 async_query_manager_factory = AsyncQueryManagerFactory()
@@ -154,7 +185,7 @@ async_query_manager: AsyncQueryManager = LocalProxy(
 cache_manager = CacheManager()
 celery_app = celery.Celery()
 csrf = CSRFProtect()
-db = get_sqla_class()()
+db = get_sqla_class()(session_options={"scopefunc": _session_scope_ident})
 
 # make_versioned() MUST be called immediately after db is constructed and before
 # any versioned model class is defined.  Continuum patches the SQLAlchemy

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -88,6 +88,18 @@ MCP_STATELESS_HTTP = True
 # against the FAB security_manager before execution.
 MCP_RBAC_ENABLED = True
 
+# How many async tool calls may run at once. Each call holds its own SQLAlchemy
+# session, and therefore its own connection, for its whole duration — so
+# admitting more calls than the pool can serve means a task waits for a
+# connection while blocking the event loop that the calls holding connections
+# need in order to release them (see tool_concurrency.py).
+#
+# None derives the limit from the connection pool: SQLALCHEMY_ENGINE_OPTIONS
+# pool_size + max_overflow, falling back to SQLAlchemy's own 5 + 10. Set an
+# integer to pin it, or 0 to remove the limit — with no limit, a burst larger
+# than the pool stalls until the pool timeout expires.
+MCP_MAX_CONCURRENT_TOOL_CALLS: int | None = None
+
 # MCP Disabled Tools - a set of tool names to remove from the MCP server at
 # startup. Disabled tools are silently omitted from tool discovery, so AI
 # clients never see them. Use this when a Superset-provided tool conflicts with
@@ -736,6 +748,7 @@ def get_mcp_config(app_config: dict[str, Any] | None = None) -> dict[str, Any]:
         "MCP_DEBUG": MCP_DEBUG,
         "MCP_STATELESS_HTTP": MCP_STATELESS_HTTP,
         "MCP_RBAC_ENABLED": MCP_RBAC_ENABLED,
+        "MCP_MAX_CONCURRENT_TOOL_CALLS": MCP_MAX_CONCURRENT_TOOL_CALLS,
         "MCP_DISABLED_TOOLS": set(MCP_DISABLED_TOOLS),
         "MCP_DISABLED_CHART_PLUGINS": MCP_DISABLED_CHART_PLUGINS,
         "MCP_CHART_PLUGIN_ENABLED_FUNC": MCP_CHART_PLUGIN_ENABLED_FUNC,

--- a/superset/mcp_service/middleware.py
+++ b/superset/mcp_service/middleware.py
@@ -51,6 +51,7 @@ from superset.mcp_service.constants import (
     DEFAULT_TOKEN_LIMIT,
     DEFAULT_WARN_THRESHOLD_PCT,
 )
+from superset.mcp_service.tool_concurrency import bounded_tool_call
 from superset.mcp_service.utils.token_utils import (
     DATA_QUERY_TOOLS,
     estimate_response_tokens,
@@ -230,6 +231,32 @@ def _sanitize_params(params: dict[str, Any]) -> dict[str, Any]:
         else:
             result[k] = v
     return result
+
+
+class ToolConcurrencyMiddleware(Middleware):
+    """Admit at most ``MCP_MAX_CONCURRENT_TOOL_CALLS`` tool calls at a time.
+
+    Every admitted call holds a SQLAlchemy session — and therefore a
+    connection — for its whole duration, and the tool bodies do blocking
+    database work on the event loop. Once the pool is empty, the task waiting
+    for a connection blocks the only thread there is, including the tasks that
+    are holding the connections and can no longer reach their app context
+    teardown to release them. Admission turns that into a wait the event loop
+    can service (see tool_concurrency.py).
+
+    It deliberately sits outside ``LoggingMiddleware``: the audit log write is
+    itself a connection checkout, so it has to happen inside the admission that
+    accounts for it. The trade-off is that ``duration_ms`` then measures
+    execution only, excluding time spent queueing for admission.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: Callable[[MiddlewareContext], Awaitable[ToolResult]],
+    ) -> ToolResult:
+        async with bounded_tool_call():
+            return await call_next(context)
 
 
 class LoggingMiddleware(Middleware):

--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -46,6 +46,7 @@ from superset.mcp_service.middleware import (
     LoggingMiddleware,
     RBACToolVisibilityMiddleware,
     StructuredContentStripperMiddleware,
+    ToolConcurrencyMiddleware,
 )
 from superset.mcp_service.storage import _create_redis_store
 from superset.utils import json
@@ -860,12 +861,16 @@ def build_middleware_list() -> list[Middleware]:
     2. RBACToolVisibilityMiddleware — filters tools/list by RBAC;
        positioned inside the Stripper so it sees full tool objects
        (with outputSchema) before stripping occurs
-    3. LoggingMiddleware — logs tool calls with success/failure status
-    4. GlobalErrorHandler — catches tool exceptions, raises ToolError
+    3. ToolConcurrencyMiddleware — admits at most as many concurrent tool
+       calls as the connection pool can serve; outside the logger because the
+       audit log write is itself a connection checkout
+    4. LoggingMiddleware — logs tool calls with success/failure status
+    5. GlobalErrorHandler — catches tool exceptions, raises ToolError
     """
     return [
         StructuredContentStripperMiddleware(),
         RBACToolVisibilityMiddleware(),
+        ToolConcurrencyMiddleware(),
         LoggingMiddleware(),
         GlobalErrorHandlerMiddleware(),
     ]

--- a/superset/mcp_service/tool_concurrency.py
+++ b/superset/mcp_service/tool_concurrency.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Bounded concurrency for async MCP tool calls.
+
+Each tool call holds its own SQLAlchemy session, hence its own connection, for
+the duration of the call. Tool bodies do blocking database work on the event
+loop, so once the pool is empty the task that waits for a connection blocks the
+only thread there is — including the tasks holding the connections, which can
+no longer reach their app context teardown to release them. Nothing moves until
+the pool timeout fires, tens of seconds later.
+
+Admitting at most ``pool_size + max_overflow`` calls at a time keeps that from
+happening: the queue forms on an ``await`` the loop can service, instead of
+inside the connection checkout that it cannot.
+
+The sync tool path needs none of this — it already runs on a bounded thread
+pool, where each worker waits on its own without stopping the others.
+"""
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, MutableMapping, Optional
+from weakref import WeakKeyDictionary
+
+logger = logging.getLogger(__name__)
+
+# SQLAlchemy's own QueuePool defaults, used when SQLALCHEMY_ENGINE_OPTIONS
+# does not set them.
+_DEFAULT_POOL_SIZE = 5
+_DEFAULT_MAX_OVERFLOW = 10
+
+_limiters: MutableMapping[asyncio.AbstractEventLoop, asyncio.Semaphore] = (
+    WeakKeyDictionary()
+)
+
+
+def max_concurrent_tool_calls() -> int:
+    """How many async tool calls may run at once. 0 means unbounded."""
+    from superset.mcp_service.flask_singleton import get_flask_app  # noqa: PLC0415
+
+    config = get_flask_app().config
+    configured = config.get("MCP_MAX_CONCURRENT_TOOL_CALLS")
+    if configured is not None:
+        return max(0, int(configured))
+
+    engine_options = config.get("SQLALCHEMY_ENGINE_OPTIONS") or {}
+    return int(
+        engine_options.get("pool_size", _DEFAULT_POOL_SIZE)
+        + engine_options.get("max_overflow", _DEFAULT_MAX_OVERFLOW)
+    )
+
+
+def _limiter() -> Optional[asyncio.Semaphore]:
+    """The running loop's semaphore, created on first use. None if unbounded."""
+    loop = asyncio.get_running_loop()
+    if (limiter := _limiters.get(loop)) is not None:
+        return limiter
+
+    limit = max_concurrent_tool_calls()
+    if limit <= 0:
+        return None
+
+    limiter = asyncio.Semaphore(limit)
+    _limiters[loop] = limiter
+    logger.info("MCP async tool calls limited to %d concurrent", limit)
+    return limiter
+
+
+@asynccontextmanager
+async def bounded_tool_call() -> AsyncGenerator[None, None]:
+    """Admit one async tool call, waiting on the loop rather than on the pool."""
+    if (limiter := _limiter()) is None:
+        yield
+        return
+
+    async with limiter:
+        yield

--- a/superset/mcp_service/tool_concurrency.py
+++ b/superset/mcp_service/tool_concurrency.py
@@ -63,8 +63,7 @@ def max_concurrent_tool_calls() -> int:
     from superset.mcp_service.flask_singleton import get_flask_app  # noqa: PLC0415
 
     config = get_flask_app().config
-    configured = config.get("MCP_MAX_CONCURRENT_TOOL_CALLS")
-    if configured is not None:
+    if (configured := config.get("MCP_MAX_CONCURRENT_TOOL_CALLS")) is not None:
         return max(0, int(configured))
 
     engine_options = config.get("SQLALCHEMY_ENGINE_OPTIONS") or {}

--- a/superset/mcp_service/tool_concurrency.py
+++ b/superset/mcp_service/tool_concurrency.py
@@ -34,6 +34,7 @@ pool, where each worker waits on its own without stopping the others.
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from typing import AsyncGenerator, MutableMapping, Optional
 from weakref import WeakKeyDictionary
 
@@ -47,6 +48,14 @@ _DEFAULT_MAX_OVERFLOW = 10
 _limiters: MutableMapping[asyncio.AbstractEventLoop, asyncio.Semaphore] = (
     WeakKeyDictionary()
 )
+
+# Tool calls nest: with tool search enabled (the default), a client calls the
+# ``call_tool`` proxy, which calls the target tool through
+# ``FastMCP.call_tool()`` — and that runs the middleware chain again. Both
+# passes are the same call holding the same connection, so only the outer one
+# takes a slot. Taking one per pass would have every call hold a slot while
+# waiting for a second, which deadlocks the moment the limit is reached.
+_admitted: ContextVar[bool] = ContextVar("mcp_tool_call_admitted", default=False)
 
 
 def max_concurrent_tool_calls() -> int:
@@ -83,10 +92,18 @@ def _limiter() -> Optional[asyncio.Semaphore]:
 
 @asynccontextmanager
 async def bounded_tool_call() -> AsyncGenerator[None, None]:
-    """Admit one async tool call, waiting on the loop rather than on the pool."""
-    if (limiter := _limiter()) is None:
+    """Admit one async tool call, waiting on the loop rather than on the pool.
+
+    Re-entrant: a nested pass for the same call (the ``call_tool`` search
+    proxy invoking its target) runs inside the slot the outer pass took.
+    """
+    if _admitted.get() or (limiter := _limiter()) is None:
         yield
         return
 
-    async with limiter:
-        yield
+    token = _admitted.set(True)
+    try:
+        async with limiter:
+            yield
+    finally:
+        _admitted.reset(token)

--- a/tests/unit_tests/extensions/test_session_scope.py
+++ b/tests/unit_tests/extensions/test_session_scope.py
@@ -54,7 +54,7 @@ def _make_app(scopefunc: Optional[Callable[[], Any]]) -> tuple[Flask, SQLAlchemy
         engine_options={"poolclass": StaticPool},
     )
 
-    class Thing(db.Model):  # type: ignore[name-defined, misc]
+    class Thing(db.Model):  # type: ignore[name-defined]
         id = db.Column(db.Integer, primary_key=True)
         name = db.Column(db.String(16))
 

--- a/tests/unit_tests/extensions/test_session_scope.py
+++ b/tests/unit_tests/extensions/test_session_scope.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests for db.session isolation across concurrent asyncio tasks.
+
+MCP tool calls are asyncio tasks, and each of them runs inside its own Flask
+app context. ``flask-sqlalchemy`` scopes the session on the current greenlet,
+which does not tell tasks apart — so without a task-aware scope function they
+all share one session, and the first app context torn down removes it from
+under the calls still in flight.
+
+These tests verify that:
+- the scope function returns the running task, and falls back to the greenlet
+  identity off the event loop (unchanged web tier / Celery / thread pool)
+- concurrent tasks keep working instances when a sibling's context is torn down
+- the default greenlet scoping loses them (the bug being fixed)
+"""
+
+import asyncio
+from typing import Any, Callable, Optional
+
+import pytest
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm.exc import DetachedInstanceError
+from sqlalchemy.pool import StaticPool
+
+from superset.extensions import _greenlet_ident, _session_scope_ident
+
+
+def _make_app(scopefunc: Optional[Callable[[], Any]]) -> tuple[Flask, SQLAlchemy, Any]:
+    """A minimal app owning one row per task, scoped with the given function."""
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite://"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db = SQLAlchemy(
+        app,
+        session_options={"scopefunc": scopefunc} if scopefunc else None,
+        # One shared in-memory connection, so every session sees the same rows.
+        engine_options={"poolclass": StaticPool},
+    )
+
+    class Thing(db.Model):  # type: ignore[name-defined, misc]
+        id = db.Column(db.Integer, primary_key=True)
+        name = db.Column(db.String(16))
+
+    with app.app_context():
+        db.create_all()
+        db.session.add_all([Thing(id=1, name="chart-1"), Thing(id=2, name="chart-2")])
+        db.session.commit()
+
+    return app, db, Thing
+
+
+async def _read_after_sibling_teardown(
+    scopefunc: Optional[Callable[[], Any]],
+) -> str:
+    """Read an instance after a concurrent task tore its app context down.
+
+    Mirrors a tool call that commits and then reports what it wrote, while
+    another call — working on its own row, as two concurrent calls creating
+    their own chart would — finishes first. This is the shape of the
+    DetachedInstanceError reported in apache/superset#42567.
+    """
+    app, db, model = _make_app(scopefunc)
+    loaded = asyncio.Event()
+    torn_down = asyncio.Event()
+
+    async def reader() -> str:
+        with app.app_context():
+            thing = db.session.query(model).filter_by(id=1).one()
+            db.session.commit()  # expires attributes, as a command commit does
+            loaded.set()
+            await torn_down.wait()
+            return str(thing.name)  # needs a live session to refresh
+
+    async def sibling() -> None:
+        with app.app_context():
+            db.session.query(model).filter_by(id=2).one()
+            await loaded.wait()
+        # leaving the context fires teardown_appcontext → session.remove()
+        torn_down.set()
+
+    read, _ = await asyncio.gather(reader(), sibling())
+    return read
+
+
+def test_scope_ident_falls_back_to_greenlet_off_the_event_loop() -> None:
+    """No running loop — the identity flask-sqlalchemy would have used."""
+    assert _session_scope_ident() == _greenlet_ident()
+
+
+async def _ident_of_this_task() -> Any:
+    await asyncio.sleep(0)
+    return _session_scope_ident()
+
+
+async def test_scope_ident_returns_the_running_task() -> None:
+    """Inside a task — the task itself, so sibling tasks never collide."""
+    assert _session_scope_ident() is asyncio.current_task()
+
+    first, second = await asyncio.gather(_ident_of_this_task(), _ident_of_this_task())
+    assert first is not second
+
+
+async def test_task_scoping_keeps_the_instance_alive() -> None:
+    """A sibling's teardown no longer removes this task's session."""
+    assert await _read_after_sibling_teardown(_session_scope_ident) == "chart-1"
+
+
+async def test_greenlet_scoping_detaches_the_instance() -> None:
+    """The bug: with the library default both tasks share one session."""
+    with pytest.raises(DetachedInstanceError):
+        await _read_after_sibling_teardown(None)

--- a/tests/unit_tests/mcp_service/test_tool_concurrency.py
+++ b/tests/unit_tests/mcp_service/test_tool_concurrency.py
@@ -1,0 +1,146 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests for the admission limit on concurrent async MCP tool calls.
+
+Each call holds a connection for its whole duration, so more calls in flight
+than the pool can serve means a task waits inside the connection checkout —
+blocking the event loop the other calls need to release theirs. The limit
+moves that queue onto an await the loop can service.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from superset.mcp_service import tool_concurrency
+from superset.mcp_service.tool_concurrency import (
+    bounded_tool_call,
+    max_concurrent_tool_calls,
+)
+
+
+class _FakeApp:
+    def __init__(self, **config):
+        self.config = config
+
+
+@pytest.fixture(autouse=True)
+def _clear_limiters():
+    tool_concurrency._limiters.clear()
+    yield
+    tool_concurrency._limiters.clear()
+
+
+def test_limit_defaults_to_the_pool_size() -> None:
+    """No explicit setting, no engine options: SQLAlchemy's own 5 + 10."""
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(),
+    ):
+        assert max_concurrent_tool_calls() == 15
+
+
+def test_limit_follows_the_configured_pool() -> None:
+    """A pool sized for the workload raises the limit with it."""
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(
+            SQLALCHEMY_ENGINE_OPTIONS={"pool_size": 20, "max_overflow": 20}
+        ),
+    ):
+        assert max_concurrent_tool_calls() == 40
+
+
+def test_explicit_setting_wins_over_the_pool() -> None:
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(
+            MCP_MAX_CONCURRENT_TOOL_CALLS=3,
+            SQLALCHEMY_ENGINE_OPTIONS={"pool_size": 20, "max_overflow": 20},
+        ),
+    ):
+        assert max_concurrent_tool_calls() == 3
+
+
+async def _peak_concurrency(calls: int) -> int:
+    """Run `calls` bounded bodies at once, return the highest overlap seen."""
+    in_flight = 0
+    peak = 0
+
+    async def body() -> None:
+        nonlocal in_flight, peak
+        async with bounded_tool_call():
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0)  # let every admitted call pile up
+            in_flight -= 1
+
+    await asyncio.gather(*(body() for _ in range(calls)))
+    return peak
+
+
+async def test_calls_beyond_the_limit_wait_instead_of_running() -> None:
+    """Twenty calls against a limit of four never overlap more than four."""
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(MCP_MAX_CONCURRENT_TOOL_CALLS=4),
+    ):
+        assert await _peak_concurrency(20) == 4
+
+
+async def test_every_call_still_completes() -> None:
+    """The limit queues calls, it does not drop them."""
+    completed = 0
+
+    async def body() -> None:
+        nonlocal completed
+        async with bounded_tool_call():
+            await asyncio.sleep(0)
+            completed += 1
+
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(MCP_MAX_CONCURRENT_TOOL_CALLS=2),
+    ):
+        await asyncio.gather(*(body() for _ in range(10)))
+
+    assert completed == 10
+
+
+async def test_zero_removes_the_limit() -> None:
+    """0 is the documented escape hatch: everything runs at once."""
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(MCP_MAX_CONCURRENT_TOOL_CALLS=0),
+    ):
+        assert await _peak_concurrency(20) == 20
+
+
+async def test_a_failing_call_releases_its_slot() -> None:
+    """An exception must not leak admission, or the server wedges."""
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(MCP_MAX_CONCURRENT_TOOL_CALLS=1),
+    ):
+        for _ in range(3):
+            with pytest.raises(RuntimeError):
+                async with bounded_tool_call():
+                    raise RuntimeError("tool blew up")
+
+        assert await _peak_concurrency(2) == 1

--- a/tests/unit_tests/mcp_service/test_tool_concurrency.py
+++ b/tests/unit_tests/mcp_service/test_tool_concurrency.py
@@ -132,6 +132,29 @@ async def test_zero_removes_the_limit() -> None:
         assert await _peak_concurrency(20) == 20
 
 
+async def test_a_nested_pass_reuses_the_outer_slot() -> None:
+    """The call_tool search proxy runs the middleware chain twice per call.
+
+    Tool search is enabled by default, and the proxy reaches its target
+    through ``FastMCP.call_tool()``, which runs the chain again. If each pass
+    took a slot, every call would hold one while waiting for a second — a
+    deadlock as soon as the limit is reached. Here the limit is one.
+    """
+    with patch(
+        "superset.mcp_service.flask_singleton.get_flask_app",
+        return_value=_FakeApp(MCP_MAX_CONCURRENT_TOOL_CALLS=1),
+    ):
+
+        async def proxy_then_target() -> str:
+            async with bounded_tool_call():  # the call_tool proxy
+                async with bounded_tool_call():  # the target tool
+                    return "done"
+
+        assert await asyncio.wait_for(proxy_then_target(), timeout=2) == "done"
+        # and the slot is handed back, so the next call still gets in
+        assert await asyncio.wait_for(proxy_then_target(), timeout=2) == "done"
+
+
 async def test_a_failing_call_releases_its_slot() -> None:
     """An exception must not leak admission, or the server wedges."""
     with patch(


### PR DESCRIPTION
### SUMMARY

Fixes #42622, taking up @rusackas' preference in the issue thread: scope the session per asyncio task, mirroring what the thread pool already does for sync calls.

`flask-sqlalchemy` 2.5.1 scopes `db.session` with `scopefunc=_ident_func`, and `_ident_func` is `greenlet.getcurrent`. Async MCP tool calls are asyncio tasks, not greenlets: they all run in the same greenlet on the event loop thread, so **they all resolve to the same `Session`**. Each call still runs in its own Flask app context — deliberately, so `g.user` does not race — and `flask-sqlalchemy` registers `teardown_appcontext → session.remove()`. So the **first call to finish removes the session shared by every call still running**, leaving them holding detached instances. The next attribute read raises `DetachedInstanceError`: for a chart the tool has already committed (#42567), or on a `User` lazy-load before any write at all.

This scopes on the running task, and keeps the greenlet identity off the event loop so the WSGI web tier, Celery workers and the MCP thread pool are untouched:

```python
def _session_scope_ident() -> Any:
    try:
        task = asyncio.current_task()
    except RuntimeError:  # no running event loop
        return _greenlet_ident()
    return task if task is not None else _greenlet_ident()


db = get_sqla_class()(session_options={"scopefunc": _session_scope_ident})
```

Measured on `apache/superset:6.1.0-py311`, `superset mcp run`, `stateless_http=True`, N concurrent `generate_chart` calls with `save_chart=true`, asserted against rows in the metadata database — the response envelope alone is not trustworthy here, the rows get written either way and it is the responses that lie:

| concurrency | before | after |
|---|---|---|
| 10 | 2/10 succeeded, 8 `DetachedInstanceError` | 10/10, 0 errors |
| 20 | 6/20 succeeded, 14 `DetachedInstanceError` | 20/20, 0 errors (pool sized, see below) |

A probe on the auth hook logging `id(db.session())` per call counts what is actually handed out: **one session for ten concurrent calls before, ten after** — ten distinct tasks in both runs.

### The connection demand this creates, and the limit that answers it

Sessions are no longer shared, so N concurrent calls hold N connections instead of one. On `master` the async path never contends for a connection — one session, one connection, however many calls — which is precisely why the corruption was silent. Isolation surfaces the real demand, and on the stock pool (`pool_size=5, max_overflow=10`) it produces a cliff rather than a queue:

| concurrent calls, stock pool | isolation only | with the admission limit |
|---|---|---|
| 15 | 15/15 in 4s | 15/15 |
| 16 | 15/16, one `QueuePool ... timeout 30.00`, 35–66s | **16/16 in 4s** |
| 20 | never finished: 5 of 20 rows written in 15min | **20/20 in 5s** |
| 40 | — | **40/40 in 160s** |

The cliff sits exactly at `pool_size + max_overflow` because of **where the wait happens**. Oversubscription itself is normal here and copes everywhere else: the web tier runs `gunicorn --worker-class gthread --threads 20` against that same 15-connection pool ([`docker/entrypoints/run-server.sh`](https://github.com/apache/superset/blob/master/docker/entrypoints/run-server.sh)), and the MCP **sync** path runs tools through anyio's default 40-thread limiter against those same 15. Both drain, because each thread waits on its own. On the event loop there is one thread, and the task waiting for a connection *is* that thread — the tasks holding connections cannot reach their app context teardown to release them, so nothing moves until the 30s timeout fires.

`ToolConcurrencyMiddleware` admits at most `MCP_MAX_CONCURRENT_TOOL_CALLS` calls at a time, defaulting to the pool's own capacity (`SQLALCHEMY_ENGINE_OPTIONS` `pool_size + max_overflow`, falling back to SQLAlchemy's 5 + 10). The queue then forms on an `await` the loop can service instead of inside a connection checkout it cannot. Set an integer to pin it, `0` to remove it.

Two things worth flagging about that middleware:

- **It sits outside `LoggingMiddleware` on purpose.** My first attempt put admission in `mcp_auth_hook`, which passed at 16 and 20 and still exhausted the pool at 40 — the audit log write is itself a connection checkout, and it happens before the hook (`DBEventLogger failed to log event(s)`). Admission has to enclose everything the call does, not just the tool body.
- The consequence is that `duration_ms` now measures execution without the time a call spent queueing for admission.

Worth noting where this leaves the async path in general: the tools are declared `async def`, but they perform no async I/O. In `generate_chart`, all 34 `await`s are on `ctx.*` — `report_progress`, `info`, `debug`, i.e. talking to the MCP client. Every database call underneath is blocking. The tools are async in order to report progress, not to yield the loop. That is what turns a pool wait into a stall, it predates this PR, and the limit caps the symptom rather than removing it. Running the blocking sections on a worker thread (option 2 in #42622) is the fuller answer — it restores real concurrency instead of bounding it — but it touches every tool and belongs in its own change.

For the avoidance of doubt: I am not suggesting async drivers. That would be Superset's whole data layer, and it would buy nothing for work that is short queries and CPU.

### TESTING INSTRUCTIONS

Two suites, neither needs a database or an MCP server:

```bash
pytest tests/unit_tests/extensions/test_session_scope.py
pytest tests/unit_tests/mcp_service/test_tool_concurrency.py
```

`test_session_scope.py` covers both directions of the fix: the scope function returns the running task inside a loop and the greenlet identity outside one (unchanged web tier); two concurrent tasks, each in its own app context and on its own row, keep working instances when a sibling's context tears down; and the same scenario on the library default still raises `DetachedInstanceError` — the bug, pinned.

`test_tool_concurrency.py` covers the limit: derived from the pool, overridable, `0` to disable, calls beyond the limit wait rather than run, every call still completes, and a failing call releases its slot.

Full `tests/unit_tests` run green (11885 passed).

End to end: run `superset mcp run` with JWT auth, fire 20 concurrent `generate_chart` calls with `save_chart=true` against a valid dataset, and assert on rows in `slices` rather than on the response envelope.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42622
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
