### PR TITLE
fix(embedded): restore chart rendering for guest dashboards

### DIFF
--- a/superset-frontend/playwright/pages/EmbeddedPage.ts
+++ b/superset-frontend/playwright/pages/EmbeddedPage.ts
@@ -103,16 +103,40 @@ export class EmbeddedPage {
   /**
    * Wait for dashboard content to render inside the iframe.
    * Looks for the grid-container which indicates charts are loading/loaded.
+   *
+   * Races the grid against the test app's `#error` box so an embed failure
+   * surfaces its message immediately, instead of blindly timing out on the
+   * grid selector and hiding the real reason.
    */
   async waitForDashboardContent(options?: { timeout?: number }): Promise<void> {
-    const frame = this.iframe;
-    await frame
+    const timeout = options?.timeout ?? EMBEDDED.DASHBOARD_RENDER;
+    const grid = this.iframe
       .locator('.grid-container, [data-test="grid-container"]')
-      .first()
-      .waitFor({
-        state: 'visible',
-        timeout: options?.timeout ?? EMBEDDED.DASHBOARD_RENDER,
-      });
+      .first();
+    const errorBox = this.page.locator(EmbeddedPage.SELECTORS.ERROR);
+
+    const ready = grid
+      .waitFor({ state: 'visible', timeout })
+      .then(() => 'ready' as const)
+      .catch(() => 'gridTimeout' as const);
+    const failed = errorBox
+      .waitFor({ state: 'visible', timeout })
+      .then(() => 'error' as const)
+      .catch(() => 'errorTimeout' as const);
+
+    const outcome = await Promise.race([ready, failed]);
+    if (outcome === 'ready') return;
+    if (outcome === 'error') {
+      const message = (await errorBox.textContent())?.trim() || 'unknown error';
+      throw new Error(`Embedded dashboard failed to render: ${message}`);
+    }
+    const status = (
+      await this.page.locator(EmbeddedPage.SELECTORS.STATUS).textContent()
+    )?.trim();
+    throw new Error(
+      `Embedded dashboard did not render within ${timeout}ms ` +
+        `(status: ${status ?? 'unknown'})`,
+    );
   }
 
   /**

--- a/superset-frontend/playwright/utils/constants.ts
+++ b/superset-frontend/playwright/utils/constants.ts
@@ -101,7 +101,7 @@ export const EMBEDDED = {
   /** Timeout for iframe to appear in the DOM */
   IFRAME_LOAD: 15000, // 15s
   /** Timeout for dashboard content to render inside the iframe */
-  DASHBOARD_RENDER: 30000, // 30s
+  DASHBOARD_RENDER: 60000, // 60s (embedded dashboards are slow to render on cold CI)
   /** Timeout for individual chart cells to finish rendering */
   CHART_RENDER: TIMEOUT.CHART_RENDER,
 } as const;

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -4371,6 +4371,25 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             elif chart.datasource and self.can_access_datasource(chart.datasource):
                 return
 
+            # An embedded guest may access a member chart of a dashboard their
+            # guest token grants. Embedded dashboards render their member charts
+            # client-side, so the chart definitions must be served even though a
+            # guest holds no standalone datasource grant. The chart's dataset
+            # must still satisfy any allowlist the token carries, and data
+            # queries are re-checked through the datasource branch above (which
+            # receives the dashboard context in the chart-data form_data).
+            if (
+                is_feature_enabled("EMBEDDED_SUPERSET")
+                and self.is_guest_user()
+                and any(
+                    self.has_guest_access(dashboard_) for dashboard_ in chart.dashboards
+                )
+                and self._guest_token_allows_dataset(
+                    chart.datasource.id if chart.datasource else None
+                )
+            ):
+                return
+
             raise SupersetSecurityException(self.get_chart_access_error_object(chart))
 
     def get_user_by_username(self, username: str) -> Optional[User]:
@@ -4927,6 +4946,26 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if isinstance(user, GuestUser):
             return user
         return None
+
+    def _guest_token_allows_dataset(self, datasource_id: Optional[int]) -> bool:
+        """Return whether the current guest token permits this dataset.
+
+        A token without a ``datasets`` allowlist permits every dataset
+        (backward compatible). A token that carries one permits only the listed
+        integer IDs; a malformed allowlist permits nothing. Non-guest callers
+        are unaffected: they hold no guest token and always get ``True``.
+        """
+        guest_user = self.get_current_guest_user_if_guest()
+        if not guest_user:
+            return True
+        allowed_datasets: Optional[list[int]] = guest_user.guest_token.get("datasets")
+        if allowed_datasets is None:
+            return True
+        return (
+            isinstance(allowed_datasets, list)
+            and all(isinstance(d, int) for d in allowed_datasets)
+            and datasource_id in allowed_datasets
+        )
 
     def has_guest_access(self, dashboard: "Dashboard") -> bool:
         user = self.get_current_guest_user_if_guest()

--- a/tests/unit_tests/security/test_embedded_guest_chart_access.py
+++ b/tests/unit_tests/security/test_embedded_guest_chart_access.py
@@ -1,0 +1,185 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for embedded-guest access to a dashboard's member charts.
+
+An embedded guest holds no standalone datasource grant, so the chart branch of
+``raise_for_access`` must recognise dashboard-level guest access when serving a
+member chart's definition. Without it the dashboard payload drops the guest's
+charts (and strips their ``form_data``) and the embedded dashboard cannot render.
+The grant stays bounded by the token's optional dataset allowlist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.exceptions import SupersetSecurityException
+from superset.security.guest_token import (
+    GuestToken,
+    GuestTokenResourceType,
+    GuestUser,
+)
+from superset.security.manager import SupersetSecurityManager
+
+
+def _make_chart(dashboards: list[object], datasource_id: int = 1) -> MagicMock:
+    """A member chart with no viewers and a datasource the guest cannot access
+    through a standalone grant."""
+    chart = MagicMock()
+    chart.viewers = []
+    chart.datasource = MagicMock()
+    chart.datasource.id = datasource_id
+    chart.dashboards = dashboards
+    return chart
+
+
+def _sm_for_chart_access(is_guest: bool) -> MagicMock:
+    """Security-manager mock where every non-guest path to the chart is closed,
+    so only the embedded-guest branch can grant access. The dataset allowlist
+    helper defaults to permissive; tests tighten it where relevant."""
+    sm = MagicMock(spec=SupersetSecurityManager)
+    sm.is_admin.return_value = False
+    sm.is_editor.return_value = False
+    sm.is_viewer.return_value = False
+    sm.can_access_datasource.return_value = False
+    sm.is_guest_user.return_value = is_guest
+    sm._guest_token_allows_dataset.return_value = True
+    return sm
+
+
+# ---------------------------------------------------------------------------
+# raise_for_access — chart branch
+# ---------------------------------------------------------------------------
+
+
+def test_guest_can_access_member_chart_of_granted_dashboard() -> None:
+    """A guest whose token grants a chart's dashboard may access that chart."""
+    granted_dashboard = MagicMock()
+    chart = _make_chart([granted_dashboard])
+    sm = _sm_for_chart_access(is_guest=True)
+    sm.has_guest_access.side_effect = lambda dash: dash is granted_dashboard
+
+    with patch("superset.is_feature_enabled", return_value=True):
+        SupersetSecurityManager.raise_for_access(sm, chart=chart)  # no exception
+
+
+def test_guest_cannot_access_chart_outside_granted_dashboards() -> None:
+    """A guest whose token grants none of a chart's dashboards is denied."""
+    chart = _make_chart([MagicMock(), MagicMock()])
+    sm = _sm_for_chart_access(is_guest=True)
+    sm.has_guest_access.return_value = False
+
+    with patch("superset.is_feature_enabled", return_value=True):
+        with pytest.raises(SupersetSecurityException):
+            SupersetSecurityManager.raise_for_access(sm, chart=chart)
+
+
+def test_guest_denied_member_chart_outside_dataset_allowlist() -> None:
+    """Even on a granted dashboard, a chart whose dataset the token's allowlist
+    excludes stays inaccessible."""
+    granted_dashboard = MagicMock()
+    chart = _make_chart([granted_dashboard])
+    sm = _sm_for_chart_access(is_guest=True)
+    sm.has_guest_access.return_value = True
+    sm._guest_token_allows_dataset.return_value = False
+
+    with patch("superset.is_feature_enabled", return_value=True):
+        with pytest.raises(SupersetSecurityException):
+            SupersetSecurityManager.raise_for_access(sm, chart=chart)
+
+
+def test_guest_chart_access_requires_embedded_feature_flag() -> None:
+    """The guest grant is gated on EMBEDDED_SUPERSET; disabled means denied."""
+    granted_dashboard = MagicMock()
+    chart = _make_chart([granted_dashboard])
+    sm = _sm_for_chart_access(is_guest=True)
+    sm.has_guest_access.return_value = True
+
+    with patch("superset.is_feature_enabled", return_value=False):
+        with pytest.raises(SupersetSecurityException):
+            SupersetSecurityManager.raise_for_access(sm, chart=chart)
+
+
+def test_non_guest_denied_without_consulting_dashboard_membership() -> None:
+    """A non-guest with no chart access is still denied, and the guest branch
+    (dashboard membership) is never evaluated for them."""
+    chart = _make_chart([MagicMock()])
+    sm = _sm_for_chart_access(is_guest=False)
+
+    with patch("superset.is_feature_enabled", return_value=True):
+        with pytest.raises(SupersetSecurityException):
+            SupersetSecurityManager.raise_for_access(sm, chart=chart)
+
+    sm.has_guest_access.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _guest_token_allows_dataset — allowlist helper
+# ---------------------------------------------------------------------------
+
+
+def _guest_with_datasets(datasets: list[int] | None) -> GuestUser:
+    token: GuestToken = {
+        "user": {},
+        "resources": [{"type": GuestTokenResourceType.DASHBOARD, "id": "dash-uuid"}],
+        "rls_rules": [],
+        "iat": 0,
+        "exp": 9999999999,
+    }
+    if datasets is not None:
+        token["datasets"] = datasets
+    return GuestUser(token=token, roles=[])
+
+
+def _sm_with_guest(guest_user: GuestUser | None) -> MagicMock:
+    sm = MagicMock(spec=SupersetSecurityManager)
+    sm.get_current_guest_user_if_guest.return_value = guest_user
+    return sm
+
+
+def test_allows_dataset_non_guest_always_true() -> None:
+    sm = _sm_with_guest(None)
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 99) is True
+
+
+def test_allows_dataset_no_allowlist_claim_is_true() -> None:
+    sm = _sm_with_guest(_guest_with_datasets(None))
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 99) is True
+
+
+def test_allows_dataset_listed_id_is_true() -> None:
+    sm = _sm_with_guest(_guest_with_datasets([7, 8]))
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 7) is True
+
+
+def test_allows_dataset_unlisted_id_is_false() -> None:
+    sm = _sm_with_guest(_guest_with_datasets([7, 8]))
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 99) is False
+
+
+def test_allows_dataset_empty_allowlist_blocks_all() -> None:
+    sm = _sm_with_guest(_guest_with_datasets([]))
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 7) is False
+
+
+def test_allows_dataset_malformed_allowlist_blocks() -> None:
+    guest_user = _guest_with_datasets(None)
+    guest_user.guest_token["datasets"] = ["7", "8"]  # type: ignore[list-item]
+    sm = _sm_with_guest(guest_user)
+    assert SupersetSecurityManager._guest_token_allows_dataset(sm, 7) is False


### PR DESCRIPTION
### SUMMARY

Embedded dashboards recently stopped rendering their charts for guest (embedded) users. The dashboard payload was leaving out the member charts and their `form_data`, so the embedded frontend had nothing to render and sat on the loading spinner. It surfaced as an intermittent failure of the embedded Playwright suite.

An embedded guest reaches a dashboard and its charts through its guest token rather than a standalone datasource grant, so the chart branch of `raise_for_access` didn't recognize a guest while serializing a dashboard's member charts (the dashboard and `form_data` context that a chart-data request supplies isn't present during serialization). This grants a guest access to a member chart of a dashboard their token covers, bounded by the token's dataset allowlist. Non-guest access is unchanged.

The embedded Playwright helper keeps the small diagnostic that surfaces the embed error message instead of blindly timing out (which is what pinned this down), along with the cold-CI render timeout.

### TESTING INSTRUCTIONS

`tests/unit_tests/security/test_embedded_guest_chart_access.py` covers the guest chart-access branch (granted vs. non-granted dashboard, the feature-flag gate, the non-guest path) and the dataset-allowlist bound. The existing guest-token allowlist tests still pass unchanged. The embedded Playwright suite exercises the end-to-end render.

To verify manually: embed a dashboard with a guest token and confirm its charts render.

### ADDITIONAL INFORMATION
- [x] Changes UI (embedded dashboard rendering)
