### PR TITLE
fix(GridTable): remove unused rowSelection option to silence AG Grid error #200

### DIFF
--- a/superset-frontend/src/components/GridTable/index.tsx
+++ b/superset-frontend/src/components/GridTable/index.tsx
@@ -148,7 +148,6 @@ export function GridTable<RecordType extends object>({
       ensureDomOrder: true,
       suppressFieldDotNotation: true,
       headerHeight,
-      rowSelection: 'multiple',
       rowHeight,
     }),
     [rowHeight, headerHeight],


### PR DESCRIPTION
### SUMMARY

Explore's **Results/Samples** data panel and **SQL Lab** result grids render `GridTable`, which set the AG Grid option `rowSelection: 'multiple'`. Since the AG Grid tree-shaking migration (#32334, Feb 2025, moving to the modular v33+ architecture), the global module registry in `ThemedAgGridReact/setupAGGridModules.ts` registers an opt-in subset of modules and **never includes `RowSelectionModule`**. Using a feature whose module isn't registered makes AG Grid log, on every grid mount/re-render (notably after clicking **Stop** on a running Explore query):

```
AG Grid: error #200 … moduleName=RowSelection&reasonOrId=rowSelection
```

Investigation shows the `rowSelection` option is **dead config**:

- No consumer reads selection — no `onSelectionChanged`, no checkbox column, no `getSelectedRows`, and none since it was introduced.
- It was only functional for ~26 days on ag-grid `32.2.1` (batteries-included) before the modular migration silently broke it; it has logged #200 continuously ever since (~1.5 years).
- Cell copy (Ctrl/Cmd+C) is **unaffected** — it relies on `enableCellTextSelection` + the `onCellKeyDown` handler, independent of `rowSelection`.

Rather than register `RowSelectionModule` and migrate to the v33+ object form (which would *newly* introduce a checkbox column and select-all UX that nothing consumes), this PR removes the unused option. That fully silences error #200 (and the deprecated string-form warning) with **zero user-facing change**.

Note: the AG Grid chart plugin (`plugin-chart-ag-grid-table`) also uses the deprecated `rowSelection="multiple"` string, but it registers `AllCommunityModule`, so it does not throw #200 (only a cosmetic deprecation warning). That's out of scope here and can be a follow-up.

Internal ref: sc-112604.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** console logs `AG Grid: error #200 … moduleName=RowSelection` when the Explore Results/Samples (or SQL Lab) grid renders — e.g. after Stop-ing a running query.

**After:** no #200 error; grids render and cell copy behave identically.

### TESTING INSTRUCTIONS

1. Open Explore on any chart with query results (e.g. Degrees vs Income).
2. Expand the data panel and open the **Results** or **Samples** tab; open DevTools → Console.
3. Click **Update chart**, then **Stop** while the query runs (or let it finish and re-render).
4. Confirm **no** `AG Grid: error #200 … RowSelection` message appears.
5. Repeat in **SQL Lab** (result set and table preview grids).
6. Confirm Ctrl/Cmd+C cell copy still works.

Unit tests: `cd superset-frontend && npm run test -- GridTable`

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API