### PR TITLE
test(warm_up_cache): pin native filter defaults dropped from cache warming

### DIFF
--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -59,7 +59,7 @@ def test_get_form_data_handles_non_dict_json_body() -> None:
     assert slc is None
 
 
-def test_get_dashboard_extra_filters_ignores_native_filter_defaults(
+def test_get_dashboard_extra_filters_includes_native_filter_defaults(
     session: Session,
 ) -> None:
     """

--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -125,9 +125,15 @@ def test_get_dashboard_extra_filters_includes_native_filter_defaults(
 
     extra_filters = get_dashboard_extra_filters(chart.id, dashboard.id)
 
-    assert extra_filters, (
-        "get_dashboard_extra_filters returned no filters for a dashboard "
-        "with a native filter default value -- it currently only reads the "
-        "legacy default_filters/filter_scopes metadata, so native filter "
-        "defaults are silently dropped from cache warming."
+    # Pin the actual predicate, not just non-emptiness -- a fix that returns
+    # any placeholder/non-empty value without extracting the native filter's
+    # own col/op/val (from defaultDataMask.extraFormData.filters) would
+    # otherwise still pass this test while producing a cache key that
+    # diverges from what the browser actually requests.
+    assert {"col": "region", "op": "IN", "val": ["APAC"]} in extra_filters, (
+        "get_dashboard_extra_filters must surface the native filter's "
+        "region=APAC predicate from defaultDataMask.extraFormData.filters -- "
+        "it currently only reads the legacy default_filters/filter_scopes "
+        "metadata, so native filter defaults are silently dropped from "
+        f"cache warming. Got: {extra_filters!r}"
     )

--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -17,8 +17,14 @@
 """Tests for superset.views.utils module"""
 
 from flask import current_app
+from sqlalchemy.orm.session import Session
 
-from superset.views.utils import get_form_data
+from superset import db
+from superset.connectors.sqla.models import Database, SqlaTable
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset.utils import json
+from superset.views.utils import get_dashboard_extra_filters, get_form_data
 
 
 def test_get_form_data_handles_non_json_body_with_json_content_type() -> None:
@@ -51,3 +57,77 @@ def test_get_form_data_handles_non_dict_json_body() -> None:
 
     assert form_data == {}
     assert slc is None
+
+
+def test_get_dashboard_extra_filters_ignores_native_filter_defaults(
+    session: Session,
+) -> None:
+    """
+    get_dashboard_extra_filters must surface native filter defaults, not just
+    the legacy Filter Box ``default_filters``/``filter_scopes`` metadata.
+
+    Reported in apache/superset#43024 (originally raised in discussion #42382):
+    ``ChartWarmUpCacheCommand`` relies on this function to reconstruct a
+    dashboard's applied filters for cache warming. Because it only reads the
+    legacy fields, warming a
+    dashboard that uses native filters (the standard mechanism today, not the
+    deprecated Filter Box) silently drops every native filter's default
+    value, so the warmed cache key never matches what the browser actually
+    requests and warm_up_cache is effectively a no-op for such dashboards.
+
+    A working native-filter extractor already exists and is wired into the
+    real ``/api/v1/chart/data`` endpoint (see
+    ``superset.charts.data.dashboard_filter_context.get_dashboard_filter_context``)
+    -- this function just isn't using it.
+    """
+    Dashboard.metadata.create_all(session.get_bind())
+
+    dataset = SqlaTable(
+        table_name="extra_filters_table",
+        database=Database(database_name="extra_filters_db", sqlalchemy_uri="sqlite://"),
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    chart = Slice(
+        slice_name="chart_with_native_filter",
+        datasource_id=dataset.id,
+        datasource_type="table",
+    )
+
+    native_filter_configuration = [
+        {
+            "id": "NATIVE_FILTER-1",
+            "name": "Region filter",
+            "type": "NATIVE_FILTER",
+            "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            "targets": [{"column": {"name": "region"}}],
+            "defaultDataMask": {
+                "extraFormData": {
+                    "filters": [{"col": "region", "op": "IN", "val": ["APAC"]}]
+                },
+                "filterState": {"value": ["APAC"]},
+            },
+            "controlValues": {},
+        }
+    ]
+    dashboard = Dashboard(
+        dashboard_title="native_filter_dash",
+        slices=[chart],
+        published=True,
+        json_metadata=json.dumps(
+            {"native_filter_configuration": native_filter_configuration}
+        ),
+        position_json="{}",
+    )
+    db.session.add_all([chart, dashboard])
+    db.session.flush()
+
+    extra_filters = get_dashboard_extra_filters(chart.id, dashboard.id)
+
+    assert extra_filters, (
+        "get_dashboard_extra_filters returned no filters for a dashboard "
+        "with a native filter default value -- it currently only reads the "
+        "legacy default_filters/filter_scopes metadata, so native filter "
+        "defaults are silently dropped from cache warming."
+    )


### PR DESCRIPTION
### SUMMARY
Test-only PR pinning a real bug: `warm_up_cache` silently drops native filter defaults, so warming a dashboard's cache produces a different key than what the browser actually requests, and the warmed cache entry is never hit for dashboards built with native filters (the standard mechanism today).

`get_dashboard_extra_filters()` in `superset/views/utils.py` only reads the legacy Filter Box `default_filters`/`filter_scopes` dashboard metadata:

```python
default_filters = json.loads(json_metadata.get("default_filters", "null"))
if not default_filters:
    return []
```

It never reads `native_filter_configuration` at all. `ChartWarmUpCacheCommand` relies on this function to reconstruct a dashboard's applied filters for cache warming, so for any dashboard using native filters, warming applies none of them.

Worth noting for whoever picks up the fix: a correct native-filter extractor already exists and is wired into the real `/api/v1/chart/data` endpoint — `superset.charts.data.dashboard_filter_context.get_dashboard_filter_context()` / `apply_dashboard_filter_context()` (see `superset/charts/data/api.py`). `ChartWarmUpCacheCommand` just isn't using it; that looks like the natural fix to reuse rather than reinventing native-filter parsing inside `get_dashboard_extra_filters`.

Originally raised in discussion #42382 with solid root-cause analysis; filed as #43024 since it's a confirmed bug (verified independently against current `master`, not just the original report), not a question. That issue also covers a second, related root cause (filter list *order* affecting the cache key hash) which isn't covered by this specific test — worth a follow-up test/fix once the native-filter gap above is addressed, since fixing one without the other would still leave cache warming broken.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/views/test_utils.py -v` — `test_get_dashboard_extra_filters_ignores_native_filter_defaults` currently fails (red), confirming the bug reproduces on `master`. Confirmed it fails without this PR's changes and passes once a correct fix is in place (built and reverted a fix locally to verify the test's shape, not included here — this PR is test-only per project convention).

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #43024
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API