### PR TITLE
fix(frontend): remove any type and duplicate route in routes.tsx

### DIFF
--- a/superset-frontend/src/views/routes.tsx
+++ b/superset-frontend/src/views/routes.tsx
@@ -195,8 +195,8 @@ const RedirectWarning = lazy(
 
 type Routes = {
   path: string;
-  Component: ComponentType<any>;
-  Fallback?: ComponentType<any>;
+  Component: ComponentType;
+  Fallback?: ComponentType;
   props?: ComponentProps<any>;
 }[];
 
@@ -241,7 +241,6 @@ export const routes: Routes = [
   { path: RoutePaths.SQLLAB, Component: SqlLab },
   { path: RoutePaths.USER_INFO, Component: UserInfo },
   { path: RoutePaths.ACTION_LOG, Component: ActionLogList },
-  { path: RoutePaths.REGISTRATIONS, Component: UserRegistrations },
 ];
 
 if (isFeatureEnabled(FeatureFlag.TaggingSystem)) {


### PR DESCRIPTION
Follow-up to #41205.

### SUMMARY
That PR widened the `Routes` type in `superset-frontend/src/views/routes.tsx` from `ComponentType` to `ComponentType<any>`, which violates the project's no-`any` policy, and it left `RoutePaths.REGISTRATIONS` registered twice: once unconditionally in the base `routes` array and again gated behind `authRegistrationEnabled`. This PR restores the narrower `ComponentType` generic and removes the redundant unconditional entry so the registrations route is only registered when user self-registration is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - no UI change.

### TESTING INSTRUCTIONS

- Confirm `superset-frontend/src/views/routes.tsx` no longer has a duplicate `RoutePaths.REGISTRATIONS` entry.
- With `AUTH_USER_REGISTRATION` disabled, `/registrations/` is no longer registered as a frontend route.
- With `AUTH_USER_REGISTRATION` enabled, `/registrations/` still routes to `UserRegistrations` as before.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API