### PR TITLE
fix(reports): fail closed on alert screenshot capture instead of delivering a blank

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -131,6 +131,29 @@ def resolve_executor_user(model: ReportSchedule) -> tuple["User", str]:
     return user, username
 
 
+def _should_build_execution_context(model: ReportSchedule) -> bool:
+    """
+    Whether an execution should run under a :class:`ReportExecutionContext`.
+
+    Reports always do — their behavior is unchanged. Alerts join them only when
+    they deliver a rendered PNG/PDF screenshot to recipients, which happens when
+    ``ALERTS_ATTACH_REPORTS`` is enabled. Delivered screenshots must fail closed:
+    the context selects the fail-closed readiness predicate and disables
+    partial-tile fallback, so a blank or incomplete capture raises instead of
+    being delivered.
+
+    CSV/text alerts, alerts without the attach flag, the non-delivered
+    query-context capture, and UI thumbnails are deliberately excluded and keep
+    their lenient capture contract.
+    """
+    if model.type == ReportScheduleType.REPORT:
+        return True
+    return model.report_format in (
+        ReportDataFormat.PNG,
+        ReportDataFormat.PDF,
+    ) and feature_flag_manager.is_feature_enabled("ALERTS_ATTACH_REPORTS")
+
+
 def log_report_delivery_phase(
     report_context: ReportExecutionContext | None,
     recipient_type: ReportRecipientType | None,
@@ -1963,13 +1986,13 @@ class ReportSuccessState(BaseReportState):
 
         try:
             self.send()
-        except Exception as ex:  # pylint: disable=broad-except
-            if self._handle_retry_or_error(str(ex), ex):
+        except Exception as first_ex:  # pylint: disable=broad-except
+            if self._handle_retry_or_error(str(first_ex), first_ex):
                 return  # retry scheduled — exit cleanly
 
             try:
                 self.update_report_schedule_and_log(
-                    ReportState.ERROR, error_message=str(ex)
+                    ReportState.ERROR, error_message=str(first_ex)
                 )
             except (ReportScheduleUnexpectedError, SQLAlchemyError) as logging_ex:
                 # Logging failed (likely StaleDataError), but we still want to
@@ -1982,7 +2005,45 @@ class ReportSuccessState(BaseReportState):
                     exc_info=True,
                 )
                 # Re-raise the original exception, not the logging failure
-                raise ex from logging_ex
+                raise first_ex from logging_ex
+
+            # A delivery failure from the Success/Grace path must notify the
+            # owner just like the first-run path (ReportNotTriggeredErrorState).
+            # Without this, a schedule whose previous run succeeded would fail
+            # silently — e.g. once a screenshot capture starts failing closed.
+            # The error grace period still throttles repeated notifications.
+            if not self.is_in_error_grace_period():
+                second_error_message = REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER
+                try:
+                    self.send_error(
+                        f"Error occurred for {self._report_schedule.type}:"
+                        f" {self._report_schedule.name}",
+                        str(first_ex),
+                    )
+                except SupersetErrorsException as second_ex:
+                    second_error_message = ";".join(
+                        [error.message for error in second_ex.errors]
+                    )
+                except ReportScheduleUnexpectedError:
+                    # send_error failed due to logging issue; log and continue
+                    # to raise the original error
+                    logger.warning(
+                        "Failed to send error notification due to database issue",
+                        exc_info=True,
+                    )
+                except Exception as second_ex:  # pylint: disable=broad-except
+                    second_error_message = str(second_ex)
+                finally:
+                    try:
+                        self.update_report_schedule_and_log(
+                            ReportState.ERROR, error_message=second_error_message
+                        )
+                    except ReportScheduleUnexpectedError:
+                        # Logging failed again; log it but don't hide first_ex
+                        logger.warning(
+                            "Failed to log final error state due to database issue",
+                            exc_info=True,
+                        )
             raise
 
         # send() succeeded — clear retry state and log success.
@@ -2054,13 +2115,18 @@ class AsyncExecuteReportScheduleCommand(BaseCommand):
             if not self._model:
                 raise ReportScheduleExecuteUnexpectedError()
 
-            if self._model.type == ReportScheduleType.REPORT:
+            # Reports always run under an execution context; alerts join them
+            # only when they deliver a rendered screenshot, so a blank/partial
+            # capture fails closed instead of being delivered. Ownership and
+            # terminal-error persistence remain report-only recovery semantics.
+            if _should_build_execution_context(self._model):
                 # An invocation that enters on WORKING is a duplicate or stale
                 # recovery, not the owner that created the active row. Its state
                 # handler may terminalize a stale execution, but the command
                 # boundary must never infer ownership from a replayed UUID.
                 owns_report_working_state = (
-                    self._model.last_state != ReportState.WORKING
+                    self._model.type == ReportScheduleType.REPORT
+                    and self._model.last_state != ReportState.WORKING
                 )
                 total_seconds = resolve_report_execution_budget_seconds(
                     app.config,

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -3038,7 +3038,7 @@ def test_success_state_send_failure_notifies_owner(
     # False immediately without sending anything.
     mocker.patch.object(state, "is_in_grace_period", return_value=False)
     mocker.patch.object(state, "is_in_error_grace_period", return_value=False)
-    mocker.patch.object(state, "update_report_schedule_and_log")
+    mock_update = mocker.patch.object(state, "update_report_schedule_and_log")
     mock_send_error = mocker.patch.object(state, "send_error")
     if schedule_type == ReportScheduleType.ALERT:
         mocker.patch(
@@ -3054,6 +3054,10 @@ def test_success_state_send_failure_notifies_owner(
         state.next()
 
     mock_send_error.assert_called_once()
+    # The owner-notification path must also persist a terminal ERROR state,
+    # not leave the schedule stuck in WORKING (mirrors how the grace-period
+    # sibling test asserts the recorded terminal state).
+    assert mock_update.call_args_list[-1].args[0] == ReportState.ERROR
 
 
 def test_success_state_send_failure_skips_notification_in_error_grace(
@@ -3079,6 +3083,73 @@ def test_success_state_send_failure_skips_notification_in_error_grace(
     mock_send_error.assert_not_called()
     states = [call.args[0] for call in mock_update.call_args_list]
     assert ReportState.ERROR in states
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_message"),
+    [
+        ("superset_errors", "smtp down;retry failed"),
+        ("generic", "smtp down"),
+    ],
+)
+def test_success_state_send_error_failure_overwrites_marker(
+    mocker: MockerFixture,
+    failure_kind: str,
+    expected_message: str,
+) -> None:
+    """When the Success/Grace path's own error notification fails, the
+    placeholder marker is overwritten with the real failure message before
+    ERROR is logged -- mirroring the first-run (ReportNotTriggeredErrorState)
+    path. A SupersetErrorsException contributes its joined error messages; any
+    other exception contributes its ``str()``."""
+    from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+    from superset.exceptions import SupersetErrorsException
+
+    if failure_kind == "superset_errors":
+        send_error_exc: Exception = SupersetErrorsException(
+            [
+                SupersetError(
+                    message="smtp down",
+                    error_type=SupersetErrorType.REPORT_NOTIFICATION_ERROR,
+                    level=ErrorLevel.ERROR,
+                ),
+                SupersetError(
+                    message="retry failed",
+                    error_type=SupersetErrorType.REPORT_NOTIFICATION_ERROR,
+                    level=ErrorLevel.ERROR,
+                ),
+            ]
+        )
+    else:
+        send_error_exc = RuntimeError("smtp down")
+
+    state = _make_state_instance(
+        mocker, ReportSuccessState, schedule_type=ReportScheduleType.REPORT
+    )
+    mocker.patch.object(state, "is_in_error_grace_period", return_value=False)
+    mock_update = mocker.patch.object(state, "update_report_schedule_and_log")
+    mock_send_error = mocker.patch.object(
+        state, "send_error", side_effect=send_error_exc
+    )
+    mocker.patch.object(
+        state,
+        "send",
+        side_effect=ReportScheduleScreenshotFailedError("blank screenshot"),
+    )
+
+    with pytest.raises(ReportScheduleScreenshotFailedError, match="blank screenshot"):
+        state.next()
+
+    mock_send_error.assert_called_once()
+    # The placeholder marker must be replaced by the real notification failure
+    # before the terminal ERROR row is written.
+    final_call = mock_update.call_args_list[-1]
+    assert final_call.args[0] == ReportState.ERROR
+    assert final_call.kwargs.get("error_message") == expected_message
+    assert (
+        final_call.kwargs.get("error_message")
+        != REPORT_SCHEDULE_ERROR_NOTIFICATION_MARKER
+    )
 
 
 def test_get_url_for_csv_uses_post_processed_type(

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -43,6 +43,7 @@ from superset.commands.report.exceptions import (
     ReportScheduleXlsxFailedError,
 )
 from superset.commands.report.execute import (
+    _should_build_execution_context,
     BaseReportState,
     log_report_delivery_phase,
     persist_owned_report_execution_terminal_error,
@@ -2590,6 +2591,8 @@ def test_success_state_send_error_logs_and_reraises(
         mocker, ReportSuccessState, schedule_type=ReportScheduleType.REPORT
     )
     mocker.patch.object(state, "send", side_effect=RuntimeError("send boom"))
+    mocker.patch.object(state, "is_in_error_grace_period", return_value=False)
+    mocker.patch.object(state, "send_error")
     mocker.patch.object(state, "update_report_schedule_and_log")
 
     with pytest.raises(RuntimeError, match="send boom"):
@@ -2649,6 +2652,46 @@ def test_get_notification_content_alert_no_flag_skips_attachment(
     mock_screenshots.assert_not_called()
     assert content.screenshots == []
     assert content.text is None
+
+
+@pytest.mark.parametrize(
+    ("schedule_type", "report_format", "attach_flag", "expected"),
+    [
+        # Reports always run under an execution context, regardless of format.
+        (ReportScheduleType.REPORT, ReportDataFormat.PNG, False, True),
+        (ReportScheduleType.REPORT, ReportDataFormat.PDF, False, True),
+        (ReportScheduleType.REPORT, ReportDataFormat.CSV, False, True),
+        (ReportScheduleType.REPORT, ReportDataFormat.TEXT, False, True),
+        # Alerts that deliver a rendered screenshot fail closed only when the
+        # ALERTS_ATTACH_REPORTS flag is on (otherwise no artifact is attached).
+        (ReportScheduleType.ALERT, ReportDataFormat.PNG, True, True),
+        (ReportScheduleType.ALERT, ReportDataFormat.PDF, True, True),
+        (ReportScheduleType.ALERT, ReportDataFormat.PNG, False, False),
+        (ReportScheduleType.ALERT, ReportDataFormat.PDF, False, False),
+        # CSV/text/xlsx alerts never deliver a rendered screenshot; they stay
+        # lenient even with the attach flag on.
+        (ReportScheduleType.ALERT, ReportDataFormat.CSV, True, False),
+        (ReportScheduleType.ALERT, ReportDataFormat.TEXT, True, False),
+        (ReportScheduleType.ALERT, ReportDataFormat.XLSX, True, False),
+    ],
+)
+@patch("superset.commands.report.execute.feature_flag_manager")
+def test_should_build_execution_context(
+    mock_ff: MagicMock,
+    mocker: MockerFixture,
+    schedule_type: ReportScheduleType,
+    report_format: ReportDataFormat,
+    attach_flag: bool,
+    expected: bool,
+) -> None:
+    """Only reports and rendered-screenshot alerts run fail closed under a
+    ReportExecutionContext; CSV/text alerts and flag-off alerts stay lenient."""
+    mock_ff.is_feature_enabled.return_value = attach_flag
+    model = mocker.Mock(spec=ReportSchedule)
+    model.type = schedule_type
+    model.report_format = report_format
+
+    assert _should_build_execution_context(model) is expected
 
 
 def test_create_log_success_commits(mocker: MockerFixture) -> None:
@@ -2972,6 +3015,68 @@ def test_success_state_error_logged_when_send_error_raises(
         state.next()
 
     # ...but ERROR was still logged despite send_error() failing.
+    states = [call.args[0] for call in mock_update.call_args_list]
+    assert ReportState.ERROR in states
+
+
+@pytest.mark.parametrize(
+    "schedule_type",
+    [ReportScheduleType.REPORT, ReportScheduleType.ALERT],
+)
+def test_success_state_send_failure_notifies_owner(
+    mocker: MockerFixture,
+    schedule_type: ReportScheduleType,
+) -> None:
+    """A delivery failure from the Success/Grace path must notify the owner,
+    mirroring the first-run (ReportNotTriggeredErrorState) path — otherwise a
+    previously-successful schedule fails silently (e.g. once a screenshot
+    capture starts failing closed)."""
+    state = _make_state_instance(
+        mocker, ReportSuccessState, schedule_type=schedule_type
+    )
+    # No retries configured (the default), so _handle_retry_or_error returns
+    # False immediately without sending anything.
+    mocker.patch.object(state, "is_in_grace_period", return_value=False)
+    mocker.patch.object(state, "is_in_error_grace_period", return_value=False)
+    mocker.patch.object(state, "update_report_schedule_and_log")
+    mock_send_error = mocker.patch.object(state, "send_error")
+    if schedule_type == ReportScheduleType.ALERT:
+        mocker.patch(
+            "superset.commands.report.execute.AlertCommand"
+        ).return_value.run.return_value = (True, "triggered")
+    mocker.patch.object(
+        state,
+        "send",
+        side_effect=ReportScheduleScreenshotFailedError("blank screenshot"),
+    )
+
+    with pytest.raises(ReportScheduleScreenshotFailedError, match="blank screenshot"):
+        state.next()
+
+    mock_send_error.assert_called_once()
+
+
+def test_success_state_send_failure_skips_notification_in_error_grace(
+    mocker: MockerFixture,
+) -> None:
+    """When inside the error grace period, the Success/Grace path logs ERROR
+    but suppresses the (throttled) error notification."""
+    state = _make_state_instance(
+        mocker, ReportSuccessState, schedule_type=ReportScheduleType.REPORT
+    )
+    mocker.patch.object(state, "is_in_error_grace_period", return_value=True)
+    mock_update = mocker.patch.object(state, "update_report_schedule_and_log")
+    mock_send_error = mocker.patch.object(state, "send_error")
+    mocker.patch.object(
+        state,
+        "send",
+        side_effect=ReportScheduleScreenshotFailedError("blank screenshot"),
+    )
+
+    with pytest.raises(ReportScheduleScreenshotFailedError):
+        state.next()
+
+    mock_send_error.assert_not_called()
     states = [call.args[0] for call in mock_update.call_args_list]
     assert ReportState.ERROR in states
 


### PR DESCRIPTION
### SUMMARY

Scheduled **alerts** that attach a dashboard/chart screenshot (PNG/PDF) could deliver a **blank or partial image** on large or slow-rendering dashboards, while scheduled **reports** were already protected.

**Root cause.** `AsyncExecuteReportScheduleCommand.run()` built a `ReportExecutionContext` only when `type == REPORT`. Alerts ran with `report_execution_context=None`, and in `superset/utils/screenshot_utils.py` that `None`:

- selects the lenient readiness predicate (`CHART_HOLDERS_READY_JS`) instead of the fail-closed `REPORT_CHART_HOLDERS_READY_JS`, and
- sets `allow_partial_fallback=True`,

so partial/blank tiles were combined and delivered instead of failing.

**Fix.** Route alerts that deliver a rendered screenshot (PNG/PDF with `ALERTS_ATTACH_REPORTS` enabled) through the same execution context reports use, so a blank/incomplete capture raises `ReportScheduleScreenshotFailedError` and hands off to the **existing** retry/notification and error-handling machinery. The `type == REPORT` discriminator is replaced with an explicit "delivers a rendered artifact" check (`_should_build_execution_context`).

Deliberately left **unchanged / lenient**: CSV/text alerts, alerts without the attach flag, the non-delivered query-context capture (used to force a chart's saved query context), and UI thumbnails. Report behavior is unchanged (reports still always run under a context, regardless of format).

**Secondary fix.** `ReportSuccessState` (the Success/Grace path) logged `ERROR` on a delivery failure but did **not** notify the owner, unlike the first-run `ReportNotTriggeredErrorState` path which calls `send_error()`. A schedule whose previous run succeeded and then failed to deliver would fail silently — the common case once screenshots fail closed. The Success/Grace path now sends the owner error notification (respecting the error grace period), mirroring the first-run path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (no UI change).

### TESTING INSTRUCTIONS

Automated (unit):

- `_should_build_execution_context` is `True` for all reports and for PNG/PDF alerts when `ALERTS_ATTACH_REPORTS` is enabled; `False` for CSV/text/xlsx alerts and for alerts with the flag off — see `test_should_build_execution_context`.
- The Success/Grace path notifies the owner on a delivery failure and respects the error grace period — see `test_success_state_send_failure_notifies_owner` and `test_success_state_send_failure_skips_notification_in_error_grace`.
- The delivered-screenshot fail-open vs fail-closed contract at the tile-combine layer is already covered in `tests/unit_tests/utils/test_screenshot_utils.py`.

Run:

```bash
pytest tests/unit_tests/commands/report/ \
       tests/unit_tests/utils/test_screenshot_utils.py \
       tests/unit_tests/utils/test_report_execution.py \
       tests/unit_tests/reports/
```

Manual: configure an alert with a PNG/PDF screenshot attachment (`ALERTS_ATTACH_REPORTS` on) against a large/slow dashboard. Instead of emailing a blank image, the execution now fails closed and follows the schedule's configured retry/error-notification behavior.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ALERTS_ATTACH_REPORTS` (governs whether alerts attach a rendered screenshot; the fail-closed path applies only when it is enabled)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API