### PR TITLE
fix(explore): clear stale custom time-shift date error

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/timeComparison.tsx
@@ -122,6 +122,12 @@ export const timeComparisonControls: ({
             }
             return newState;
           },
+          // Re-run this control's validation whenever `time_compare` changes so
+          // the "date required" error clears once a non-custom shift is picked.
+          // Without it the stale error survives in Redux (see the
+          // dependantControls path in exploreReducer's SET_FIELD_VALUE handler)
+          // and blocks further chart updates until a page refresh.
+          validationDependencies: ['time_compare'],
         },
       },
     ],

--- a/superset-frontend/src/explore/reducers/exploreReducer.test.ts
+++ b/superset-frontend/src/explore/reducers/exploreReducer.test.ts
@@ -17,9 +17,11 @@
  * under the License.
  */
 
-import exploreReducer, { ExploreState } from './exploreReducer';
-import { setStashFormData } from '../actions/exploreActions';
 import { QueryFormData } from '@superset-ui/core';
+import { sections, CustomControlItem } from '@superset-ui/chart-controls';
+import { getControlStateFromControlConfig } from 'src/explore/controlUtils';
+import exploreReducer, { ExploreState } from './exploreReducer';
+import { setControlValue, setStashFormData } from '../actions/exploreActions';
 
 test('reset hiddenFormData on SET_STASH_FORM_DATA', () => {
   const initialState: ExploreState = {
@@ -51,4 +53,73 @@ test('skips updates when the field is already updated on SET_STASH_FORM_DATA', (
   >[1];
   const newState = exploreReducer(initialState, restoreAction);
   expect(newState).toBe(initialState);
+});
+
+// Regression guard for the shared Time Comparison section (used by the Table
+// chart, among others): selecting "Custom date" for Time shift and then
+// clearing "Shift start date" raises a required-date validation error. When the
+// user then switches Time shift to a non-custom preset the error must clear.
+// Because `start_date_offset` did not declare `validationDependencies` on
+// `time_compare`, SET_FIELD_VALUE never re-ran its mapStateToProps and the stale
+// error survived in Redux, blocking further chart updates until a page refresh.
+test('SET_FIELD_VALUE clears the custom-shift date error when time_compare leaves "custom"', () => {
+  const REQUIRED_DATE_ERROR = 'A date is required when using custom date shift';
+  const timeComparisonSection = sections.timeComparisonControls({
+    multi: false,
+    showCalculationType: false,
+    showFullChoices: false,
+  });
+  const timeCompareConfig = (
+    timeComparisonSection.controlSetRows[0][0] as CustomControlItem
+  ).config;
+  const startDateOffsetConfig = (
+    timeComparisonSection.controlSetRows[1][0] as CustomControlItem
+  ).config;
+
+  const form_data = {
+    time_compare: 'custom',
+    start_date_offset: '2021-01-01',
+  } as unknown as QueryFormData;
+
+  // Build the control states the way the explore store does so they carry the
+  // real mapStateToProps / validationDependencies from the control config.
+  const controlPanelState = { controls: {}, form_data };
+  const initialState: ExploreState = {
+    form_data,
+    controls: {
+      time_compare: getControlStateFromControlConfig(
+        timeCompareConfig,
+        controlPanelState,
+        'custom',
+      )!,
+      start_date_offset: getControlStateFromControlConfig(
+        startDateOffsetConfig,
+        controlPanelState,
+        '2021-01-01',
+      )!,
+    },
+  };
+
+  // A valid custom date starts without a validation error.
+  expect(initialState.controls.start_date_offset.validationErrors).toEqual([]);
+
+  // 1) Clearing "Shift start date" raises the required-date error (expected).
+  const afterClear = exploreReducer(
+    initialState,
+    setControlValue('start_date_offset', '') as Parameters<
+      typeof exploreReducer
+    >[1],
+  );
+  expect(afterClear.controls.start_date_offset.validationErrors).toEqual([
+    REQUIRED_DATE_ERROR,
+  ]);
+
+  // 2) Switching Time shift to a non-custom preset must clear the stale error.
+  const afterSwitch = exploreReducer(
+    afterClear,
+    setControlValue('time_compare', '1 week ago') as Parameters<
+      typeof exploreReducer
+    >[1],
+  );
+  expect(afterSwitch.controls.start_date_offset.validationErrors).toEqual([]);
 });


### PR DESCRIPTION
### SUMMARY
On a chart's Explore control panel (Table chart and others sharing the
`timeComparisonControls` section), selecting **Custom date** for **Time shift**
and then clicking the `x` on **Shift start date** to clear it correctly raises
a "date required" validation error. However, switching **Time shift** to a
different preset afterward (e.g. *1 week ago*) did not clear that error — it
stayed stuck, blocking further chart updates until a full page refresh.

The `start_date_offset` control's `mapStateToProps` derives its validation
error from a sibling control's value (`time_compare`), but the control config
never declared `validationDependencies: ['time_compare']`. The Explore
reducer's `SET_FIELD_VALUE` handler only re-runs a control's `mapStateToProps`
for the control that changed or for controls that declare it as a
`validationDependencies` entry, so `start_date_offset` was never re-validated
when `time_compare` changed.

This adds the missing `validationDependencies: ['time_compare']` declaration,
mirroring the existing `validationDependencies: ['server_pagination']`
pattern already used for a different control in the Table chart's control
panel.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: Time shift = Custom date → clear Shift start date (error appears,
correctly) → change Time shift to a preset (e.g. "1 week ago") → error
persists and the chart cannot be updated until the page is refreshed.

[before.webm](https://github.com/user-attachments/assets/9b8e127f-2ae0-4788-9b6c-1c53d734f686)


After: same steps → the error clears as soon as Time shift changes away from
"Custom date", and the chart can be updated immediately.

[after.webm](https://github.com/user-attachments/assets/fc107d71-2756-4d48-9aec-c5b9c62f9820)


### TESTING INSTRUCTIONS
1. Create or open a Table chart in Explore.
2. Expand **Time Comparison**, set **Time shift** to **Custom date**.
3. Click the `x` on **Shift start date** to clear it — a "date required" error
   appears (expected).
4. Change **Time shift** to any other preset (e.g. "1 week ago").
5. Confirm the error clears immediately and the chart can be updated without a
   page refresh.

A reducer-level regression test covering this exact clear-then-switch sequence
was added at `superset-frontend/src/explore/reducers/exploreReducer.test.ts`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
