### PR TITLE
fix(cache): align dashboard cache warm-up filters

### DIFF
--- a/superset/charts/data/dashboard_filter_context.py
+++ b/superset/charts/data/dashboard_filter_context.py
@@ -92,29 +92,30 @@ def _is_filter_in_scope_for_chart(
     if chart_id in excluded:
         return False
 
-    if chart_layout_item := _find_chart_layout_item(chart_id, position_json):
-        parents: list[str] = chart_layout_item.get("parents", [])
-        return any(parent in root_path for parent in parents)
+    if chart_layout_items := _find_chart_layout_items(chart_id, position_json):
+        return any(
+            parent in root_path
+            for chart_layout_item in chart_layout_items
+            for parent in chart_layout_item.get("parents", [])
+        )
 
     # If the chart doesn't exist in the dashboard layout, treat it as a
     # root-level chart.
     return "ROOT_ID" in root_path
 
 
-def _find_chart_layout_item(
+def _find_chart_layout_items(
     chart_id: int,
     position_json: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Find the layout item for a chart in the dashboard position JSON."""
-    for item in position_json.values():
-        if not isinstance(item, dict):
-            continue
-        if (
-            item.get("type") == CHART_TYPE
-            and item.get("meta", {}).get("chartId") == chart_id
-        ):
-            return item
-    return None
+) -> list[dict[str, Any]]:
+    """Find every layout item for a chart in the dashboard position JSON."""
+    return [
+        item
+        for item in position_json.values()
+        if isinstance(item, dict)
+        and item.get("type") == CHART_TYPE
+        and item.get("meta", {}).get("chartId") == chart_id
+    ]
 
 
 def _merge_extra_form_data(
@@ -266,40 +267,19 @@ def _check_dashboard_access(dashboard: Dashboard) -> None:
     security_manager.raise_for_access(dashboard=dashboard)
 
 
-def get_dashboard_filter_context(
-    dashboard_id: int,
+def build_dashboard_filter_context(
+    dashboard: Dashboard,
     chart_id: int,
     *,
     active_data_mask: dict[str, Any] | None = None,
 ) -> DashboardFilterContext:
     """
-    Build a DashboardFilterContext for a chart on a dashboard.
+    Build filter context from an already-loaded dashboard.
 
-    Loads the dashboard's native filter configuration, determines which
-    filters are in scope for the given chart, resolves each filter's value,
-    and returns the merged extra_form_data along with metadata about each filter.
-
-    When ``active_data_mask`` is provided (e.g. the live filter state from a
-    dashboard view), each in-scope filter present in the mask uses its active
-    ``extraFormData`` instead of the saved default; an empty active value means
-    the filter was cleared. Filters absent from the mask fall back to their
-    saved defaults, so omitting ``active_data_mask`` reproduces the dashboard's
-    initial-load behavior.
-
-    :param dashboard_id: The ID of the dashboard
-    :param chart_id: The ID of the chart
-    :param active_data_mask: Optional live filter state keyed by native filter id
-    :returns: DashboardFilterContext with merged extra_form_data and filter metadata
-    :raises ValueError: if dashboard not found or chart not on dashboard
-    :raises SupersetSecurityException: if the user cannot access the dashboard
+    This helper intentionally does not perform an access check. Callers that expose
+    dashboard data must validate access before invoking it; callers such as cache
+    warming already operate on dashboard metadata loaded by their existing path.
     """
-    dashboard = db.session.query(Dashboard).filter_by(id=dashboard_id).one_or_none()
-    if not dashboard:
-        raise ValueError(
-            _("Dashboard %(dashboard_id)s not found", dashboard_id=dashboard_id)
-        )
-
-    _check_dashboard_access(dashboard)
     _validate_chart_on_dashboard(dashboard, chart_id)
 
     metadata = json.loads(dashboard.json_metadata or "{}")
@@ -339,6 +319,47 @@ def get_dashboard_filter_context(
         )
 
     return context
+
+
+def get_dashboard_filter_context(
+    dashboard_id: int,
+    chart_id: int,
+    *,
+    active_data_mask: dict[str, Any] | None = None,
+) -> DashboardFilterContext:
+    """
+    Build a DashboardFilterContext for a chart on a dashboard.
+
+    Loads the dashboard's native filter configuration, determines which
+    filters are in scope for the given chart, resolves each filter's value,
+    and returns the merged extra_form_data along with metadata about each filter.
+
+    When ``active_data_mask`` is provided (e.g. the live filter state from a
+    dashboard view), each in-scope filter present in the mask uses its active
+    ``extraFormData`` instead of the saved default; an empty active value means
+    the filter was cleared. Filters absent from the mask fall back to their
+    saved defaults, so omitting ``active_data_mask`` reproduces the dashboard's
+    initial-load behavior.
+
+    :param dashboard_id: The ID of the dashboard
+    :param chart_id: The ID of the chart
+    :param active_data_mask: Optional live filter state keyed by native filter id
+    :returns: DashboardFilterContext with merged extra_form_data and filter metadata
+    :raises ValueError: if dashboard not found or chart not on dashboard
+    :raises SupersetSecurityException: if the user cannot access the dashboard
+    """
+    dashboard = db.session.query(Dashboard).filter_by(id=dashboard_id).one_or_none()
+    if not dashboard:
+        raise ValueError(
+            _("Dashboard %(dashboard_id)s not found", dashboard_id=dashboard_id)
+        )
+
+    _check_dashboard_access(dashboard)
+    return build_dashboard_filter_context(
+        dashboard,
+        chart_id,
+        active_data_mask=active_data_mask,
+    )
 
 
 def apply_dashboard_filter_context(  # noqa: C901

--- a/superset/commands/chart/warm_up_cache.py
+++ b/superset/commands/chart/warm_up_cache.py
@@ -46,7 +46,7 @@ class ChartWarmUpCacheCommand(BaseCommand):
         self._extra_filters = extra_filters
 
     def _get_dashboard_filters(self, chart_id: int) -> list[dict[str, Any]]:
-        """Retrieve dashboard filters from extra_filters or dashboard metadata."""
+        """Retrieve dashboard filters from explicit or persisted defaults."""
         if not self._dashboard_id:
             return []
 
@@ -65,12 +65,12 @@ class ChartWarmUpCacheCommand(BaseCommand):
                 "Explore once (or re-save it) to generate it."
             )
 
-        # Apply dashboard filters if dashboard_id is provided
         if dashboard_filters := self._get_dashboard_filters(chart.id):
             for query in query_context.queries:
-                query.filter.extend(
-                    cast(list[QueryObjectFilterClause], dashboard_filters)
-                )
+                query.filter = [
+                    *cast(list[QueryObjectFilterClause], dashboard_filters),
+                    *query.filter,
+                ]
 
         query_context.force = True
         command = ChartDataCommand(query_context)

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -37,6 +37,9 @@ from flask_babel import _
 from werkzeug.exceptions import BadRequest
 
 from superset import appbuilder, dataframe, db, result_set
+from superset.charts.data.dashboard_filter_context import (
+    build_dashboard_filter_context,
+)
 from superset.common.db_query_status import QueryStatus
 from superset.exceptions import (
     SerializationError,
@@ -502,11 +505,19 @@ def get_dashboard_extra_filters(
         return []
 
     with contextlib.suppress(json.JSONDecodeError):
-        # does this dashboard have default filters?
         json_metadata = json.loads(dashboard.json_metadata)
+        native_context = build_dashboard_filter_context(dashboard, slice_id)
+        native_filters = [
+            flt
+            for flt in native_context.extra_form_data.get("filters", [])
+            if isinstance(flt, dict)
+        ]
+
+        # Legacy Filter Box defaults and native filter defaults are applied
+        # independently by the frontend, so preserve both in the same order.
         default_filters = json.loads(json_metadata.get("default_filters", "null"))
         if not default_filters:
-            return []
+            return native_filters
 
         # are default filters applicable to the given slice?
         filter_scopes = json_metadata.get("filter_scopes", {})
@@ -517,7 +528,11 @@ def get_dashboard_extra_filters(
             and isinstance(filter_scopes, dict)
             and isinstance(default_filters, dict)
         ):
-            return build_extra_filters(layout, filter_scopes, default_filters, slice_id)
+            legacy_filters = build_extra_filters(
+                layout, filter_scopes, default_filters, slice_id
+            )
+            return [*legacy_filters, *native_filters]
+        return native_filters
     return []
 
 
@@ -568,7 +583,7 @@ def build_extra_filters(  # pylint: disable=too-many-locals,too-many-nested-bloc
                     extra_filters.append(
                         {
                             "col": col,
-                            "op": "in" if isinstance(val, list) else "==",
+                            "op": "IN" if isinstance(val, list) else "==",
                             "val": val,
                         }
                     )

--- a/tests/unit_tests/charts/test_dashboard_filter_context.py
+++ b/tests/unit_tests/charts/test_dashboard_filter_context.py
@@ -23,7 +23,7 @@ import pytest
 
 from superset.charts.data.dashboard_filter_context import (
     _extract_filter_extra_form_data,
-    _find_chart_layout_item,
+    _find_chart_layout_items,
     _is_filter_in_scope_for_chart,
     _merge_extra_form_data,
     _validate_chart_on_dashboard,
@@ -111,25 +111,23 @@ def _make_filter(
     return flt
 
 
-# --- _find_chart_layout_item ---
+# --- _find_chart_layout_items ---
 
 
-def test_find_chart_layout_item_found() -> None:
-    result = _find_chart_layout_item(10, SAMPLE_POSITION_JSON)
-    assert result is not None
-    assert result["id"] == "CHART-xyz"
-    assert result["meta"]["chartId"] == 10
+def test_find_chart_layout_items_found() -> None:
+    result = _find_chart_layout_items(10, SAMPLE_POSITION_JSON)
+    assert len(result) == 1
+    assert result[0]["id"] == "CHART-xyz"
+    assert result[0]["meta"]["chartId"] == 10
 
 
-def test_find_chart_layout_item_not_found() -> None:
-    result = _find_chart_layout_item(999, SAMPLE_POSITION_JSON)
-    assert result is None
+def test_find_chart_layout_items_not_found() -> None:
+    assert _find_chart_layout_items(999, SAMPLE_POSITION_JSON) == []
 
 
-def test_find_chart_layout_item_skips_non_dict_entries() -> None:
+def test_find_chart_layout_items_skips_non_dict_entries() -> None:
     position = {**SAMPLE_POSITION_JSON, "DASHBOARD_VERSION_KEY": "v2"}
-    result = _find_chart_layout_item(10, position)
-    assert result is not None
+    assert len(_find_chart_layout_items(10, position)) == 1
 
 
 # --- _is_filter_in_scope_for_chart ---
@@ -163,6 +161,35 @@ def test_filter_in_scope_ignores_empty_charts_in_scope() -> None:
 def test_filter_in_scope_via_root_path() -> None:
     flt = _make_filter(scope_root=["ROOT_ID"])
     assert _is_filter_in_scope_for_chart(flt, 10, SAMPLE_POSITION_JSON) is True
+
+
+@pytest.mark.parametrize("reverse_layout", [False, True])
+def test_filter_in_scope_when_any_duplicate_layout_item_matches(
+    reverse_layout: bool,
+) -> None:
+    flt = _make_filter(scope_root=["TAB-in-scope"])
+    items = [
+        (
+            "CHART-out-of-scope",
+            {
+                "type": "CHART",
+                "meta": {"chartId": 10},
+                "parents": ["ROOT_ID", "TAB-out-of-scope"],
+            },
+        ),
+        (
+            "CHART-in-scope",
+            {
+                "type": "CHART",
+                "meta": {"chartId": 10},
+                "parents": ["ROOT_ID", "TAB-in-scope"],
+            },
+        ),
+    ]
+    if reverse_layout:
+        items.reverse()
+
+    assert _is_filter_in_scope_for_chart(flt, 10, dict(items)) is True
 
 
 def test_filter_excluded_from_scope() -> None:
@@ -249,7 +276,7 @@ def test_extract_default_to_first_item_overrides_static_default() -> None:
 
 
 def test_extract_filter_state_value_but_no_extra_form_data() -> None:
-    """Edge case: filterState.value set but extraFormData not persisted."""
+    """A value alone is insufficient to rebuild plugin-specific filter data."""
     flt = _make_filter()
     flt["defaultDataMask"] = {"filterState": {"value": ["US"]}}
     extra_form_data, status = _extract_filter_extra_form_data(flt)
@@ -369,6 +396,24 @@ def test_get_dashboard_filter_context_dashboard_not_found(
     ) = None
     with pytest.raises(ValueError, match="not found"):
         get_dashboard_filter_context(dashboard_id=999, chart_id=10)
+
+
+@patch("superset.charts.data.dashboard_filter_context._check_dashboard_access")
+@patch("superset.charts.data.dashboard_filter_context.db")
+def test_get_dashboard_filter_context_checks_access_before_building(
+    mock_db: MagicMock,
+    mock_check_access: MagicMock,
+) -> None:
+    dashboard = MagicMock()
+    (
+        mock_db.session.query.return_value.filter_by.return_value.one_or_none.return_value
+    ) = dashboard
+    mock_check_access.side_effect = RuntimeError("access denied")
+
+    with pytest.raises(RuntimeError, match="access denied"):
+        get_dashboard_filter_context(dashboard_id=42, chart_id=10)
+
+    mock_check_access.assert_called_once_with(dashboard)
 
 
 @patch("superset.charts.data.dashboard_filter_context._check_dashboard_access")

--- a/tests/unit_tests/commands/chart/warm_up_cache_test.py
+++ b/tests/unit_tests/commands/chart/warm_up_cache_test.py
@@ -14,29 +14,36 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from unittest.mock import Mock, patch
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from superset.commands.chart.warm_up_cache import ChartWarmUpCacheCommand
 from superset.models.slice import Slice
+from superset.utils import json
 
 
 @pytest.fixture(autouse=True)
-def mock_security_manager():
-    with patch("superset.commands.chart.warm_up_cache.security_manager"):
-        yield
+def mock_security_manager() -> Iterator[Mock]:
+    with patch(
+        "superset.commands.chart.warm_up_cache.security_manager",
+        new=Mock(),
+    ) as security_manager:
+        yield security_manager
 
 
 @patch("superset.commands.chart.warm_up_cache.get_dashboard_extra_filters")
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
-def test_applies_dashboard_filters_to_non_legacy_chart(
-    mock_chart_data_command, mock_get_dashboard_filters
+def test_prepends_dashboard_filters_to_non_legacy_chart(
+    mock_chart_data_command: Mock,
+    mock_get_dashboard_filters: Mock,
 ):
-    """Verify dashboard filters are added to query.filter for non-legacy viz"""
-    # Setup: Mock dashboard filters response
+    """Dashboard filters must precede chart filters to match the frontend."""
     mock_get_dashboard_filters.return_value = [
-        {"col": "country", "op": "in", "val": ["USA", "France"]}
+        {"col": "country", "op": "IN", "val": ["USA", "France"]}
     ]
 
     # Create a chart with non-legacy viz type
@@ -48,38 +55,81 @@ def test_applies_dashboard_filters_to_non_legacy_chart(
         datasource_type="table",
     )
 
-    # Create mock query with empty filter list
     mock_query = Mock()
-    mock_query.filter = []
-    mock_qc = Mock()
-    mock_qc.queries = [mock_query]
-    mock_qc.force = False
+    mock_query.filter = [{"col": "year", "op": "==", "val": 2026}]
+    mock_qc = Mock(queries=[mock_query], force=False)
 
-    # Mock dependencies
     with patch.object(chart, "get_query_context", return_value=mock_qc):
         mock_chart_data_command.return_value.run.return_value = {
             "queries": [{"error": None, "status": "success"}]
         }
 
-        # Execute with dashboard_id
         result = ChartWarmUpCacheCommand(chart, 42, None).run()
 
-        # VALIDATE: Filters were added to query.filter
-        assert len(mock_query.filter) == 1, "Filter should be added to query"
-        assert mock_query.filter[0] == {
-            "col": "country",
-            "op": "in",
-            "val": ["USA", "France"],
-        }, "Filter content should match dashboard filter"
-
-        # VALIDATE: get_dashboard_extra_filters was called correctly
+        assert mock_query.filter == [
+            {"col": "country", "op": "IN", "val": ["USA", "France"]},
+            {"col": "year", "op": "==", "val": 2026},
+        ]
         mock_get_dashboard_filters.assert_called_once_with(123, 42)
-
-        # VALIDATE: force flag was set
-        assert mock_qc.force is True, "force should be set to True"
-
-        # VALIDATE: Result is correct
+        assert mock_qc.force is True
         assert result["chart_id"] == 123
+
+
+@patch("superset.views.utils.db")
+@patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
+def test_persisted_native_default_reaches_warm_up_query(
+    mock_chart_data_command: Mock,
+    mock_dashboard_db: MagicMock,
+) -> None:
+    chart = Slice(
+        id=131,
+        slice_name="Persisted native default",
+        viz_type="echarts_timeseries_bar",
+        datasource_id=1,
+        datasource_type="table",
+    )
+    mock_query = Mock()
+    mock_query.filter = [{"col": "year", "op": "==", "val": 2026}]
+    mock_query_context = Mock(queries=[mock_query])
+    dashboard = MagicMock()
+    dashboard.id = 42
+    dashboard.slices = [chart]
+    dashboard.position_json = "{}"
+    dashboard.json_metadata = json.dumps(
+        {
+            "native_filter_configuration": [
+                {
+                    "id": "NATIVE_FILTER-1",
+                    "name": "Region",
+                    "type": "NATIVE_FILTER",
+                    "filterType": "filter_select",
+                    "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+                    "targets": [{"column": {"name": "region"}}],
+                    "defaultDataMask": {
+                        "extraFormData": {
+                            "filters": [{"col": "region", "op": "IN", "val": ["APAC"]}]
+                        },
+                        "filterState": {"value": ["APAC"]},
+                    },
+                    "controlValues": {},
+                }
+            ]
+        }
+    )
+    (
+        mock_dashboard_db.session.query.return_value.filter_by.return_value.one_or_none.return_value
+    ) = dashboard
+    mock_chart_data_command.return_value.run.return_value = {
+        "queries": [{"error": None, "status": "success"}]
+    }
+
+    with patch.object(chart, "get_query_context", return_value=mock_query_context):
+        ChartWarmUpCacheCommand(chart, 42, None).run()
+
+    assert mock_query.filter == [
+        {"col": "region", "op": "IN", "val": ["APAC"]},
+        {"col": "year", "op": "==", "val": 2026},
+    ]
 
 
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
@@ -117,7 +167,8 @@ def test_no_filters_applied_without_dashboard_id(mock_chart_data_command):
 @patch("superset.commands.chart.warm_up_cache.get_dashboard_extra_filters")
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
 def test_extra_filters_parameter_takes_precedence(
-    mock_chart_data_command, mock_get_dashboard_filters
+    mock_chart_data_command: Mock,
+    mock_get_dashboard_filters: Mock,
 ):
     """Verify extra_filters parameter is used instead of fetching from dashboard"""
     chart = Slice(
@@ -130,8 +181,7 @@ def test_extra_filters_parameter_takes_precedence(
 
     mock_query = Mock()
     mock_query.filter = []
-    mock_qc = Mock()
-    mock_qc.queries = [mock_query]
+    mock_qc = Mock(queries=[mock_query])
 
     with patch.object(chart, "get_query_context", return_value=mock_qc):
         mock_chart_data_command.return_value.run.return_value = {
@@ -142,18 +192,18 @@ def test_extra_filters_parameter_takes_precedence(
         extra_filters_json = '[{"col": "state", "op": "==", "val": "CA"}]'
         ChartWarmUpCacheCommand(chart, 42, extra_filters_json).run()
 
-        # VALIDATE: get_dashboard_extra_filters should NOT be called
+        # VALIDATE: persisted dashboard context should NOT be loaded
         mock_get_dashboard_filters.assert_not_called()
 
         # VALIDATE: extra_filters were parsed and applied
-        assert len(mock_query.filter) == 1
-        assert mock_query.filter[0] == {"col": "state", "op": "==", "val": "CA"}
+        assert mock_query.filter == [{"col": "state", "op": "==", "val": "CA"}]
 
 
 @patch("superset.commands.chart.warm_up_cache.get_dashboard_extra_filters")
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
 def test_handles_multiple_queries_in_query_context(
-    mock_chart_data_command, mock_get_dashboard_filters
+    mock_chart_data_command: Mock,
+    mock_get_dashboard_filters: Mock,
 ):
     """Verify filters are added to ALL queries in the query context"""
     mock_get_dashboard_filters.return_value = [
@@ -168,13 +218,11 @@ def test_handles_multiple_queries_in_query_context(
         datasource_type="table",
     )
 
-    # Create query context with MULTIPLE queries
     mock_query1 = Mock()
     mock_query1.filter = []
     mock_query2 = Mock()
     mock_query2.filter = []
-    mock_qc = Mock()
-    mock_qc.queries = [mock_query1, mock_query2]
+    mock_qc = Mock(queries=[mock_query1, mock_query2])
 
     with patch.object(chart, "get_query_context", return_value=mock_qc):
         mock_chart_data_command.return_value.run.return_value = {
@@ -187,19 +235,17 @@ def test_handles_multiple_queries_in_query_context(
         ChartWarmUpCacheCommand(chart, 42, None).run()
 
         # VALIDATE: Filters added to BOTH queries
-        assert len(mock_query1.filter) == 1, "Filter should be added to query 1"
-        assert len(mock_query2.filter) == 1, "Filter should be added to query 2"
-        assert mock_query1.filter[0]["col"] == "country"
-        assert mock_query2.filter[0]["col"] == "country"
+        assert mock_query1.filter == [{"col": "country", "op": "==", "val": "USA"}]
+        assert mock_query2.filter == [{"col": "country", "op": "==", "val": "USA"}]
 
 
 @patch("superset.commands.chart.warm_up_cache.get_dashboard_extra_filters")
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")
 def test_handles_empty_dashboard_filters(
-    mock_chart_data_command, mock_get_dashboard_filters
+    mock_chart_data_command: Mock,
+    mock_get_dashboard_filters: Mock,
 ):
     """Verify graceful handling when dashboard has no filters configured"""
-    # get_dashboard_extra_filters returns empty list
     mock_get_dashboard_filters.return_value = []
 
     chart = Slice(
@@ -226,9 +272,7 @@ def test_handles_empty_dashboard_filters(
         assert len(mock_query.filter) == 0, (
             "No filters should be added when dashboard has no filters"
         )
-        assert mock_get_dashboard_filters.called, (
-            "Should still call get_dashboard_extra_filters"
-        )
+        assert mock_get_dashboard_filters.called, "Should still load dashboard filters"
 
 
 @patch("superset.commands.chart.warm_up_cache.ChartDataCommand")

--- a/tests/unit_tests/views/test_utils.py
+++ b/tests/unit_tests/views/test_utils.py
@@ -16,9 +16,22 @@
 # under the License.
 """Tests for superset.views.utils module"""
 
-from flask import current_app
+from typing import cast
 
-from superset.views.utils import get_form_data
+from flask import current_app
+from sqlalchemy.orm.session import Session
+
+from superset import db
+from superset.common.query_object import QueryObject
+from superset.connectors.sqla.models import Database, SqlaTable
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset.utils import json
+from superset.utils.core import QueryObjectFilterClause
+from superset.views.utils import (
+    get_dashboard_extra_filters,
+    get_form_data,
+)
 
 
 def test_get_form_data_handles_non_json_body_with_json_content_type() -> None:
@@ -51,3 +64,136 @@ def test_get_form_data_handles_non_dict_json_body() -> None:
 
     assert form_data == {}
     assert slc is None
+
+
+def test_get_dashboard_extra_filters_includes_native_filter_defaults(
+    session: Session,
+) -> None:
+    """Persisted native filter defaults must reach cache warming."""
+    Dashboard.metadata.create_all(session.get_bind())
+
+    dataset = SqlaTable(
+        table_name="extra_filters_table",
+        database=Database(database_name="extra_filters_db", sqlalchemy_uri="sqlite://"),
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    chart = Slice(
+        slice_name="chart_with_native_filter",
+        datasource_id=dataset.id,
+        datasource_type="table",
+    )
+
+    native_filter_configuration = [
+        {
+            "id": "NATIVE_FILTER-1",
+            "name": "Region filter",
+            "type": "NATIVE_FILTER",
+            "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            "targets": [{"column": {"name": "region"}}],
+            "defaultDataMask": {
+                "extraFormData": {
+                    "filters": [{"col": "region", "op": "IN", "val": ["APAC"]}]
+                },
+                "filterState": {"value": ["APAC"]},
+            },
+            "controlValues": {},
+        }
+    ]
+    dashboard = Dashboard(
+        dashboard_title="native_filter_dash",
+        slices=[chart],
+        published=True,
+        json_metadata=json.dumps(
+            {"native_filter_configuration": native_filter_configuration}
+        ),
+        position_json="{}",
+    )
+    db.session.add_all([chart, dashboard])
+    db.session.flush()
+
+    extra_filters = get_dashboard_extra_filters(chart.id, dashboard.id)
+
+    assert extra_filters == [{"col": "region", "op": "IN", "val": ["APAC"]}], (
+        "Native filter defaults must be included in cache warming"
+    )
+
+
+def test_get_dashboard_extra_filters_combines_legacy_and_native_defaults(
+    session: Session,
+) -> None:
+    Dashboard.metadata.create_all(session.get_bind())
+    dataset = SqlaTable(
+        table_name="mixed_filters_table",
+        database=Database(database_name="mixed_filters_db", sqlalchemy_uri="sqlite://"),
+    )
+    db.session.add(dataset)
+    db.session.flush()
+    chart = Slice(
+        slice_name="chart_with_mixed_filters",
+        datasource_id=dataset.id,
+        datasource_type="table",
+    )
+    legacy_filter = Slice(
+        slice_name="legacy_filter_box",
+        datasource_id=dataset.id,
+        datasource_type="table",
+        params=json.dumps(
+            {"filter_configs": [{"column": "legacy_region", "multiple": True}]}
+        ),
+    )
+    db.session.add_all([chart, legacy_filter])
+    db.session.flush()
+
+    native_filter_configuration = [
+        {
+            "id": "NATIVE_FILTER-REGION",
+            "name": "Native region filter",
+            "type": "NATIVE_FILTER",
+            "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            "targets": [{"column": {"name": "region"}}],
+            "defaultDataMask": {
+                "extraFormData": {
+                    "filters": [{"col": "region", "op": "IN", "val": ["APAC"]}]
+                },
+                "filterState": {"value": ["APAC"]},
+            },
+            "controlValues": {},
+        }
+    ]
+    dashboard = Dashboard(
+        dashboard_title="mixed_filter_dash",
+        slices=[chart, legacy_filter],
+        published=True,
+        json_metadata=json.dumps(
+            {
+                "native_filter_configuration": native_filter_configuration,
+                "default_filters": json.dumps(
+                    {str(legacy_filter.id): {"legacy_region": ["EMEA"]}}
+                ),
+                "filter_scopes": {
+                    str(legacy_filter.id): {
+                        "legacy_region": {"scope": ["ROOT_ID"], "immune": []}
+                    }
+                },
+            }
+        ),
+        position_json="{}",
+    )
+    db.session.add(dashboard)
+    db.session.flush()
+
+    warm_up_filters = get_dashboard_extra_filters(chart.id, dashboard.id)
+    browser_filters: list[QueryObjectFilterClause] = [
+        {"col": "legacy_region", "op": "IN", "val": ["EMEA"]},
+        {"col": "region", "op": "IN", "val": ["APAC"]},
+    ]
+
+    assert warm_up_filters == browser_filters
+    assert (
+        QueryObject(
+            filters=cast(list[QueryObjectFilterClause], warm_up_filters)
+        ).cache_key()
+        == QueryObject(filters=browser_filters).cache_key()
+    )


### PR DESCRIPTION
### SUMMARY

Fixes #43024.

Dashboard cache warming only applied legacy Filter Box defaults and appended them after chart filters. The browser also applies persisted native-filter defaults and places dashboard filters before chart filters, so the warm-up and browser could generate different query object cache keys.

This change:

- reuses the shared dashboard filter-context extraction for persisted native `defaultDataMask.extraFormData.filters`;
- preserves legacy and native defaults in frontend order;
- prepends dashboard filters to each chart query;
- emits the frontend-compatible `IN` operator for legacy multi-select defaults;
- evaluates every layout occurrence when a chart is duplicated.

The implementation deliberately does not reconstruct plugin-specific filter data from historical `filterState.value` shapes. Persisted `extraFormData` is the supported static warm-up contract.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this is a backend cache-warming fix.

### TESTING INSTRUCTIONS

Run the focused unit tests:

```bash
venv/bin/pytest \
  tests/unit_tests/charts/test_dashboard_filter_context.py \
  tests/unit_tests/commands/chart/warm_up_cache_test.py \
  tests/unit_tests/views/test_utils.py -q
```

Expected result: `58 passed`.

Run the staged checks:

```bash
env SKIP=pylint venv/bin/pre-commit run
venv/bin/pylint --rcfile=.pylintrc \
  --load-plugins=superset.extensions.pylint \
  --reports=no \
  superset/charts/data/dashboard_filter_context.py \
  superset/commands/chart/warm_up_cache.py \
  superset/views/utils.py
```

The Pylint hook is run directly because the local pre-commit wrapper resolves the global Python interpreter instead of the Superset virtualenv.

Manual regression:

1. Create a dashboard containing a chart and a native select filter with a persisted default.
2. Warm the chart cache with the dashboard ID.
3. Load the dashboard without forcing a refresh.
4. Confirm the chart request uses the warmed cache entry.
5. Repeat with a legacy multi-select default and with the same chart placed twice in different layout scopes.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43024
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
