### PR TITLE
test(explore): add end-to-end regression test for DatasourcePanel through the real AutoSizer + react-window List pipeline

### DIFF
--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.real-autosizer.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.real-autosizer.test.tsx
@@ -30,14 +30,14 @@ import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelect
 import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
 
 /**
- * The rest of this test file mocks react-virtualized-auto-sizer to a fixed
+ * DatasourcePanel.test.tsx mocks react-virtualized-auto-sizer to a fixed
  * height, which bypasses react-window's own size self-measurement path
  * entirely. This test instead drives a real ResizeObserver callback so the
  * panel renders through the same AutoSizer -> react-window List pipeline
  * the browser uses, to guard against regressions like
  * https://github.com/apache/superset/issues/43008.
  */
-class FakeResizeObserver implements ResizeObserver {
+class FakeResizeObserver {
   callback: ResizeObserverCallback;
 
   constructor(callback: ResizeObserverCallback) {

--- a/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.real-autosizer.test.tsx
+++ b/superset-frontend/src/explore/components/DatasourcePanel/DatasourcePanel.real-autosizer.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { DatasourceType } from '@superset-ui/core';
+import DatasourcePanel, {
+  IDatasource,
+} from 'src/explore/components/DatasourcePanel';
+import {
+  columns,
+  metrics,
+} from 'src/explore/components/DatasourcePanel/fixtures';
+import ExploreContainer from 'src/explore/components/ExploreContainer';
+import { DndMetricSelect } from 'src/explore/components/controls/DndColumnSelectControl';
+import DatasourceControl from 'src/explore/components/controls/DatasourceControl';
+
+/**
+ * The rest of this test file mocks react-virtualized-auto-sizer to a fixed
+ * height, which bypasses react-window's own size self-measurement path
+ * entirely. This test instead drives a real ResizeObserver callback so the
+ * panel renders through the same AutoSizer -> react-window List pipeline
+ * the browser uses, to guard against regressions like
+ * https://github.com/apache/superset/issues/43008.
+ */
+class FakeResizeObserver implements ResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe(target: Element) {
+    Object.defineProperty(target, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        width: 300,
+        height: 600,
+        top: 0,
+        left: 0,
+        bottom: 600,
+        right: 300,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }),
+    });
+    setTimeout(() => {
+      this.callback(
+        [
+          {
+            target,
+            contentRect: { width: 300, height: 600 },
+          } as ResizeObserverEntry,
+        ],
+        this,
+      );
+    }, 0);
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+const originalResizeObserver = window.ResizeObserver;
+
+beforeEach(() => {
+  window.ResizeObserver = FakeResizeObserver;
+});
+
+afterEach(() => {
+  window.ResizeObserver = originalResizeObserver;
+});
+
+const datasource: IDatasource = {
+  id: 1,
+  type: DatasourceType.Table,
+  columns,
+  metrics,
+  database: { id: 1 },
+  datasource_name: 'table1',
+};
+
+test('renders metrics and columns through the real (unmocked) AutoSizer + react-window List pipeline', async () => {
+  render(
+    <ExploreContainer>
+      <DatasourcePanel
+        datasource={datasource}
+        controls={{
+          datasource: {
+            validationErrors: null,
+            mapStateToProps: () => ({ value: undefined }),
+            type: DatasourceControl,
+            label: 'Datasource',
+            datasource,
+          },
+        }}
+        actions={{ setControlValue: jest.fn() }}
+        width={300}
+      />
+      <DndMetricSelect savedMetrics={[]} columns={[]} onChange={jest.fn()} />
+    </ExploreContainer>,
+    { useDnd: true, useRedux: true },
+  );
+
+  await waitFor(
+    () => {
+      expect(screen.getByText(metrics[0].metric_name)).toBeInTheDocument();
+    },
+    { timeout: 3000 },
+  );
+  expect(screen.getByText(columns[0].column_name)).toBeInTheDocument();
+});


### PR DESCRIPTION
## SUMMARY

Investigated #43008 (metrics/columns not showing in the Explore Datasource
Panel, bisected to the react-window v1->v2 bump in #42528).

Dosu's automated diagnosis on that issue claims `DatasourceItems.tsx` and
`DatasourcePanelItem.tsx` are still using the old v1 `VariableSizeList` API.
That's not accurate against current `master` -- both files were correctly
migrated to react-window v2's `List`/`rowHeight`/`rowCount`/`rowProps`/
`rowComponent` API in the same commit the bisect flagged, and haven't
changed since.

I couldn't reproduce the blank-panel bug in code:
- An isolated real-browser (Playwright/Chromium) repro of the exact
  `List` + `AutoSizer` wiring pattern, using the pinned `react-window@2.3.0`
  and `react-virtualized-auto-sizer@1.0.26` versions, renders rows
  correctly.
- The existing unit test suite for this component passes on `master`, but
  it mocks `react-virtualized-auto-sizer` to a fixed height, which bypasses
  react-window's own sizing path entirely and wouldn't catch a regression
  here.

This PR adds a test that exercises the real (unmocked) `AutoSizer` + real
`List` + real `DatasourcePanelItem` end to end, driving an actual
`ResizeObserver` callback the way the browser does. It renders metrics and
columns correctly against the current code. I verified the test actually
catches breakage by temporarily zeroing out `rowCount` in
`DatasourceItems.tsx` and confirming the test fails.

No code fix is included since I couldn't find a bug to fix -- this adds
permanent regression coverage for the one gap in this area's existing test
suite either way.

## BEFORE/AFTER

N/A -- test-only change, no behavior change.

## TESTING INSTRUCTIONS

```
npm run test -- src/explore/components/DatasourcePanel/DatasourcePanel.real-autosizer.test.tsx
```

## ADDITIONAL INFORMATION

- [x] Has associated issue: #43008
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB migration
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Introduces new feature or API
- [ ] Removes existing feature