### PR TITLE
fix(reports): make webhook notification request timeout configurable

### DIFF
--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -175,6 +175,16 @@ ALERT_REPORTS_WEBHOOK_HTTPS_ONLY = True
 
 When enabled, Superset rejects webhook configurations that use `http://` URLs.
 
+#### Request Timeout
+
+Webhook deliveries use a socket timeout so a request can't hang forever if the webhook target is unreachable, which would otherwise leave the report schedule stuck in a `WORKING` state. Configure it with:
+
+```python
+ALERT_REPORTS_WEBHOOK_TIMEOUT = 60  # seconds
+```
+
+Set to `None` to disable the timeout (not recommended).
+
 #### Retry Behavior
 
 Superset automatically retries webhook deliveries on `429 Too Many Requests` and `5xx` server errors using exponential backoff. Retries are bounded to roughly 120 seconds of cumulative wall-clock time (worst case ~210 seconds, because the bound is checked against the time elapsed before each attempt, so the final request can begin just under the limit and still run its full request timeout), after which the delivery is abandoned.

--- a/superset/config.py
+++ b/superset/config.py
@@ -2532,6 +2532,12 @@ REPORT_MINIMUM_INTERVAL = int(timedelta(minutes=0).total_seconds())
 # Enforce HTTPS for webhook alerts/reports
 ALERT_REPORTS_WEBHOOK_HTTPS_ONLY = True
 
+# Socket timeout (in seconds) for the HTTP request that dispatches webhook
+# alerts/reports. Without a timeout the request blocks indefinitely if the
+# webhook target is unreachable, which leaves the report schedule stuck in
+# the WORKING state. Set to None to disable (not recommended).
+ALERT_REPORTS_WEBHOOK_TIMEOUT = 60
+
 # When True, webhook alert/report dispatch is permitted to call private/internal
 # IP addresses (RFC-1918, loopback, link-local). Intended for deployments where
 # the webhook target is on an internal network (a chatops bridge, an internal

--- a/superset/reports/notifications/webhook.py
+++ b/superset/reports/notifications/webhook.py
@@ -153,12 +153,13 @@ class WebhookNotification(BaseNotification):
         # start of each attempt and checks it against max_time only after that
         # attempt fails -- so the giveup decision uses the time measured before
         # the attempt ran, ignoring the attempt's own duration. With each
-        # request carrying timeout=60, a third attempt can begin past the 120s
-        # mark (its start gated by the prior check, which still saw ~60-70s) and
-        # then run its full 60s before the check trips. The loop therefore makes
-        # 3 attempts: total wall-clock is ~180-210s (180s of requests + up to
-        # ~30s of jitter sleeps: <=10s then <=20s), not 120s. factor is kept at
-        # 10 so legitimately-transient 5xx targets are not abandoned early.
+        # request carrying the ALERT_REPORTS_WEBHOOK_TIMEOUT (default 60s), a
+        # third attempt can begin past the 120s mark (its start gated by the
+        # prior check, which still saw ~60-70s) and then run its full request
+        # timeout before the check trips. The loop therefore makes 3 attempts:
+        # total wall-clock can exceed 120s by up to one request timeout plus
+        # jitter sleeps (<=10s then <=20s). factor is kept at 10 so
+        # legitimately-transient 5xx targets are not abandoned early.
         max_time=120,
     )
     @statsd_gauge("reports.webhook.send")

--- a/superset/reports/notifications/webhook.py
+++ b/superset/reports/notifications/webhook.py
@@ -172,6 +172,7 @@ class WebhookNotification(BaseNotification):
         self._validate_webhook_url(wh_url)
         payload = self._get_req_payload()
         files = self._get_files()
+        timeout = current_app.config["ALERT_REPORTS_WEBHOOK_TIMEOUT"]
 
         try:
             if files:
@@ -186,12 +187,12 @@ class WebhookNotification(BaseNotification):
                     wh_url,
                     data=data,
                     files=files,
-                    timeout=60,
+                    timeout=timeout,
                     allow_redirects=False,
                 )
             else:
                 response = requests.post(
-                    wh_url, json=payload, timeout=60, allow_redirects=False
+                    wh_url, json=payload, timeout=timeout, allow_redirects=False
                 )
 
             logger.info(

--- a/tests/unit_tests/reports/notifications/webhook_tests.py
+++ b/tests/unit_tests/reports/notifications/webhook_tests.py
@@ -282,6 +282,7 @@ def test_send_treats_redirect_as_failure(monkeypatch, mock_header_data) -> None:
         config = {
             "ALERT_REPORTS_WEBHOOK_HTTPS_ONLY": True,
             "ALERT_REPORTS_WEBHOOK_ALLOW_INTERNAL_HOSTS": True,
+            "ALERT_REPORTS_WEBHOOK_TIMEOUT": 60,
         }
 
     class MockResponse:
@@ -302,6 +303,58 @@ def test_send_treats_redirect_as_failure(monkeypatch, mock_header_data) -> None:
 
     with pytest.raises(NotificationParamException, match="redirect"):
         webhook_notification.send()
+
+
+def test_send_forwards_configured_timeout(monkeypatch, mock_header_data) -> None:
+    """
+    send() forwards ALERT_REPORTS_WEBHOOK_TIMEOUT to requests.post so the
+    call can't hang forever if the webhook target is unreachable.
+    """
+    from superset.reports.models import ReportRecipients, ReportRecipientType
+    from superset.reports.notifications.base import NotificationContent
+
+    content = NotificationContent(
+        name="test alert", header_data=mock_header_data, description="Test description"
+    )
+    webhook_notification = WebhookNotification(
+        recipient=ReportRecipients(
+            type=ReportRecipientType.WEBHOOK,
+            recipient_config_json='{"target": "https://example.com/webhook"}',
+        ),
+        content=content,
+    )
+
+    class MockCurrentApp:
+        config = {
+            "ALERT_REPORTS_WEBHOOK_HTTPS_ONLY": True,
+            "ALERT_REPORTS_WEBHOOK_ALLOW_INTERNAL_HOSTS": True,
+            "ALERT_REPORTS_WEBHOOK_TIMEOUT": 45,
+        }
+
+    class MockResponse:
+        status_code = 200
+        text = ""
+
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_post(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return MockResponse()
+
+    monkeypatch.setattr(
+        "superset.reports.notifications.webhook.current_app", MockCurrentApp
+    )
+    monkeypatch.setattr(
+        "superset.reports.notifications.webhook.feature_flag_manager.is_feature_enabled",
+        lambda flag: True,
+    )
+    monkeypatch.setattr(
+        "superset.reports.notifications.webhook.requests.post", fake_post
+    )
+
+    webhook_notification.send()
+
+    assert captured_kwargs["timeout"] == 45
 
 
 def _make_webhook(mock_header_data) -> WebhookNotification:
@@ -330,6 +383,7 @@ def _allow_internal_app() -> type:
         config = {
             "ALERT_REPORTS_WEBHOOK_HTTPS_ONLY": True,
             "ALERT_REPORTS_WEBHOOK_ALLOW_INTERNAL_HOSTS": True,
+            "ALERT_REPORTS_WEBHOOK_TIMEOUT": 60,
         }
 
     return MockCurrentApp


### PR DESCRIPTION
Follow-up to #41250. That PR made SMTP, CSV/dataframe, and Selenium network timeouts configurable so a hung network call can't wedge a report schedule in `WORKING` forever. It missed the webhook notification path: both `requests.post()` calls in `superset/reports/notifications/webhook.py` still hardcoded `timeout=60`.

### SUMMARY

Adds `ALERT_REPORTS_WEBHOOK_TIMEOUT` (default `60`, matching the prior hardcoded value) and wires it into both webhook `requests.post()` calls, consistent with the other timeouts #41250 introduced. Also documents the new setting alongside the existing `ALERT_REPORTS_WEBHOOK_HTTPS_ONLY` docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (backend config change).

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/reports/notifications/webhook_tests.py`
- New test `test_send_forwards_configured_timeout` asserts the configured value is passed through to `requests.post`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)