### PR TITLE
fix(deck.gl): dismiss custom tooltips on hover-out

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.test.ts
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createElement } from 'react';
 import { PickingInfo } from '@deck.gl/core';
 import { JsonObject, QueryFormData } from '@superset-ui/core';
 import {
@@ -129,6 +130,32 @@ describe('commonLayerProps', () => {
       x: 10,
       y: 20,
     });
+  });
+
+  test('clears a custom tooltip on hover-out instead of trailing the cursor', () => {
+    // Regression test for a custom (Handlebars) deck.gl tooltip that stayed
+    // visible and followed the mouse after leaving a feature.
+    const setTooltip = jest.fn();
+    const customContent = createElement('div', {
+      'data-tooltip-type': 'custom',
+    });
+    const props = commonLayerProps({
+      formData: { ...partialformData } as QueryFormData,
+      setTooltip: setTooltip as any,
+      setTooltipContent: (() => customContent) as any,
+    });
+
+    // Hovering a feature shows the custom tooltip.
+    props.onHover?.({ picked: true, x: 10, y: 20 } as any);
+    expect(setTooltip).toHaveBeenLastCalledWith({
+      content: customContent,
+      x: 10,
+      y: 20,
+    });
+
+    // Moving off the feature must dismiss it, not keep repositioning it.
+    props.onHover?.({ picked: false, x: 30, y: 40 } as any);
+    expect(setTooltip).toHaveBeenLastCalledWith(null);
   });
 
   test('calls onSelect when table_filter is enabled', () => {

--- a/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/layers/common.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode, isValidElement } from 'react';
+import { ReactNode } from 'react';
 import {
   ascending as d3ascending,
   quantile as d3quantile,
@@ -70,19 +70,16 @@ export function commonLayerProps({
   if (setTooltipContent) {
     let currentTooltipContent: ReactNode = null;
 
-    const isCustomTooltip = (content: ReactNode): boolean =>
-      isValidElement(content) &&
-      content.props?.['data-tooltip-type'] === 'custom';
-
     onHover = (o: JsonObject) => {
       if (o.picked) {
         currentTooltipContent = setTooltipContent(o);
       }
 
-      if (
-        currentTooltipContent &&
-        (o.picked || isCustomTooltip(currentTooltipContent))
-      ) {
+      // Only show the tooltip while a feature is actually hovered. Custom
+      // (Handlebars) tooltips used to stay visible and follow the cursor
+      // after hover-out because their content was kept on screen even when
+      // nothing was picked.
+      if (o.picked && currentTooltipContent) {
         setTooltip({
           content: currentTooltipContent,
           x: o.x,


### PR DESCRIPTION
### SUMMARY

Custom (Handlebars) deck.gl tooltips never dismissed. After hovering off a feature, the last tooltip stayed on screen and followed the cursor around the map. Reported in #43069 on a Polygon chart, but it affects every deck.gl layer that uses a Handlebars tooltip.

The shared `onHover` handler in `layers/common.tsx` only refreshed the tooltip content while a feature was picked, but its show/hide condition kept showing the tooltip whenever the content was a custom one, even when nothing was picked:

```js
if (currentTooltipContent && (o.picked || isCustomTooltip(currentTooltipContent))) {
  setTooltip({ content: currentTooltipContent, x: o.x, y: o.y });
}
```

Since deck.gl keeps firing `onHover` with fresh `x`/`y` as you move over empty space, this re-rendered the stale last-picked content at the moving cursor position and never cleared it. The fix is to only show the tooltip while a feature is actually picked, which is what the default (non-custom) tooltip already did:

```js
if (o.picked && currentTooltipContent) {
  setTooltip({ content: currentTooltipContent, x: o.x, y: o.y });
} else {
  setTooltip(null);
  currentTooltipContent = null;
}
```

The custom-tooltip type check is no longer needed, so it and its unused `isValidElement` import were removed.

### BEFORE/AFTER

Before: leaving a polygon (or any feature) left its Handlebars tooltip stuck to the cursor until you re-entered another feature. See the screenshots in #43069.

After: the tooltip disappears as soon as the cursor leaves the feature, matching the built-in tooltip behavior.

### TESTING INSTRUCTIONS

Added a regression test in `layers/common.test.ts` asserting that a custom tooltip is cleared (`setTooltip(null)`) on hover-out. Manually: create a deck.gl Polygon chart, add a Handlebars tooltip template, hover a polygon, then move the mouse off it — the tooltip should disappear rather than follow the cursor.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43069
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
