### PR TITLE
fix(mcp): defer unknown numeric types to compile

### DIFF
--- a/superset/mcp_service/chart/validation/dataset_validator.py
+++ b/superset/mcp_service/chart/validation/dataset_validator.py
@@ -593,7 +593,15 @@ class DatasetValidator:
                     col_ref.aggregate in numeric_aggs
                     and not col_info.get("is_numeric", False)
                     and col_info.get("type", "").upper()
-                    not in ["INTEGER", "FLOAT", "DOUBLE", "DECIMAL", "NUMERIC"]
+                    not in [
+                        "",
+                        "UNKNOWN",
+                        "INTEGER",
+                        "FLOAT",
+                        "DOUBLE",
+                        "DECIMAL",
+                        "NUMERIC",
+                    ]
                 ):
                     from superset.mcp_service.utils.error_builder import (  # noqa: E501
                         ChartErrorBuilder,

--- a/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
+++ b/tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py
@@ -58,6 +58,27 @@ def mock_dataset_context() -> DatasetContext:
     )
 
 
+def test_unknown_numeric_type_is_deferred_to_compile_check() -> None:
+    """Virtual SQL columns with unknown metadata are not assumed to be text."""
+    context = DatasetContext(
+        id=69,
+        table_name="virtual_metrics",
+        schema=None,
+        database_name="database",
+        available_columns=[
+            {"name": "computed_total", "type": "UNKNOWN", "is_numeric": False}
+        ],
+        available_metrics=[],
+    )
+    column = ColumnRef(name="computed_total", aggregate="SUM")
+
+    assert DatasetValidator._validate_aggregations([column], context) == []
+
+    context.available_columns[0]["type"] = "VARCHAR"
+    errors = DatasetValidator._validate_aggregations([column], context)
+    assert errors[0].error_type == "invalid_aggregation"
+
+
 class TestGetCanonicalColumnName:
     """Test get_canonical_column_name static method."""
 


### PR DESCRIPTION
# fix(mcp): defer unknown numeric types to compile

### SUMMARY

Do not reject numeric aggregations solely because a virtual dataset column reports empty or `UNKNOWN` type metadata. The existing compile check remains the authoritative validation.

Base: `apache/superset:master` at `e2bb33b1da17c16a51e54d84bcf496516d67a713`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend behavior only.

### TESTING INSTRUCTIONS

`pytest -q tests/unit_tests/mcp_service/chart/validation/test_column_name_normalization.py`

Result: 49 passed.

The changed files also pass the repository pre-commit hooks.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
