### PR TITLE
fix(common): remove unsupported cross join mode from left_join_df

### DIFF
--- a/superset/common/utils/dataframe_utils.py
+++ b/superset/common/utils/dataframe_utils.py
@@ -32,12 +32,15 @@ def left_join_df(
     join_keys: list[str],
     lsuffix: str = "",
     rsuffix: str = "",
-    how: Literal["left", "right", "inner", "outer", "cross"] = "left",
+    how: Literal["left", "right", "inner", "outer"] = "left",
 ) -> pd.DataFrame:
     # `how` defaults to "left" so callers that only want the left frame's rows are
     # unaffected. Passing how="outer" keeps right-only rows, which is used by the
     # time-comparison "full range" option so historical series are not truncated to
-    # the main series' time range.
+    # the main series' time range. "cross" is intentionally excluded: the join is
+    # implemented via `Index.join`, which doesn't support cross joins the way
+    # `pd.merge` does, so passing "cross" here would silently drop the join keys
+    # instead of producing a real cross join.
     df = left_df.set_index(join_keys).join(
         right_df.set_index(join_keys), how=how, lsuffix=lsuffix, rsuffix=rsuffix
     )

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -2705,7 +2705,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         df: pd.DataFrame,
         offset_df: pd.DataFrame,
         actual_join_keys: list[str],
-        how: Literal["left", "right", "inner", "outer", "cross"] = "left",
+        how: Literal["left", "right", "inner", "outer"] = "left",
     ) -> pd.DataFrame:
         """Perform the appropriate join operation."""
         if actual_join_keys:


### PR DESCRIPTION
Follow-up to #41334.

### SUMMARY

`left_join_df`'s `how` parameter is typed `Literal["left", "right", "inner", "outer", "cross"]`, but the join is implemented via `DataFrame.set_index(...).join(...)`, whose underlying `Index.join` doesn't support `"cross"` the way `pd.merge` does. Passing `how="cross"` silently drops the join keys instead of producing a real cross join, so the type signature was advertising a mode that doesn't actually work.

This removes `"cross"` from the `Literal` in `left_join_df` (`superset/common/utils/dataframe_utils.py`). `ExploreMixin._perform_join` in `superset/models/helpers.py` forwards its own `how` parameter straight into `left_join_df`, so its signature is narrowed the same way to keep mypy happy and stay consistent.

Neither function is ever called with `how="cross"` today (`join_offset_dfs`, the only caller, only ever passes `"left"` or `"outer"` for the time-comparison full-range option added in #41334), so this is a type-only fix with no behavior change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A - type-only change, no UI impact.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/common/test_time_shifts.py` and `pytest tests/unit_tests/common/test_query_context_processor.py -k join` still pass.
- `pre-commit run` (including mypy) passes on the changed files, confirming the narrower type doesn't break the one call site.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API