### PR TITLE
fix(sunburst): keep SQL null and literal string "null" as distinct groups

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -37,13 +37,30 @@ function getMetricValue(datum: DataRecord, metric: string) {
 // and get merged into a single group. A Map keeps them as distinct keys, so
 // null filtering stays deterministic regardless of what else is in the
 // column.
+//
+// `Date` values need special handling: a `Map` compares object keys by
+// identity, not value, so two separately-parsed `Date` instances for the
+// same timestamp would otherwise land in different groups. Canonicalizing
+// by epoch time keeps identical timestamps together while still keeping
+// `null` and `'null'` distinct.
 function groupByValue(
   data: DataRecord[],
   groupByKey: string,
 ): Map<DataRecordValue, DataRecord[]> {
   const groups = new Map<DataRecordValue, DataRecord[]>();
+  const keysByCanonicalTime = new Map<number, DataRecordValue>();
   data.forEach(datum => {
-    const key = datum[groupByKey];
+    const rawKey = datum[groupByKey];
+    let key = rawKey;
+    if (rawKey instanceof Date) {
+      const time = rawKey.getTime();
+      const existingKey = keysByCanonicalTime.get(time);
+      if (existingKey !== undefined) {
+        key = existingKey;
+      } else {
+        keysByCanonicalTime.set(time, rawKey);
+      }
+    }
     const group = groups.get(key);
     if (group) {
       group.push(datum);

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/treeBuilder.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { DataRecord, DataRecordValue } from '@superset-ui/core';
-import { groupBy as _groupBy, transform } from 'lodash-es';
 
 export type TreeNode = {
   name: DataRecordValue;
@@ -31,6 +30,30 @@ function getMetricValue(datum: DataRecord, metric: string) {
   return typeof datum[metric] === 'number' ? (datum[metric] as number) : 0;
 }
 
+// Groups records by the raw value of `groupByKey`, keyed with a Map instead
+// of a plain object. A plain-object accumulator (e.g. lodash's `groupBy`)
+// has to coerce every key to a string to use it as a property name, so a SQL
+// NULL and the literal string "null" both collapse to the same "null" key
+// and get merged into a single group. A Map keeps them as distinct keys, so
+// null filtering stays deterministic regardless of what else is in the
+// column.
+function groupByValue(
+  data: DataRecord[],
+  groupByKey: string,
+): Map<DataRecordValue, DataRecord[]> {
+  const groups = new Map<DataRecordValue, DataRecord[]>();
+  data.forEach(datum => {
+    const key = datum[groupByKey];
+    const group = groups.get(key);
+    if (group) {
+      group.push(datum);
+    } else {
+      groups.set(key, [datum]);
+    }
+  });
+  return groups;
+}
+
 export function treeBuilder(
   data: DataRecord[],
   groupBy: string[],
@@ -39,57 +62,52 @@ export function treeBuilder(
   filterNullNames?: boolean,
 ): TreeNode[] {
   const [curGroupBy, ...restGroupby] = groupBy;
-  const curData = _groupBy(data, curGroupBy);
-  const nodes = transform(
-    curData,
-    (result, value, key) => {
-      const name = curData[key][0][curGroupBy]!;
-      if (!restGroupby.length) {
-        (value ?? []).forEach(datum => {
-          const metricValue = getMetricValue(datum, metric);
-          const secondaryValue = secondaryMetric
-            ? getMetricValue(datum, secondaryMetric)
-            : metricValue;
-          const item = {
-            name,
-            value: metricValue,
-            secondaryValue,
-            groupBy: curGroupBy,
-          };
-          result.push(item);
-        });
-      } else {
-        // Children are already null-filtered by the recursive call, so the
-        // parent's value/secondaryValue exclude hidden nulls. This keeps the
-        // parent arc sized to its visible children (no empty gap).
-        const children = treeBuilder(
-          value,
-          restGroupby,
-          metric,
-          secondaryMetric,
-          filterNullNames,
-        );
-        const metricValue = children.reduce(
-          (prev, cur) => prev + (cur.value as number),
-          0,
-        );
+  const curData = groupByValue(data, curGroupBy);
+  const nodes: TreeNode[] = [];
+  curData.forEach((value, name) => {
+    if (!restGroupby.length) {
+      value.forEach(datum => {
+        const metricValue = getMetricValue(datum, metric);
         const secondaryValue = secondaryMetric
-          ? children.reduce(
-              (prev, cur) => prev + (cur.secondaryValue as number),
-              0,
-            )
+          ? getMetricValue(datum, secondaryMetric)
           : metricValue;
-        result.push({
+        nodes.push({
           name,
-          children,
           value: metricValue,
           secondaryValue,
           groupBy: curGroupBy,
         });
-      }
-    },
-    [] as TreeNode[],
-  );
+      });
+    } else {
+      // Children are already null-filtered by the recursive call, so the
+      // parent's value/secondaryValue exclude hidden nulls. This keeps the
+      // parent arc sized to its visible children (no empty gap).
+      const children = treeBuilder(
+        value,
+        restGroupby,
+        metric,
+        secondaryMetric,
+        filterNullNames,
+      );
+      const metricValue = children.reduce(
+        (prev, cur) => prev + (cur.value as number),
+        0,
+      );
+      const secondaryValue = secondaryMetric
+        ? children.reduce(
+            (prev, cur) => prev + (cur.secondaryValue as number),
+            0,
+          )
+        : metricValue;
+      nodes.push({
+        name,
+        children,
+        value: metricValue,
+        secondaryValue,
+        groupBy: curGroupBy,
+      });
+    }
+  });
   // Filter at every level so single-level charts and root nodes are covered,
   // not just nested children. A parent whose children were all null-filtered
   // is dropped too: keeping it would leave a zero-value arc that yields a NaN

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -667,6 +667,40 @@ describe('test treeBuilder', () => {
     ]);
   });
 
+  // Regression: distinct `Date` instances representing the same timestamp
+  // must not fragment into separate groups. A `Map` keyed on the raw object
+  // would otherwise compare `Date`s by identity rather than value.
+  test('groups distinct Date instances with the same timestamp together', () => {
+    const tree = treeBuilder(
+      [
+        { foo: new Date('2020-01-01T00:00:00Z'), bar: 'a', count: 2 },
+        { foo: new Date('2020-01-01T00:00:00Z'), bar: 'b', count: 3 },
+        { foo: new Date('2020-01-02T00:00:00Z'), bar: 'c', count: 5 },
+      ],
+      ['foo', 'bar'],
+      'count',
+    );
+    expect(tree).toEqual([
+      {
+        children: [
+          { groupBy: 'bar', name: 'a', secondaryValue: 2, value: 2 },
+          { groupBy: 'bar', name: 'b', secondaryValue: 3, value: 3 },
+        ],
+        groupBy: 'foo',
+        name: new Date('2020-01-01T00:00:00Z'),
+        secondaryValue: 5,
+        value: 5,
+      },
+      {
+        children: [{ groupBy: 'bar', name: 'c', secondaryValue: 5, value: 5 }],
+        groupBy: 'foo',
+        name: new Date('2020-01-02T00:00:00Z'),
+        secondaryValue: 5,
+        value: 5,
+      },
+    ]);
+  });
+
   test('filters only the SQL null, not the literal string "null"', () => {
     const tree = treeBuilder(
       [

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts
@@ -646,4 +646,42 @@ describe('test treeBuilder', () => {
       },
     ]);
   });
+
+  // Regression: a plain-object grouping accumulator coerces every key to a
+  // string, so a SQL NULL and the literal string "null" both land under the
+  // "null" property and merge into one group. Keep them as separate nodes.
+  test('keeps a SQL null and the literal string "null" as distinct groups', () => {
+    const tree = treeBuilder(
+      [
+        { foo: null, count: 2, count2: 3 },
+        { foo: 'null', count: 5, count2: 7 },
+        { foo: 'a', count: 1, count2: 1 },
+      ],
+      ['foo'],
+      'count',
+    );
+    expect(tree).toEqual([
+      { groupBy: 'foo', name: null, secondaryValue: 2, value: 2 },
+      { groupBy: 'foo', name: 'null', secondaryValue: 5, value: 5 },
+      { groupBy: 'foo', name: 'a', secondaryValue: 1, value: 1 },
+    ]);
+  });
+
+  test('filters only the SQL null, not the literal string "null"', () => {
+    const tree = treeBuilder(
+      [
+        { foo: null, count: 2, count2: 3 },
+        { foo: 'null', count: 5, count2: 7 },
+        { foo: 'a', count: 1, count2: 1 },
+      ],
+      ['foo'],
+      'count',
+      undefined,
+      true,
+    );
+    expect(tree).toEqual([
+      { groupBy: 'foo', name: 'null', secondaryValue: 5, value: 5 },
+      { groupBy: 'foo', name: 'a', secondaryValue: 1, value: 1 },
+    ]);
+  });
 });


### PR DESCRIPTION
Follow-up to #41442.

### SUMMARY

The Sunburst chart's null-filtering path groups rows with lodash's `groupBy`, which has to coerce whatever value it's grouping on into a string to use as an object key. That means a SQL NULL and the literal string `"null"` both land under the same `"null"` key and get merged into one group, so which of them survives the "Show Null Values" filter ends up depending on which row happened to land in that group first.

Swapped the grouping to use a `Map` instead of a plain-object accumulator, so keys keep their real type/identity instead of getting stringified. A SQL null and the string `"null"` now always produce two separate tree nodes, and the existing `node.name !== null` filter only removes the actual null one.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, logic fix covered by unit tests.

### TESTING INSTRUCTIONS

`cd superset-frontend && npx jest plugins/plugin-chart-echarts/test/utils/treeBuilder.test.ts`

Added a couple of tests: one column with a SQL null, the literal string `"null"`, and a normal value all present together, confirming they produce three distinct nodes when nulls are shown, and that turning on the filter drops only the real null.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)