### PR TITLE
fix(mcp): accept common chart input variants

### DIFF
--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -1312,6 +1312,8 @@ def map_filter_operator(op: str) -> str:
         "NOT LIKE": "NOT LIKE",
         "IN": "IN",
         "NOT IN": "NOT IN",
+        "IS NULL": "IS NULL",
+        "IS NOT NULL": "IS NOT NULL",
     }
     return operator_map.get(op, op)
 

--- a/superset/mcp_service/chart/chart_utils.py
+++ b/superset/mcp_service/chart/chart_utils.py
@@ -657,6 +657,8 @@ def add_legend_config(form_data: Dict[str, Any], config: XYChartConfig) -> None:
             # Canonical form_data key is camelCase; the echarts plugins read
             # `legendOrientation` directly off form_data.
             form_data["legendOrientation"] = config.legend.position
+    if config.legend_orientation:
+        form_data["legendOrientation"] = config.legend_orientation
 
 
 def add_color_scheme(form_data: Dict[str, Any], color_scheme: str | None) -> None:

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -779,7 +779,7 @@ class ColumnRef(UnknownFieldCheckMixin):
         None,
         min_length=1,
         max_length=255,
-        validation_alias=AliasChoices("name", "column_name"),
+        validation_alias=AliasChoices("name", "column_name", "column"),
     )
     label: str | None = Field(None, max_length=500)
     dtype: str | None = None
@@ -952,16 +952,30 @@ class FilterConfig(UnknownFieldCheckMixin):
         "NOT LIKE",
         "IN",
         "NOT IN",
+        "IS NULL",
+        "IS NOT NULL",
     ] = Field(
         ...,
-        description="LIKE/ILIKE use % wildcards. IN/NOT IN take a list.",
+        description=(
+            "LIKE/ILIKE use % wildcards. IN/NOT IN take a list. "
+            "IS NULL/IS NOT NULL omit value."
+        ),
         validation_alias=AliasChoices("op", "operator", "opr"),
     )
-    value: str | int | float | bool | list[str | int | float | bool] = Field(
-        ...,
-        description="For IN/NOT IN, provide a list.",
+    value: str | int | float | bool | list[str | int | float | bool] | None = Field(
+        None,
+        description="For IN/NOT IN, provide a list. Omit for null operators.",
         validation_alias=AliasChoices("value", "val"),
     )
+
+    @model_validator(mode="after")
+    def validate_value(self) -> "FilterConfig":
+        """Null checks have no comparator; every other operator requires one."""
+        if self.op in {"IS NULL", "IS NOT NULL"}:
+            self.value = None
+        elif self.value is None:
+            raise ValueError(f"Filter operator {self.op!r} requires 'value'.")
+        return self
 
     @field_validator("column")
     @classmethod

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -972,7 +972,8 @@ class FilterConfig(UnknownFieldCheckMixin):
     def validate_value(self) -> "FilterConfig":
         """Null checks have no comparator; every other operator requires one."""
         if self.op in {"IS NULL", "IS NOT NULL"}:
-            self.value = None
+            if self.value is not None:
+                raise ValueError(f"Filter operator {self.op!r} must not have 'value'.")
         elif self.value is None:
             raise ValueError(f"Filter operator {self.op!r} requires 'value'.")
         return self

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -1725,6 +1725,10 @@ class XYChartConfig(UnknownFieldCheckMixin):
         None,
         validation_alias=AliasChoices("legend", "show_legend"),
     )
+    legend_orientation: LEGEND_POSITION_LITERAL | None = Field(
+        None,
+        description="Legend placement around the chart",
+    )
     x_axis_time_format: str | None = Field(
         None,
         description=(

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -616,6 +616,23 @@ class TestMapXYConfig:
         assert result["show_legend"] is False
         assert result["legendOrientation"] == "top"
 
+    def test_map_xy_config_with_legend_orientation(self) -> None:
+        config = XYChartConfig.model_validate(
+            {
+                "chart_type": "xy",
+                "x": {"name": "date"},
+                "y": [{"name": "revenue", "aggregate": "SUM"}],
+                "show_legend": True,
+                "legend_orientation": "bottom",
+            }
+        )
+
+        result = map_xy_config(config)
+
+        assert config.legend is not None
+        assert config.legend.show is True
+        assert result["legendOrientation"] == "bottom"
+
     def test_map_xy_config_with_color_scheme(self) -> None:
         """color_scheme propagates to form_data when set."""
         config = XYChartConfig(

--- a/tests/unit_tests/mcp_service/chart/test_chart_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_utils.py
@@ -390,6 +390,25 @@ class TestMapTableConfig:
 
         assert result["row_limit"] == 500
 
+    def test_map_table_config_supports_null_filter(self) -> None:
+        config = TableChartConfig(
+            chart_type="table",
+            columns=[ColumnRef(name="optional_value")],
+            filters=[FilterConfig(column="optional_value", op="IS NOT NULL")],
+        )
+
+        result = map_table_config(config)
+
+        assert result["adhoc_filters"] == [
+            {
+                "clause": "WHERE",
+                "expressionType": "SIMPLE",
+                "subject": "optional_value",
+                "operator": "IS NOT NULL",
+                "comparator": None,
+            }
+        ]
+
     def test_map_table_config_default_row_limit(self) -> None:
         """Test that default row_limit is mapped to form_data."""
         config = TableChartConfig(

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -190,6 +190,11 @@ class TestGenerateChart:
         for i, f in enumerate(filters):
             assert f.op == operators[i]
 
+        null_filter = FilterConfig(column="optional_value", op="IS NOT NULL")
+        assert null_filter.value is None
+        with pytest.raises(ValueError, match="requires 'value'"):
+            FilterConfig(column="optional_value", op="=")
+
     @pytest.mark.asyncio
     async def test_generate_chart_response_structure(self):
         """Test the expected response structure for chart generation."""
@@ -307,6 +312,10 @@ class TestGenerateChart:
         assert col2.name == "sales"
         assert col2.aggregate == "SUM"
         assert col2.label == "Total Sales"
+
+        aliased = ColumnRef.model_validate({"column": "sales", "aggregate": "AVG"})
+        assert aliased.name == "sales"
+        assert aliased.aggregate == "AVG"
 
         # All supported aggregations
         aggs = ["SUM", "AVG", "COUNT", "MIN", "MAX", "COUNT_DISTINCT"]

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -192,6 +192,8 @@ class TestGenerateChart:
 
         null_filter = FilterConfig(column="optional_value", op="IS NOT NULL")
         assert null_filter.value is None
+        with pytest.raises(ValueError, match="must not have 'value'"):
+            FilterConfig(column="optional_value", op="IS NULL", value="unexpected")
         with pytest.raises(ValueError, match="requires 'value'"):
             FilterConfig(column="optional_value", op="=")
 


### PR DESCRIPTION
# fix(mcp): accept common chart input variants

### SUMMARY

Accept `column` as a column-reference alias and support `IS NULL`/`IS NOT NULL` filters without comparator values. Reject supplied comparator values for null operators and preserve value validation for other operators. Accept `legend_orientation` for XY charts and map it to Superset's canonical `legendOrientation` form-data key.

Base: `apache/superset:master` at `e2bb33b1da17c16a51e54d84bcf496516d67a713`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend behavior only.

### TESTING INSTRUCTIONS

`pytest -q tests/unit_tests/mcp_service/chart/test_chart_utils.py tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py`

Result: 183 passed.

Ruff check, Ruff format check, and `git diff --check` pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API