### PR TITLE
chore: fix stale developer_portal paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 
 # Notify PMC members of changes to extension-related files
 
-/docs/developer_portal/extensions/ @michael-s-molina @villebro @rusackas
+/docs/developer_docs/extensions/ @michael-s-molina @villebro @rusackas
 /superset-extensions-cli/ @michael-s-molina @villebro @rusackas @sadpandajoe
 /superset/extensions/ @michael-s-molina @villebro @rusackas @sadpandajoe
 /superset-frontend/src/extensions/ @michael-s-molina @villebro @rusackas @sadpandajoe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ The Developer Portal auto-generates MDX documentation from Storybook stories. **
 ### Generator Location
 - Script: `docs/scripts/generate-superset-components.mjs`
 - Wrapper: `docs/src/components/StorybookWrapper.jsx`
-- Output: `docs/developer_portal/components/`
+- Output: `docs/developer_docs/components/`
 
 ## Architecture Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ The Developer Portal includes comprehensive guides for:
 - [Code Review Process](https://superset.apache.org/developer_portal/contributing/code-review)
 - [Development How-tos](https://superset.apache.org/developer_portal/contributing/howtos)
 
-Source for the Developer Portal documentation is [located here](https://github.com/apache/superset/tree/master/docs/developer_portal).
+Source for the Developer Portal documentation is [located here](https://github.com/apache/superset/tree/master/docs/developer_docs).

--- a/docs/developer_docs/guidelines/frontend/component-style-guidelines.md
+++ b/docs/developer_docs/guidelines/frontend/component-style-guidelines.md
@@ -198,7 +198,7 @@ Each component should come with its dedicated storybook file.
 
 **One component per story:** Each storybook file should only contain one component unless substantially different variants are required
 
-**Component variants:** If the component behavior is substantially different when certain props are used, it is best to separate the story into different types. See the `superset-frontend/src/components/Select/Select.stories.tsx` as an example.
+**Component variants:** If the component behavior is substantially different when certain props are used, it is best to separate the story into different types. See the `superset-frontend/packages/superset-ui-core/src/components/Select/Select.stories.tsx` as an example.
 
 **Isolated state:** The storybook should show how the component works in an isolated state and with as few dependencies as possible
 


### PR DESCRIPTION
### SUMMARY

Four of these references became stale when their directories were moved. The lines themselves were left unchanged while the paths they referenced disappeared from the tree.

Four one-line edits resolve the stale references: one in CODEOWNERS and three elsewhere.

1. Update CODEOWNERS line 22 to: `/docs/developer_docs/extensions/`
2. Outside CODEOWNERS, update one line in each of the following:
   - the Select stories path in `component-style-guidelines.md:201`
   - the output path in `AGENTS.md:170`
   - the source link in `CONTRIBUTING.md:38`

### TESTING INSTRUCTIONS

    # the stale line
    sed -n '22p' .github/CODEOWNERS

    # tracked files under the referenced path, 0 before this PR
    git ls-files -- 'docs/developer_portal/' | wc -l

### ADDITIONAL INFORMATION

While the three component rules matched their directories, 114 commits recorded changes under them. Since the move, 58 commits changed those directories over 419 days without a matching CODEOWNERS rule (the rules themselves were removed in #43079). The docs owners authored 15 of the 20 commits under docs/developer_docs/extensions themselves.

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API