### PR TITLE
fix(mcp): surface virtual dataset SQL errors

### DIFF
--- a/superset/mcp_service/dataset/tool/create_virtual_dataset.py
+++ b/superset/mcp_service/dataset/tool/create_virtual_dataset.py
@@ -21,6 +21,7 @@ from typing import Any
 from fastmcp import Context
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.exceptions import SupersetGenericDBErrorException
 from superset.extensions import event_logger
 from superset.mcp_service.dataset.schemas import (
     CreateVirtualDatasetRequest,
@@ -89,7 +90,7 @@ def _update_virtual_dataset(dataset_id: int, update_props: dict[str, Any]) -> An
         destructiveHint=False,
     ),
 )
-async def create_virtual_dataset(
+async def create_virtual_dataset(  # noqa: C901
     request: CreateVirtualDatasetRequest, ctx: Context
 ) -> CreateVirtualDatasetResponse:
     """Save a SQL query as a virtual dataset so it can be charted.
@@ -212,6 +213,17 @@ async def create_virtual_dataset(
             columns=[],
             url=None,
             error=f"Failed to update dataset metadata (creation rolled back): {exc}",
+        )
+    except SupersetGenericDBErrorException as exc:
+        await ctx.warning(f"Virtual dataset SQL failed validation: {exc}")
+        return CreateVirtualDatasetResponse(
+            id=None,
+            dataset_name=request.dataset_name,
+            sql=request.sql,
+            database_id=request.database_id,
+            columns=[],
+            url=None,
+            error=f"Dataset SQL could not be executed: {exc}",
         )
     except Exception as exc:
         await ctx.error(

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -2079,6 +2079,37 @@ async def test_create_virtual_dataset_create_failed(mcp_server: object) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_virtual_dataset_sql_error_is_actionable(
+    mcp_server: object,
+) -> None:
+    """Warehouse SQL errors are recoverable tool results, not adapter crashes."""
+    from superset.exceptions import SupersetGenericDBErrorException
+
+    mock_command = MagicMock()
+    mock_command.run.side_effect = SupersetGenericDBErrorException(
+        "Invalid column name 'missing_value'"
+    )
+
+    with patch(
+        "superset.commands.dataset.create.CreateDatasetCommand",
+        return_value=mock_command,
+    ):
+        async with Client(mcp_server) as client:
+            request = CreateVirtualDatasetRequest(
+                database_id=1,
+                sql="SELECT missing_value FROM sample_events",
+                dataset_name="Test",
+            )
+            result = await client.call_tool(
+                "create_virtual_dataset", {"request": request.model_dump()}
+            )
+            data = json.loads(result.content[0].text)
+
+    assert data["id"] is None
+    assert "Invalid column name" in data["error"]
+
+
+@pytest.mark.asyncio
 async def test_create_virtual_dataset_permission_denied(mcp_server: object) -> None:
     """SQL access denied surfaces as DatasetInvalidError with id=None."""
     from superset.commands.dataset.exceptions import (


### PR DESCRIPTION
# fix(mcp): surface virtual dataset SQL errors

### SUMMARY

Return database validation failures from `create_virtual_dataset` as actionable MCP results instead of unexpected adapter failures.

Base: `apache/superset:master` at `e2bb33b1da17c16a51e54d84bcf496516d67a713`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend behavior only.

### TESTING INSTRUCTIONS

`pytest -q tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py`

Result: 80 passed.

The changed files also pass the repository pre-commit hooks.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
