### PR TITLE
fix(dataset): apply datasource-access check consistently on repoint

### DIFF
--- a/superset/commands/dataset/source.py
+++ b/superset/commands/dataset/source.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared handling of the source a dataset reads from."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from superset import security_manager
+from superset.models.core import Database
+from superset.sql.parse import Table
+
+
+class DatasetSource(NamedTuple):
+    """
+    Where a dataset reads its rows from.
+
+    A dataset is either virtual, reading through ``sql``, or physical, reading
+    through ``table_name``. Either way the read is qualified by a connection,
+    a catalog and a schema.
+    """
+
+    database_id: int | None
+    catalog: str | None
+    schema: str | None
+    table_name: str
+    sql: str | None
+
+    @classmethod
+    def build(
+        cls,
+        database_id: int | None,
+        catalog: str | None,
+        schema: str | None,
+        table_name: str,
+        sql: str | None,
+    ) -> DatasetSource:
+        """Build a source, treating blank catalog, schema and SQL as null."""
+        return cls(
+            database_id,
+            catalog or None,
+            schema or None,
+            table_name,
+            sql or None,
+        )
+
+    @property
+    def table(self) -> Table:
+        return Table(self.table_name, self.schema, self.catalog)
+
+    def resolve_catalog(self, default_catalog: str | None) -> DatasetSource:
+        """Return this source with a null catalog resolved to ``default_catalog``."""
+        return self._replace(catalog=self.catalog or default_catalog)
+
+    def moved_from(self, other: DatasetSource) -> bool:
+        """
+        Whether this source reads from somewhere other than ``other``.
+
+        The name only counts for physical datasets: renaming a virtual dataset
+        relabels it without changing what it reads. Turning a virtual dataset
+        physical, or the reverse, always counts as a move.
+        """
+        if (self.database_id, self.catalog, self.schema) != (
+            other.database_id,
+            other.catalog,
+            other.schema,
+        ) or bool(self.sql) != bool(other.sql):
+            return True
+        if self.sql:
+            return self.sql != other.sql
+        return self.table_name != other.table_name
+
+
+def raise_for_source_access(database: Database, source: DatasetSource) -> None:
+    """
+    Authorise the source a dataset reads from.
+
+    The two branches mirror ``CreateDatasetCommand``: SQL for virtual datasets,
+    ``database`` plus ``table`` for physical ones. Every path that points a
+    dataset at a source runs this, so that a dataset cannot be used to reach a
+    connection, table or query the caller lacks access to.
+
+    :param database: the connection the dataset will read through
+    :param source: the source the dataset will read from
+    :raises SupersetSecurityException: if the user cannot access the source
+    :raises SupersetParseError: if the SQL cannot be parsed
+    """
+    if source.sql:
+        security_manager.raise_for_access(
+            database=database,
+            sql=source.sql,
+            catalog=source.catalog,
+            schema=source.schema,
+        )
+    else:
+        security_manager.raise_for_access(database=database, table=source.table)

--- a/superset/commands/dataset/source.py
+++ b/superset/commands/dataset/source.py
@@ -62,21 +62,28 @@ class DatasetSource(NamedTuple):
     def table(self) -> Table:
         return Table(self.table_name, self.schema, self.catalog)
 
-    def resolve_catalog(self, default_catalog: str | None) -> DatasetSource:
-        """Return this source with a null catalog resolved to ``default_catalog``."""
-        return self._replace(catalog=self.catalog or default_catalog)
-
-    def moved_from(self, other: DatasetSource) -> bool:
+    def moved_from(
+        self,
+        other: DatasetSource,
+        default_catalog: str | None = None,
+    ) -> bool:
         """
         Whether this source reads from somewhere other than ``other``.
+
+        A null catalog reads through the connection's default, so both sides
+        resolve nulls to ``default_catalog`` before being compared.
 
         The name only counts for physical datasets: renaming a virtual dataset
         relabels it without changing what it reads. Turning a virtual dataset
         physical, or the reverse, always counts as a move.
         """
-        if (self.database_id, self.catalog, self.schema) != (
+        if (
+            self.database_id,
+            self.catalog or default_catalog,
+            self.schema,
+        ) != (
             other.database_id,
-            other.catalog,
+            other.catalog or default_catalog,
             other.schema,
         ) or bool(self.sql) != bool(other.sql):
             return True
@@ -89,10 +96,10 @@ def raise_for_source_access(database: Database, source: DatasetSource) -> None:
     """
     Authorise the source a dataset reads from.
 
-    The two branches mirror ``CreateDatasetCommand``: SQL for virtual datasets,
-    ``database`` plus ``table`` for physical ones. Every path that points a
-    dataset at a source runs this, so that a dataset cannot be used to reach a
-    connection, table or query the caller lacks access to.
+    The two branches match the create path: SQL for virtual datasets,
+    ``database`` plus ``table`` for physical ones. Every path that points an
+    existing dataset at a new source runs this, so that a dataset cannot be
+    used to reach a connection, table or query the caller lacks access to.
 
     :param database: the connection the dataset will read through
     :param source: the source the dataset will read from

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -210,12 +210,7 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
             self._model.table_name,
             self._model.sql,
         )
-        # A null catalog reads through the connection default, and single-catalog
-        # connections have already normalised the requested value to it, so both
-        # sides resolve nulls the same way before being compared.
-        if not requested.resolve_catalog(default_catalog).moved_from(
-            current.resolve_catalog(default_catalog)
-        ):
+        if not requested.moved_from(current, default_catalog):
             return
 
         try:

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -172,7 +172,56 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         ):
             exceptions.append(DatasetExistsValidationError(table))
 
+        self._validate_source_access(db, table, catalog, schema, exceptions)
+
+    def _validate_source_access(
+        self,
+        db: Database,
+        table: Table,
+        catalog: str | None,
+        schema: str | None,
+        exceptions: list[ValidationError],
+    ) -> None:
+        """
+        Enforce the datasource-access check whenever the dataset's source
+        changes, mirroring ``CreateDatasetCommand``.
+
+        The create path runs ``raise_for_access`` on every new dataset: the
+        SQL branch for virtual datasets, the physical branch (``database`` +
+        ``table``) for physical ones. On update the SQL branch already runs
+        when ``sql`` changes; this method adds the physical branch so that
+        moving a dataset to a different database connection (or physical
+        table) is authorised against that target the same way, instead of
+        only being gated by editorship of the existing model.
+        """
+        # we know we have a valid model
+        self._model = cast(SqlaTable, self._model)
+
         self._validate_sql_access(db, catalog, schema, exceptions)
+
+        # Physical branch: only relevant when the dataset is (or becomes)
+        # physical and the source moved. A SQL change is already covered by
+        # ``_validate_sql_access`` above.
+        sql = self._properties.get("sql")
+        if sql:
+            return
+
+        source_changed = (
+            db.id != self._model.database.id
+            or table.table != self._model.table_name
+            or (schema or None) != (self._model.schema or None)
+            or (catalog or None) != (self._model.catalog or None)
+        )
+        if not source_changed:
+            return
+
+        try:
+            security_manager.raise_for_access(
+                database=db,
+                table=table,
+            )
+        except SupersetSecurityException as ex:
+            exceptions.append(DatasetDataAccessIsNotAllowed(ex.error.message))
 
     def _validate_sql_access(
         self,

--- a/superset/commands/dataset/update.py
+++ b/superset/commands/dataset/update.py
@@ -44,6 +44,7 @@ from superset.commands.dataset.exceptions import (
     DatasetUpdateFailedError,
     MultiCatalogDisabledValidationError,
 )
+from superset.commands.dataset.source import DatasetSource, raise_for_source_access
 from superset.commands.utils import compute_subjects
 from superset.connectors.sqla.models import SqlaTable, validate_stored_expression
 from superset.daos.dataset import DatasetDAO
@@ -172,86 +173,62 @@ class UpdateDatasetCommand(UpdateMixin, BaseCommand):
         ):
             exceptions.append(DatasetExistsValidationError(table))
 
-        self._validate_source_access(db, table, catalog, schema, exceptions)
+        self._validate_source_access(db, table, default_catalog, exceptions)
 
     def _validate_source_access(
         self,
         db: Database,
         table: Table,
-        catalog: str | None,
-        schema: str | None,
+        default_catalog: str | None,
         exceptions: list[ValidationError],
     ) -> None:
         """
-        Enforce the datasource-access check whenever the dataset's source
-        changes, mirroring ``CreateDatasetCommand``.
+        Authorise the dataset's source whenever the update moves it, mirroring
+        ``CreateDatasetCommand``.
 
-        The create path runs ``raise_for_access`` on every new dataset: the
-        SQL branch for virtual datasets, the physical branch (``database`` +
-        ``table``) for physical ones. On update the SQL branch already runs
-        when ``sql`` changes; this method adds the physical branch so that
-        moving a dataset to a different database connection (or physical
-        table) is authorised against that target the same way, instead of
-        only being gated by editorship of the existing model.
+        The create path authorises every new dataset against what it will read.
+        The same applies here, derived from the *resulting* dataset rather than
+        from whichever keys the payload happens to carry, so that pointing a
+        dataset at a different connection, catalog, schema or table is
+        authorised against that target instead of only being gated by
+        editorship of the existing model.
         """
         # we know we have a valid model
         self._model = cast(SqlaTable, self._model)
 
-        self._validate_sql_access(db, catalog, schema, exceptions)
-
-        # Physical branch: only relevant when the dataset is (or becomes)
-        # physical and the source moved. A SQL change is already covered by
-        # ``_validate_sql_access`` above.
-        sql = self._properties.get("sql")
-        if sql:
-            return
-
-        source_changed = (
-            db.id != self._model.database.id
-            or table.table != self._model.table_name
-            or (schema or None) != (self._model.schema or None)
-            or (catalog or None) != (self._model.catalog or None)
+        requested = DatasetSource.build(
+            db.id,
+            table.catalog,
+            table.schema,
+            table.table,
+            self._properties.get("sql", self._model.sql),
         )
-        if not source_changed:
+        current = DatasetSource.build(
+            self._model.database.id,
+            self._model.catalog,
+            self._model.schema,
+            self._model.table_name,
+            self._model.sql,
+        )
+        # A null catalog reads through the connection default, and single-catalog
+        # connections have already normalised the requested value to it, so both
+        # sides resolve nulls the same way before being compared.
+        if not requested.resolve_catalog(default_catalog).moved_from(
+            current.resolve_catalog(default_catalog)
+        ):
             return
 
         try:
-            security_manager.raise_for_access(
-                database=db,
-                table=table,
-            )
+            raise_for_source_access(db, requested)
         except SupersetSecurityException as ex:
             exceptions.append(DatasetDataAccessIsNotAllowed(ex.error.message))
-
-    def _validate_sql_access(
-        self,
-        db: Database,
-        catalog: str | None,
-        schema: str | None,
-        exceptions: list[ValidationError],
-    ) -> None:
-        """Validate SQL query access if SQL is being updated."""
-        # we know we have a valid model
-        self._model = cast(SqlaTable, self._model)
-
-        sql = self._properties.get("sql")
-        if sql and sql != self._model.sql:
-            try:
-                security_manager.raise_for_access(
-                    database=db,
-                    sql=sql,
-                    catalog=catalog,
-                    schema=schema,
+        except SupersetParseError as ex:
+            exceptions.append(
+                ValidationError(
+                    f"Invalid SQL: {ex.error.message}",
+                    field_name="sql",
                 )
-            except SupersetSecurityException as ex:
-                exceptions.append(DatasetDataAccessIsNotAllowed(ex.error.message))
-            except SupersetParseError as ex:
-                exceptions.append(
-                    ValidationError(
-                        f"Invalid SQL: {ex.error.message}",
-                        field_name="sql",
-                    )
-                )
+            )
 
     def _validate_semantics(self, exceptions: list[ValidationError]) -> None:
         # we know we have a valid model

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -84,6 +84,17 @@ class Datasource(BaseSupersetView):
         orm_datasource = DatasourceDAO.get_datasource(
             DatasourceType(datasource_type), datasource_id
         )
+
+        try:
+            security_manager.raise_for_editorship(orm_datasource)
+        except SupersetSecurityException as ex:
+            raise DatasetForbiddenError() from ex
+
+        # The repoint and ``update_from_object`` below overwrite the stored
+        # source, so the move is authorised against the requested values. Both
+        # run only once every check has passed: the datasource is a live ORM
+        # object, so mutating it earlier would let a rejected save reach the
+        # database anyway on the next flush.
         current_source = DatasetSource.build(
             orm_datasource.database_id,
             orm_datasource.catalog,
@@ -91,18 +102,6 @@ class Datasource(BaseSupersetView):
             orm_datasource.table_name,
             orm_datasource.sql,
         )
-
-        try:
-            security_manager.raise_for_editorship(orm_datasource)
-        except SupersetSecurityException as ex:
-            raise DatasetForbiddenError() from ex
-
-        # The connection is repointed and ``update_from_object`` overwrites the
-        # table name, schema, catalog and SQL further down, so the move is
-        # authorised against the requested values rather than the stored ones.
-        # Both happen only once every check below has passed: the datasource is
-        # a live ORM object, so mutating it before then would let a rejected
-        # save reach the database anyway on the next flush.
         requested_source = DatasetSource.build(
             database_id,
             datasource_dict.get("catalog"),
@@ -110,7 +109,12 @@ class Datasource(BaseSupersetView):
             datasource_dict.get("table_name"),
             datasource_dict.get("sql"),
         )
-        if requested_source.moved_from(current_source):
+        # A null catalog reads through the connection's default. That only
+        # affects the comparison while the connection is unchanged, so the
+        # stored database's default resolves both sides.
+        if requested_source.moved_from(
+            current_source, orm_datasource.database.get_default_catalog()
+        ):
             target_database = DatasetDAO.get_database_by_id(database_id)
             if target_database is None:
                 return json_error_response(_("Database not found."), status=404)

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -90,6 +90,23 @@ class Datasource(BaseSupersetView):
         except SupersetSecurityException as ex:
             raise DatasetForbiddenError() from ex
 
+        # When the datasource is repointed to a different database connection,
+        # authorise the target the same way the create path does, so editing a
+        # datasource cannot be used to reach a connection the caller lacks
+        # access to. Mirrors the physical branch of ``CreateDatasetCommand``.
+        target_database = (
+            db.session.query(Database).filter_by(id=database_id).one_or_none()
+        )
+        if target_database is not None:
+            security_manager.raise_for_access(
+                database=target_database,
+                table=Table(
+                    orm_datasource.table_name,
+                    orm_datasource.schema,
+                    orm_datasource.catalog,
+                ),
+            )
+
         duplicates = [
             name
             for name, count in Counter(

--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -30,6 +30,7 @@ from superset.commands.dataset.exceptions import (
     DatasetForbiddenError,
     DatasetNotFoundError,
 )
+from superset.commands.dataset.source import DatasetSource, raise_for_source_access
 from superset.connectors.sqla.models import SqlaTable
 from superset.connectors.sqla.utils import get_physical_table_metadata
 from superset.daos.dashboard import DashboardDAO
@@ -83,29 +84,37 @@ class Datasource(BaseSupersetView):
         orm_datasource = DatasourceDAO.get_datasource(
             DatasourceType(datasource_type), datasource_id
         )
-        orm_datasource.database_id = database_id
+        current_source = DatasetSource.build(
+            orm_datasource.database_id,
+            orm_datasource.catalog,
+            orm_datasource.schema,
+            orm_datasource.table_name,
+            orm_datasource.sql,
+        )
 
         try:
             security_manager.raise_for_editorship(orm_datasource)
         except SupersetSecurityException as ex:
             raise DatasetForbiddenError() from ex
 
-        # When the datasource is repointed to a different database connection,
-        # authorise the target the same way the create path does, so editing a
-        # datasource cannot be used to reach a connection the caller lacks
-        # access to. Mirrors the physical branch of ``CreateDatasetCommand``.
-        target_database = (
-            db.session.query(Database).filter_by(id=database_id).one_or_none()
+        # The connection is repointed and ``update_from_object`` overwrites the
+        # table name, schema, catalog and SQL further down, so the move is
+        # authorised against the requested values rather than the stored ones.
+        # Both happen only once every check below has passed: the datasource is
+        # a live ORM object, so mutating it before then would let a rejected
+        # save reach the database anyway on the next flush.
+        requested_source = DatasetSource.build(
+            database_id,
+            datasource_dict.get("catalog"),
+            datasource_dict.get("schema"),
+            datasource_dict.get("table_name"),
+            datasource_dict.get("sql"),
         )
-        if target_database is not None:
-            security_manager.raise_for_access(
-                database=target_database,
-                table=Table(
-                    orm_datasource.table_name,
-                    orm_datasource.schema,
-                    orm_datasource.catalog,
-                ),
-            )
+        if requested_source.moved_from(current_source):
+            target_database = DatasetDAO.get_database_by_id(database_id)
+            if target_database is None:
+                return json_error_response(_("Database not found."), status=404)
+            raise_for_source_access(target_database, requested_source)
 
         duplicates = [
             name
@@ -122,6 +131,8 @@ class Datasource(BaseSupersetView):
                 ),
                 status=409,
             )
+
+        orm_datasource.database_id = database_id
         orm_datasource.update_from_object(datasource_dict)
         data = orm_datasource.data
         db.session.commit()  # pylint: disable=consider-using-transaction

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -174,30 +174,44 @@ def test_update_dataset_sql_unauthorized_schema(mocker: MockerFixture) -> None:
     )
 
 
-def test_update_dataset_repoint_database_authorized(mocker: MockerFixture) -> None:
+def _mock_repoint_env(
+    mocker: MockerFixture,
+    *,
+    stored_sql: str | None = None,
+    table_name: str = "test_table",
+    repointed: bool = True,
+) -> tuple[Any, Any, Any]:
     """
-    Repointing a physical dataset to a different database connection the user
-    can access succeeds, matching the create path's physical access check.
+    Mock out an update of a dataset stored on database 1.
+
+    Returns the patched DAO, the dataset and the database the update targets,
+    which is a second connection when ``repointed`` and the dataset's own
+    otherwise.
     """
     mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
 
     old_database = mocker.MagicMock()
     old_database.id = 1
-    new_database = mocker.MagicMock()
-    new_database.id = 2
-    new_database.get_default_catalog.return_value = "catalog"
-    new_database.allow_multi_catalog = False
+    old_database.get_default_catalog.return_value = "catalog"
+    old_database.allow_multi_catalog = False
+
+    target_database = old_database
+    if repointed:
+        target_database = mocker.MagicMock()
+        target_database.id = 2
+        target_database.get_default_catalog.return_value = "catalog"
+        target_database.allow_multi_catalog = False
 
     mock_dataset = mocker.MagicMock()
     mock_dataset.database = old_database
     mock_dataset.catalog = "catalog"
     mock_dataset.schema = "public"
-    mock_dataset.table_name = "test_table"
-    mock_dataset.sql = None
+    mock_dataset.table_name = table_name
+    mock_dataset.sql = stored_sql
     mock_dataset.editors = []
 
     mock_dataset_dao.find_by_id.return_value = mock_dataset
-    mock_dataset_dao.get_database_by_id.return_value = new_database
+    mock_dataset_dao.get_database_by_id.return_value = target_database
     mock_dataset_dao.validate_update_uniqueness.return_value = True
     mock_dataset_dao.update.return_value = mock_dataset
 
@@ -205,14 +219,21 @@ def test_update_dataset_repoint_database_authorized(mocker: MockerFixture) -> No
         "superset.commands.dataset.update.security_manager.raise_for_editorship",
     )
     mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
-    # Access to the target database is granted.
+
+    return mock_dataset_dao, mock_dataset, target_database
+
+
+def test_update_dataset_repoint_database_authorized(mocker: MockerFixture) -> None:
+    """
+    Repointing a physical dataset to a different database connection the user
+    can access succeeds, matching the create path's physical access check.
+    """
+    mock_dataset_dao, mock_dataset, new_database = _mock_repoint_env(mocker)
     raise_for_access = mocker.patch(
         "superset.commands.dataset.update.security_manager.raise_for_access",
     )
 
-    result = UpdateDatasetCommand(1, {"database_id": 2}).run()
-
-    assert result == mock_dataset
+    assert UpdateDatasetCommand(1, {"database_id": 2}).run() == mock_dataset
     mock_dataset_dao.update.assert_called_once()
     # The physical branch must run against the new database and table.
     raise_for_access.assert_called_once()
@@ -221,38 +242,28 @@ def test_update_dataset_repoint_database_authorized(mocker: MockerFixture) -> No
     assert call_kwargs["table"].table == "test_table"
 
 
-def test_update_dataset_repoint_database_unauthorized(mocker: MockerFixture) -> None:
+@pytest.mark.parametrize(
+    ("stored_sql", "payload"),
+    [
+        pytest.param(None, {"database_id": 2}, id="physical"),
+        pytest.param(
+            "SELECT * FROM some_table",
+            {"database_id": 2, "sql": "SELECT * FROM some_table"},
+            id="virtual_unchanged_sql",
+        ),
+    ],
+)
+def test_update_dataset_repoint_database_unauthorized(
+    mocker: MockerFixture,
+    stored_sql: str | None,
+    payload: dict[str, Any],
+) -> None:
     """
-    Repointing a physical dataset (no SQL change) to a database connection the
-    user cannot access is rejected. Previously this branch was only checked
-    when the SQL text changed, so a physical repoint went unauthorised.
+    Repointing to a database connection the user cannot access is rejected.
+    Neither leaving the SQL out of the payload nor resending it unchanged
+    skips the check on the target.
     """
-    mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
-
-    old_database = mocker.MagicMock()
-    old_database.id = 1
-    new_database = mocker.MagicMock()
-    new_database.id = 2
-    new_database.get_default_catalog.return_value = "catalog"
-    new_database.allow_multi_catalog = False
-
-    mock_dataset = mocker.MagicMock()
-    mock_dataset.database = old_database
-    mock_dataset.catalog = "catalog"
-    mock_dataset.schema = "public"
-    mock_dataset.table_name = "test_table"
-    mock_dataset.sql = None
-    mock_dataset.editors = []
-
-    mock_dataset_dao.find_by_id.return_value = mock_dataset
-    mock_dataset_dao.get_database_by_id.return_value = new_database
-    mock_dataset_dao.validate_update_uniqueness.return_value = True
-
-    mocker.patch(
-        "superset.commands.dataset.update.security_manager.raise_for_editorship",
-    )
-    mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
-    # Access to the target database is denied.
+    _mock_repoint_env(mocker, stored_sql=stored_sql)
     mocker.patch(
         "superset.commands.dataset.update.security_manager.raise_for_access",
         side_effect=SupersetSecurityException(
@@ -265,12 +276,33 @@ def test_update_dataset_repoint_database_unauthorized(mocker: MockerFixture) -> 
     )
 
     with pytest.raises(DatasetInvalidError) as excinfo:
-        UpdateDatasetCommand(1, {"database_id": 2}).run()
+        UpdateDatasetCommand(1, payload).run()
 
     assert any(
         "You don't have access to the 'target_db' database" in str(exc)
         for exc in excinfo.value._exceptions
     )
+
+
+def test_update_dataset_rename_virtual_dataset_skips_access_check(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Renaming a virtual dataset leaves its source untouched, so it is not gated
+    on access to a physical table sharing the new name.
+    """
+    _, mock_dataset, _ = _mock_repoint_env(
+        mocker,
+        stored_sql="SELECT * FROM some_table",
+        table_name="virtual_dataset",
+        repointed=False,
+    )
+    raise_for_access = mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
+    )
+
+    assert UpdateDatasetCommand(1, {"table_name": "renamed"}).run() == mock_dataset
+    raise_for_access.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/commands/dataset/update_test.py
+++ b/tests/unit_tests/commands/dataset/update_test.py
@@ -174,6 +174,105 @@ def test_update_dataset_sql_unauthorized_schema(mocker: MockerFixture) -> None:
     )
 
 
+def test_update_dataset_repoint_database_authorized(mocker: MockerFixture) -> None:
+    """
+    Repointing a physical dataset to a different database connection the user
+    can access succeeds, matching the create path's physical access check.
+    """
+    mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
+
+    old_database = mocker.MagicMock()
+    old_database.id = 1
+    new_database = mocker.MagicMock()
+    new_database.id = 2
+    new_database.get_default_catalog.return_value = "catalog"
+    new_database.allow_multi_catalog = False
+
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.database = old_database
+    mock_dataset.catalog = "catalog"
+    mock_dataset.schema = "public"
+    mock_dataset.table_name = "test_table"
+    mock_dataset.sql = None
+    mock_dataset.editors = []
+
+    mock_dataset_dao.find_by_id.return_value = mock_dataset
+    mock_dataset_dao.get_database_by_id.return_value = new_database
+    mock_dataset_dao.validate_update_uniqueness.return_value = True
+    mock_dataset_dao.update.return_value = mock_dataset
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_editorship",
+    )
+    mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
+    # Access to the target database is granted.
+    raise_for_access = mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
+    )
+
+    result = UpdateDatasetCommand(1, {"database_id": 2}).run()
+
+    assert result == mock_dataset
+    mock_dataset_dao.update.assert_called_once()
+    # The physical branch must run against the new database and table.
+    raise_for_access.assert_called_once()
+    call_kwargs = raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is new_database
+    assert call_kwargs["table"].table == "test_table"
+
+
+def test_update_dataset_repoint_database_unauthorized(mocker: MockerFixture) -> None:
+    """
+    Repointing a physical dataset (no SQL change) to a database connection the
+    user cannot access is rejected. Previously this branch was only checked
+    when the SQL text changed, so a physical repoint went unauthorised.
+    """
+    mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
+
+    old_database = mocker.MagicMock()
+    old_database.id = 1
+    new_database = mocker.MagicMock()
+    new_database.id = 2
+    new_database.get_default_catalog.return_value = "catalog"
+    new_database.allow_multi_catalog = False
+
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.database = old_database
+    mock_dataset.catalog = "catalog"
+    mock_dataset.schema = "public"
+    mock_dataset.table_name = "test_table"
+    mock_dataset.sql = None
+    mock_dataset.editors = []
+
+    mock_dataset_dao.find_by_id.return_value = mock_dataset
+    mock_dataset_dao.get_database_by_id.return_value = new_database
+    mock_dataset_dao.validate_update_uniqueness.return_value = True
+
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_editorship",
+    )
+    mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
+    # Access to the target database is denied.
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
+        side_effect=SupersetSecurityException(
+            SupersetError(
+                error_type=SupersetErrorType.DATASOURCE_SECURITY_ACCESS_ERROR,
+                message="You don't have access to the 'target_db' database",
+                level=ErrorLevel.ERROR,
+            )
+        ),
+    )
+
+    with pytest.raises(DatasetInvalidError) as excinfo:
+        UpdateDatasetCommand(1, {"database_id": 2}).run()
+
+    assert any(
+        "You don't have access to the 'target_db' database" in str(exc)
+        for exc in excinfo.value._exceptions
+    )
+
+
 @pytest.mark.parametrize(
     ("payload, exception, error_msg"),
     [
@@ -211,6 +310,12 @@ def test_update_dataset_validation_errors(
     mock_dataset_dao = mocker.patch("superset.commands.dataset.update.DatasetDAO")
     mocker.patch(
         "superset.commands.dataset.update.security_manager.raise_for_editorship",
+    )
+    # A physical source change routes through the target-database access check
+    # (mirroring the create path); allow it so this test isolates the other
+    # validation errors.
+    mocker.patch(
+        "superset.commands.dataset.update.security_manager.raise_for_access",
     )
     mocker.patch("superset.commands.utils.security_manager.is_admin", return_value=True)
     mocker.patch(

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -21,6 +21,7 @@ bypassing the Flask-AppBuilder permission decorator machinery.
 """
 
 import inspect
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -52,6 +53,17 @@ def _view_self() -> MagicMock:
     self = MagicMock()
     self.json_response = MagicMock(return_value="ok")
     return self
+
+
+def _save_request_context(payload: dict[str, Any]):
+    """Build a request context for ``Datasource.save`` carrying ``payload``."""
+    from flask import Flask
+
+    return Flask(__name__).test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={"data": superset_json.dumps(payload)},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -312,109 +324,249 @@ def test_save_non_editor_with_editors_field_is_rejected(
     mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
 
 
-@patch("superset.views.datasource.views.Table")
-@patch("superset.views.datasource.views.db")
+@patch("superset.commands.dataset.source.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
 @patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
 @patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
-def test_save_repoint_to_unauthorized_database_is_rejected(
+@pytest.mark.parametrize(
+    ("stored", "payload", "expected"),
+    [
+        pytest.param(
+            {"database_id": 1, "table_name": "some_table", "sql": None},
+            {"table_name": "some_table"},
+            {"table": "some_table"},
+            id="connection",
+        ),
+        pytest.param(
+            {"database_id": 2, "table_name": "old_table", "sql": None},
+            {"table_name": "other_table"},
+            {"table": "other_table"},
+            id="physical_table",
+        ),
+        pytest.param(
+            {"database_id": 1, "table_name": "virtual_ds", "sql": "SELECT 1"},
+            {"table_name": "virtual_ds", "sql": "SELECT 1"},
+            {"sql": "SELECT 1"},
+            id="virtual_unchanged_sql",
+        ),
+    ],
+)
+def test_save_repoint_authorizes_requested_source(
     mock_get_datasource: MagicMock,
     mock_security_manager: MagicMock,
-    mock_db: MagicMock,
-    mock_table: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_source_security_manager: MagicMock,
+    stored: dict[str, Any],
+    payload: dict[str, Any],
+    expected: dict[str, str],
 ) -> None:
     """
-    Repointing a datasource to a database connection the caller cannot access
-    is rejected, matching the create path's target-database access check.
+    A move is authorised against the source the save will persist: the target
+    connection, and the requested table for physical datasets or the requested
+    SQL for virtual ones. Resending unchanged SQL does not skip the check.
     """
-    mock_orm = MagicMock()
+    mock_orm = MagicMock(catalog="cat", schema="public", **stored)
     mock_get_datasource.return_value = mock_orm
     mock_security_manager.raise_for_editorship.return_value = None
 
     target_database = MagicMock()
-    mock_db.session.query.return_value.filter_by.return_value.one_or_none.return_value = (  # noqa: E501
-        target_database
-    )
-    mock_security_manager.raise_for_access.side_effect = _security_exception()
-
-    from flask import Flask
+    mock_get_database_by_id.return_value = target_database
+    mock_source_security_manager.raise_for_access.side_effect = _security_exception()
 
     raw_save = _get_view_func("save")
-    app = Flask(__name__)
-    with app.test_request_context(
-        "/datasource/save/",
-        method="POST",
-        data={
-            "data": superset_json.dumps(
-                {
-                    "id": 1,
-                    "type": "table",
-                    "database": {"id": 2},
-                    "columns": [],
-                }
-            )
-        },
+    with _save_request_context(
+        {
+            "id": 1,
+            "type": "table",
+            "database": {"id": 2},
+            "schema": "public",
+            "catalog": "cat",
+            "columns": [],
+            **payload,
+        }
     ):
         with pytest.raises(SupersetSecurityException):
             raw_save(_view_self())
 
-    mock_security_manager.raise_for_access.assert_called_once()
-    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    mock_get_database_by_id.assert_called_once_with(2)
+    call_kwargs = mock_source_security_manager.raise_for_access.call_args.kwargs
     assert call_kwargs["database"] is target_database
+    # The datasource is a live ORM object: a rejected save must leave it on its
+    # original connection, or the next flush would persist the refused move.
+    assert mock_orm.database_id == stored["database_id"]
+    mock_orm.update_from_object.assert_not_called()
+    if "table" in expected:
+        assert call_kwargs["table"].table == expected["table"]
+        assert "sql" not in call_kwargs
+    else:
+        assert call_kwargs["sql"] == expected["sql"]
+        assert "table" not in call_kwargs
 
 
-@patch("superset.views.datasource.views.sanitize_datasource_data")
-@patch("superset.views.datasource.views.Table")
 @patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.sanitize_datasource_data")
+@patch("superset.commands.dataset.source.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
 @patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
 @patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
 def test_save_repoint_to_authorized_database_succeeds(
     mock_get_datasource: MagicMock,
     mock_security_manager: MagicMock,
-    mock_db: MagicMock,
-    mock_table: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_source_security_manager: MagicMock,
     mock_sanitize: MagicMock,
+    mock_db: MagicMock,
 ) -> None:
     """
-    Repointing a datasource to a database the caller can access proceeds past
-    the access check and persists.
+    Moving a datasource to a connection the caller can access proceeds past the
+    access check and persists.
     """
-    mock_orm = MagicMock()
+    mock_orm = MagicMock(
+        database_id=1,
+        catalog="cat",
+        schema="public",
+        table_name="some_table",
+        sql=None,
+    )
     mock_orm.data = {"id": 1}
     mock_get_datasource.return_value = mock_orm
     mock_security_manager.raise_for_editorship.return_value = None
 
     target_database = MagicMock()
-    mock_db.session.query.return_value.filter_by.return_value.one_or_none.return_value = (  # noqa: E501
-        target_database
-    )
-    mock_security_manager.raise_for_access.return_value = None
+    mock_get_database_by_id.return_value = target_database
+    mock_source_security_manager.raise_for_access.return_value = None
     mock_sanitize.return_value = {"id": 1}
-
-    from flask import Flask
 
     view = _view_self()
     raw_save = _get_view_func("save")
-    app = Flask(__name__)
-    with app.test_request_context(
-        "/datasource/save/",
-        method="POST",
-        data={
-            "data": superset_json.dumps(
-                {
-                    "id": 1,
-                    "type": "table",
-                    "database": {"id": 2},
-                    "columns": [],
-                }
-            )
-        },
+    with _save_request_context(
+        {
+            "id": 1,
+            "type": "table",
+            "database": {"id": 2},
+            "table_name": "some_table",
+            "schema": "public",
+            "catalog": "cat",
+            "columns": [],
+        }
     ):
         raw_save(view)
 
-    mock_security_manager.raise_for_access.assert_called_once()
-    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
-    assert call_kwargs["database"] is target_database
+    mock_source_security_manager.raise_for_access.assert_called_once()
+    assert (
+        mock_source_security_manager.raise_for_access.call_args.kwargs["database"]
+        is target_database
+    )
     view.json_response.assert_called_once_with({"id": 1})
+
+
+@patch("superset.views.datasource.views._", lambda s: s)
+@patch("superset.views.datasource.views.json_error_response")
+@patch("superset.commands.dataset.source.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_repoint_to_unknown_database_is_rejected(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_source_security_manager: MagicMock,
+    mock_json_error_response: MagicMock,
+) -> None:
+    """
+    A move to a connection that does not resolve is rejected rather than
+    silently skipping the access check.
+    """
+    mock_orm = MagicMock(
+        database_id=1,
+        catalog="cat",
+        schema="public",
+        table_name="some_table",
+        sql=None,
+    )
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+    mock_get_database_by_id.return_value = None
+
+    raw_save = _get_view_func("save")
+    with _save_request_context(
+        {
+            "id": 1,
+            "type": "table",
+            "database": {"id": 2},
+            "table_name": "some_table",
+            "schema": "public",
+            "catalog": "cat",
+            "columns": [],
+        }
+    ):
+        raw_save(_view_self())
+
+    mock_source_security_manager.raise_for_access.assert_not_called()
+    assert mock_json_error_response.call_args.kwargs["status"] == 404
+    assert mock_orm.database_id == 1
+    mock_orm.update_from_object.assert_not_called()
+
+
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.sanitize_datasource_data")
+@patch("superset.commands.dataset.source.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+@pytest.mark.parametrize(
+    ("stored", "payload"),
+    [
+        pytest.param(
+            {"table_name": "some_table", "sql": None},
+            {"table_name": "some_table"},
+            id="physical_metadata_edit",
+        ),
+        pytest.param(
+            {"table_name": "virtual_ds", "sql": "SELECT 1"},
+            {"table_name": "renamed", "sql": "SELECT 1"},
+            id="virtual_rename",
+        ),
+    ],
+)
+def test_save_without_move_skips_access_check(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_source_security_manager: MagicMock,
+    mock_sanitize: MagicMock,
+    mock_db: MagicMock,
+    stored: dict[str, Any],
+    payload: dict[str, Any],
+) -> None:
+    """
+    Edits that leave the source alone stay gated on editorship: a metadata-only
+    change, and renaming a virtual dataset, which relabels it without changing
+    what it reads.
+    """
+    mock_orm = MagicMock(database_id=2, catalog="cat", schema="public", **stored)
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+    mock_sanitize.return_value = {"id": 1}
+
+    raw_save = _get_view_func("save")
+    with _save_request_context(
+        {
+            "id": 1,
+            "type": "table",
+            "database": {"id": 2},
+            "schema": "public",
+            "catalog": "cat",
+            "description": "a new description",
+            "columns": [],
+            **payload,
+        }
+    ):
+        raw_save(_view_self())
+
+    mock_source_security_manager.raise_for_access.assert_not_called()
+    mock_get_database_by_id.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -312,6 +312,111 @@ def test_save_non_editor_with_editors_field_is_rejected(
     mock_security_manager.raise_for_editorship.assert_called_once_with(mock_orm)
 
 
+@patch("superset.views.datasource.views.Table")
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_repoint_to_unauthorized_database_is_rejected(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_db: MagicMock,
+    mock_table: MagicMock,
+) -> None:
+    """
+    Repointing a datasource to a database connection the caller cannot access
+    is rejected, matching the create path's target-database access check.
+    """
+    mock_orm = MagicMock()
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    target_database = MagicMock()
+    mock_db.session.query.return_value.filter_by.return_value.one_or_none.return_value = (  # noqa: E501
+        target_database
+    )
+    mock_security_manager.raise_for_access.side_effect = _security_exception()
+
+    from flask import Flask
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 2},
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        with pytest.raises(SupersetSecurityException):
+            raw_save(_view_self())
+
+    mock_security_manager.raise_for_access.assert_called_once()
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is target_database
+
+
+@patch("superset.views.datasource.views.sanitize_datasource_data")
+@patch("superset.views.datasource.views.Table")
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_repoint_to_authorized_database_succeeds(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_db: MagicMock,
+    mock_table: MagicMock,
+    mock_sanitize: MagicMock,
+) -> None:
+    """
+    Repointing a datasource to a database the caller can access proceeds past
+    the access check and persists.
+    """
+    mock_orm = MagicMock()
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    target_database = MagicMock()
+    mock_db.session.query.return_value.filter_by.return_value.one_or_none.return_value = (  # noqa: E501
+        target_database
+    )
+    mock_security_manager.raise_for_access.return_value = None
+    mock_sanitize.return_value = {"id": 1}
+
+    from flask import Flask
+
+    view = _view_self()
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 2},
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        raw_save(view)
+
+    mock_security_manager.raise_for_access.assert_called_once()
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is target_database
+    view.json_response.assert_called_once_with({"id": 1})
+
+
 # ---------------------------------------------------------------------------
 # Datasource.samples
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -55,14 +55,31 @@ def _view_self() -> MagicMock:
     return self
 
 
-def _save_request_context(payload: dict[str, Any]):
-    """Build a request context for ``Datasource.save`` carrying ``payload``."""
+def _save_request_context(**payload: Any):
+    """
+    Build a request context for ``Datasource.save``.
+
+    Saves dataset 1 against connection 2 in ``cat.public``; ``payload``
+    overrides or adds individual fields.
+    """
     from flask import Flask
 
     return Flask(__name__).test_request_context(
         "/datasource/save/",
         method="POST",
-        data={"data": superset_json.dumps(payload)},
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 2},
+                    "schema": "public",
+                    "catalog": "cat",
+                    "columns": [],
+                    **payload,
+                }
+            )
+        },
     )
 
 
@@ -374,17 +391,7 @@ def test_save_repoint_authorizes_requested_source(
     mock_source_security_manager.raise_for_access.side_effect = _security_exception()
 
     raw_save = _get_view_func("save")
-    with _save_request_context(
-        {
-            "id": 1,
-            "type": "table",
-            "database": {"id": 2},
-            "schema": "public",
-            "catalog": "cat",
-            "columns": [],
-            **payload,
-        }
-    ):
+    with _save_request_context(**payload):
         with pytest.raises(SupersetSecurityException):
             raw_save(_view_self())
 
@@ -439,17 +446,7 @@ def test_save_repoint_to_authorized_database_succeeds(
 
     view = _view_self()
     raw_save = _get_view_func("save")
-    with _save_request_context(
-        {
-            "id": 1,
-            "type": "table",
-            "database": {"id": 2},
-            "table_name": "some_table",
-            "schema": "public",
-            "catalog": "cat",
-            "columns": [],
-        }
-    ):
+    with _save_request_context(table_name="some_table"):
         raw_save(view)
 
     mock_source_security_manager.raise_for_access.assert_called_once()
@@ -489,17 +486,7 @@ def test_save_repoint_to_unknown_database_is_rejected(
     mock_get_database_by_id.return_value = None
 
     raw_save = _get_view_func("save")
-    with _save_request_context(
-        {
-            "id": 1,
-            "type": "table",
-            "database": {"id": 2},
-            "table_name": "some_table",
-            "schema": "public",
-            "catalog": "cat",
-            "columns": [],
-        }
-    ):
+    with _save_request_context(table_name="some_table"):
         raw_save(_view_self())
 
     mock_source_security_manager.raise_for_access.assert_not_called()
@@ -551,18 +538,48 @@ def test_save_without_move_skips_access_check(
     mock_sanitize.return_value = {"id": 1}
 
     raw_save = _get_view_func("save")
-    with _save_request_context(
-        {
-            "id": 1,
-            "type": "table",
-            "database": {"id": 2},
-            "schema": "public",
-            "catalog": "cat",
-            "description": "a new description",
-            "columns": [],
-            **payload,
-        }
-    ):
+    with _save_request_context(description="a new description", **payload):
+        raw_save(_view_self())
+
+    mock_source_security_manager.raise_for_access.assert_not_called()
+    mock_get_database_by_id.assert_not_called()
+
+
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.sanitize_datasource_data")
+@patch("superset.commands.dataset.source.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_omitted_catalog_reads_through_connection_default(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_source_security_manager: MagicMock,
+    mock_sanitize: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    A payload that leaves the catalog out reads through the connection's
+    default, so a dataset already stored on that default has not moved. The
+    update command normalises the stored catalog to it on single-catalog
+    connections, so the two spellings must not read as a move.
+    """
+    mock_orm = MagicMock(
+        database_id=2,
+        catalog="cat",
+        schema="public",
+        table_name="some_table",
+        sql=None,
+    )
+    mock_orm.database.get_default_catalog.return_value = "cat"
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+    mock_sanitize.return_value = {"id": 1}
+
+    raw_save = _get_view_func("save")
+    with _save_request_context(table_name="some_table", catalog=None):
         raw_save(_view_self())
 
     mock_source_security_manager.raise_for_access.assert_not_called()


### PR DESCRIPTION
The create path authorises every dataset against its target: the SQL branch for virtual datasets and a database+table check for physical ones. The two edit paths did not mirror this. `UpdateDatasetCommand` only ran the check when the SQL text changed, so moving a physical dataset to a different database connection (or physical table) skipped it; the legacy `/datasource/save/` view reassigned the database and only checked editorship.

Both paths now run the same `raise_for_access(database=..., table=...)` check the create path uses whenever the dataset's source changes, so the behaviour is consistent regardless of which endpoint performs the edit. Adds regression coverage for authorised and unauthorised repoints via both the update command and the legacy save view.