### PR TITLE
fix(chart/data): handle QueryObjectValidationError in _get_data_response

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -644,7 +644,7 @@ class ChartDataRestApi(ChartRestApi):
             result = command.execute(force_cached=force_cached)
         except ChartDataCacheLoadError as exc:
             return self.response_422(message=sanitize_error_message(exc.message))
-        except ChartDataQueryFailedError as exc:
+        except (ChartDataQueryFailedError, QueryObjectValidationError) as exc:
             return self.response_400(message=sanitize_error_message(exc.message))
 
             # Log is_cached if extra payload callback is provided


### PR DESCRIPTION
### Summary
`ChartDataRestApi._get_data_response()` catches `ChartDataCacheLoadError` and `ChartDataQueryFailedError` but leaves `QueryObjectValidationError` unhandled. When this exception escapes `command.execute()` through paths outside `get_df_payload_result()`'s try/except — such as `ensure_totals_available()`, the invalid-result-type check in `get_query_results_with_timing()`, or preparers like `_prepare_drill_detail_query()` — Flask's global handler returns HTTP 500 instead of 400.

`QueryObjectValidationError` is already imported in this file and has `status = 400`. This PR adds the missing except clause, consistent with the equivalent handler in the command-setup block above.

### Testing
- `pytest tests/unit_tests/charts/data/test_api.py`
- `pytest tests/integration_tests/charts/charts_test.py`

Tracking: sc-117145