### PR TITLE
fix(sql_lab): return 400 not 500 when raise_for_access hits malformed Jinja in results.py

### DIFF
--- a/superset/commands/sql_lab/results.py
+++ b/superset/commands/sql_lab/results.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 
 from flask import current_app as app
 from flask_babel import gettext as __
+from jinja2.exceptions import TemplateError
 
 from superset import db, results_backend, results_backend_use_msgpack
 from superset.commands.base import BaseCommand
@@ -97,6 +98,15 @@ class SqlExecutionResultsCommand(BaseCommand):
                     level=ErrorLevel.ERROR,
                 ),
                 status=403,
+            ) from ex
+        except TemplateError as ex:
+            raise SupersetErrorException(
+                SupersetError(
+                    message=str(ex),
+                    error_type=SupersetErrorType.GENERIC_COMMAND_ERROR,
+                    level=ErrorLevel.ERROR,
+                ),
+                status=400,
             ) from ex
 
         # Now fetch results from backend (query exists, so this is a valid request)

--- a/tests/integration_tests/sql_lab/commands_tests.py
+++ b/tests/integration_tests/sql_lab/commands_tests.py
@@ -21,6 +21,7 @@ import pandas as pd
 import pytest
 from flask import current_app
 from flask_babel import gettext as __
+from jinja2.exceptions import TemplateError, TemplateSyntaxError
 
 from superset import db, sql_lab
 from superset.commands.sql_lab import estimate, export, results
@@ -404,6 +405,29 @@ class TestSqlExecutionResultsCommand(SupersetTestCase):
                 == SupersetErrorType.QUERY_SECURITY_ACCESS_ERROR
             )
             assert ex_info.value.status == 403
+
+    @pytest.mark.usefixtures("create_database_and_query")
+    @patch("superset.commands.sql_lab.results.results_backend_use_msgpack", False)
+    def test_validation_malformed_jinja(self) -> None:
+        # ``raise_for_access`` re-parses the query's unrendered Jinja via
+        # ``process_jinja_sql`` and can raise a raw ``TemplateError`` (e.g. an
+        # unclosed ``{% if %}``). ``TemplateSyntaxError`` is a subclass of
+        # ``TemplateError``. It must surface as a 400, not an opaque 500.
+        assert issubclass(TemplateSyntaxError, TemplateError)
+
+        command = results.SqlExecutionResultsCommand("abc_query", 1000)
+
+        with mock.patch(
+            "superset.models.sql_lab.Query.raise_for_access",
+            side_effect=TemplateSyntaxError("unexpected end of template", lineno=1),
+        ):
+            with pytest.raises(SupersetErrorException) as ex_info:
+                command.run()
+            assert (
+                ex_info.value.error.error_type
+                == SupersetErrorType.GENERIC_COMMAND_ERROR
+            )
+            assert ex_info.value.status == 400
 
     @pytest.mark.usefixtures("create_database_and_query")
     @patch("superset.commands.sql_lab.results.results_backend_use_msgpack", False)


### PR DESCRIPTION
### SUMMARY

`SqlExecutionResultsCommand.validate()` in `superset/commands/sql_lab/results.py`
calls `self._query.raise_for_access()` guarded **only** by
`except SupersetSecurityException`. `raise_for_access()` re-parses the query's
unrendered Jinja via `process_jinja_sql()` (when `executed_sql` isn't yet
persisted) and can raise a **raw** `jinja2.exceptions.TemplateError` — e.g. a
`TemplateSyntaxError` from an unclosed `{% if %}`. Because that exception type
wasn't caught here, it surfaced as an opaque **HTTP 500** when a client polled
`GET /api/v1/sqllab/results/` for a SQL Lab async query containing malformed
Jinja.

The sibling sites `superset/sqllab/api.py` and
`superset/commands/sql_lab/estimate.py` (the latter shipped through this same
cleanup pipeline in #42757) already wrap the identical call with
`except TemplateError`, translating it to a clean **400** `GENERIC_COMMAND_ERROR`.
`results.py` was simply a copy-paste omission. This PR adds the same guard, so
malformed Jinja on the results endpoint now returns a well-formed 400 instead of
a 500.

This is an additive catch — it only narrows a previously-uncaught exception into
the existing structured-error path. There is **no change to any success-path or
existing failure-mode semantics**, so no Tradeoffs section is warranted.

### PROBLEM

- Route: `GET /api/v1/sqllab/results/` → `SqlExecutionResultsCommand.validate()`
- `raise_for_access()` → `process_jinja_sql()` raises a raw `TemplateError`
  subclass on malformed Jinja.
- Only `SupersetSecurityException` was caught, so the raw `TemplateError`
  escaped the command and became an opaque HTTP 500.

### FIX

Add, alongside the existing `except SupersetSecurityException` clause in
`validate()`, the same guard used verbatim by the two sibling sites:

```python
except TemplateError as ex:
    raise SupersetErrorException(
        SupersetError(
            message=str(ex),
            error_type=SupersetErrorType.GENERIC_COMMAND_ERROR,
            level=ErrorLevel.ERROR,
        ),
        status=400,
    ) from ex
```

plus the missing `from jinja2.exceptions import TemplateError` import. The fix is
surgical: one method, one bug class. Sibling files `export.py` /
`streaming_export_command.py` have the identical gap but are intentionally left
for a separate follow-up.

### TESTING INSTRUCTIONS

Added `test_validation_malformed_jinja` to `TestSqlExecutionResultsCommand` in
`tests/integration_tests/sql_lab/commands_tests.py`, modeled on the existing
`test_validation_unauthorized_access`: it mocks `Query.raise_for_access` to raise
`TemplateSyntaxError('unexpected end of template', lineno=1)` (a `TemplateError`
subclass, asserted in-test) and verifies the command raises
`SupersetErrorException` with `error_type == GENERIC_COMMAND_ERROR` and
`status == 400`.

> **Note on local execution:** the integration-test harness (which needs a DB +
> Flask app context) could not be brought up in this clone — Superset's runtime
> dependencies are not installed in the environment — so the integration test was
> **added but not executed locally**; CI will be its first full run. The fix logic
> and exception hierarchy were verified independently: `TemplateSyntaxError.__mro__`
> confirms it subclasses `TemplateError`, and a standalone control-flow repro
> confirms the pre-fix code leaks the raw `TemplateSyntaxError` (→ 500) while the
> post-fix code returns a 400 `GENERIC_COMMAND_ERROR`.

Manual verification: submit a SQL Lab async query whose SQL contains malformed
Jinja (e.g. `SELECT 1 {% if %}`) and poll the results endpoint; the response is a
structured 400 instead of a 500.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: internal Shortcut sc-117368
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follows the same SQL Lab error-cleanup pattern as #42366 (precedent) and #42757 /
#42917 (the sibling `estimate.py` guard this mirrors).
