### PR TITLE
fix(sql): handle ORDER BY in embedded MSSQL queries

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -181,6 +181,24 @@ OFFSET_JOIN_COLUMN_SUFFIX = "__offset_join_column_"
 R_SUFFIX = "__right_suffix"
 
 
+def _normalize_mssql_virtual_dataset_sql(
+    sql: str, parsed_script: SQLScript, engine: str
+) -> str:
+    """Remove SQL Server ordering that is invalid inside a derived table."""
+    if engine != "mssql" or not parsed_script.statements:
+        return sql
+
+    statement = parsed_script.statements[0]
+    if not isinstance(statement, SQLStatement):
+        return sql
+
+    return (
+        f"{statement.format()}\n"
+        if statement.remove_unbounded_top_level_order_by()
+        else sql
+    )
+
+
 def _as_wall_clock(series: pd.Series) -> pd.Series:
     """
     Return a datetime series as local wall-clock readings, dropping any
@@ -3173,6 +3191,10 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     "predicates apply to its tables; continuing: %s",
                     ex,
                 )
+
+        from_sql = _normalize_mssql_virtual_dataset_sql(
+            from_sql, parsed_script, self.db_engine_spec.engine
+        )
 
         cte = self.db_engine_spec.get_cte_query(from_sql)
         from_clause = (

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1440,6 +1440,17 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         """
         return bool(self._parsed.args.get("with_"))
 
+    def remove_unbounded_top_level_order_by(self) -> bool:
+        """Drop ordering that becomes invalid when this query is embedded."""
+        if (
+            self._parsed.args.get("order")
+            and not self._parsed.args.get("limit")
+            and not self._parsed.args.get("offset")
+        ):
+            self._parsed.set("order", None)
+            return True
+        return False
+
     def as_cte(self, alias: str = "__cte") -> SQLStatement:
         """
         Rewrite the statement as a CTE.
@@ -1453,8 +1464,14 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         """
         existing_ctes = self._parsed.args["with_"].expressions if self.has_cte() else []
         self._parsed.args["with_"] = None
+        query = SQLStatement(ast=self._parsed.copy(), engine=self.engine)
+        # SQL Server rejects ORDER BY in a CTE unless it limits rows. Ordering
+        # without TOP/OFFSET is not part of a relation's semantics anyway; the
+        # outer chart query owns its final ordering.
+        if self.engine == "mssql":
+            query.remove_unbounded_top_level_order_by()
         new_cte = exp.CTE(
-            this=self._parsed.copy(),
+            this=query._parsed,  # pylint: disable=protected-access
             alias=exp.TableAlias(this=exp.Identifier(this=alias)),
         )
         return SQLStatement(

--- a/tests/unit_tests/models/test_virtual_dataset_format.py
+++ b/tests/unit_tests/models/test_virtual_dataset_format.py
@@ -164,6 +164,21 @@ class TestVirtualDatasetNoRLS:
         inner_sql = _get_subquery_sql(virtual_datasource)
         assert "::varchar(256)" in inner_sql
 
+    @patch("superset.models.helpers.apply_rls", return_value=False)
+    def test_mssql_unbounded_order_by_removed_when_embedded(
+        self,
+        mock_apply_rls: MagicMock,
+        virtual_datasource: MagicMock,
+        app: Flask,
+    ) -> None:
+        virtual_datasource.db_engine_spec.engine = "mssql"
+        _set_virtual_sql(
+            virtual_datasource,
+            "SELECT category, amount FROM sample_events ORDER BY category, amount",
+        )
+
+        assert "ORDER BY" not in _get_subquery_sql(virtual_datasource)
+
 
 class TestVirtualDatasetWithRLS:
     """

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2762,6 +2762,21 @@ def test_as_cte_called_twice() -> None:
     stmt.as_cte()
 
 
+def test_as_cte_drops_unbounded_mssql_order_by() -> None:
+    statement = SQLStatement(
+        "WITH source AS (SELECT 1 AS value) SELECT value FROM source ORDER BY value",
+        "mssql",
+    )
+    bounded = SQLStatement(
+        "WITH source AS (SELECT 1 AS value) "
+        "SELECT TOP 1 value FROM source ORDER BY value",
+        "mssql",
+    )
+
+    assert "ORDER BY" not in statement.as_cte().format()
+    assert "ORDER BY" in bounded.as_cte().format()
+
+
 @pytest.mark.parametrize(
     "sql, rules, expected",
     [


### PR DESCRIPTION
# fix(sql): handle ORDER BY in embedded MSSQL queries

### SUMMARY

Strip an unbounded top-level `ORDER BY` when a virtual dataset query is embedded as an MSSQL derived table or CTE. Queries using `TOP` or `OFFSET` keep their ordering.

Base: `apache/superset:master` at `e2bb33b1da17c16a51e54d84bcf496516d67a713`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend behavior only.

### TESTING INSTRUCTIONS

`pytest -q tests/unit_tests/sql/parse_tests.py tests/unit_tests/models/test_virtual_dataset_format.py`

Result: 888 passed, 1 xfailed.

The changed files also pass the repository pre-commit hooks.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
