### PR TITLE
fix(theming): guard ensureStaticPrefix against null/undefined input

### DIFF
--- a/superset-frontend/src/utils/assetUrl.test.ts
+++ b/superset-frontend/src/utils/assetUrl.test.ts
@@ -84,4 +84,14 @@ describe('ensureStaticPrefix should be idempotent', () => {
     staticAssetsPrefixMock.mockReturnValue('');
     expect(ensureStaticPrefix('/static/x.png')).toBe('/static/x.png');
   });
+
+  test('returns undefined instead of throwing when passed undefined', () => {
+    staticAssetsPrefixMock.mockReturnValue('/superset');
+    expect(ensureStaticPrefix(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined instead of throwing when passed null', () => {
+    staticAssetsPrefixMock.mockReturnValue('/superset');
+    expect(ensureStaticPrefix(null)).toBeUndefined();
+  });
 });

--- a/superset-frontend/src/utils/assetUrl.ts
+++ b/superset-frontend/src/utils/assetUrl.ts
@@ -35,9 +35,17 @@ export function assetUrl(path: string): string {
  * segment boundary is returned unchanged, mirroring the dedupe pattern used by
  * `ensureAppRoot` in pathUtils.ts and `SupersetClient.getUrl`.
  *
+ * If `url_or_path` is null or undefined, `undefined` is returned so callers
+ * (e.g. a partial theme reaching the frontend from a source other than
+ * `superset_config.py`, such as a DB-stored theme created via the API) don't
+ * crash on the unconditional `.startsWith()` call below.
+ *
  * @param url_or_path A url or relative path to a resource
  */
-export function ensureStaticPrefix(url_or_path: string): string {
+export function ensureStaticPrefix(
+  url_or_path: string | null | undefined,
+): string | undefined {
+  if (url_or_path == null) return undefined;
   if (!url_or_path.startsWith('/')) return url_or_path;
   const prefix = staticAssetsPrefix();
   if (


### PR DESCRIPTION
Follow-up to #41347.

### SUMMARY

#41347 fixed a white-screen crash caused by a partial `THEME_DEFAULT`/`THEME_DARK` override in `superset_config.py`, where an unset token (e.g. `fontFamily`) reached `.startsWith()` in the frontend as `undefined`.

`ensureStaticPrefix()` in `superset-frontend/src/utils/assetUrl.ts` has the same unconditional `.startsWith()` call. Its callers in `Menu.tsx` pass `theme.brandLogoUrl` and `brand.icon`, both typed as required `string` fields — but a partial theme reaching the frontend from a source other than `superset_config.py` (e.g. a DB-stored theme created via the API) can still leave these fields unset at runtime, reproducing the same crash for a different theme source.

This adds a null/undefined guard to `ensureStaticPrefix()` so it returns `undefined` instead of throwing when handed a missing value, mirroring the existing `ensureAppRoot()` null-safety pattern in `pathUtils.ts`.

### BEFORE/AFTER

**Before:** A theme missing `brandLogoUrl` or `brand.icon` (e.g. incompletely configured via a non-`superset_config.py` source) crashes on `ensureStaticPrefix(undefined).startsWith(...)`.

**After:** `ensureStaticPrefix(undefined)` returns `undefined` instead of throwing, letting the image render without a `src` rather than crashing the page.

### TESTING INSTRUCTIONS

```bash
npm run test -- src/utils/assetUrl.test.ts
```

Added two unit tests covering `null` and `undefined` inputs.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)