### PR TITLE
docs: document FAB_API_SWAGGER_UI_SUPERSET_APP_ROOT config flag

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -307,6 +307,22 @@ to simplify the process of setting up a non-default root path across the service
 In `docker/.env-local` set `SUPERSET_APP_ROOT` to the desired prefix and then bring the
 services up with `docker compose up --detach`.
 
+### Swagger UI
+
+By default, Superset's Swagger UI and OpenAPI spec (enabled via `FAB_API_SWAGGER_UI`) are
+served by Flask-AppBuilder and don't account for a non-root `APPLICATION_ROOT` prefix. If
+you're running Superset behind a URL prefix and want the Swagger UI and OpenAPI spec to
+resolve correctly, set:
+
+```python
+FAB_API_SWAGGER_UI_SUPERSET_APP_ROOT = True
+```
+
+in your `superset_config.py` file. This serves an `APPLICATION_ROOT`-aware Swagger UI and
+OpenAPI spec at `/swagger/<version>` and `/api/<version>/_openapi` respectively, resolved
+through the configured prefix. This flag only takes effect when `FAB_API_SWAGGER_UI` is
+also enabled, and defaults to `False`.
+
 ## Custom OAuth2 Configuration
 
 Superset is built on Flask-AppBuilder (FAB), which supports many providers out of the box


### PR DESCRIPTION
### SUMMARY
#40908 introduces `FAB_API_SWAGGER_UI_SUPERSET_APP_ROOT`, a new config flag that enables an `APPLICATION_ROOT`-aware Swagger UI and OpenAPI spec for deployments running behind a reverse-proxy URL prefix. That PR doesn't document the flag anywhere, so this adds a short section to the configuring-superset docs (next to the existing "Configuring the application root" content) explaining what it does and how to enable it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
Docs-only change. Build the docs site (`cd docs && npm run build`) or review the rendered markdown in the diff.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API