### PR TITLE
fix(explore): exclude time-comparison derived columns from stacked Only Total (Closes #43068)

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -33,7 +33,7 @@ import {
 } from '@superset-ui/core';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { GenericDataType } from '@apache-superset/core/common';
-import { SortSeriesType, LegendPaddingType } from '@superset-ui/chart-controls';
+import { SortSeriesType, LegendPaddingType, TIME_COMPARISON_SEPARATOR } from '@superset-ui/chart-controls';
 import { format } from 'echarts/core';
 import type { LegendComponentOption } from 'echarts/components';
 import type { SeriesOption } from 'echarts';
@@ -407,6 +407,10 @@ export function extractDataTotalValues(
     data.forEach(datum => {
       const values = Object.keys(datum).reduce((prev, curr) => {
         if (excludedKeys.has(curr)) {
+          return prev;
+        }
+        // Exclude time-comparison derived columns of excluded keys (e.g. SortMetric__1 year ago)
+        if (Array.from(excludedKeys).some(key => curr !== key && curr.startsWith(key + TIME_COMPARISON_SEPARATOR))) {
           return prev;
         }
         if (legendState && !legendState[curr]) {


### PR DESCRIPTION
## Summary

#42881 fixed the stacked "Only Total" label so it no longer includes a sort-only metric. It handles the plain and verbose-named cases, but the exclusion is an exact-name match, so **time-comparison derived columns of that same sort-only metric are still summed into the total**.

### Before

`extractDataTotalValues` creates `excludedKeys` with the sort-only metric labels, but a time-comparison derived column like `SortMetric__1 year ago` does not match `SortMetric` exactly, so it passes through and inflates the stacked total.

### After

Check if a column key starts with any excluded key followed by the `TIME_COMPARISON_SEPARATOR` (`__`). This ensures that `SortMetric__1 year ago`, `SortMetric__2 years ago`, etc. are also excluded from the stacked total.

### Impact

- **Fix**: Stacked "Only Total" on time-comparison charts with a sort-only metric no longer includes the sort-only metric's derived columns
- **Scope**: `superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts` — `extractDataTotalValues` function
- **No regression**: The original exact-match exclusion is preserved; the derived-column check is an additional guard

Closes #43068
