### PR TITLE
fix(reports): translate execute-now success message

### DIFF
--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -27,7 +27,7 @@ from flask_appbuilder.api import (
 )
 from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_babel import ngettext
+from flask_babel import gettext, ngettext
 from marshmallow import ValidationError
 
 from superset import is_feature_enabled
@@ -773,7 +773,9 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
                 **response_schema.dump(
                     {
                         "execution_id": execution_id,
-                        "message": "Report schedule execution started successfully",
+                        "message": gettext(
+                            "Report schedule execution started successfully"
+                        ),
                     }
                 ),
             )


### PR DESCRIPTION
Follow-up to #41336. Addresses review feedback that was left unresolved when that PR merged.

### SUMMARY
Wraps the "Report schedule execution started successfully" response message from the new `POST /api/v1/report/{pk}/execute` endpoint in `gettext()`, matching how other messages in `superset/reports/api.py` are translated (e.g. the delete endpoint's `ngettext` usage).

The other item flagged in review, using `fields.UUID()` for `execution_id` in `ReportScheduleExecuteResponseSchema`, is already in place as of #41336, so no change was needed there.

### TESTING INSTRUCTIONS
- `pre-commit run --files superset/reports/api.py`
- Existing coverage: `tests/integration_tests/reports/api_tests.py -k execute`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API