### PR TITLE
fix(dashboard): report the real error when saving a dashboard fails

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.test.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.test.ts
@@ -135,6 +135,15 @@ describe('dashboardState actions', () => {
 
   // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
   describe('saveDashboardRequest', () => {
+    const findDangerToast = (dispatch: jest.Mock) =>
+      dispatch.mock.calls
+        .map(call => call[0])
+        .find(
+          action =>
+            action?.type === ADD_TOAST &&
+            action.payload.toastType === ToastType.Danger,
+        );
+
     test('should dispatch UPDATE_COMPONENTS_PARENTS_LIST action', () => {
       const { getState, dispatch } = setup({
         dashboardState: { hasUnsavedChanges: false },
@@ -226,6 +235,89 @@ describe('dashboardState actions', () => {
         await waitFor(() => expect(putStub.mock.calls.length).toBe(1));
         const { body } = putStub.mock.calls[0][0];
         expect(body).toBe(JSON.stringify(confirmedDashboardData));
+      });
+
+      test('warns about the overwrite values when a diff is detected', async () => {
+        const { getState, dispatch } = setup();
+        const thunk = saveDashboardRequest(
+          newDashboardData,
+          192,
+          SAVE_TYPE_OVERWRITE,
+        );
+        thunk(dispatch, getState);
+        await waitFor(() =>
+          expect(findDangerToast(dispatch)?.payload.text).toBe(
+            'Please confirm the overwrite values.',
+          ),
+        );
+        expect(putStub.mock.calls.length).toBe(0);
+      });
+
+      test('reports the actual error when the overwrite precheck fails', async () => {
+        getStub.mockRestore();
+        getStub = jest
+          .spyOn(SupersetClient, 'get')
+          .mockRejectedValue(new Error('precheck exploded'));
+        const { getState, dispatch } = setup();
+        const thunk = saveDashboardRequest(
+          newDashboardData,
+          192,
+          SAVE_TYPE_OVERWRITE,
+        );
+        thunk(dispatch, getState);
+        await waitFor(() =>
+          expect(findDangerToast(dispatch)?.payload.text).toContain(
+            'precheck exploded',
+          ),
+        );
+        expect(putStub.mock.calls.length).toBe(0);
+      });
+    });
+
+    // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+    describe('when FeatureFlag.CONFIRM_DASHBOARD_DIFF is disabled', () => {
+      beforeEach(() => {
+        mockIsFeatureEnabled.mockImplementation(() => false);
+      });
+
+      afterEach(() => {
+        mockIsFeatureEnabled.mockRestore();
+      });
+
+      test('never runs the overwrite precheck', async () => {
+        const { getState, dispatch } = setup();
+        const thunk = saveDashboardRequest(
+          newDashboardData,
+          192,
+          SAVE_TYPE_OVERWRITE,
+        );
+        thunk(dispatch, getState);
+        await waitFor(() => expect(putStub.mock.calls.length).toBe(1));
+        expect(getStub).not.toHaveBeenCalledWith(
+          expect.objectContaining({ endpoint: '/api/v1/dashboard/192' }),
+        );
+      });
+
+      // An unexpected failure used to reach the overwrite-confirm handler,
+      // which reported it as "Please confirm the overwrite values." even with
+      // the feature flag off, hiding the real error.
+      test('reports the actual error when the update throws unexpectedly', async () => {
+        putStub.mockRestore();
+        putStub = jest.spyOn(SupersetClient, 'put').mockImplementation(() => {
+          throw new Error('unexpected boom');
+        });
+        const { getState, dispatch } = setup();
+        const thunk = saveDashboardRequest(
+          newDashboardData,
+          192,
+          SAVE_TYPE_OVERWRITE,
+        );
+        thunk(dispatch, getState);
+        await waitFor(() =>
+          expect(findDangerToast(dispatch)?.payload.text).toContain(
+            'unexpected boom',
+          ),
+        );
       });
     });
 
@@ -379,15 +471,6 @@ describe('dashboardState actions', () => {
     // permission-denied copy, while a 403 from outside Superset (reverse proxy,
     // WAF, SSO gateway) carries a non-JSON body and must fall back to the
     // generic status-derived toast. See #42239.
-    const findDangerToast = (dispatch: jest.Mock) =>
-      dispatch.mock.calls
-        .map(call => call[0])
-        .find(
-          action =>
-            action?.type === ADD_TOAST &&
-            action.payload.toastType === ToastType.Danger,
-        );
-
     test('maps a non-JSON 403 save failure to the generic error toast', async () => {
       const { getState, dispatch } = setup();
       putStub.mockRestore();

--- a/superset-frontend/src/dashboard/actions/dashboardState.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardState.ts
@@ -646,6 +646,7 @@ export function saveDashboardRequest(
     };
 
     const onError = async (response: Response): Promise<void> => {
+      logging.error(response);
       const { error, message } = await getClientErrorObject(response);
       let errorText = t('Sorry, an unknown error occurred');
 
@@ -689,64 +690,64 @@ export function saveDashboardRequest(
               }),
             };
 
-      const updateDashboard = (): Promise<JsonObject | void> =>
-        SupersetClient.put({
-          endpoint: `/api/v1/dashboard/${id}`,
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(updatedDashboard),
-        })
-          .then(response => onUpdateSuccess(response))
-          .catch(response => onError(response));
-      return new Promise<void>((resolve, reject) => {
-        if (
-          !isFeatureEnabled(FeatureFlag.ConfirmDashboardDiff) ||
-          saveType === SAVE_TYPE_OVERWRITE_CONFIRMED
-        ) {
-          // skip overwrite precheck
-          resolve();
-          return;
+      const updateDashboard = async (): Promise<JsonObject | void> => {
+        try {
+          const response = await SupersetClient.put({
+            endpoint: `/api/v1/dashboard/${id}`,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(updatedDashboard),
+          });
+          return await onUpdateSuccess(response);
+        } catch (error) {
+          return onError(error as Response);
         }
+      };
 
-        // precheck for overwrite items
-        SupersetClient.get({
-          endpoint: `/api/v1/dashboard/${id}`,
-        }).then((response: JsonObject) => {
+      if (
+        !isFeatureEnabled(FeatureFlag.ConfirmDashboardDiff) ||
+        saveType === SAVE_TYPE_OVERWRITE_CONFIRMED
+      ) {
+        // skip overwrite precheck
+        return updateDashboard();
+      }
+
+      // precheck for overwrite items
+      return SupersetClient.get({
+        endpoint: `/api/v1/dashboard/${id}`,
+      })
+        .then((response: JsonObject) => {
           const dashboard = (response.json as JsonObject).result as JsonObject;
           const overwriteConfirmItems = getOverwriteItems(
             dashboard,
             updatedDashboard,
           );
-          if (overwriteConfirmItems.length > 0) {
-            dispatch(
-              setOverrideConfirm({
-                updatedAt: dashboard.changed_on as string,
-                updatedBy: dashboard.changed_by_name as string,
-                overwriteConfirmItems:
-                  overwriteConfirmItems as DashboardState['overwriteConfirmMetadata'] extends
-                    | { overwriteConfirmItems: infer I }
-                    | undefined
-                    ? I
-                    : never,
-                dashboardId: id,
-                data: updatedDashboard,
-              }),
-            );
-            return reject(overwriteConfirmItems);
+          if (overwriteConfirmItems.length === 0) {
+            return updateDashboard();
           }
-          return resolve();
-        });
-      })
-        .then(updateDashboard)
-        .catch((overwriteConfirmItems: JsonObject[]) => {
-          const errorText = t('Please confirm the overwrite values.');
+          dispatch(
+            setOverrideConfirm({
+              updatedAt: dashboard.changed_on as string,
+              updatedBy: dashboard.changed_by_name as string,
+              overwriteConfirmItems:
+                overwriteConfirmItems as DashboardState['overwriteConfirmMetadata'] extends
+                  | { overwriteConfirmItems: infer I }
+                  | undefined
+                  ? I
+                  : never,
+              dashboardId: id,
+              data: updatedDashboard,
+            }),
+          );
           dispatch(
             logEvent(LOG_ACTIONS_CONFIRM_OVERWRITE_DASHBOARD_METADATA, {
               dashboard_id: id,
               items: overwriteConfirmItems,
             }),
           );
-          dispatch(addDangerToast(errorText));
-        });
+          dispatch(addDangerToast(t('Please confirm the overwrite values.')));
+          return undefined;
+        })
+        .catch(onError);
     }
     // changing the data as the endpoint requires
     if (


### PR DESCRIPTION
### SUMMARY

Saving a dashboard reports "Please confirm the overwrite values." for errors that have nothing to do with the overwrite diff, and drops the real error.

The precheck rejects with its diff items and lets a single `.catch` at the end of the save chain handle them, but that catch sits after `updateDashboard`, so it catches every failure in the chain. Since `CONFIRM_DASHBOARD_DIFF` is not in `DEFAULT_FEATURE_FLAGS`, most users see this message for a feature that never ran — the annotation `(overwriteConfirmItems: JsonObject[])` only holds for the confirm case.

The confirm case is now handled inside the precheck where it is detected, so real failures reach `onError`, which already builds an accurate message and dispatches `saveDashboardFinished()`. Two related gaps close with it: the precheck `GET` had no error handling, so a failing precheck left the promise unsettled and the dashboard stuck saving; and anything thrown before the request went out was swallowed silently. `onError` now also logs the raw error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

With `CONFIRM_DASHBOARD_DIFF` off (the default):

1. Open a dashboard, enter edit mode, make a change.
2. Make the save fail — e.g. in devtools, block `PUT /api/v1/dashboard/<id>`, or revoke edit permission.
3. Save. The toast names the actual failure instead of asking you to confirm overwrite values.

With `CONFIRM_DASHBOARD_DIFF` on, confirm the diff modal and its "Please confirm the overwrite values." toast still appear when another user has changed the dashboard.

Unit tests cover both flag states, including a failing precheck.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API