### PR TITLE
feat(dashboard-v2): theme a building block's chart

### DIFF
--- a/superset-frontend/packages/superset-core/src/dashboard/index.ts
+++ b/superset-frontend/packages/superset-core/src/dashboard/index.ts
@@ -240,3 +240,85 @@ export interface QueryDataResult {
 export declare function fetchQueryData(
   binding: DataBindingSpec,
 ): Promise<QueryDataResult>;
+
+/**
+ * The categorical series colors of the active color scheme, in order.
+ *
+ * A widget that draws its own chart has to colour its series itself,
+ * and an extension can't reach `CategoricalColorNamespace` — it isn't part of
+ * this API. Without this, every renderer falls back to its own library's stock
+ * palette (ECharts' blues, Vega-Lite's `category10`), so two widgets on one
+ * dashboard disagree about what "the first series" looks like.
+ */
+export declare function getCategoricalColors(): string[];
+
+/**
+ * What the active theme means for a chart, stated without reference to any
+ * charting library.
+ *
+ * A widget draws with whatever renderer it likes, and every charting library
+ * ships its own palette and its own near-black text — so without this, a widget
+ * looks like its library rather than like Superset, and two widgets on one
+ * dashboard disagree about what "the first series" is. Map these few fields onto
+ * your renderer's own config and merge your spec *over* the result, so a widget
+ * that genuinely wants different colours can still say so while theme
+ * compatibility is what it gets for free.
+ *
+ * `getColor` is how a series gets its colour: by what it is called, not by
+ * where it sits. See the field's own note for why that matters across widgets.
+ *
+ * `sequentialColors` is for a continuous measure — heatmap cells, a colour ramp
+ * — where a categorical palette is the wrong answer. It may be empty if the
+ * deployment registers no sequential scheme, in which case keep your renderer's
+ * own default rather than inventing one.
+ */
+export interface ChartTheme {
+  /** Transparent, so a chart sits on the widget surface rather than over it. */
+  background: string;
+  text: {
+    color: string;
+    /** Text that labels rather than states — axis ticks, legend entries. */
+    mutedColor: string;
+    /** Present but inactive — a toggled-off legend entry. */
+    disabledColor: string;
+    fontFamily: string;
+    fontSize: number;
+  };
+  axis: {
+    lineColor: string;
+    labelColor: string;
+    gridColor: string;
+    /** Minor gridlines, where a renderer draws them. */
+    minorGridColor: string;
+  };
+  tooltip: {
+    background: string;
+    color: string;
+  };
+  /** Accent for hover markers, crosshairs, selection. */
+  accent: string;
+  /** The active categorical scheme, in order. One colour per series. */
+  categoricalColors: string[];
+  /**
+   * The colour for a named series or category — "EMEA", "Direct", a product
+   * name.
+   *
+   * Prefer this to indexing {@link categoricalColors} yourself. A dashboard is
+   * read across its widgets, and by position "EMEA" is the second colour in a
+   * chart that happens to list it second and the fifth in one that does not —
+   * so the same thing is a different colour in every widget it appears in.
+   * Asked for by name it is one colour everywhere, including in the v1 charts
+   * beside it, which resolve their colours the same way.
+   */
+  getColor: (label: string) => string;
+  /** The active sequential scheme, light to dark. Possibly empty. */
+  sequentialColors: string[];
+}
+
+/**
+ * The active theme, as a chart cares about it. See {@link ChartTheme}.
+ *
+ * Read it per render rather than once at module load: both the colour scheme and
+ * the light/dark theme can change while a widget is mounted.
+ */
+export declare function getChartTheme(): ChartTheme;

--- a/superset-frontend/packages/superset-core/src/dashboard/index.ts
+++ b/superset-frontend/packages/superset-core/src/dashboard/index.ts
@@ -308,3 +308,85 @@ export interface QueryDataResult {
 export declare function fetchQueryData(
   binding: DataBindingSpec,
 ): Promise<QueryDataResult>;
+
+/**
+ * The categorical series colors of the active color scheme, in order.
+ *
+ * A widget that draws its own chart has to colour its series itself,
+ * and an extension can't reach `CategoricalColorNamespace` — it isn't part of
+ * this API. Without this, every renderer falls back to its own library's stock
+ * palette (ECharts' blues, Vega-Lite's `category10`), so two widgets on one
+ * dashboard disagree about what "the first series" looks like.
+ */
+export declare function getCategoricalColors(): string[];
+
+/**
+ * What the active theme means for a chart, stated without reference to any
+ * charting library.
+ *
+ * A widget draws with whatever renderer it likes, and every charting library
+ * ships its own palette and its own near-black text — so without this, a widget
+ * looks like its library rather than like Superset, and two widgets on one
+ * dashboard disagree about what "the first series" is. Map these few fields onto
+ * your renderer's own config and merge your spec *over* the result, so a widget
+ * that genuinely wants different colours can still say so while theme
+ * compatibility is what it gets for free.
+ *
+ * `getColor` is how a series gets its colour: by what it is called, not by
+ * where it sits. See the field's own note for why that matters across widgets.
+ *
+ * `sequentialColors` is for a continuous measure — heatmap cells, a colour ramp
+ * — where a categorical palette is the wrong answer. It may be empty if the
+ * deployment registers no sequential scheme, in which case keep your renderer's
+ * own default rather than inventing one.
+ */
+export interface ChartTheme {
+  /** Transparent, so a chart sits on the widget surface rather than over it. */
+  background: string;
+  text: {
+    color: string;
+    /** Text that labels rather than states — axis ticks, legend entries. */
+    mutedColor: string;
+    /** Present but inactive — a toggled-off legend entry. */
+    disabledColor: string;
+    fontFamily: string;
+    fontSize: number;
+  };
+  axis: {
+    lineColor: string;
+    labelColor: string;
+    gridColor: string;
+    /** Minor gridlines, where a renderer draws them. */
+    minorGridColor: string;
+  };
+  tooltip: {
+    background: string;
+    color: string;
+  };
+  /** Accent for hover markers, crosshairs, selection. */
+  accent: string;
+  /** The active categorical scheme, in order. One colour per series. */
+  categoricalColors: string[];
+  /**
+   * The colour for a named series or category — "EMEA", "Direct", a product
+   * name.
+   *
+   * Prefer this to indexing {@link categoricalColors} yourself. A dashboard is
+   * read across its widgets, and by position "EMEA" is the second colour in a
+   * chart that happens to list it second and the fifth in one that does not —
+   * so the same thing is a different colour in every widget it appears in.
+   * Asked for by name it is one colour everywhere, including in the v1 charts
+   * beside it, which resolve their colours the same way.
+   */
+  getColor: (label: string) => string;
+  /** The active sequential scheme, light to dark. Possibly empty. */
+  sequentialColors: string[];
+}
+
+/**
+ * The active theme, as a chart cares about it. See {@link ChartTheme}.
+ *
+ * Read it per render rather than once at module load: both the colour scheme and
+ * the light/dark theme can change while a widget is mounted.
+ */
+export declare function getChartTheme(): ChartTheme;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -72,6 +72,7 @@ import {
 } from '../types';
 import { DEFAULT_LOCALE } from '../constants';
 import { mergeEchartsThemeOverrides } from '../utils/themeOverrides';
+import { getEchartsTheme } from '../utils/echartsTheme';
 import { loadLocale } from './echartsLocale';
 
 // Define this interface here to avoid creating a dependency back to superset-frontend,
@@ -228,58 +229,7 @@ function Echart(
         chartRef.current?.getZr().on(name, handler);
       });
 
-      const getEchartsTheme = (options: any) => {
-        const antdTheme = theme;
-        const echartsTheme = {
-          textStyle: {
-            color: antdTheme.colorText,
-            fontFamily: antdTheme.fontFamily,
-          },
-          title: {
-            textStyle: { color: antdTheme.colorText },
-          },
-          legend: {
-            textStyle: { color: antdTheme.colorTextSecondary },
-            pageTextStyle: {
-              color: antdTheme.colorTextSecondary,
-            },
-            pageIconColor: antdTheme.colorTextSecondary,
-            pageIconInactiveColor: antdTheme.colorTextDisabled,
-            inactiveColor: antdTheme.colorTextDisabled,
-          },
-          tooltip: {
-            backgroundColor: antdTheme.colorBgContainer,
-            textStyle: { color: antdTheme.colorText },
-          },
-          axisPointer: {
-            lineStyle: { color: antdTheme.colorPrimary },
-            label: { color: antdTheme.colorText },
-          },
-        } as any;
-        if (options?.xAxis) {
-          echartsTheme.xAxis = {
-            axisLine: { lineStyle: { color: antdTheme.colorSplit } },
-            axisLabel: { color: antdTheme.colorTextSecondary },
-            splitLine: { lineStyle: { color: antdTheme.colorSplit } },
-            minorSplitLine: {
-              lineStyle: { color: antdTheme.colorBorderSecondary },
-            },
-          };
-        }
-        if (options?.yAxis) {
-          echartsTheme.yAxis = {
-            axisLine: { lineStyle: { color: antdTheme.colorSplit } },
-            axisLabel: { color: antdTheme.colorTextSecondary },
-            splitLine: { lineStyle: { color: antdTheme.colorSplit } },
-            minorSplitLine: {
-              lineStyle: { color: antdTheme.colorBorderSecondary },
-            },
-          };
-        }
-        return echartsTheme;
-      };
-
-      const baseTheme = getEchartsTheme(echartOptions);
+      const baseTheme = getEchartsTheme(theme, echartOptions);
       const globalOverrides = theme.echartsOptionsOverrides || {};
       const chartOverrides = vizType
         ? theme.echartsOptionsOverridesByChartType?.[vizType] || {}

--- a/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/index.ts
@@ -67,6 +67,10 @@ export { DEFAULT_FORM_DATA as TimeseriesDefaultFormData } from './Timeseries/con
 
 export * from './utils/eChartOptionsSchema';
 export * from './utils/safeEChartOptionsParser';
+// Used by renderers that draw ECharts options without SuperChart/ChartPlugin —
+// see the Dashboard v2 widgets.
+export * from './utils/echartsTheme';
+export * from './utils/themeOverrides';
 
 export * from './types';
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/echartsTheme.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/echartsTheme.ts
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { SupersetTheme } from '@apache-superset/core/theme';
+
+/**
+ * Derives the ECharts styling implied by the active theme's tokens — text,
+ * legend, tooltip, axis-pointer, and (when the chart declares them) axis
+ * colors.
+ *
+ * Lives here rather than inside `Echart.tsx` because that component isn't the
+ * only renderer: the Dashboard v2 widgets draw AI-authored options on a bare
+ * `echarts.init` canvas, bypassing `SuperChart`/`ChartPlugin` entirely, and
+ * without this they render ECharts' stock near-black text regardless of the
+ * theme.
+ *
+ * Returns only what the theme implies — merge it *under* the chart's own
+ * options (see `mergeEchartsThemeOverrides`) so anything the chart sets
+ * explicitly still wins.
+ */
+export function getEchartsTheme(theme: SupersetTheme, options?: any) {
+  const echartsTheme = {
+    textStyle: {
+      color: theme.colorText,
+      fontFamily: theme.fontFamily,
+    },
+    title: {
+      textStyle: { color: theme.colorText },
+    },
+    legend: {
+      textStyle: { color: theme.colorTextSecondary },
+      pageTextStyle: {
+        color: theme.colorTextSecondary,
+      },
+      pageIconColor: theme.colorTextSecondary,
+      pageIconInactiveColor: theme.colorTextDisabled,
+      inactiveColor: theme.colorTextDisabled,
+    },
+    tooltip: {
+      backgroundColor: theme.colorBgContainer,
+      textStyle: { color: theme.colorText },
+    },
+    axisPointer: {
+      lineStyle: { color: theme.colorPrimary },
+      label: { color: theme.colorText },
+    },
+  } as any;
+
+  // Only styled when the chart actually declares an axis — an axis section on a
+  // pie or gauge option would otherwise draw a cartesian grid that isn't there.
+  const axisTheme = {
+    axisLine: { lineStyle: { color: theme.colorSplit } },
+    axisLabel: { color: theme.colorTextSecondary },
+    splitLine: { lineStyle: { color: theme.colorSplit } },
+    minorSplitLine: {
+      lineStyle: { color: theme.colorBorderSecondary },
+    },
+  };
+  if (options?.xAxis) {
+    echartsTheme.xAxis = axisTheme;
+  }
+  if (options?.yAxis) {
+    echartsTheme.yAxis = axisTheme;
+  }
+
+  return echartsTheme;
+}
+
+export default getEchartsTheme;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/echartsTheme.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/echartsTheme.ts
@@ -71,11 +71,17 @@ export function getEchartsTheme(theme: SupersetTheme, options?: any) {
       lineStyle: { color: theme.colorBorderSecondary },
     },
   };
+  // ECharts accepts one axis or several. A single object merged over an
+  // authored array is replaced wholesale by it, so a chart with two y-axes
+  // lost every bit of axis styling the theme meant to give it — matched in
+  // shape here instead, one default per authored axis.
+  const forAxis = (axis: unknown) =>
+    Array.isArray(axis) ? axis.map(() => axisTheme) : axisTheme;
   if (options?.xAxis) {
-    echartsTheme.xAxis = axisTheme;
+    echartsTheme.xAxis = forAxis(options.xAxis);
   }
   if (options?.yAxis) {
-    echartsTheme.yAxis = axisTheme;
+    echartsTheme.yAxis = forAxis(options.yAxis);
   }
 
   return echartsTheme;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/echartsTheme.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/echartsTheme.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getEchartsTheme } from '../../src/utils/echartsTheme';
+
+const theme = {
+  colorText: '#111',
+  colorTextSecondary: '#666',
+  colorTextDisabled: '#aaa',
+  colorSplit: '#eee',
+  colorBorderSecondary: '#ddd',
+  colorBgContainer: '#fff',
+  colorPrimary: '#20a7c9',
+  fontFamily: 'Inter',
+} as unknown as Parameters<typeof getEchartsTheme>[0];
+
+test('styles an axis only when the option declares one', () => {
+  // An axis section on a pie would draw a cartesian grid that is not there.
+  expect(
+    getEchartsTheme(theme, { series: [{ type: 'pie' }] }).xAxis,
+  ).toBeUndefined();
+});
+
+test('matches the shape of an axis authored as an array', () => {
+  const themed = getEchartsTheme(theme, {
+    xAxis: { type: 'category' },
+    yAxis: [{ type: 'value' }, { type: 'value' }],
+  });
+
+  // A single object merged over an authored array is replaced wholesale by
+  // it, so a chart with two y-axes lost all of its axis styling.
+  expect(Array.isArray(themed.yAxis)).toBe(true);
+  expect(themed.yAxis).toHaveLength(2);
+  expect(themed.yAxis[1].axisLabel.color).toBe('#666');
+  expect(Array.isArray(themed.xAxis)).toBe(false);
+  expect(themed.xAxis.splitLine.lineStyle.color).toBe('#eee');
+});

--- a/superset-frontend/src/core/dashboard/WidgetView.tsx
+++ b/superset-frontend/src/core/dashboard/WidgetView.tsx
@@ -278,11 +278,24 @@ const WidgetView = forwardRef<HTMLDivElement, WidgetViewProps>(
           // dashboard, it *is* the dashboard — the surface everything else is
           // arranged on, not a card among them — so it gets none of a card's
           // trappings: no fill, no border, no rounded corners of its own.
-          backgroundColor: isRoot ? undefined : theme.colorBgContainer,
+          //
+          // The values are v1's dashboard tile, including its three
+          // `dashboardTile*` theme override points (see
+          // `.dashboard-component-chart-holder` in `DashboardBuilder.tsx`).
+          // That matters more than the specific pixels: a deployment that
+          // themes its dashboard tiles was having no effect whatsoever here,
+          // so a v2 dashboard in a customised deployment looked like a
+          // different product. Reading the same tokens means v2 inherits that
+          // customisation for free.
+          backgroundColor: isRoot
+            ? undefined
+            : (theme.dashboardTileBg ?? theme.colorBgContainer),
           border: isRoot
             ? undefined
-            : `1px solid ${theme.colorBorderSecondary}`,
-          borderRadius: isRoot ? undefined : theme.borderRadiusLG,
+            : (theme.dashboardTileBorder ?? `1px solid ${theme.colorBorder}`),
+          borderRadius: isRoot
+            ? undefined
+            : (theme.dashboardTileBorderRadius ?? theme.borderRadius),
           // Nothing reaches past the corners this rounds — a widget's content
           // is square and would otherwise fill them back in. Moot on the
           // root, which rounds nothing.

--- a/superset-frontend/src/core/dashboard/WidgetView.tsx
+++ b/superset-frontend/src/core/dashboard/WidgetView.tsx
@@ -311,11 +311,24 @@ const WidgetView = forwardRef<HTMLDivElement, WidgetViewProps>(
           // dashboard, it *is* the dashboard — the surface everything else is
           // arranged on, not a card among them — so it gets none of a card's
           // trappings: no fill, no border, no rounded corners of its own.
-          backgroundColor: isRoot ? undefined : theme.colorBgContainer,
+          //
+          // The values are v1's dashboard tile, including its three
+          // `dashboardTile*` theme override points (see
+          // `.dashboard-component-chart-holder` in `DashboardBuilder.tsx`).
+          // That matters more than the specific pixels: a deployment that
+          // themes its dashboard tiles was having no effect whatsoever here,
+          // so a v2 dashboard in a customised deployment looked like a
+          // different product. Reading the same tokens means v2 inherits that
+          // customisation for free.
+          backgroundColor: isRoot
+            ? undefined
+            : (theme.dashboardTileBg ?? theme.colorBgContainer),
           border: isRoot
             ? undefined
-            : `1px solid ${theme.colorBorderSecondary}`,
-          borderRadius: isRoot ? undefined : theme.borderRadiusLG,
+            : (theme.dashboardTileBorder ?? `1px solid ${theme.colorBorder}`),
+          borderRadius: isRoot
+            ? undefined
+            : (theme.dashboardTileBorderRadius ?? theme.borderRadius),
           // Nothing reaches past the corners this rounds — a widget's content
           // is square and would otherwise fill them back in. Moot on the
           // root, which rounds nothing.

--- a/superset-frontend/src/core/dashboard/chartTheme.test.ts
+++ b/superset-frontend/src/core/dashboard/chartTheme.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  CategoricalColorNamespace,
+  CategoricalScheme,
+  getCategoricalSchemeRegistry,
+  getSequentialSchemeRegistry,
+  SequentialScheme,
+} from '@superset-ui/core';
+import { getChartTheme } from './chartTheme';
+
+const theme = {
+  colorText: '#111',
+  colorTextSecondary: '#666',
+  colorTextDisabled: '#aaa',
+  colorSplit: '#eee',
+  colorBorderSecondary: '#ddd',
+  colorBgContainer: '#fff',
+  colorPrimary: '#20a7c9',
+  fontFamily: 'Inter',
+  fontSize: 12,
+} as unknown as Parameters<typeof getChartTheme>[0];
+
+test('maps theme tokens onto renderer-agnostic chart fields', () => {
+  const chartTheme = getChartTheme(theme);
+
+  expect(chartTheme.text).toEqual({
+    color: '#111',
+    mutedColor: '#666',
+    disabledColor: '#aaa',
+    fontFamily: 'Inter',
+    fontSize: 12,
+  });
+  expect(chartTheme.axis.lineColor).toBe('#eee');
+  expect(chartTheme.axis.minorGridColor).toBe('#ddd');
+  expect(chartTheme.tooltip).toEqual({ background: '#fff', color: '#111' });
+  expect(chartTheme.accent).toBe('#20a7c9');
+});
+
+test('is transparent so a chart sits on the widget, not over it', () => {
+  expect(getChartTheme(theme).background).toBe('transparent');
+});
+
+test('carries the active categorical scheme in order', () => {
+  const { colors } = CategoricalColorNamespace.getScale();
+
+  expect(getChartTheme(theme).categoricalColors).toEqual(colors);
+  expect(colors.length).toBeGreaterThan(0);
+});
+
+test('exposes the registered sequential scheme for continuous colour', () => {
+  const registry = getSequentialSchemeRegistry();
+  registry.registerValue(
+    'test_ramp',
+    new SequentialScheme({
+      id: 'test_ramp',
+      colors: ['#fff', '#888', '#000'],
+    }),
+  );
+  registry.setDefaultKey('test_ramp');
+
+  // The whole reason this field exists: nothing was exposing Superset's
+  // sequential schemes, so a heatmap in a widget fell back to its library's own
+  // ramp — the most visible mismatch available.
+  expect(getChartTheme(theme).sequentialColors).toEqual([
+    '#fff',
+    '#888',
+    '#000',
+  ]);
+});
+
+test('reports no sequential colours rather than inventing a ramp', () => {
+  const registry = getSequentialSchemeRegistry();
+  jest.spyOn(registry, 'get').mockReturnValue(undefined);
+
+  // A renderer that gets nothing keeps its own default, which beats a
+  // Superset-looking ramp no Superset chart actually uses.
+  expect(getChartTheme(theme).sequentialColors).toEqual([]);
+
+  jest.restoreAllMocks();
+});
+
+test('gives a label the same colour whatever order a chart lists it in', () => {
+  const chartTheme = getChartTheme(theme);
+
+  const first = chartTheme.getColor('EMEA');
+  chartTheme.getColor('APAC');
+
+  // The point of asking by name: a second chart that lists EMEA after APAC
+  // still draws it in the colour the first one used.
+  expect(getChartTheme(theme).getColor('EMEA')).toBe(first);
+});
+
+test('takes the canvas own scheme when it has one', () => {
+  getCategoricalSchemeRegistry().registerValue(
+    'test_palette',
+    new CategoricalScheme({
+      id: 'test_palette',
+      colors: ['#010101', '#020202'],
+    }),
+  );
+
+  // A canvas that picked a palette gets that palette rather than the
+  // deployment default — which is what makes the Styling section's colour
+  // scheme field mean anything, having been written and read by nothing.
+  expect(getChartTheme(theme, 'test_palette').categoricalColors).toEqual([
+    '#010101',
+    '#020202',
+  ]);
+});

--- a/superset-frontend/src/core/dashboard/chartTheme.ts
+++ b/superset-frontend/src/core/dashboard/chartTheme.ts
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview What the active theme means for a chart, stated without
+ * reference to any charting library.
+ *
+ * Widgets draw with whatever renderer they like — ECharts, Vega-Lite, plain
+ * SVG — and each library ships its own palette and its own near-black text.
+ * Left to itself, every widget therefore looks like its library rather than
+ * like Superset, and two widgets on one dashboard disagree about what "the
+ * first series" is. The only affordance a contributed widget had here was
+ * `getCategoricalColors()`, so each one hand-rolled the rest from raw tokens:
+ * three extensions, three different mappings, all destined to drift.
+ *
+ * The fix is that theme compatibility should be the default a widget starts
+ * from rather than something its author remembers to implement. So the host
+ * states the theme once, semantically, and each renderer maps those few fields
+ * onto its own config — a mapping that is a handful of lines, unlike
+ * re-deriving what a theme means. A widget that genuinely wants different
+ * colours still says so: its own spec is merged *over* this, never under it.
+ *
+ * Superset's sequential schemes are included because nothing was exposing them
+ * at all, so any continuous colour a widget drew — a heatmap, a `visualMap`, a
+ * choropleth — fell back to its library's default ramp. That is the most
+ * visible mismatch of the lot, and the least excusable, since Superset has had
+ * the schemes all along.
+ */
+
+import {
+  CategoricalColorNamespace,
+  getSequentialSchemeRegistry,
+} from '@superset-ui/core';
+import type { useTheme } from '@apache-superset/core/theme';
+
+type Theme = ReturnType<typeof useTheme>;
+
+export interface ChartTheme {
+  /** Transparent, so a chart sits on the widget surface rather than over it. */
+  background: string;
+  text: {
+    color: string;
+    /** Text that labels rather than states — axis ticks, legend entries. */
+    mutedColor: string;
+    /** Text that is present but inactive — a toggled-off legend entry. */
+    disabledColor: string;
+    fontFamily: string;
+    fontSize: number;
+  };
+  axis: {
+    lineColor: string;
+    labelColor: string;
+    gridColor: string;
+    /** Minor gridlines, where a renderer draws them. */
+    minorGridColor: string;
+  };
+  tooltip: {
+    background: string;
+    color: string;
+  };
+  /** Accent for hover markers, crosshairs, selection. */
+  accent: string;
+  /** The active categorical scheme, in order. One colour per series. */
+  categoricalColors: string[];
+  /**
+   * The colour for a named series or category.
+   *
+   * By position, "EMEA" is the second colour in a chart that lists it second
+   * and the fifth in one that does not, so the same category comes out a
+   * different colour in every widget it appears in — the thing that most makes
+   * a set of widgets read as unrelated charts rather than as one dashboard.
+   * Superset already solves this: the scale remembers what it gave a label and
+   * gives it the same one again, which is also how the v1 charts beside a
+   * canvas resolve theirs.
+   */
+  getColor: (label: string) => string;
+  /**
+   * The active sequential scheme, light to dark — for a continuous measure
+   * (heatmap cells, a colour ramp), where a categorical palette is wrong.
+   */
+  sequentialColors: string[];
+}
+
+/**
+ * The default sequential scheme's colours, or an empty list if none is
+ * registered. Empty rather than a hardcoded fallback ramp: a renderer that gets
+ * nothing keeps its own default, which is a better outcome than inventing a
+ * Superset-looking ramp that no Superset chart actually uses.
+ */
+function getSequentialColors(): string[] {
+  try {
+    return getSequentialSchemeRegistry().get()?.colors ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Reads live rather than being captured once: the active colour scheme and the
+ * light/dark theme can both change after any given module was imported.
+ *
+ * `scheme` is the canvas's own choice of categorical palette, stored on its
+ * root node; omitted, the deployment's default is used. Passed through to the
+ * scale rather than resolved here so that the label→colour memory is the
+ * shared one — a canvas and the v1 charts around it agree on what colour
+ * "EMEA" is.
+ */
+export function getChartTheme(theme: Theme, scheme?: string): ChartTheme {
+  const scale = CategoricalColorNamespace.getScale(scheme);
+  return {
+    background: 'transparent',
+    text: {
+      color: theme.colorText,
+      mutedColor: theme.colorTextSecondary,
+      disabledColor: theme.colorTextDisabled,
+      fontFamily: theme.fontFamily,
+      fontSize: theme.fontSize,
+    },
+    axis: {
+      lineColor: theme.colorSplit,
+      labelColor: theme.colorTextSecondary,
+      gridColor: theme.colorSplit,
+      minorGridColor: theme.colorBorderSecondary,
+    },
+    tooltip: {
+      background: theme.colorBgContainer,
+      color: theme.colorText,
+    },
+    accent: theme.colorPrimary,
+    categoricalColors: scale.colors,
+    getColor: (label: string) => scale.getColor(label),
+    sequentialColors: getSequentialColors(),
+  };
+}
+
+export default getChartTheme;

--- a/superset-frontend/src/core/dashboard/echartsSeriesDefaults.test.ts
+++ b/superset-frontend/src/core/dashboard/echartsSeriesDefaults.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { applySeriesDefaults } from './echartsSeriesDefaults';
+import type { ChartTheme } from './chartTheme';
+
+const theme = {
+  background: 'transparent',
+  text: {
+    color: '#111',
+    mutedColor: '#666',
+    disabledColor: '#aaa',
+    fontFamily: 'Inter',
+    fontSize: 12,
+  },
+  axis: {
+    lineColor: '#eee',
+    labelColor: '#666',
+    gridColor: '#eee',
+    minorGridColor: '#ddd',
+  },
+  tooltip: { background: '#fff', color: '#111' },
+  accent: '#20a7c9',
+  categoricalColors: ['#1f77b4'],
+  sequentialColors: [],
+  // Stands in for the shared label→colour memory: same label, same colour,
+  // whatever order a chart happens to list it in.
+  getColor: (label: string) => `colour-of-${label}`,
+} satisfies ChartTheme;
+
+const seriesOf = (option: Record<string, unknown>) =>
+  (option.series as Record<string, any>[])[0];
+
+test('gives a pie an explicit label colour, which is what suppresses the halo', () => {
+  const out = applySeriesDefaults(
+    { series: [{ type: 'pie', data: [] }] },
+    theme,
+  );
+
+  // zrender draws its own contrasting stroke only when the label has no fill
+  // of its own — an explicit colour is the whole fix.
+  expect(seriesOf(out).label).toEqual({ color: '#111', fontFamily: 'Inter' });
+});
+
+test('leaves an authored label colour alone', () => {
+  const out = applySeriesDefaults(
+    { series: [{ type: 'pie', label: { color: 'red' } }] },
+    theme,
+  );
+
+  // The point of applying defaults rather than overrides: full ECharts access
+  // survives intact.
+  expect(seriesOf(out).label.color).toBe('red');
+  // …while still filling what the author didn't mention.
+  expect(seriesOf(out).label.fontFamily).toBe('Inter');
+});
+
+test('preserves an authored value even when it is falsy or null', () => {
+  const out = applySeriesDefaults(
+    { series: [{ type: 'pie', labelLine: { lineStyle: { color: null } } }] },
+    theme,
+  );
+
+  // `null` is how ECharts is told to drop something; treating it as "absent"
+  // would silently re-enable what the author switched off.
+  expect(seriesOf(out).labelLine.lineStyle.color).toBeNull();
+});
+
+test('themes pie leader lines and slice borders', () => {
+  const out = applySeriesDefaults({ series: [{ type: 'pie' }] }, theme);
+
+  expect(seriesOf(out).labelLine.lineStyle.color).toBe('#eee');
+  expect(seriesOf(out).itemStyle.borderColor).toBe('#fff');
+});
+
+test('applies per-type defaults independently across a mixed option', () => {
+  const out = applySeriesDefaults(
+    { series: [{ type: 'bar' }, { type: 'pie' }, { type: 'gauge' }] },
+    theme,
+  );
+  const series = out.series as Record<string, any>[];
+
+  expect(series[0].labelLine).toBeUndefined(); // bar has no leader lines
+  expect(series[1].labelLine.lineStyle.color).toBe('#eee');
+  expect(series[2].detail.color).toBe('#111');
+  series.forEach(s => expect(s.label.color).toBe('#111'));
+});
+
+test('accepts a single series object as well as an array', () => {
+  const out = applySeriesDefaults({ series: { type: 'pie' } }, theme);
+
+  expect((out.series as Record<string, any>).label.color).toBe('#111');
+});
+
+test('leaves an option with no series untouched', () => {
+  const option = { xAxis: { type: 'category' } };
+
+  expect(applySeriesDefaults(option, theme)).toBe(option);
+});
+
+test('does not mutate the option it is given', () => {
+  const option = { series: [{ type: 'pie' as const }] };
+  const before = JSON.stringify(option);
+
+  applySeriesDefaults(option, theme);
+
+  expect(JSON.stringify(option)).toBe(before);
+});
+
+test('colours a series by its name rather than by its position', () => {
+  const out = applySeriesDefaults(
+    {
+      series: [
+        { type: 'bar', name: 'EMEA' },
+        { type: 'bar', name: 'APAC' },
+      ],
+    },
+    theme,
+  );
+
+  // What makes two widgets on one dashboard agree: neither is coloured by where
+  // its series happens to sit.
+  const series = out.series as Record<string, any>[];
+  expect(series[0].itemStyle.color).toBe('colour-of-EMEA');
+  expect(series[1].itemStyle.color).toBe('colour-of-APAC');
+});
+
+test('colours a pie by slice, since a pie is one series of many categories', () => {
+  const out = applySeriesDefaults(
+    {
+      series: [
+        {
+          type: 'pie',
+          data: [
+            { name: 'EMEA', value: 3 },
+            { name: 'APAC', value: 1 },
+          ],
+        },
+      ],
+    },
+    theme,
+  );
+
+  const data = seriesOf(out).data as Record<string, any>[];
+  expect(data[0].itemStyle.color).toBe('colour-of-EMEA');
+  expect(data[1].itemStyle.color).toBe('colour-of-APAC');
+});
+
+test('leaves a colour the author chose alone', () => {
+  const out = applySeriesDefaults(
+    { series: [{ type: 'bar', name: 'EMEA', itemStyle: { color: '#f00' } }] },
+    theme,
+  );
+
+  expect(seriesOf(out).itemStyle.color).toBe('#f00');
+});
+
+test('leaves an unnamed series to the palette', () => {
+  const out = applySeriesDefaults({ series: [{ type: 'bar' }] }, theme);
+
+  // Nothing to ask the scale for, so the option says nothing and ECharts takes
+  // the next colour off `color` as it always did.
+  expect(seriesOf(out).itemStyle?.color).toBeUndefined();
+});

--- a/superset-frontend/src/core/dashboard/echartsSeriesDefaults.ts
+++ b/superset-frontend/src/core/dashboard/echartsSeriesDefaults.ts
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @fileoverview Theming that a global `textStyle` cannot reach.
+ *
+ * v1 charts are theme-correct because each of ~40 `transformProps` files knows
+ * which of *its* chart's elements are themeable — pie sets
+ * `label.color = theme.colorText`, and so on. A generic option has no
+ * `viz_type` to look that up by, which is why an AI-authored pie renders with a
+ * white halo around every label: with no explicit label colour, zrender falls
+ * back to drawing its own contrasting stroke (`zrender/graphic/Text.js`, the
+ * `useDefaultFill` branch), on the assumption that text over an arbitrary mark
+ * needs one.
+ *
+ * The fix does not need a `viz_type`. The option already says what it is —
+ * `series[].type` — so per-chart-type theming can be derived from the option
+ * itself, the same way `getEchartsTheme` already keys axis styling off whether
+ * the option declares an axis.
+ *
+ * The same pass is where a series gets its colour by name rather than by
+ * position. ECharts colours by index off the palette, so a category is one
+ * colour in a chart that lists it second and another in a chart that lists it
+ * fifth — on one dashboard, the same "EMEA" in three widgets in three colours.
+ * `theme.getColor` is the shared label→colour memory, so asking it here makes
+ * a canvas agree with itself and with the v1 charts beside it.
+ *
+ * Applied *after* the theme merge rather than as another merge source, because
+ * `mergeEchartsThemeOverrides` replaces a destination array whenever a source
+ * has one — so any `series` the theme layer contributed would be discarded the
+ * moment the authored `series: [...]` merged over it, whatever the ordering.
+ * Filling only absent keys afterwards gives the same precedence a merge would
+ * have: whatever the author set explicitly is left alone.
+ */
+
+import type { ChartTheme } from './chartTheme';
+
+/**
+ * Series types whose *data items* are the categories rather than the series.
+ *
+ * A bar series is one category and carries its name; a pie is one series of
+ * many slices, each named. So the colour goes on the datum for these and on
+ * the series for everything else.
+ */
+const CATEGORIES_ARE_DATA = new Set(['pie', 'funnel', 'treemap', 'sunburst']);
+
+type Dict = Record<string, unknown>;
+
+const isDict = (v: unknown): v is Dict =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * Recursively writes `defaults` into `target` wherever `target` says nothing,
+ * leaving every value it does specify untouched. Returns a copy.
+ */
+function fillAbsent(target: unknown, defaults: Dict): unknown {
+  if (!isDict(target)) {
+    // An author who set this key to a non-object meant it — even `null`, which
+    // is how ECharts is told to drop something.
+    return target === undefined ? defaults : target;
+  }
+  const out: Dict = { ...target };
+  Object.entries(defaults).forEach(([key, value]) => {
+    if (isDict(value)) {
+      out[key] = fillAbsent(out[key], value);
+    } else if (out[key] === undefined) {
+      out[key] = value;
+    }
+  });
+  return out;
+}
+
+/**
+ * The theme's opinion about one series type, as an ECharts series fragment.
+ *
+ * `label.color` is the load-bearing entry and applies to every type: it is
+ * absent-by-default in ECharts, and its absence is exactly what triggers the
+ * white auto-stroke. Setting it is what v1's `transformProps` files each do by
+ * hand.
+ */
+function seriesDefaults(type: string | undefined, theme: ChartTheme): Dict {
+  const label = { color: theme.text.color, fontFamily: theme.text.fontFamily };
+
+  switch (type) {
+    case 'pie':
+    case 'funnel':
+      return {
+        label,
+        // Leader lines default to the slice colour, which reads as chart junk
+        // once there are more than a handful of slices.
+        labelLine: { lineStyle: { color: theme.axis.lineColor } },
+        // Slice borders separate neighbours whose colours are adjacent in the
+        // palette; the container colour makes them read as gaps rather than
+        // outlines.
+        itemStyle: { borderColor: theme.tooltip.background },
+      };
+    case 'treemap':
+    case 'sunburst':
+      return { label, itemStyle: { borderColor: theme.tooltip.background } };
+    case 'gauge':
+      return {
+        // A gauge's detail/title sit inside the dial, over the axis line.
+        label,
+        detail: { color: theme.text.color },
+        title: { color: theme.text.mutedColor },
+      };
+    case 'heatmap':
+      return { label, itemStyle: { borderColor: theme.tooltip.background } };
+    default:
+      return { label };
+  }
+}
+
+/**
+ * Colours one series by what it is called, where the author said nothing.
+ *
+ * Left absent, ECharts takes the next colour off the palette by position. An
+ * explicit colour in the spec is untouched, so a chart that means to be red
+ * stays red.
+ */
+function colorByName(series: Dict, theme: ChartTheme): Dict {
+  const type = series.type as string | undefined;
+
+  if (type !== undefined && CATEGORIES_ARE_DATA.has(type)) {
+    const { data } = series;
+    if (!Array.isArray(data)) {
+      return series;
+    }
+    return {
+      ...series,
+      data: data.map(datum =>
+        isDict(datum) && typeof datum.name === 'string'
+          ? fillAbsent(datum, {
+              itemStyle: { color: theme.getColor(datum.name) },
+            })
+          : datum,
+      ),
+    };
+  }
+
+  return typeof series.name === 'string'
+    ? (fillAbsent(series, {
+        itemStyle: { color: theme.getColor(series.name) },
+      }) as Dict)
+    : series;
+}
+
+/**
+ * Fills in per-series-type theming the author left unspecified.
+ *
+ * Deliberately additive: an option that sets its own `label.color` keeps it, so
+ * this costs nothing in expressiveness. It only decides what happens when the
+ * author says nothing — which today means "whatever the charting library
+ * guesses", and for labels that guess is a white halo.
+ */
+export function applySeriesDefaults(option: Dict, theme: ChartTheme): Dict {
+  const { series } = option;
+  if (!series) return option;
+
+  if (Array.isArray(series)) {
+    return {
+      ...option,
+      series: series.map(item =>
+        isDict(item)
+          ? colorByName(
+              fillAbsent(
+                item,
+                seriesDefaults(item.type as string, theme),
+              ) as Dict,
+              theme,
+            )
+          : item,
+      ),
+    };
+  }
+  if (isDict(series)) {
+    return {
+      ...option,
+      series: colorByName(
+        fillAbsent(
+          series,
+          seriesDefaults(series.type as string, theme),
+        ) as Dict,
+        theme,
+      ),
+    };
+  }
+  return option;
+}
+
+export default applySeriesDefaults;

--- a/superset-frontend/src/core/dashboard/index.ts
+++ b/superset-frontend/src/core/dashboard/index.ts
@@ -31,6 +31,9 @@
  */
 
 import type { dashboard as dashboardApi } from '@apache-superset/core';
+import { CategoricalColorNamespace } from '@superset-ui/core';
+import { themeObject } from '@apache-superset/core/theme';
+import { getChartTheme } from './chartTheme';
 import { provider, useDashboardRevision } from './store';
 import { fetchQueryData } from './chartData';
 import { registerBuiltInWidgets } from './registerBuiltInWidgets';
@@ -43,6 +46,19 @@ registerBuiltInWidgets();
 
 export { useDashboardRevision };
 
+/**
+ * The canvas's own categorical scheme, or undefined for the deployment's
+ * default.
+ *
+ * On the root node, beside its title: a colour scheme is a property of the
+ * dashboard, so it travels with the saved definition and the assistant can
+ * both read and set it through the same API it edits everything else with.
+ */
+function canvasColorScheme(): string | undefined {
+  const scheme = provider.getRoot().props?.colorScheme;
+  return typeof scheme === 'string' && scheme !== '' ? scheme : undefined;
+}
+
 export const dashboard: typeof dashboardApi = {
   getRoot: provider.getRoot,
   getNode: provider.getNode,
@@ -53,4 +69,10 @@ export const dashboard: typeof dashboardApi = {
   updateProps: provider.updateProps.bind(provider),
   onDidLayoutChange: provider.onDidLayoutChange,
   fetchQueryData,
+  // Both read per call rather than captured once: the canvas's scheme, the
+  // deployment's default and the light/dark theme can each change after this
+  // module is imported.
+  getCategoricalColors: () =>
+    CategoricalColorNamespace.getScale(canvasColorScheme()).colors,
+  getChartTheme: () => getChartTheme(themeObject.theme, canvasColorScheme()),
 };

--- a/superset-frontend/src/core/dashboard/index.ts
+++ b/superset-frontend/src/core/dashboard/index.ts
@@ -35,6 +35,9 @@
 // `const` export (unlike the ambient `declare function`s alongside it, which
 // this object exists to implement and have no JS output of their own).
 import { dashboard as dashboardApi } from '@apache-superset/core';
+import { CategoricalColorNamespace } from '@superset-ui/core';
+import { themeObject } from '@apache-superset/core/theme';
+import { getChartTheme } from './chartTheme';
 import { provider, useDashboardRevision } from './store';
 import { fetchQueryData } from './chartData';
 import { registerBuiltInWidgets } from './registerBuiltInWidgets';
@@ -46,6 +49,19 @@ import { registerBuiltInWidgets } from './registerBuiltInWidgets';
 registerBuiltInWidgets();
 
 export { useDashboardRevision };
+
+/**
+ * The canvas's own categorical scheme, or undefined for the deployment's
+ * default.
+ *
+ * On the root node, beside its title: a colour scheme is a property of the
+ * dashboard, so it travels with the saved definition and the assistant can
+ * both read and set it through the same API it edits everything else with.
+ */
+function canvasColorScheme(): string | undefined {
+  const scheme = provider.getRoot().props?.colorScheme;
+  return typeof scheme === 'string' && scheme !== '' ? scheme : undefined;
+}
 
 export const dashboard: typeof dashboardApi = {
   getRoot: provider.getRoot,
@@ -61,4 +77,10 @@ export const dashboard: typeof dashboardApi = {
   getValue: provider.getValue,
   on: provider.on,
   fetchQueryData,
+  // Both read per call rather than captured once: the canvas's scheme, the
+  // deployment's default and the light/dark theme can each change after this
+  // module is imported.
+  getCategoricalColors: () =>
+    CategoricalColorNamespace.getScale(canvasColorScheme()).colors,
+  getChartTheme: () => getChartTheme(themeObject.theme, canvasColorScheme()),
 };

--- a/superset-frontend/src/core/dashboard/resolveBindings.test.ts
+++ b/superset-frontend/src/core/dashboard/resolveBindings.test.ts
@@ -93,3 +93,14 @@ test('does not splice a theme function in as if it were a value', () => {
     ),
   ).toThrow(/not a chart theme field/);
 });
+
+test('a token that is only on Object.prototype is not a theme value', () => {
+  // Reachable by plain property access, so `constructor` used to resolve to a
+  // function and be spliced straight into the option.
+  expect(() =>
+    resolveBindings(
+      { color: { $bind: { source: 'theme', token: 'constructor' } } },
+      ctx,
+    ),
+  ).toThrow(/not a chart theme field/);
+});

--- a/superset-frontend/src/core/dashboard/resolveBindings.test.ts
+++ b/superset-frontend/src/core/dashboard/resolveBindings.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { resolveBindings } from './resolveBindings';
+import type { BindContext } from './resolveBindings';
+
+const chartTheme = {
+  background: 'transparent',
+  text: {
+    color: '#111',
+    mutedColor: '#666',
+    disabledColor: '#aaa',
+    fontFamily: 'Inter',
+    fontSize: 12,
+  },
+  axis: {
+    lineColor: '#eee',
+    labelColor: '#666',
+    gridColor: '#eee',
+    minorGridColor: '#ddd',
+  },
+  tooltip: { background: '#fff', color: '#111' },
+  accent: '#20a7c9',
+  categoricalColors: ['#1f77b4'],
+  sequentialColors: [],
+  getColor: (label: string) => `colour-of-${label}`,
+};
+
+const ctx: BindContext = {
+  rows: [
+    { country: 'Norway', sales: 10 },
+    { country: 'Spain', sales: 7 },
+  ],
+  chartTheme,
+  theme: { colorPrimary: '#legacy' } as unknown as BindContext['theme'],
+};
+
+test('binds a theme value by what it means rather than by its token name', () => {
+  const out = resolveBindings(
+    {
+      textStyle: { color: { $bind: { source: 'theme', token: 'text.color' } } },
+      marker: { $bind: { source: 'theme', token: 'accent' } },
+    },
+    ctx,
+  );
+
+  expect(out).toEqual({ textStyle: { color: '#111' }, marker: '#20a7c9' });
+});
+
+test('still resolves an option authored against the raw token names', () => {
+  // A vocabulary change should not blank out the charts on every canvas
+  // already saved against the old one.
+  expect(
+    resolveBindings(
+      { color: { $bind: { source: 'theme', token: 'colorPrimary' } } },
+      ctx,
+    ),
+  ).toEqual({ color: '#legacy' });
+});
+
+test('names the fields it accepts when a theme token is neither', () => {
+  expect(() =>
+    resolveBindings(
+      { color: { $bind: { source: 'theme', token: 'colourPrimary' } } },
+      ctx,
+    ),
+  ).toThrow(/not a chart theme field/);
+});
+
+test('does not splice a theme function in as if it were a value', () => {
+  // `getColor` is a field of the chart theme and not a thing an option can
+  // carry; a series is coloured by name in `applySeriesDefaults` instead.
+  expect(() =>
+    resolveBindings(
+      { color: { $bind: { source: 'theme', token: 'getColor' } } },
+      ctx,
+    ),
+  ).toThrow(/not a chart theme field/);
+});

--- a/superset-frontend/src/core/dashboard/resolveBindings.ts
+++ b/superset-frontend/src/core/dashboard/resolveBindings.ts
@@ -18,12 +18,23 @@
  */
 import type { dashboard as dashboardApi } from '@apache-superset/core';
 import type { useTheme } from '@apache-superset/core/theme';
+import type { ChartTheme } from './chartTheme';
 
 type DataRow = dashboardApi.DataRow;
 type Theme = ReturnType<typeof useTheme>;
 
 export interface BindContext {
   rows: DataRow[];
+  /**
+   * What the theme means for a chart, which is what a `theme` bind resolves
+   * against — `text.mutedColor` rather than whatever antd calls it.
+   */
+  chartTheme: ChartTheme;
+  /**
+   * The raw token bag, for a `theme` bind naming a token that has no chart
+   * theme field. Kept so that options authored against the token names keep
+   * working; not what a new one should be written against.
+   */
   theme: Theme;
 }
 
@@ -32,7 +43,10 @@ interface BindMarker {
     source: 'metric' | 'dimension' | 'theme' | 'records';
     /** `metric`/`dimension` — the row field to pull one column's values from. */
     alias?: string;
-    /** `theme` — the theme token to substitute. */
+    /**
+     * `theme` — the chart theme field to substitute, as a dotted path:
+     * `accent`, `text.mutedColor`, `axis.gridColor`.
+     */
     token?: string;
     /**
      * `records` — zip several row fields into one array of plain objects,
@@ -57,6 +71,71 @@ interface BindMarker {
 }
 
 const BIND_SOURCES = new Set(['metric', 'dimension', 'theme', 'records']);
+
+/** Named for the error message, so a wrong token says what the right ones are. */
+const CHART_THEME_FIELDS = [
+  'background',
+  'text.color',
+  'text.mutedColor',
+  'text.disabledColor',
+  'text.fontFamily',
+  'text.fontSize',
+  'axis.lineColor',
+  'axis.labelColor',
+  'axis.gridColor',
+  'axis.minorGridColor',
+  'tooltip.background',
+  'tooltip.color',
+  'accent',
+  'categoricalColors',
+  'sequentialColors',
+];
+
+function readPath(source: unknown, path: string): unknown {
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (value, key) =>
+        value !== null && typeof value === 'object'
+          ? (value as Record<string, unknown>)[key]
+          : undefined,
+      source,
+    );
+}
+
+/**
+ * Resolves a `theme` bind against the chart theme, falling back to the raw
+ * token bag.
+ *
+ * The chart theme is the vocabulary every other part of a widget already gets
+ * its colours from — a renderer is handed `text.mutedColor`, not whatever antd
+ * happens to call it this version. A `$bind` reaching past that into the token
+ * bag was the one place left where an authored option had to know the token
+ * names, which is the coupling `getChartTheme` exists to remove.
+ *
+ * The fallback keeps options already authored against token names rendering,
+ * rather than breaking every saved canvas over a vocabulary change. New ones
+ * are taught the chart theme fields — see the `$bind` guidance in
+ * `clientTools`.
+ *
+ * A function field (`getColor`) is not a value an option can carry, so it is
+ * skipped rather than spliced in as one: a series is coloured by name in
+ * `applySeriesDefaults`, which is where that belongs.
+ */
+function resolveThemeToken(token: string, ctx: BindContext): unknown {
+  const field = readPath(ctx.chartTheme, token);
+  if (field !== undefined && typeof field !== 'function') {
+    return field;
+  }
+  const legacy = (ctx.theme as unknown as Record<string, unknown>)[token];
+  if (legacy !== undefined) {
+    return legacy;
+  }
+  throw new Error(
+    `$bind theme token "${token}" is not a chart theme field. ` +
+      `Use one of: ${CHART_THEME_FIELDS.join(', ')}.`,
+  );
+}
 
 function isBindMarker(value: unknown): value is BindMarker {
   return (
@@ -100,7 +179,7 @@ function resolveBind(bind: BindMarker['$bind'], ctx: BindContext): unknown {
     if (!bind.token) {
       throw new Error('$bind with source "theme" is missing "token"');
     }
-    return (ctx.theme as unknown as Record<string, unknown>)[bind.token];
+    return resolveThemeToken(bind.token, ctx);
   }
   if (bind.source === 'metric' || bind.source === 'dimension') {
     if (!bind.alias) {

--- a/superset-frontend/src/core/dashboard/resolveBindings.ts
+++ b/superset-frontend/src/core/dashboard/resolveBindings.ts
@@ -127,8 +127,14 @@ function resolveThemeToken(token: string, ctx: BindContext): unknown {
   if (field !== undefined && typeof field !== 'function') {
     return field;
   }
-  const legacy = (ctx.theme as unknown as Record<string, unknown>)[token];
-  if (legacy !== undefined) {
+  // Own properties only: `constructor` and `toString` are reachable by plain
+  // property access and would splice a function out of `Object.prototype`
+  // into an authored option instead of raising the error below.
+  const tokens = ctx.theme as unknown as Record<string, unknown>;
+  const legacy = Object.prototype.hasOwnProperty.call(tokens, token)
+    ? tokens[token]
+    : undefined;
+  if (legacy !== undefined && typeof legacy !== 'function') {
     return legacy;
   }
   throw new Error(

--- a/superset-frontend/src/core/dashboard/resolveBindings.ts
+++ b/superset-frontend/src/core/dashboard/resolveBindings.ts
@@ -115,8 +115,9 @@ function readPath(source: unknown, path: string): unknown {
  *
  * The fallback keeps options already authored against token names rendering,
  * rather than breaking every saved canvas over a vocabulary change. New ones
- * are taught the chart theme fields — see the `$bind` guidance in
- * `clientTools`.
+ * are taught the chart theme fields by the widget control schema — see the
+ * `$bind` guidance on `EchartsControls.echarts_options` in
+ * `superset/widgets/controls.py`.
  *
  * A function field (`getColor`) is not a value an option can carry, so it is
  * skipped rather than spliced in as one: a series is coloured by name in

--- a/superset-frontend/src/core/dashboard/widgets/ChartWidget.test.tsx
+++ b/superset-frontend/src/core/dashboard/widgets/ChartWidget.test.tsx
@@ -105,7 +105,7 @@ test('a chart does not draw the name its header already carries', async () => {
   expect(option).toHaveProperty('series');
 });
 
-test('an existing raw-only echarts widget (no chartType) renders exactly as before', async () => {
+test('an existing raw-only echarts widget (no chartType) keeps what it authored', async () => {
   const rawSeries = [{ type: 'pie', data: [{ name: 'a', value: 1 }] }];
   const id = provider.addWidget(provider.getRoot().id, 0, {
     type: 'echarts',
@@ -118,9 +118,11 @@ test('an existing raw-only echarts widget (no chartType) renders exactly as befo
 
   await waitFor(() => expect(mockSetOption).toHaveBeenCalled());
 
+  // The theme fills in what the option leaves unsaid (label colours, palette
+  // entries, and so on), so the authored shape is checked as a subset.
   const [option] = mockSetOption.mock.calls[0];
-  expect(option.series).toEqual(rawSeries);
-  expect(option.legend).toEqual({ show: true });
+  expect(option.series).toMatchObject(rawSeries);
+  expect(option.legend).toMatchObject({ show: true });
 });
 
 test('selecting a structured chart type replaces series with one generated per metric', async () => {
@@ -143,8 +145,8 @@ test('selecting a structured chart type replaces series with one generated per m
   const [option] = mockSetOption.mock.calls[0];
   // The structured layer only manages `series` — everything else the raw
   // option authored survives unmanaged.
-  expect(option.legend).toEqual({ show: true });
-  expect(option.series).toEqual([
+  expect(option.legend).toMatchObject({ show: true });
+  expect(option.series).toMatchObject([
     {
       name: 'count',
       type: 'bar',
@@ -172,7 +174,7 @@ test('a series override is applied by stable metric key when chartType is set', 
   await waitFor(() => expect(mockSetOption).toHaveBeenCalled());
 
   const [option] = mockSetOption.mock.calls[0];
-  expect(option.series).toEqual([
+  expect(option.series).toMatchObject([
     {
       name: 'Total',
       type: 'line',
@@ -203,9 +205,9 @@ test('structured chrome (legend/tooltip/axis) applies alongside raw echartsOptio
   await waitFor(() => expect(mockSetOption).toHaveBeenCalled());
 
   const [option] = mockSetOption.mock.calls[0];
-  expect(option.legend).toEqual({ show: false });
-  expect(option.tooltip).toEqual({ trigger: 'axis' });
-  expect(option.xAxis).toEqual({
+  expect(option.legend).toMatchObject({ show: false });
+  expect(option.tooltip).toMatchObject({ trigger: 'axis' });
+  expect(option.xAxis).toMatchObject({
     type: 'category',
     name: 'Product',
     axisLabel: { color: 'red', rotate: 45 },

--- a/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
+++ b/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
@@ -56,7 +56,13 @@ import { useTheme } from '@apache-superset/core/theme';
 import { Flex, Loading, Typography } from '@superset-ui/core/components';
 import { provider, useDashboardRevision } from '../store';
 import { fetchQueryData } from '../chartData';
+import {
+  getEchartsTheme,
+  mergeEchartsThemeOverrides,
+} from '@superset-ui/plugin-chart-echarts';
 import { resolveBindings } from '../resolveBindings';
+import { getChartTheme } from '../chartTheme';
+import { applySeriesDefaults } from '../echartsSeriesDefaults';
 
 type DataBindingSpec = dashboardApi.DataBindingSpec;
 type DataRow = dashboardApi.DataRow;
@@ -223,11 +229,20 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bindingKey]);
 
+  const colorScheme = provider.getRoot().props?.colorScheme;
+  const chartTheme = useMemo(
+    () =>
+      getChartTheme(
+        theme,
+        typeof colorScheme === 'string' ? colorScheme : undefined,
+      ),
+    [theme, colorScheme],
+  );
   const option = useMemo(() => {
     if (!rows) return undefined;
     const resolved = resolveBindings(
       (node?.props?.echartsOptions as Record<string, unknown>) ?? {},
-      { rows, theme },
+      { rows, chartTheme, theme },
     );
     // The chart's name is drawn by the widget's header, which reads it from
     // this same option (see `widgetLabel`). Leaving it here too would print it
@@ -235,8 +250,31 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     // that sits where every other widget's name sits.
     const withoutTitle = { ...resolved };
     delete withoutTitle.title;
-    return withoutTitle;
-  }, [node?.props?.echartsOptions, rows, theme]);
+
+    // Everything an AI-authored option doesn't say for itself comes from the
+    // theme: text/axis/legend/tooltip colors, the categorical palette, and
+    // whatever chart overrides the theme carries. Merged *under* the option
+    // (rightmost source wins in `mergeEchartsThemeOverrides`), so an explicit
+    // choice in the spec still takes precedence.
+    const merged = mergeEchartsThemeOverrides(
+      {
+        ...getEchartsTheme(theme, withoutTitle),
+        // The fallback for a series with no name of its own. A named one is
+        // coloured by that name in `applySeriesDefaults`, so it never reaches
+        // this list.
+        color: chartTheme.categoricalColors,
+        backgroundColor: 'transparent',
+      },
+      withoutTitle,
+      theme.echartsOptionsOverrides ?? {},
+    );
+
+    // Per-series-type theming can't ride along in the merge — a source array
+    // replaces the destination's, so any `series` the theme layer added would
+    // be dropped by the authored one. Filled in afterwards, and only where the
+    // option is silent, which leaves an explicit choice in the spec intact.
+    return applySeriesDefaults(merged, chartTheme);
+  }, [node?.props?.echartsOptions, rows, theme, chartTheme]);
 
   if (!node) return null;
 

--- a/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
+++ b/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
@@ -234,7 +234,12 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     () =>
       getChartTheme(
         theme,
-        typeof colorScheme === 'string' ? colorScheme : undefined,
+        // Empty is unset, not a scheme named "": the registry would look up
+        // the empty key and hand back no palette at all. Matches how the
+        // dashboard API reads the same prop.
+        typeof colorScheme === 'string' && colorScheme !== ''
+          ? colorScheme
+          : undefined,
       ),
     [theme, colorScheme],
   );

--- a/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
+++ b/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
@@ -328,7 +328,12 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     () =>
       getChartTheme(
         theme,
-        typeof colorScheme === 'string' ? colorScheme : undefined,
+        // Empty is unset, not a scheme named "": the registry would look up
+        // the empty key and hand back no palette at all. Matches how the
+        // dashboard API reads the same prop.
+        typeof colorScheme === 'string' && colorScheme !== ''
+          ? colorScheme
+          : undefined,
       ),
     [theme, colorScheme],
   );

--- a/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
+++ b/superset-frontend/src/core/dashboard/widgets/ChartWidget.tsx
@@ -56,9 +56,15 @@ import { useTheme } from '@apache-superset/core/theme';
 import { Flex, Loading, Typography } from '@superset-ui/core/components';
 import { provider, useDashboardRevision } from '../store';
 import { fetchQueryData } from '../chartData';
+import {
+  getEchartsTheme,
+  mergeEchartsThemeOverrides,
+} from '@superset-ui/plugin-chart-echarts';
 import { resolveBindings } from '../resolveBindings';
 import { getActiveFiltersForDataset } from '../collectActiveFilters';
 import type { FilterValueChangedPayload } from '../filterVocabulary';
+import { getChartTheme } from '../chartTheme';
+import { applySeriesDefaults } from '../echartsSeriesDefaults';
 
 type DataBindingSpec = dashboardApi.DataBindingSpec;
 type DataRow = dashboardApi.DataRow;
@@ -317,11 +323,20 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bindingKey]);
 
+  const colorScheme = provider.getRoot().props?.colorScheme;
+  const chartTheme = useMemo(
+    () =>
+      getChartTheme(
+        theme,
+        typeof colorScheme === 'string' ? colorScheme : undefined,
+      ),
+    [theme, colorScheme],
+  );
   const option = useMemo(() => {
     if (!rows) return undefined;
     const resolved = resolveBindings(
       (node?.props?.echartsOptions as Record<string, unknown>) ?? {},
-      { rows, theme },
+      { rows, chartTheme, theme },
     );
     // The chart's name is drawn by the widget's header, which reads it from
     // this same option (see `widgetLabel`). Leaving it here too would print it
@@ -329,8 +344,31 @@ export default function ChartWidget({ nodeId }: { nodeId: string }) {
     // that sits where every other widget's name sits.
     const withoutTitle = { ...resolved };
     delete withoutTitle.title;
-    return withoutTitle;
-  }, [node?.props?.echartsOptions, rows, theme]);
+
+    // Everything an AI-authored option doesn't say for itself comes from the
+    // theme: text/axis/legend/tooltip colors, the categorical palette, and
+    // whatever chart overrides the theme carries. Merged *under* the option
+    // (rightmost source wins in `mergeEchartsThemeOverrides`), so an explicit
+    // choice in the spec still takes precedence.
+    const merged = mergeEchartsThemeOverrides(
+      {
+        ...getEchartsTheme(theme, withoutTitle),
+        // The fallback for a series with no name of its own. A named one is
+        // coloured by that name in `applySeriesDefaults`, so it never reaches
+        // this list.
+        color: chartTheme.categoricalColors,
+        backgroundColor: 'transparent',
+      },
+      withoutTitle,
+      theme.echartsOptionsOverrides ?? {},
+    );
+
+    // Per-series-type theming can't ride along in the merge — a source array
+    // replaces the destination's, so any `series` the theme layer added would
+    // be dropped by the authored one. Filled in afterwards, and only where the
+    // option is silent, which leaves an explicit choice in the spec intact.
+    return applySeriesDefaults(merged, chartTheme);
+  }, [node?.props?.echartsOptions, rows, theme, chartTheme]);
 
   if (!node) return null;
 

--- a/superset/widgets/api.py
+++ b/superset/widgets/api.py
@@ -155,11 +155,11 @@ class WidgetControlsRestApi(BaseSupersetApi):
                       items:
                         type: string
                       description: >-
-                        When given, return a `{path: schema}` map of just these
+                        When given, return a "{path: schema}" map of just these
                         drill-in subtrees instead of the whole schema.
           responses:
             200:
-              description: Control JSON Schema, or a `{path: schema}` map
+              description: "Control JSON Schema, or a {path: schema} map"
               content:
                 application/json:
                   schema:

--- a/superset/widgets/controls.py
+++ b/superset/widgets/controls.py
@@ -280,8 +280,10 @@ class EchartsControls(BaseModel):
             '"single": true to unwrap a single-row value); {"$bind": {"source": '
             '"records", "fields": {"name": "<col>", "value": "<col>"}}} yields '
             "an array of {name, value} objects (e.g. for pie series data); and "
-            '{"$bind": {"source": "theme", "token": "<token>"}} yields a Superset '
-            "theme value. The $bind wrapper is required."
+            '{"$bind": {"source": "theme", "token": "<field>"}} yields a chart '
+            'theme value, addressed by dotted path (e.g. "accent", '
+            '"text.mutedColor", "axis.gridColor"); a raw theme token name also '
+            "resolves. The $bind wrapper is required."
         ),
         json_schema_extra={
             "x-control": "code",


### PR DESCRIPTION
### SUMMARY

Targets `dashboard-v2`, on top of the containers work merged in #43065.

A Dashboard v2 block draws its ECharts option on a bare canvas, bypassing `SuperChart`/`ChartPlugin` — so nothing applied the theme to it. Three consequences, fixed here:

1. **A chart ignored the theme.** It rendered ECharts' stock near-black text and default blue palette whatever theme was active. `getEchartsTheme` moves out of `Echart.tsx`'s inline closure into `utils/echartsTheme.ts` so something other than that one component can reach it, and `ChartBlock` merges it *under* the authored option — an explicit choice in the spec still wins. Axis styling applies only when the option declares an axis, so it no longer draws a cartesian grid onto a pie.

2. **A block had no way to know what the theme means.** The only affordance was `getCategoricalColors()`, so each contributed block re-derived the rest from raw antd tokens — every extension its own mapping, all destined to drift. `dashboard.getChartTheme()` states it once, semantically (background, text, axis, tooltip, accent, categorical + sequential colours); a renderer maps those few fields and merges its own spec over the result. It also exposes Superset's sequential schemes, which nothing was exposing at all, so any continuous colour fell back to the library's default blues.

   `getColor(label)` colours a series by name through the scale that remembers what it gave a label — the same one v1 charts use. By position, a category is one colour in a chart that lists it second and another in a chart that lists it fifth, which is what makes a set of blocks read as unrelated charts rather than one dashboard.

3. **A themed deployment didn't reach a canvas.** The card used `colorBgContainer`/`colorBorderSecondary`/`borderRadiusLG` — close to v1's dashboard tile but not it. v1 reads three `dashboardTile*` override points, so a deployment that themes its tiles had no effect here at all. Same tokens now, same fallbacks.

   Also adds per-series-type theming, which a global `textStyle` cannot reach: v1 is theme-correct because ~40 `transformProps` files each know which of *their* chart's elements are themeable, and a generic option has no `viz_type` to look that up by. It does carry `series[].type`, so the same thing is derived from the option — which is what stops an AI-authored pie drawing a white halo around every label (zrender's `useDefaultFill` stroke when no label colour is set).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — the visible change is charts matching the active theme rather than ECharts' defaults; no layout or chrome changes beyond the card's token source.

### TESTING INSTRUCTIONS

1. Open a v2 dashboard and add an `echarts` block with a `dataBinding` and a bar or pie option that sets no colours.
2. Confirm text, axes, legend and tooltip follow the active theme, and that the series takes a colour from the active categorical scheme rather than ECharts' blue.
3. Add a second chart whose series has the same name; confirm both draw it in the same colour.
4. Switch light/dark and confirm both follow without a reload.
5. Set `colorScheme` on the root node; confirm charts pick up that palette.
6. With a theme defining `dashboardTileBg`/`dashboardTileBorder`/`dashboardTileBorderRadius`, confirm a block's card matches a v1 dashboard tile.
7. `npm run test -- src/core/dashboard` — `chartTheme`, `echartsSeriesDefaults` and `resolveBindings` suites.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [x] Changes UI — charts inside v2 building blocks follow the theme; the block card reads v1's `dashboardTile*` tokens
- [ ] Includes DB Migration: No — frontend only
- [x] Introduces new feature or API — `dashboard.getChartTheme()` on the extension API; `getEchartsTheme`/`mergeEchartsThemeOverrides` newly exported from `plugin-chart-echarts`
- [ ] Removes existing feature or API: No — `getCategoricalColors()` stays, though `getChartTheme().categoricalColors` supersedes it
