### PR TITLE
docs(dashboard): document the expand_all_slices metadata flag

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -277,6 +277,22 @@ second etc). Example:
 }
 ```
 
+## How do I expand all chart descriptions on a dashboard by default?
+
+Charts can have a markdown description, set in the chart's **Edit chart properties** dialog, that's
+hidden by default and toggled on a per-chart basis from the chart's context menu on a dashboard. If
+you'd rather have every chart's description expanded by default when the dashboard loads, add the
+`expand_all_slices` key to the dashboard JSON Metadata field:
+
+```json
+{
+  "expand_all_slices": true
+}
+```
+
+Charts that have already been manually expanded or collapsed on the dashboard keep that per-chart
+override (tracked in the `expanded_slices` key) regardless of the `expand_all_slices` setting.
+
 ## Does Superset work with [insert database engine here]?
 
 The [Connecting to Databases section](/user-docs/databases/) provides the best


### PR DESCRIPTION
### SUMMARY
#32958 added the `expand_all_slices` dashboard JSON metadata flag, but there wasn't any documentation for it (or its `expanded_slices` sibling, which was also undocumented). The PR author flagged this ([comment](https://github.com/apache/superset/pull/32958#issuecomment-3151422838)) but wasn't sure where it should live. This adds an FAQ entry alongside the other dashboard JSON metadata examples (`timed_refresh_immune_slices`, `label_colors`, etc.) explaining how `expand_all_slices` works and how it interacts with per-chart overrides.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - docs only.

### TESTING INSTRUCTIONS
- Read `docs/docs/faq.mdx` and confirm the new "How do I expand all chart descriptions on a dashboard by default?" section renders correctly.
- `cd docs && npm run start` to preview the FAQ page locally if desired.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API