### PR TITLE
fix(reports): wait for ECharts paint before capturing report screenshots

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
@@ -18,44 +18,26 @@
  */
 import { render, waitFor } from '../../../../spec/helpers/testing-library';
 import type { EChartsCoreOption } from 'echarts/core';
-import Echart, { isReportScreenshotMode } from './Echart';
+import Echart, {
+  ECHARTS_HOST_CLASS,
+  ECHARTS_RENDER_FINISHED_CLASS,
+} from './Echart';
 import type { EchartsProps } from '../types';
 
 type Handler = (params: unknown) => void;
-type Listener = {
-  query?: string;
-  handler: Handler;
-};
 
-const listeners: Record<string, Listener[]> = {};
+const listeners: Record<string, Handler[]> = {};
 
 const mockChart = {
   dispatchAction: jest.fn(),
   dispose: jest.fn(),
   getOption: jest.fn(() => ({})),
-  getZr: jest.fn(() => ({
-    off: jest.fn(),
-    on: jest.fn(),
-  })),
-  off: jest.fn((name: string, handler?: Handler) => {
-    if (!handler) {
-      delete listeners[name];
-      return;
-    }
-    listeners[name] = (listeners[name] || []).filter(
-      listener => listener.handler !== handler,
-    );
+  getZr: jest.fn(() => ({ off: jest.fn(), on: jest.fn() })),
+  off: jest.fn(),
+  on: jest.fn((name: string, handler: Handler) => {
+    listeners[name] = listeners[name] || [];
+    listeners[name].push(handler);
   }),
-  on: jest.fn(
-    (name: string, queryOrHandler: string | Handler, handler?: Handler) => {
-      listeners[name] = listeners[name] || [];
-      listeners[name].push(
-        handler
-          ? { query: queryOrHandler as string, handler }
-          : { handler: queryOrHandler as Handler },
-      );
-    },
-  ),
   resize: jest.fn(),
   setOption: jest.fn(),
 };
@@ -65,54 +47,14 @@ jest.mock('echarts/core', () => ({
   registerLocale: jest.fn(),
   use: jest.fn(),
 }));
-
-jest.mock('echarts/charts', () => ({
-  BarChart: 'BarChart',
-  BoxplotChart: 'BoxplotChart',
-  CustomChart: 'CustomChart',
-  FunnelChart: 'FunnelChart',
-  GaugeChart: 'GaugeChart',
-  GraphChart: 'GraphChart',
-  HeatmapChart: 'HeatmapChart',
-  LineChart: 'LineChart',
-  PieChart: 'PieChart',
-  RadarChart: 'RadarChart',
-  SankeyChart: 'SankeyChart',
-  ScatterChart: 'ScatterChart',
-  SunburstChart: 'SunburstChart',
-  TreeChart: 'TreeChart',
-  TreemapChart: 'TreemapChart',
-}));
-
-jest.mock('echarts/components', () => ({
-  AriaComponent: 'AriaComponent',
-  DataZoomComponent: 'DataZoomComponent',
-  GraphicComponent: 'GraphicComponent',
-  GridComponent: 'GridComponent',
-  LegendComponent: 'LegendComponent',
-  MarkAreaComponent: 'MarkAreaComponent',
-  MarkLineComponent: 'MarkLineComponent',
-  TitleComponent: 'TitleComponent',
-  ToolboxComponent: 'ToolboxComponent',
-  TooltipComponent: 'TooltipComponent',
-  VisualMapComponent: 'VisualMapComponent',
-}));
-
-jest.mock('echarts/features', () => ({
-  LabelLayout: 'LabelLayout',
-}));
-
-jest.mock('echarts/renderers', () => ({
-  CanvasRenderer: 'CanvasRenderer',
-}));
+jest.mock('echarts/charts', () => ({}));
+jest.mock('echarts/components', () => ({}));
+jest.mock('echarts/features', () => ({ LabelLayout: 'LabelLayout' }));
+jest.mock('echarts/renderers', () => ({ CanvasRenderer: 'CanvasRenderer' }));
 
 const initialState = {
-  common: {
-    locale: 'en',
-  },
-  dashboardState: {
-    isRefreshing: false,
-  },
+  common: { locale: 'en' },
+  dashboardState: { isRefreshing: false },
 };
 
 const defaultProps: EchartsProps = {
@@ -126,149 +68,36 @@ const renderEchart = (props: Partial<EchartsProps> = {}) => (
   <Echart {...defaultProps} {...props} />
 );
 
-const trigger = (name: string) => {
-  (listeners[name] || []).forEach(listener => listener.handler({}));
-};
-
-const originalLocation = `${window.location.pathname}${window.location.search}`;
-
-const setStandalone = (standalone?: string) => {
-  window.history.replaceState(
-    {},
-    '',
-    standalone === undefined ? '/' : `/?standalone=${standalone}`,
-  );
-};
-
-afterEach(() => {
-  window.history.replaceState({}, '', originalLocation);
-});
+const trigger = (name: string) =>
+  (listeners[name] || []).forEach(handler => handler({}));
 
 beforeEach(() => {
-  Object.keys(listeners).forEach(name => {
-    delete listeners[name];
-  });
+  Object.keys(listeners).forEach(name => delete listeners[name]);
   Object.values(mockChart).forEach(value => {
-    if (jest.isMockFunction(value)) {
-      value.mockClear();
-    }
+    if (jest.isMockFunction(value)) value.mockClear();
   });
 });
 
-test('replaces stale query event handlers without clearing regular event handlers', async () => {
-  const regularClickHandler = jest.fn();
-  const firstQueryHandler = jest.fn();
-  const secondQueryHandler = jest.fn();
-
-  const { rerender } = render(
-    renderEchart({
-      eventHandlers: {
-        click: regularClickHandler,
-      },
-      queryEventHandlers: [
-        {
-          handler: firstQueryHandler,
-          name: 'click',
-          query: 'xAxis.category',
-        },
-      ],
-    }),
-    { initialState, useRedux: true },
-  );
-
-  await waitFor(() =>
-    expect(mockChart.on).toHaveBeenCalledWith(
-      'click',
-      'xAxis.category',
-      firstQueryHandler,
-    ),
-  );
-
-  rerender(
-    renderEchart({
-      eventHandlers: {
-        click: regularClickHandler,
-      },
-      queryEventHandlers: [
-        {
-          handler: secondQueryHandler,
-          name: 'click',
-          query: 'xAxis.category',
-        },
-      ],
-    }),
-  );
-
-  await waitFor(() =>
-    expect(mockChart.on).toHaveBeenCalledWith(
-      'click',
-      'xAxis.category',
-      secondQueryHandler,
-    ),
-  );
-
-  trigger('click');
-
-  expect(regularClickHandler).toHaveBeenCalledTimes(1);
-  expect(firstQueryHandler).not.toHaveBeenCalled();
-  expect(secondQueryHandler).toHaveBeenCalledTimes(1);
-
-  regularClickHandler.mockClear();
-  secondQueryHandler.mockClear();
-
-  rerender(
-    renderEchart({
-      eventHandlers: {
-        click: regularClickHandler,
-      },
-      queryEventHandlers: [],
-    }),
-  );
-
-  await waitFor(() =>
-    expect(mockChart.off).toHaveBeenCalledWith('click', secondQueryHandler),
-  );
-
-  trigger('click');
-
-  expect(regularClickHandler).toHaveBeenCalledTimes(1);
-  expect(firstQueryHandler).not.toHaveBeenCalled();
-  expect(secondQueryHandler).not.toHaveBeenCalled();
+test('tags the ECharts canvas host with the readiness-gate class', async () => {
+  const { container } = render(renderEchart(), { initialState, useRedux: true });
+  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+  expect(container.querySelector(`.${ECHARTS_HOST_CLASS}`)).not.toBeNull();
 });
 
-test.each([
-  // Report/thumbnail screenshots render in standalone "true" (charts) or 3 (reports)
-  ['true', true],
-  ['3', true],
-  // Live embeds use 1/2 and must keep animation
-  ['1', false],
-  ['2', false],
-  ['0', false],
-  [undefined, false],
-])(
-  'isReportScreenshotMode() is %p for standalone=%p',
-  (standalone, expected) => {
-    setStandalone(standalone);
-    expect(isReportScreenshotMode()).toBe(expected);
-  },
-);
-
-test('disables animation when rendering in report screenshot mode', async () => {
-  setStandalone('true');
-  render(renderEchart(), { initialState, useRedux: true });
-
+test('marks the host painted only on the ECharts `finished` event', async () => {
+  const { container } = render(renderEchart(), { initialState, useRedux: true });
   await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
 
-  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
-  expect(lastOptions.animation).toBe(false);
-});
+  const host = container.querySelector(
+    `.${ECHARTS_HOST_CLASS}`,
+  ) as HTMLElement;
+  expect(host).not.toBeNull();
 
-test('keeps animation enabled when not in report screenshot mode', async () => {
-  setStandalone(undefined);
-  render(renderEchart(), { initialState, useRedux: true });
+  // `setOption` ran during mount, which clears the marker; `finished` has not
+  // fired yet, so the host must NOT be flagged as painted.
+  expect(host.classList.contains(ECHARTS_RENDER_FINISHED_CLASS)).toBe(false);
 
-  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
-
-  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
-  expect(lastOptions.animation).not.toBe(false);
+  // Simulate ECharts completing its draw -> the host is flagged painted.
+  trigger('finished');
+  expect(host.classList.contains(ECHARTS_RENDER_FINISHED_CLASS)).toBe(true);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, waitFor } from '../../../../spec/helpers/testing-library';
 import type { EChartsCoreOption } from 'echarts/core';
+import { render, waitFor } from '../../../../spec/helpers/testing-library';
 import Echart, {
   ECHARTS_HOST_CLASS,
   ECHARTS_RENDER_FINISHED_CLASS,
@@ -79,25 +79,29 @@ beforeEach(() => {
 });
 
 test('tags the ECharts canvas host with the readiness-gate class', async () => {
-  const { container } = render(renderEchart(), { initialState, useRedux: true });
+  const { container } = render(renderEchart(), {
+    initialState,
+    useRedux: true,
+  });
   await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
   expect(container.querySelector(`.${ECHARTS_HOST_CLASS}`)).not.toBeNull();
 });
 
 test('marks the host painted only on the ECharts `finished` event', async () => {
-  const { container } = render(renderEchart(), { initialState, useRedux: true });
+  const { container } = render(renderEchart(), {
+    initialState,
+    useRedux: true,
+  });
   await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
 
-  const host = container.querySelector(
-    `.${ECHARTS_HOST_CLASS}`,
-  ) as HTMLElement;
+  const host = container.querySelector(`.${ECHARTS_HOST_CLASS}`) as HTMLElement;
   expect(host).not.toBeNull();
 
   // `setOption` ran during mount, which clears the marker; `finished` has not
   // fired yet, so the host must NOT be flagged as painted.
-  expect(host.classList.contains(ECHARTS_RENDER_FINISHED_CLASS)).toBe(false);
+  expect(host).not.toHaveClass(ECHARTS_RENDER_FINISHED_CLASS);
 
   // Simulate ECharts completing its draw -> the host is flagged painted.
   trigger('finished');
-  expect(host.classList.contains(ECHARTS_RENDER_FINISHED_CLASS)).toBe(true);
+  expect(host).toHaveClass(ECHARTS_RENDER_FINISHED_CLASS);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.test.tsx
@@ -21,23 +21,45 @@ import { render, waitFor } from '../../../../spec/helpers/testing-library';
 import Echart, {
   ECHARTS_HOST_CLASS,
   ECHARTS_RENDER_FINISHED_CLASS,
+  isReportScreenshotMode,
 } from './Echart';
 import type { EchartsProps } from '../types';
 
 type Handler = (params: unknown) => void;
+type Listener = {
+  query?: string;
+  handler: Handler;
+};
 
-const listeners: Record<string, Handler[]> = {};
+const listeners: Record<string, Listener[]> = {};
 
 const mockChart = {
   dispatchAction: jest.fn(),
   dispose: jest.fn(),
   getOption: jest.fn(() => ({})),
-  getZr: jest.fn(() => ({ off: jest.fn(), on: jest.fn() })),
-  off: jest.fn(),
-  on: jest.fn((name: string, handler: Handler) => {
-    listeners[name] = listeners[name] || [];
-    listeners[name].push(handler);
+  getZr: jest.fn(() => ({
+    off: jest.fn(),
+    on: jest.fn(),
+  })),
+  off: jest.fn((name: string, handler?: Handler) => {
+    if (!handler) {
+      delete listeners[name];
+      return;
+    }
+    listeners[name] = (listeners[name] || []).filter(
+      listener => listener.handler !== handler,
+    );
   }),
+  on: jest.fn(
+    (name: string, queryOrHandler: string | Handler, handler?: Handler) => {
+      listeners[name] = listeners[name] || [];
+      listeners[name].push(
+        handler
+          ? { query: queryOrHandler as string, handler }
+          : { handler: queryOrHandler as Handler },
+      );
+    },
+  ),
   resize: jest.fn(),
   setOption: jest.fn(),
 };
@@ -47,14 +69,54 @@ jest.mock('echarts/core', () => ({
   registerLocale: jest.fn(),
   use: jest.fn(),
 }));
-jest.mock('echarts/charts', () => ({}));
-jest.mock('echarts/components', () => ({}));
-jest.mock('echarts/features', () => ({ LabelLayout: 'LabelLayout' }));
-jest.mock('echarts/renderers', () => ({ CanvasRenderer: 'CanvasRenderer' }));
+
+jest.mock('echarts/charts', () => ({
+  BarChart: 'BarChart',
+  BoxplotChart: 'BoxplotChart',
+  CustomChart: 'CustomChart',
+  FunnelChart: 'FunnelChart',
+  GaugeChart: 'GaugeChart',
+  GraphChart: 'GraphChart',
+  HeatmapChart: 'HeatmapChart',
+  LineChart: 'LineChart',
+  PieChart: 'PieChart',
+  RadarChart: 'RadarChart',
+  SankeyChart: 'SankeyChart',
+  ScatterChart: 'ScatterChart',
+  SunburstChart: 'SunburstChart',
+  TreeChart: 'TreeChart',
+  TreemapChart: 'TreemapChart',
+}));
+
+jest.mock('echarts/components', () => ({
+  AriaComponent: 'AriaComponent',
+  DataZoomComponent: 'DataZoomComponent',
+  GraphicComponent: 'GraphicComponent',
+  GridComponent: 'GridComponent',
+  LegendComponent: 'LegendComponent',
+  MarkAreaComponent: 'MarkAreaComponent',
+  MarkLineComponent: 'MarkLineComponent',
+  TitleComponent: 'TitleComponent',
+  ToolboxComponent: 'ToolboxComponent',
+  TooltipComponent: 'TooltipComponent',
+  VisualMapComponent: 'VisualMapComponent',
+}));
+
+jest.mock('echarts/features', () => ({
+  LabelLayout: 'LabelLayout',
+}));
+
+jest.mock('echarts/renderers', () => ({
+  CanvasRenderer: 'CanvasRenderer',
+}));
 
 const initialState = {
-  common: { locale: 'en' },
-  dashboardState: { isRefreshing: false },
+  common: {
+    locale: 'en',
+  },
+  dashboardState: {
+    isRefreshing: false,
+  },
 };
 
 const defaultProps: EchartsProps = {
@@ -68,14 +130,151 @@ const renderEchart = (props: Partial<EchartsProps> = {}) => (
   <Echart {...defaultProps} {...props} />
 );
 
-const trigger = (name: string) =>
-  (listeners[name] || []).forEach(handler => handler({}));
+const trigger = (name: string) => {
+  (listeners[name] || []).forEach(listener => listener.handler({}));
+};
+
+const originalLocation = `${window.location.pathname}${window.location.search}`;
+
+const setStandalone = (standalone?: string) => {
+  window.history.replaceState(
+    {},
+    '',
+    standalone === undefined ? '/' : `/?standalone=${standalone}`,
+  );
+};
+
+afterEach(() => {
+  window.history.replaceState({}, '', originalLocation);
+});
 
 beforeEach(() => {
-  Object.keys(listeners).forEach(name => delete listeners[name]);
-  Object.values(mockChart).forEach(value => {
-    if (jest.isMockFunction(value)) value.mockClear();
+  Object.keys(listeners).forEach(name => {
+    delete listeners[name];
   });
+  Object.values(mockChart).forEach(value => {
+    if (jest.isMockFunction(value)) {
+      value.mockClear();
+    }
+  });
+});
+
+test('replaces stale query event handlers without clearing regular event handlers', async () => {
+  const regularClickHandler = jest.fn();
+  const firstQueryHandler = jest.fn();
+  const secondQueryHandler = jest.fn();
+
+  const { rerender } = render(
+    renderEchart({
+      eventHandlers: {
+        click: regularClickHandler,
+      },
+      queryEventHandlers: [
+        {
+          handler: firstQueryHandler,
+          name: 'click',
+          query: 'xAxis.category',
+        },
+      ],
+    }),
+    { initialState, useRedux: true },
+  );
+
+  await waitFor(() =>
+    expect(mockChart.on).toHaveBeenCalledWith(
+      'click',
+      'xAxis.category',
+      firstQueryHandler,
+    ),
+  );
+
+  rerender(
+    renderEchart({
+      eventHandlers: {
+        click: regularClickHandler,
+      },
+      queryEventHandlers: [
+        {
+          handler: secondQueryHandler,
+          name: 'click',
+          query: 'xAxis.category',
+        },
+      ],
+    }),
+  );
+
+  await waitFor(() =>
+    expect(mockChart.on).toHaveBeenCalledWith(
+      'click',
+      'xAxis.category',
+      secondQueryHandler,
+    ),
+  );
+
+  trigger('click');
+
+  expect(regularClickHandler).toHaveBeenCalledTimes(1);
+  expect(firstQueryHandler).not.toHaveBeenCalled();
+  expect(secondQueryHandler).toHaveBeenCalledTimes(1);
+
+  regularClickHandler.mockClear();
+  secondQueryHandler.mockClear();
+
+  rerender(
+    renderEchart({
+      eventHandlers: {
+        click: regularClickHandler,
+      },
+      queryEventHandlers: [],
+    }),
+  );
+
+  await waitFor(() =>
+    expect(mockChart.off).toHaveBeenCalledWith('click', secondQueryHandler),
+  );
+
+  trigger('click');
+
+  expect(regularClickHandler).toHaveBeenCalledTimes(1);
+  expect(firstQueryHandler).not.toHaveBeenCalled();
+  expect(secondQueryHandler).not.toHaveBeenCalled();
+});
+
+test.each([
+  // Report/thumbnail screenshots render in standalone "true" (charts) or 3 (reports)
+  ['true', true],
+  ['3', true],
+  // Live embeds use 1/2 and must keep animation
+  ['1', false],
+  ['2', false],
+  ['0', false],
+  [undefined, false],
+])(
+  'isReportScreenshotMode() is %p for standalone=%p',
+  (standalone, expected) => {
+    setStandalone(standalone);
+    expect(isReportScreenshotMode()).toBe(expected);
+  },
+);
+
+test('disables animation when rendering in report screenshot mode', async () => {
+  setStandalone('true');
+  render(renderEchart(), { initialState, useRedux: true });
+
+  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+
+  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
+  expect(lastOptions.animation).toBe(false);
+});
+
+test('keeps animation enabled when not in report screenshot mode', async () => {
+  setStandalone(undefined);
+  render(renderEchart(), { initialState, useRedux: true });
+
+  await waitFor(() => expect(mockChart.setOption).toHaveBeenCalled());
+
+  const lastOptions = mockChart.setOption.mock.calls.at(-1)?.[0];
+  expect(lastOptions.animation).not.toBe(false);
 });
 
 test('tags the ECharts canvas host with the readiness-gate class', async () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/components/Echart.tsx
@@ -138,6 +138,15 @@ export function isReportScreenshotMode(): boolean {
   }
 }
 
+// Report-screenshot readiness contract (see superset/utils/screenshot_utils.py).
+// `echarts-host` marks the canvas host element; `echarts-render-finished` is
+// toggled OFF before each setOption and ON in the ECharts `finished` event --
+// the only signal that the canvas is fully painted (chartStatus/onRenderSuccess
+// both fire pre-paint). The readiness gate treats a host that lacks
+// `echarts-render-finished` as not-yet-painted so it never captures a blank chart.
+export const ECHARTS_HOST_CLASS = 'echarts-host';
+export const ECHARTS_RENDER_FINISHED_CLASS = 'echarts-render-finished';
+
 function Echart(
   {
     width,
@@ -200,6 +209,11 @@ function Echart(
           locale,
           width,
           height,
+        });
+        // Paint marker for the report-screenshot readiness gate. `finished`
+        // is the only event that guarantees the canvas is fully drawn.
+        chartRef.current.on('finished', () => {
+          divRef.current?.classList.add(ECHARTS_RENDER_FINISHED_CLASS);
         });
       }
       // did mount
@@ -321,6 +335,9 @@ function Echart(
             }
           )?.dataZoom
         : undefined;
+      // Clear the paint marker before (re)drawing; the `finished` handler
+      // re-adds it once the new frame is fully rendered.
+      divRef.current?.classList.remove(ECHARTS_RENDER_FINISHED_CLASS);
       chartRef.current?.setOption(themedEchartOptions, {
         notMerge,
         replaceMerge: notMerge ? undefined : ['series'],
@@ -412,7 +429,14 @@ function Echart(
     handleSizeChange({ width, height });
   }, [width, height, handleSizeChange]);
 
-  return <Styles ref={divRef} height={height} width={width} />;
+  return (
+    <Styles
+      ref={divRef}
+      className={ECHARTS_HOST_CLASS}
+      height={height}
+      width={width}
+    />
+  );
 }
 
 export default forwardRef(Echart);

--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -144,6 +144,21 @@ TERMINAL_MARKER_SELECTOR = (
 )
 CHART_ID_CLASS_PATTERN = r"\bdashboard-chart-id-(\d+)\b"
 
+# ECharts paint marker. The frontend
+# (plugins/plugin-chart-echarts/src/components/Echart.tsx) tags the canvas host
+# ``.echarts-host`` and adds ``.echarts-render-finished`` only in the ECharts
+# ``finished`` event -- the sole signal that the canvas is fully painted.
+# ``.slice_container`` alone is a pre-paint signal (it mounts when data arrives,
+# before the canvas is drawn; chartStatus/onRenderSuccess fire pre-paint too), so
+# a holder that still contains an unpainted host is treated as not-yet-rendered and
+# the report screenshot waits for it instead of capturing a blank chart. Only
+# ECharts hosts are gated; DOM/SVG vizzes paint on commit and non-ECharts canvas
+# vizzes (deck.gl/mapbox/etc.) have no ``.echarts-host`` so they are unaffected.
+ECHARTS_UNPAINTED_HOST_SELECTOR = r".echarts-host:not(.echarts-render-finished)"
+CHART_ERROR_OR_EMPTY_SELECTOR = (
+    f"{ALERT_SELECTOR}, {EMPTY_SELECTOR}, {MISSING_CHART_SELECTOR}"
+)
+
 # Shared body for holder readiness and timeout diagnostics. A holder is ready
 # only after a terminal marker appears and its loading marker disappears.
 UNREADY_CHART_HOLDERS_JS_BODY = f"""
@@ -158,8 +173,19 @@ UNREADY_CHART_HOLDERS_JS_BODY = f"""
             '{SLICE_CONTAINER_SELECTOR}'
         ) !== null;
         const stillLoading = holder.querySelector('{LOADING_SELECTOR}') !== null;
-        const isReady = holder.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null;
-        if (stillLoading || !isReady) {{
+        const hasErrorOrEmpty = holder.querySelector(
+            '{CHART_ERROR_OR_EMPTY_SELECTOR}'
+        ) !== null;
+        const hasUnpaintedEchart = holder.querySelector(
+            '{ECHARTS_UNPAINTED_HOST_SELECTOR}'
+        ) !== null;
+        // Ready = a settled error/empty/missing state, or a slice container
+        // whose ECharts canvas has finished painting. An unpainted ECharts host
+        // keeps the holder unready so a blank chart is never captured.
+        const isReady = !stillLoading && (
+            hasErrorOrEmpty || (hasSliceContainer && !hasUnpaintedEchart)
+        );
+        if (!isReady) {{
             const chartIdMatch = holder.className.match(/{CHART_ID_CLASS_PATTERN}/);
             const chartId = chartIdMatch ? chartIdMatch[1] : null;
             let state;
@@ -167,6 +193,8 @@ UNREADY_CHART_HOLDERS_JS_BODY = f"""
                 state = 'spinner_mounted';
             }} else if (stillLoading) {{
                 state = 'waiting_on_database';
+            }} else if (hasSliceContainer && hasUnpaintedEchart) {{
+                state = 'mounted_unpainted';
             }} else {{
                 state = 'nothing_mounted';
             }}
@@ -208,6 +236,11 @@ FIND_CHART_HOLDER_STATES_JS = f"""
         ) !== null) {{
             return {{ chartId, state: 'empty' }};
         }}
+        if (hasSliceContainer && holder.querySelector(
+            '{ECHARTS_UNPAINTED_HOST_SELECTOR}'
+        ) !== null) {{
+            return {{ chartId, state: 'mounted_unpainted' }};
+        }}
         if (hasSliceContainer) {{
             return {{ chartId, state: 'rendered' }};
         }}
@@ -237,7 +270,8 @@ CHART_CONTAINER_READY_JS = f"""
     const chart = document.querySelector('.chart-container');
     return chart !== null
         && chart.querySelector('{LOADING_SELECTOR}') === null
-        && chart.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null;
+        && chart.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null
+        && chart.querySelector('{ECHARTS_UNPAINTED_HOST_SELECTOR}') === null;
 }}
 """
 
@@ -249,6 +283,9 @@ CHART_CONTAINER_STATE_JS = f"""
     const chart = document.querySelector('.chart-container');
     if (chart === null) {{ return 'missing'; }}
     if (chart.querySelector('{LOADING_SELECTOR}') !== null) {{ return 'loading'; }}
+    if (chart.querySelector('{ECHARTS_UNPAINTED_HOST_SELECTOR}') !== null) {{
+        return 'mounted_unpainted';
+    }}
     if (chart.querySelector('{TERMINAL_MARKER_SELECTOR}') !== null) {{
         return 'terminal';
     }}

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -1148,3 +1148,22 @@ class TestTileWaitBudget:
             assert args[1] == i + 1  # tile index
             assert args[2] == 3  # total tiles
             assert args[-1] == " [cache_key=xyz]"
+
+
+def test_readiness_predicates_gate_on_unpainted_echarts_hosts() -> None:
+    """The report gate, the single-chart gate, and the diagnostics query all
+    key on the ECharts paint marker so a pre-paint canvas is never captured."""
+    from superset.utils.screenshot_utils import (
+        CHART_CONTAINER_READY_JS,
+        ECHARTS_UNPAINTED_HOST_SELECTOR,
+        FIND_CHART_HOLDER_STATES_JS,
+        REPORT_CHART_HOLDERS_READY_JS,
+    )
+
+    assert (
+        ECHARTS_UNPAINTED_HOST_SELECTOR
+        == ".echarts-host:not(.echarts-render-finished)"
+    )
+    assert ECHARTS_UNPAINTED_HOST_SELECTOR in REPORT_CHART_HOLDERS_READY_JS
+    assert ECHARTS_UNPAINTED_HOST_SELECTOR in CHART_CONTAINER_READY_JS
+    assert "mounted_unpainted" in FIND_CHART_HOLDER_STATES_JS

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -1161,8 +1161,7 @@ def test_readiness_predicates_gate_on_unpainted_echarts_hosts() -> None:
     )
 
     assert (
-        ECHARTS_UNPAINTED_HOST_SELECTOR
-        == ".echarts-host:not(.echarts-render-finished)"
+        ECHARTS_UNPAINTED_HOST_SELECTOR == ".echarts-host:not(.echarts-render-finished)"
     )
     assert ECHARTS_UNPAINTED_HOST_SELECTOR in REPORT_CHART_HOLDERS_READY_JS
     assert ECHARTS_UNPAINTED_HOST_SELECTOR in CHART_CONTAINER_READY_JS


### PR DESCRIPTION
### Summary

Scheduled dashboard reports (and the report screenshot path generally) can deliver an image with **blank chart regions**. The non-tiled readiness gate added in #42624 / #42253 treats a chart holder as *rendered* as soon as `.slice_container` is present with no `.loading`. But `.slice_container` mounts when the chart's **data arrives** — before the ECharts canvas is actually drawn — so a `full_page` capture can fire on an empty canvas.

There is no existing "render finished" signal for screenshots (see the comment in `Echart.tsx` that disables animation for exactly this reason). `chartStatus === 'rendered'` / `onRenderSuccess` both fire on loadable module-load, *before* paint. The only signal that guarantees the canvas is painted is ECharts' own `finished` event.

### Fix

- **Frontend** (`plugin-chart-echarts/.../Echart.tsx`): tag the canvas host with the runtime class `echarts-host`, and add `echarts-render-finished` **only** in the ECharts `finished` event (cleared before each `setOption`). Classes are used because production strips `data-test`.
- **Readiness gate** (`screenshot_utils.py`): a holder that still contains an unpainted `.echarts-host` is non-terminal (new `mounted_unpainted` state) — the gate waits for it and **fails loud on timeout** rather than capturing blank. Applied to both the dashboard holder gate and the single `chart-container` gate.

Only ECharts hosts are gated. DOM/SVG vizzes paint synchronously on React commit, and non-ECharts canvas vizzes (deck.gl, mapbox, OpenLayers) have no `.echarts-host`, so they are unaffected (and the gate never *waits* on them — no risk of hanging those reports). Giving those canvas vizzes their own completion markers is a natural follow-up.

This is complementary to #42901 (which grows the viewport so off-screen holders mount): that ensures holders are *present*; this ensures they are *painted* before capture.

### Testing

- Added a unit test asserting the readiness predicates and diagnostics key on the paint marker.
- The readiness predicate JS was verified in a headless browser against a synthetic DOM: an in-viewport unpainted ECharts host makes the report gate return `false`; a painted host passes; DOM/non-ECharts holders are unchanged; off-screen holders are still skipped.
- The `finished`-means-painted premise was verified directly against echarts 5.6 (the `finished` event fires only once the canvas is fully drawn, with animation on or off).

### Additional info

- [x] Jest test for the paint marker — `Echart.test.tsx` asserts the canvas host is tagged with `echarts-host` and is only flagged `echarts-render-finished` on the ECharts `finished` event.
- Follow-up (not in this PR): an end-to-end report-capture check in CI, to guard the gate against regressions in a real browser render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
