### PR TITLE
chore(deps): bump sqlglot from 30.15.0 to 30.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
     "sqlalchemy>=1.4.43, <2", # 1.4.43 adds the python-oracledb (oracle+oracledb) dialect
     "sqlalchemy-continuum>=1.6.0, <2.0.0",
     "sqlalchemy-utils>=0.42.1, <0.43", # expanding lowerbound to work with pydoris
-    "sqlglot>=30.14.0, <31",
+    "sqlglot>=30.16.0, <31", # 30.16.0 adds Trino inline UDF IF/CASE routine statement parsing
     # newer pandas needs 0.9+
     "tabulate>=0.10.0, <1.0",
     "typing-extensions>=4.16.0, <5",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -418,7 +418,7 @@ sqlalchemy-utils==0.42.1
     #   apache-superset (pyproject.toml)
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==30.15.0
+sqlglot==30.16.0
     # via
     #   apache-superset (pyproject.toml)
     #   apache-superset-core

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1002,7 +1002,7 @@ sqlalchemy-utils==0.42.1
     #   apache-superset
     #   apache-superset-core
     #   flask-appbuilder
-sqlglot==30.15.0
+sqlglot==30.16.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset


### PR DESCRIPTION
### SUMMARY
Bumps sqlglot from 30.15.0 to 30.16.0, picking up Trino inline SQL UDF routine-statement parsing support (`IF`/`ELSEIF`/`ELSE` in [tobymao/sqlglot#8044](https://github.com/tobymao/sqlglot/pull/8044), `CASE`/`WHEN`/`END CASE` in [#8068](https://github.com/tobymao/sqlglot/pull/8068)).

Fixes #26162. The exact query reported there:

```sql
WITH FUNCTION simple_case(a bigint)
RETURNS varchar
BEGIN
  CASE a
    WHEN 0 THEN RETURN 'zero';
    WHEN 1 THEN RETURN 'one';
    WHEN 10 THEN RETURN 'ten';
    WHEN 20 THEN RETURN 'twenty';
    ELSE RETURN 'other';
  END CASE;
  RETURN NULL;
END
SELECT simple_case(0);
```

now parses as a single statement instead of 8 (the root cause reported in the issue: sqlglot was splitting on every semicolon inside the routine body, including the ones inside `BEGIN`/`CASE` blocks). Verified against the actual released 30.16.0 package: it parses to one top-level statement, round-trips correctly, and Superset's own scope-based `extract_tables_from_statement` correctly still finds only the query's real `FROM`-clause table, not the UDF's own name (sqlglot represents a UDF's name internally with the same `exp.Table` wrapper used for real table references, but the scope-aware extraction already excludes it since it's not an actual `FROM`/`JOIN` source).

### Follow-up work
`WHILE`/`DO`/`END WHILE` and `LOOP`/`REPEAT`/`ITERATE`/`LEAVE` Trino routine statements aren't supported upstream yet (`WHILE` is in review at [tobymao/sqlglot#8122](https://github.com/tobymao/sqlglot/pull/8122), the rest hasn't been started). Trino UDFs using those constructs will still fail to parse until that work lands and gets released. #41803 (a custom Trino dialect covering the full grammar today, as a stopgap) stays open in draft to cover that gap in the meantime.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/sql/` and the existing Trino dialect tests should pass unchanged. Manually, with a Trino 458+ database connected, paste the query above into SQL Lab and run it — should return `zero`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #26162
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API