### PR TITLE
fix(echarts): only reserve left grid padding when a Y-axis title exists

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Gantt/transformProps.ts
@@ -250,10 +250,13 @@ export default function transformProps(chartProps: EchartsGanttChartProps) {
       .second(time.second());
   }
 
+  const addYAxisTitleOffset =
+    !!yAxisTitle && convertInteger(yAxisTitleMargin) !== 0;
+
   const padding = getPadding(
     showLegend,
     legendOrientation,
-    false,
+    addYAxisTitleOffset,
     zoomable,
     legendMargin,
     !!xAxisTitle,
@@ -374,7 +377,7 @@ export default function transformProps(chartProps: EchartsGanttChartProps) {
     const adjustedPadding = getPadding(
       showLegend,
       legendOrientation,
-      false,
+      addYAxisTitleOffset,
       zoomable,
       legendLayout.effectiveMargin,
       !!xAxisTitle,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -795,8 +795,11 @@ export function getPadding(
         zoomable && !isHorizontal
           ? TIMESERIES_CONSTANTS.gridOffsetBottomZoomable + xAxisOffset
           : TIMESERIES_CONSTANTS.gridOffsetBottom + xAxisOffset,
+      // The title margin is only reserved when a Y-axis title is actually
+      // rendered. Without this guard every chart pays for the default
+      // margin, which eats a large share of the plot area on narrow charts.
       left:
-        yAxisTitlePosition === 'Left'
+        yAxisTitlePosition === 'Left' && addYAxisTitleOffset
           ? TIMESERIES_CONSTANTS.gridOffsetLeft +
             (Number(yAxisTitleMargin) || 0)
           : TIMESERIES_CONSTANTS.gridOffsetLeft,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -460,6 +460,33 @@ test('getPadding should only affect left margin when Y axis title position is Le
   }
 });
 
+test('getPadding should not reserve left margin when there is no Y axis title', () => {
+  const getChartPaddingSpy = setupGetChartPaddingMock();
+  try {
+    const result = getPadding(
+      false, // showLegend
+      LegendOrientation.Top, // legendOrientation
+      false, // addYAxisTitleOffset
+      false, // zoomable
+      null, // margin
+      false, // addXAxisTitleOffset
+      'Left', // yAxisTitlePosition
+      50, // yAxisTitleMargin
+      0, // xAxisTitleMargin
+      false, // isHorizontal
+    );
+
+    // The default title margin must not eat into the plot area when no
+    // title is rendered
+    expect(result.left).toBe(TIMESERIES_CONSTANTS.gridOffsetLeft);
+    expect(result.top).toBe(TIMESERIES_CONSTANTS.gridOffsetTop);
+    expect(result.bottom).toBe(TIMESERIES_CONSTANTS.gridOffsetBottom);
+    expect(result.right).toBe(TIMESERIES_CONSTANTS.gridOffsetRight);
+  } finally {
+    getChartPaddingSpy.mockRestore();
+  }
+});
+
 test('getPadding should only affect top margin when Y axis title position is Top', () => {
   const getChartPaddingSpy = setupGetChartPaddingMock();
   try {


### PR DESCRIPTION
### SUMMARY

On mobile, timeseries charts render with a large blank strip on the left: the plot area starts roughly a third of the way into the card, well outside the tick labels.

The cause is in `getPadding()` (`plugins/plugin-chart-echarts/src/Timeseries/transformers.ts`):

```ts
left:
  yAxisTitlePosition === 'Left'
    ? TIMESERIES_CONSTANTS.gridOffsetLeft + (Number(yAxisTitleMargin) || 0)
    : TIMESERIES_CONSTANTS.gridOffsetLeft,
```

The Y-axis title margin is added whenever the title position is `'Left'`, without checking that a title is actually rendered. The control defaults (`sections/chartTitle.tsx`) are position `'Left'` and margin `50`, so every chart with an empty `y_axis_title` — the default — reserves `20 + 50 = 70px` on the left. Because `grid.containLabel` is enabled, that reservation sits *outside* the axis labels, so it is pure dead space.

The guard already exists: callers compute `addYAxisTitleOffset = !!yAxisTitle && convertInteger(yAxisTitleMargin) !== 0`, and the `'Top'` position branch consumes it. Only the `'Left'` branch ignored it.

Changes:

- Gate the left title margin on `addYAxisTitleOffset`. Charts with a Y-axis title keep exactly the spacing they have today; charts without one reclaim 50px of plot area.
- `Gantt/transformProps.ts` hardcoded `false` for that flag at both `getPadding()` call sites while relying on the `'Left'` branch for its left padding, so it now computes the flag properly and passes it to both. Without this, Gantt charts that do have a title would lose their title padding.
- Add a `getPadding()` unit test for the no-title case.

Affected chart families: Timeseries (line/bar/area/scatter/smooth), Mixed Timeseries, Box Plot, Gantt. Bubble already passed `true` unconditionally and is unchanged.

This is negligible on wide desktop charts and very visible on narrow ones, which is why it surfaced in mobile consumption mode.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Before:_ plot area begins ~95px into a ~320px-wide mobile chart (70px reserved margin + tick-label width), leaving the series squeezed into the right portion of the card.
<img width="1406" height="2028" alt="image" src="https://github.com/user-attachments/assets/e5972a8d-1544-422b-9f41-c8506c420b13" />


_After:_ only `gridOffsetLeft` (20px) plus the tick-label width is reserved, and the series fills the card.
<img width="1422" height="2222" alt="image" src="https://github.com/user-attachments/assets/38389c0f-8068-482b-b980-dd9ec82f939f" />


### TESTING INSTRUCTIONS

1. Open any timeseries line chart on a dashboard and leave **Customize → Chart Title → Y Axis Title** empty (the default).
2. View the dashboard at a mobile width (~390px). The plot area should start just after the Y-axis tick labels, with no blank strip before them.
3. Set a **Y Axis Title** with position `Left` and a non-zero margin. The reserved space returns and the rotated title renders inside it, unchanged from before.
4. Repeat step 3 with position `Top` to confirm top spacing is untouched.
5. Check a Gantt chart both with and without a Y-axis title.

Unit tests:

```
npm run test -- plugins/plugin-chart-echarts/test
```

56 suites / 655 tests pass, including the new `getPadding` case.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
