### PR TITLE
feat(table): allow choosing Sum or Average for the "Show summary" totals row

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { QueryFormMetric } from '@superset-ui/core';
+import { getTotalsMetrics } from './getTotalsMetrics';
+
+const simpleMetric = (aggregate: string): QueryFormMetric =>
+  ({
+    label: 'simple_metric',
+    expressionType: 'SIMPLE',
+    column: { column_name: 'col' },
+    aggregate,
+  }) as QueryFormMetric;
+
+const sqlMetric = (): QueryFormMetric =>
+  ({
+    label: 'sql_metric',
+    expressionType: 'SQL',
+    sqlExpression: 'SUM(col) / COUNT(*)',
+  }) as QueryFormMetric;
+
+const savedMetric = (): QueryFormMetric => 'saved_metric';
+
+describe('getTotalsMetrics', () => {
+  test('overrides the aggregate on simple (adhoc) metrics', () => {
+    const [result] = getTotalsMetrics([simpleMetric('SUM')], 'AVG');
+    expect(result).toEqual(
+      expect.objectContaining({ aggregate: 'AVG', expressionType: 'SIMPLE' }),
+    );
+  });
+
+  test('is a no-op when the simple metric already uses the requested aggregate', () => {
+    const [result] = getTotalsMetrics([simpleMetric('SUM')], 'SUM');
+    expect(result).toEqual(
+      expect.objectContaining({ aggregate: 'SUM', expressionType: 'SIMPLE' }),
+    );
+  });
+
+  test('leaves custom SQL metrics unchanged', () => {
+    const metric = sqlMetric();
+    const [result] = getTotalsMetrics([metric], 'AVG');
+    expect(result).toBe(metric);
+  });
+
+  test('leaves saved (string) metrics unchanged', () => {
+    const metric = savedMetric();
+    const [result] = getTotalsMetrics([metric], 'AVG');
+    expect(result).toBe(metric);
+  });
+
+  test('handles a mix of metric types, only rewriting simple metrics', () => {
+    const metrics = [simpleMetric('SUM'), sqlMetric(), savedMetric()];
+    const result = getTotalsMetrics(metrics, 'AVG');
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual(expect.objectContaining({ aggregate: 'AVG' }));
+    expect(result[1]).toBe(metrics[1]);
+    expect(result[2]).toBe(metrics[2]);
+  });
+
+  test('returns an empty array when given no metrics', () => {
+    expect(getTotalsMetrics([], 'AVG')).toEqual([]);
+  });
+});

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { isAdhocMetricSimple, QueryFormMetric } from '@superset-ui/core';
+
+export type TotalsAggregate = 'SUM' | 'AVG';
+
+/**
+ * Build the metrics for a chart's "Show summary" totals query, overriding
+ * each Simple (adhoc) metric's aggregate function with the user-chosen
+ * totals aggregate. The totals query has no GROUP BY, so the database
+ * evaluates each metric fresh over all rows -- swapping the aggregate here
+ * is a correct, independent computation, not a re-aggregation of
+ * already-aggregated per-row values.
+ *
+ * Custom-SQL metrics and saved (string) metrics pass through unchanged:
+ * there is no safe way to rewrite an arbitrary SQL expression's aggregate
+ * function without parsing it, so the totals row keeps their own native
+ * aggregate for those.
+ */
+export function getTotalsMetrics(
+  metrics: QueryFormMetric[],
+  aggregate: TotalsAggregate,
+): QueryFormMetric[] {
+  return metrics.map(metric =>
+    isAdhocMetricSimple(metric) ? { ...metric, aggregate } : metric,
+  );
+}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/index.ts
@@ -22,6 +22,7 @@ export * from './selectOptions';
 export * from './D3Formatting';
 export * from './expandControlConfig';
 export * from './getColorFormatters';
+export * from './getTotalsMetrics';
 export { default as mainMetric } from './mainMetric';
 export { default as columnChoices, columnsByType } from './columnChoices';
 export * from './defineSavedMetrics';

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -38,6 +38,7 @@ import {
   getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
+  TotalsAggregate,
 } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
@@ -695,7 +696,19 @@ export const buildQueryUncached: BuildQuery<TableChartFormData> = (
       formData.show_totals &&
       queryMode === QueryMode.Aggregate,
     );
-    const totalsAggregate = formData.totals_aggregate ?? 'SUM';
+    const totalsAggregate: TotalsAggregate =
+      formData.totals_aggregate === 'AVG' ? 'AVG' : 'SUM';
+    const totalsMetrics =
+      rawSummaryColumns.length > 0
+        ? rawSummaryColumns.map(columnName => ({
+            expressionType: 'SIMPLE' as const,
+            aggregate: totalsAggregate,
+            column: { column_name: columnName },
+            label: columnName,
+          }))
+        : showAggregateTotals
+          ? getTotalsMetrics(metrics ?? [], totalsAggregate)
+          : undefined;
 
     if (showAggregateTotals || rawSummaryColumns.length > 0) {
       // Create a copy of extras without the AG Grid WHERE clause
@@ -730,18 +743,7 @@ export const buildQueryUncached: BuildQuery<TableChartFormData> = (
       extraQueries.push({
         ...queryObject,
         columns: [],
-        ...(rawSummaryColumns.length > 0
-          ? {
-              metrics: rawSummaryColumns.map(columnName => ({
-                expressionType: 'SIMPLE' as const,
-                aggregate: totalsAggregate,
-                column: { column_name: columnName },
-                label: columnName,
-              })),
-            }
-          : showAggregateTotals
-            ? { metrics: getTotalsMetrics(metrics ?? [], totalsAggregate) }
-            : {}),
+        ...(totalsMetrics ? { metrics: totalsMetrics } : {}),
         extras: totalsExtras, // Use extras with AG Grid WHERE removed
         row_limit: 0,
         row_offset: 0,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -35,6 +35,7 @@ import {
   BuildQuery,
 } from '@superset-ui/core';
 import {
+  getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
@@ -694,6 +695,7 @@ export const buildQueryUncached: BuildQuery<TableChartFormData> = (
       formData.show_totals &&
       queryMode === QueryMode.Aggregate,
     );
+    const totalsAggregate = formData.totals_aggregate ?? 'SUM';
 
     if (showAggregateTotals || rawSummaryColumns.length > 0) {
       // Create a copy of extras without the AG Grid WHERE clause
@@ -728,14 +730,18 @@ export const buildQueryUncached: BuildQuery<TableChartFormData> = (
       extraQueries.push({
         ...queryObject,
         columns: [],
-        ...(rawSummaryColumns.length > 0 && {
-          metrics: rawSummaryColumns.map(columnName => ({
-            expressionType: 'SIMPLE' as const,
-            aggregate: 'SUM' as const,
-            column: { column_name: columnName },
-            label: columnName,
-          })),
-        }),
+        ...(rawSummaryColumns.length > 0
+          ? {
+              metrics: rawSummaryColumns.map(columnName => ({
+                expressionType: 'SIMPLE' as const,
+                aggregate: totalsAggregate,
+                column: { column_name: columnName },
+                label: columnName,
+              })),
+            }
+          : showAggregateTotals
+            ? { metrics: getTotalsMetrics(metrics ?? [], totalsAggregate) }
+            : {}),
         extras: totalsExtras, // Use extras with AG Grid WHERE removed
         row_limit: 0,
         row_offset: 0,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -490,8 +490,33 @@ const config: ControlPanelConfig = {
               default: false,
               renderTrigger: true,
               description: t(
-                'Show a summary row of total aggregations: the selected metrics in aggregate mode, or the sum of numeric columns in raw records mode. Note that row limit does not apply to the result.',
+                'Show a summary row of total aggregations: the selected metrics in aggregate mode, or an aggregation of numeric columns in raw records mode. Note that row limit does not apply to the result.',
               ),
+            },
+          },
+        ],
+        [
+          {
+            name: 'totals_aggregate',
+            config: {
+              type: 'SelectControl',
+              label: t('Summary aggregation'),
+              renderTrigger: true,
+              description: t(
+                'Aggregation used for the summary row, independent of each ' +
+                  "metric's own aggregation. Only applies to simple metrics " +
+                  '(a metric built from custom SQL keeps its own aggregation ' +
+                  'in the summary row).',
+              ),
+              default: 'SUM',
+              clearable: false,
+              choices: [
+                ['SUM', t('Sum')],
+                ['AVG', t('Average')],
+              ],
+              visibility: ({ controls }) =>
+                Boolean(controls?.show_totals?.value),
+              resetOnHide: false,
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -1560,6 +1560,74 @@ describe('plugin-chart-ag-grid-table', () => {
       expect(queries[1].columns).toEqual([]);
       expect(queries[1].metrics).toEqual(['count']);
     });
+
+    test('defaults aggregate-mode totals to SUM for a simple metric', () => {
+      const simpleMetric = {
+        expressionType: 'SIMPLE' as const,
+        column: { column_name: 'sales' },
+        aggregate: 'SUM' as const,
+        label: 'sum_sales',
+      };
+      const { queries } = buildQuery(
+        {
+          viz_type: VizType.Table,
+          datasource: '11__table',
+          query_mode: QueryMode.Aggregate,
+          groupby: ['state'],
+          metrics: [simpleMetric],
+          show_totals: true,
+        },
+        { ownState: {} },
+      );
+
+      expect(queries[1].metrics).toEqual([
+        { ...simpleMetric, aggregate: 'SUM' },
+      ]);
+    });
+
+    test('overrides aggregate-mode totals to AVG for a simple metric when totals_aggregate is set', () => {
+      const simpleMetric = {
+        expressionType: 'SIMPLE' as const,
+        column: { column_name: 'sales' },
+        aggregate: 'SUM' as const,
+        label: 'sum_sales',
+      };
+      const { queries } = buildQuery(
+        {
+          viz_type: VizType.Table,
+          datasource: '11__table',
+          query_mode: QueryMode.Aggregate,
+          groupby: ['state'],
+          metrics: [simpleMetric],
+          show_totals: true,
+          totals_aggregate: 'AVG',
+        },
+        { ownState: {} },
+      );
+
+      // Main query keeps the metric's own aggregation.
+      expect(queries[0].metrics).toEqual([simpleMetric]);
+      // Summary query uses the chosen totals aggregate instead.
+      expect(queries[1].metrics).toEqual([
+        { ...simpleMetric, aggregate: 'AVG' },
+      ]);
+    });
+
+    test('applies totals_aggregate to raw-mode summary columns', () => {
+      const { queries } = buildQuery(
+        { ...rawFormData, totals_aggregate: 'AVG' },
+        { ownState: { rawSummaryColumns: ['num'] } },
+      );
+
+      expect(queries[1].metrics).toEqual([
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'AVG',
+          column: { column_name: 'num' },
+          label: 'num',
+        },
+      ]);
+    });
   });
 
   describe('buildQuery - server pagination row limit', () => {

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -34,6 +34,7 @@ import {
   getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
+  TotalsAggregate,
 } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
@@ -348,10 +349,12 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
       formData.show_totals &&
       queryMode === QueryMode.Aggregate
     ) {
+      const totalsAggregate: TotalsAggregate =
+        formData.totals_aggregate === 'AVG' ? 'AVG' : 'SUM';
       extraQueries.push({
         ...queryObject,
         columns: [],
-        metrics: getTotalsMetrics(metrics, formData.totals_aggregate ?? 'SUM'),
+        metrics: getTotalsMetrics(metrics, totalsAggregate),
         row_limit: 0,
         row_offset: 0,
         // Reapply only the percent-metric contribution rule so the totals row

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -31,6 +31,7 @@ import {
 } from '@superset-ui/core';
 
 import {
+  getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
 } from '@superset-ui/chart-controls';
@@ -350,6 +351,7 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
       extraQueries.push({
         ...queryObject,
         columns: [],
+        metrics: getTotalsMetrics(metrics, formData.totals_aggregate ?? 'SUM'),
         row_limit: 0,
         row_offset: 0,
         // Reapply only the percent-metric contribution rule so the totals row

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -468,6 +468,31 @@ const config: ControlPanelConfig = {
             },
           },
         ],
+        [
+          {
+            name: 'totals_aggregate',
+            config: {
+              type: 'SelectControl',
+              label: t('Summary aggregation'),
+              description: t(
+                'Aggregation used for the summary row, independent of each ' +
+                  "metric's own aggregation. Only applies to simple metrics " +
+                  '(a metric built from custom SQL keeps its own aggregation ' +
+                  'in the summary row).',
+              ),
+              default: 'SUM',
+              clearable: false,
+              choices: [
+                ['SUM', t('Sum')],
+                ['AVG', t('Average')],
+              ],
+              visibility: ({ controls }) =>
+                isAggMode({ controls }) &&
+                Boolean(controls?.show_totals?.value),
+              resetOnHide: false,
+            },
+          },
+        ],
       ],
     },
     {

--- a/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -332,6 +332,71 @@ describe('plugin-chart-table', () => {
       });
     });
 
+    describe('Totals Aggregation', () => {
+      const simpleMetric = {
+        expressionType: 'SIMPLE' as const,
+        column: { column_name: 'sales' },
+        aggregate: 'SUM' as const,
+        label: 'sum_sales',
+      };
+
+      test('defaults the totals query metric aggregate to SUM', () => {
+        const { queries } = buildQueryCached({
+          ...basicFormData,
+          query_mode: QueryMode.Aggregate,
+          metrics: [simpleMetric],
+          groupby: ['category'],
+          show_totals: true,
+        });
+
+        expect(queries).toHaveLength(2);
+        expect(queries[1].metrics).toEqual([
+          { ...simpleMetric, aggregate: 'SUM' },
+        ]);
+      });
+
+      test('overrides simple metric aggregate with totals_aggregate for the summary query only', () => {
+        const { queries } = buildQueryCached({
+          ...basicFormData,
+          query_mode: QueryMode.Aggregate,
+          metrics: [simpleMetric],
+          groupby: ['category'],
+          show_totals: true,
+          totals_aggregate: 'AVG',
+        });
+
+        expect(queries).toHaveLength(2);
+        // Main query keeps the metric's own aggregation.
+        expect(queries[0].metrics).toEqual([simpleMetric]);
+        // Summary query uses the chosen totals aggregate instead.
+        expect(queries[1].metrics).toEqual([
+          { ...simpleMetric, aggregate: 'AVG' },
+        ]);
+      });
+
+      test('leaves custom SQL and saved metrics untouched in the summary query', () => {
+        const sqlMetric = {
+          expressionType: 'SQL' as const,
+          sqlExpression: 'COUNT(DISTINCT user_id)',
+          label: 'unique_users',
+        };
+        const { queries } = buildQueryCached({
+          ...basicFormData,
+          query_mode: QueryMode.Aggregate,
+          metrics: [simpleMetric, sqlMetric, 'saved_metric'],
+          groupby: ['category'],
+          show_totals: true,
+          totals_aggregate: 'AVG',
+        });
+
+        expect(queries[1].metrics).toEqual([
+          { ...simpleMetric, aggregate: 'AVG' },
+          sqlMetric,
+          'saved_metric',
+        ]);
+      });
+    });
+
     describe('Testing for server pagination with search filter', () => {
       const baseFormDataWithServerPagination: TableChartFormData = {
         ...basicFormData,

--- a/tests/integration_tests/non_additive_totals_tests.py
+++ b/tests/integration_tests/non_additive_totals_tests.py
@@ -190,6 +190,44 @@ class TestNonAdditiveTotalsTable(SupersetTestCase):
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+class TestTableTotalsAggregateOverride(SupersetTestCase):
+    """
+    #43021: "Show summary" lets a user choose the totals row's aggregation
+    (Sum or Average) independently of each metric's own aggregation. The
+    frontend (``getTotalsMetrics``) implements this by cloning a SIMPLE
+    metric with its ``aggregate`` swapped for just the totals query. Since
+    that query has no GROUP BY, the database evaluates the swapped
+    aggregate fresh over every row -- this guard pins that an AVG override
+    is a true row-level average (SUM / COUNT over all rows), not the
+    metric's own SUM aggregation and not a naive average of per-group sums.
+    """
+
+    def test_avg_totals_aggregate_matches_sum_over_count(self):
+        self.login("admin")
+
+        sum_metric = {
+            "expressionType": "SIMPLE",
+            "column": {"column_name": "num"},
+            "aggregate": "SUM",
+            "label": "sum__num",
+        }
+        count_metric = {
+            "expressionType": "SIMPLE",
+            "column": {"column_name": "num"},
+            "aggregate": "COUNT",
+            "label": "count__num",
+        }
+        avg_metric = {**sum_metric, "aggregate": "AVG", "label": "avg__num"}
+
+        total_sum = _result_df(_base_payload(sum_metric, []))["sum__num"].iloc[0]
+        total_count = _result_df(_base_payload(count_metric, []))["count__num"].iloc[0]
+        avg_total = _result_df(_base_payload(avg_metric, []))["avg__num"].iloc[0]
+
+        assert avg_total == pytest.approx(total_sum / total_count)
+        assert avg_total != pytest.approx(total_sum)
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
 class TestTablePercentMetricSummary(SupersetTestCase):
     """
     #37627 / #34350: a Table "Percentage metrics" column must appear in the

--- a/tests/integration_tests/non_additive_totals_tests.py
+++ b/tests/integration_tests/non_additive_totals_tests.py
@@ -223,6 +223,10 @@ class TestTableTotalsAggregateOverride(SupersetTestCase):
         total_count = _result_df(_base_payload(count_metric, []))["count__num"].iloc[0]
         avg_total = _result_df(_base_payload(avg_metric, []))["avg__num"].iloc[0]
 
+        # Guard the fixture itself: the second assertion below only proves
+        # AVG != SUM when there's more than one row to average over.
+        assert total_count > 1
+
         assert avg_total == pytest.approx(total_sum / total_count)
         assert avg_total != pytest.approx(total_sum)
 


### PR DESCRIPTION
### SUMMARY
Today the "Show summary" (`show_totals`) row in the Table chart and AG Grid Table chart always uses whatever aggregation the underlying metric already specifies (e.g. a `SUM(x)` metric totals as a sum). A user displaying an `AVG`/rate/score metric per row has no way to get a meaningful summary — they'd have to add a second, differently-aggregated metric and hide/relabel it, which doesn't work at all for Aggregate-mode metrics that are already pre-aggregated.

This adds a `totals_aggregate` control (Sum / Average, default Sum, only visible when "Show summary" is on) that lets the user pick the totals row's aggregation independently of each metric's own aggregation. It's implemented via a new shared `getTotalsMetrics` utility (`@superset-ui/chart-controls`) that clones each **Simple (adhoc)** metric with its `aggregate` swapped, used by both plugins' totals query construction.

This is safe because the "Show summary" row is produced by a **separate query with no `GROUP BY`** (`columns: []`) — the database evaluates each metric fresh over all rows, so swapping the aggregate for just that query is a correct, independent computation, not a re-aggregation of already-aggregated per-row values (the class of bug [SIP-216](https://github.com/apache/superset/issues/41463) fixed for Pivot Table subtotals via `GROUPING SETS`).

No backend changes are required: `show_totals` has always been a frontend-only form-data key, and `ChartDataAdhocMetricSchema` already accepts `AVG` for any Simple metric on any query object.

**Known limitations (out of scope for this PR):**
- **Median is not supported.** There's no universal SQL `MEDIAN` — Postgres needs `PERCENTILE_CONT(0.5) WITHIN GROUP (...)`, MySQL <8 lacks it entirely — so it needs new backend aggregate-function support. Will be filed as a follow-up issue linked from here.
- **Custom-SQL and saved (string) metrics keep their own native aggregate** in the totals row; the Sum/Average override only applies to Simple (adhoc) metrics, since there's no safe way to rewrite an arbitrary SQL expression's aggregate function without parsing it.

Fixes #43021
Related: #41463 / #41184 (SIP-216 — same underlying "totals row aggregation" concern, but for making totals *correct* for whatever aggregation a metric already uses, on Pivot Table only)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this PR was implemented and verified via automated tests only (see Testing instructions); no interactive browser session was available to capture screenshots.

### TESTING INSTRUCTIONS
1. Create/open a Table (or AG Grid Table) chart in Aggregate mode with a `SUM`-aggregated Simple metric, group by a dimension.
2. Enable **Show summary** — note the new **Summary aggregation** dropdown appears underneath, defaulted to "Sum".
3. Confirm the summary row shows the sum of the metric (unchanged behavior).
4. Switch **Summary aggregation** to "Average" and re-run the query. Confirm the summary row now shows the average of the metric across all underlying rows (verify against a manual `AVG()` query) — not the sum, and not a naive average of the displayed per-row values.
5. Repeat for AG Grid Table in both Aggregate mode and Raw/records query mode (the summary columns primed via `rawSummaryColumns`).
6. Add a custom-SQL metric or a saved metric alongside a Simple metric; confirm its totals-row value is unaffected by the Summary aggregation setting (it keeps using its own native aggregation).

Automated coverage added:
- `plugin-chart-table/test/buildQuery.test.ts` — new `Totals Aggregation` describe block (default SUM, AVG override, SQL/saved metrics pass through unchanged).
- `plugin-chart-ag-grid-table/test/buildQuery.test.ts` — new cases for aggregate-mode and raw-mode totals aggregate override.
- `tests/integration_tests/non_additive_totals_tests.py` — new `TestTableTotalsAggregateOverride`, an end-to-end guard (against the real `birth_names` fixture) that an AVG-override totals query returns a true `SUM / COUNT` row-level average, not the metric's own SUM.

All frontend unit tests for the two plugin packages pass locally (456/456), `tsc --build` is clean, and `pre-commit run` is green on the changed files. The new backend integration test could not be run in this environment (pre-existing local test-DB migration issue unrelated to this change — reproduced with pre-existing tests in the same file) and should be verified in CI.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #43021
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API