### PR TITLE
fix(funnel): prevent horizontal legends from overlapping the chart by default

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -50,9 +50,12 @@ import { resolveLegendLayout } from '../utils/legendLayout';
 import { defaultGrid } from '../defaults';
 import { DEFAULT_LEGEND_FORM_DATA, OpacityEnum } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
-import { Refs } from '../types';
+import { LegendOrientation, Refs } from '../types';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
+
+// funnel charts need a taller default height than the regular default of 20.
+const DEFAULT_HORIZONTAL_LEGEND_MARGIN = 40;
 
 export function parseParams({
   params,
@@ -244,11 +247,19 @@ export default function transformProps(
     if (!legendSort) return 0;
     return legendSort === 'asc' ? a.localeCompare(b) : b.localeCompare(a);
   });
+  const isHorizontalLegend = [
+    LegendOrientation.Top,
+    LegendOrientation.Bottom,
+  ].includes(legendOrientation);
+  const resolvedLegendMargin =
+    typeof legendMargin !== 'number' && isHorizontalLegend
+      ? DEFAULT_HORIZONTAL_LEGEND_MARGIN
+      : legendMargin;
   const { effectiveLegendMargin, effectiveLegendType } = resolveLegendLayout({
     chartHeight: height,
     chartWidth: width,
     legendItems: legendData,
-    legendMargin,
+    legendMargin: resolvedLegendMargin,
     orientation: legendOrientation,
     show: showLegend,
     theme,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Funnel/transformProps.ts
@@ -54,7 +54,7 @@ import { LegendOrientation, Refs } from '../types';
 
 const percentFormatter = getNumberFormatter(NumberFormats.PERCENT_2_POINT);
 
-// funnel charts need a taller default height than the regular default of 20.
+// horizontal funnel legends need a taller default height than the regular default of 20.
 const DEFAULT_HORIZONTAL_LEGEND_MARGIN = 40;
 
 export function parseParams({

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -18,6 +18,7 @@
  */
 import { ChartProps, getNumberFormatter } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/theme';
+import type { FunnelSeriesOption } from 'echarts/charts';
 import transformProps, { parseParams } from '../../src/Funnel/transformProps';
 import {
   EchartsFunnelChartProps,
@@ -73,13 +74,25 @@ describe('Funnel transformProps', () => {
     );
   });
 
-  test('does not apply a text border to segment labels', () => {
-    // A white textBorder washes out the dark text on light-colored segments.
-    const result = transformProps(chartProps as EchartsFunnelChartProps);
-    const { label } = (result.echartOptions.series as any)[0];
-    expect(label.color).toBe(supersetTheme.colorText);
-    expect(label.textBorderColor).toBeUndefined();
-    expect(label.textBorderWidth).toBeUndefined();
+  test('should reserve extra space for a horizontal legend by default (40 instead of 20)', () => {
+    const { echartOptions } = transformProps(
+      chartProps as EchartsFunnelChartProps,
+    );
+    const series = echartOptions.series as FunnelSeriesOption[];
+    expect(series[0].top).toBe(40);
+  });
+
+  test('should respect an explicit legend margin', () => {
+    const props = new ChartProps({
+      formData: { ...formData, legendMargin: 80 },
+      width: 800,
+      height: 600,
+      queriesData,
+      theme: supersetTheme,
+    });
+    const { echartOptions } = transformProps(props as EchartsFunnelChartProps);
+    const series = echartOptions.series as FunnelSeriesOption[];
+    expect(series[0].top).toBe(80);
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -82,6 +82,19 @@ describe('Funnel transformProps', () => {
     expect(series[0].top).toBe(40);
   });
 
+  test('should reserve extra space for a bottom horizontal legend by default (40 instead of 20)', () => {
+    const props = new ChartProps({
+      formData: { ...formData, legendOrientation: 'bottom' },
+      width: 800,
+      height: 600,
+      queriesData,
+      theme: supersetTheme,
+    });
+    const { echartOptions } = transformProps(props as EchartsFunnelChartProps);
+    const series = echartOptions.series as FunnelSeriesOption[];
+    expect(series[0].bottom).toBe(40);
+  });
+
   test('should respect an explicit legend margin', () => {
     const props = new ChartProps({
       formData: { ...formData, legendMargin: 80 },
@@ -93,6 +106,16 @@ describe('Funnel transformProps', () => {
     const { echartOptions } = transformProps(props as EchartsFunnelChartProps);
     const series = echartOptions.series as FunnelSeriesOption[];
     expect(series[0].top).toBe(80);
+  });
+
+  test('does not apply a text border to segment labels', () => {
+    // A white textBorder washes out the dark text on light-colored segments.
+    const { echartOptions } = transformProps(chartProps as EchartsFunnelChartProps);
+    const series = echartOptions.series as FunnelSeriesOption[];
+    const label = series[0].label;
+    expect(label).toEqual(expect.objectContaining({ color: supersetTheme.colorText }));
+    expect(label).not.toHaveProperty('textBorderColor');
+    expect(label).not.toHaveProperty('textBorderWidth');
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts
@@ -74,7 +74,7 @@ describe('Funnel transformProps', () => {
     );
   });
 
-  test('should reserve extra space for a horizontal legend by default (40 instead of 20)', () => {
+  test('should reserve extra space for a top horizontal legend by default (40 instead of 20)', () => {
     const { echartOptions } = transformProps(
       chartProps as EchartsFunnelChartProps,
     );
@@ -110,12 +110,11 @@ describe('Funnel transformProps', () => {
 
   test('does not apply a text border to segment labels', () => {
     // A white textBorder washes out the dark text on light-colored segments.
-    const { echartOptions } = transformProps(chartProps as EchartsFunnelChartProps);
-    const series = echartOptions.series as FunnelSeriesOption[];
-    const label = series[0].label;
-    expect(label).toEqual(expect.objectContaining({ color: supersetTheme.colorText }));
-    expect(label).not.toHaveProperty('textBorderColor');
-    expect(label).not.toHaveProperty('textBorderWidth');
+    const result = transformProps(chartProps as EchartsFunnelChartProps);
+    const { label } = (result.echartOptions.series as any)[0];
+    expect(label.color).toBe(supersetTheme.colorText);
+    expect(label.textBorderColor).toBeUndefined();
+    expect(label.textBorderWidth).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
### SUMMARY
The shared 20px default legend margin is not enough for funnel charts. A top/bottom margin will make the chart overlap with the legend, see the image below. So you'd have to bump legend margin by hand on every new chart.
Funnel now defaults horizontal legends to 40px. An explicitly set legend margin still wins, and left/right legends are unchanged.

Added test to `superset-frontend/plugins/plugin-chart-echarts/test/Funnel/transformProps.test.ts`

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="959" height="660" alt="image" src="https://github.com/user-attachments/assets/9b53a000-0d20-49f4-8dff-0fc04ba21ea5" />
-->

<img width="959" height="649" alt="image" src="https://github.com/user-attachments/assets/0ea53486-d724-4319-9198-7987c91a1630" />

### TESTING INSTRUCTIONS
1. Create a new Funnel chart with a few groupby values and leave all customize
   options at their defaults.
2. Verify the top legend no longer overlaps the top of the funnel.
3. Set "Legend Margin" explicitly and see that the value is still respected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API