### PR TITLE
fix(explore): show the empty state when Samples returns no result payload

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -108,10 +108,14 @@ export const SamplesPane = ({
           // A 200 that carries no `result` payload resolves to undefined here.
           // Read through it so the pane falls back to its empty state instead
           // of throwing a TypeError that surfaces as an internal error message.
-          setData(ensureIsArray(response?.data));
+          const rows = ensureIsArray(response?.data);
+          setData(rows);
           setColnames(ensureIsArray(response?.colnames));
           setColtypes(ensureIsArray(response?.coltypes));
-          setRowCount(response?.rowcount ?? 0);
+          // Fall back to the rows actually returned rather than to zero: the
+          // controls only render when there are rows, and a hardcoded 0 would
+          // label a populated table as "0 rows".
+          setRowCount(response?.rowcount ?? rows.length);
           setResponseError('');
           cache.set(queryFormData, true);
           if (queryForce) {

--- a/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/SamplesPane.tsx
@@ -105,10 +105,13 @@ export const SamplesPane = ({
         1,
       )
         .then(response => {
-          setData(ensureIsArray(response.data));
-          setColnames(ensureIsArray(response.colnames));
-          setColtypes(ensureIsArray(response.coltypes));
-          setRowCount(response.rowcount);
+          // A 200 that carries no `result` payload resolves to undefined here.
+          // Read through it so the pane falls back to its empty state instead
+          // of throwing a TypeError that surfaces as an internal error message.
+          setData(ensureIsArray(response?.data));
+          setColnames(ensureIsArray(response?.colnames));
+          setColtypes(ensureIsArray(response?.coltypes));
+          setRowCount(response?.rowcount ?? 0);
           setResponseError('');
           cache.set(queryFormData, true);
           if (queryForce) {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -66,6 +66,21 @@ describe('SamplesPane', () => {
     {},
   );
 
+  // A 200 whose result carries rows but omits `rowcount`.
+  fetchMock.post(
+    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=38&per_page=100&page=1',
+    {
+      result: {
+        data: [
+          { __timestamp: 1230768000000, genre: 'Action' },
+          { __timestamp: 1230768000010, genre: 'Horror' },
+        ],
+        colnames: ['__timestamp', 'genre'],
+        coltypes: [2, 1],
+      },
+    },
+  );
+
   const setForceQuery = jest.fn();
 
   afterAll(() => {
@@ -132,5 +147,17 @@ describe('SamplesPane', () => {
     ).toBeVisible();
     // The pane should not leak an internal TypeError through the error alert.
     expect(queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('counts the returned rows when the response omits rowcount', async () => {
+    const props = createSamplesPaneProps({ datasourceId: 38 });
+    const { findByText, queryByText } = render(<SamplesPane {...props} />, {
+      useRedux: true,
+    });
+
+    expect(await findByText('Action')).toBeVisible();
+    // Falling back to 0 here would label a populated table as "0 rows".
+    expect(queryByText('0 rows')).not.toBeInTheDocument();
+    expect(queryByText('2 rows')).toBeVisible();
   });
 });

--- a/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/SamplesPane.test.tsx
@@ -60,6 +60,12 @@ describe('SamplesPane', () => {
     400,
   );
 
+  // A 200 response that carries no `result` payload, as reported in #36840.
+  fetchMock.post(
+    'end:/datasource/samples?force=false&datasource_type=table&datasource_id=37&per_page=100&page=1',
+    {},
+  );
+
   const setForceQuery = jest.fn();
 
   afterAll(() => {
@@ -113,5 +119,18 @@ describe('SamplesPane', () => {
     expect(queryByText('2 rows')).toBeVisible();
     expect(queryByText('Action')).toBeVisible();
     expect(queryByText('Horror')).toBeVisible();
+  });
+
+  test('renders the empty state when the response carries no result payload', async () => {
+    const props = createSamplesPaneProps({ datasourceId: 37 });
+    const { findByText, queryByRole } = render(<SamplesPane {...props} />, {
+      useRedux: true,
+    });
+
+    expect(
+      await findByText('No samples were returned for this dataset'),
+    ).toBeVisible();
+    // The pane should not leak an internal TypeError through the error alert.
+    expect(queryByRole('alert')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### SUMMARY

Related to #36840.

`getDatasourceSamples` returns `response.json.result`, so a 200 response that carries no `result` resolves to `undefined`. `SamplesPane` then read fields straight off it:

```ts
setData(ensureIsArray(response.data));
```

which throws `TypeError: Cannot read properties of undefined (reading 'data')`. The `.catch` in the same effect turns that into user-facing text, so the pane renders **"Failed to load samples — TypeError: Cannot read properties of undefined (reading 'data')"** — an internal error leaked into the UI, on a code path where the component already has a perfectly good empty state (`No samples were returned for this dataset`) that it never reaches.

This reads through the response so that path falls back to the existing empty state.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Rendered output of the Samples tab for a 200 response whose body has no `result` key (taken from the regression test added here):

| | rendered |
| --- | --- |
| before | `Failed to load samples` / `TypeError: Cannot read properties of undefined (reading 'data')` |
| after | `No samples were returned for this dataset` |

### TESTING INSTRUCTIONS

Automated — regression tests are included. The first fails on `master` with the exact `TypeError` above. The second pins the row count, after review surfaced a regression in the first version of this guard: defaulting an absent `rowcount` to `0` labelled a populated table "0 rows", where previously the label was simply hidden. It now falls back to the rows actually returned, which is more accurate than either behaviour.

Both pass with this change:

```bash
cd superset-frontend
npx jest src/explore/components/DataTablesPane
```

5 suites / 33 tests pass, including both new cases.

Manual:

1. Open any chart in Explore and click the **Samples** tab.
2. With `/datasource/samples` returning `200` and a body without a `result` key (the shape reported in #36840), the pane shows "No samples were returned for this dataset" rather than a `TypeError`.

### ADDITIONAL INFORMATION

A note on scope, since #36840 is labelled `validation:required`: I could not reproduce the reported **UI freeze** on current `master` — the request path now settles and renders an error alert rather than hanging, so whatever caused the freeze appears to have been fixed since the report. What does still reproduce is the misleading error above, which is what this PR addresses; it matches the issue's stated expectation that the tab "display rows or show a 'No data available' message".

One neighbouring case is deliberately left alone: a 200 with a genuinely **empty body** fails JSON parsing and surfaces `Failed to load samples — Error: Unexpected ''`. That is a malformed response, so an error state seems right there; only the "well-formed 200, no payload" case is treated as empty. Happy to fold that in if maintainers would rather both paths render the empty state.

- [x] Has associated issue: #36840
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

