### PR TITLE
fix(cache): fall back to default timeout when cache_timeout is None

### DIFF
--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -162,15 +162,20 @@ def memoized_func(key: str, cache: Cache = cache_manager.cache) -> Callable[...,
         def wrapped_f(*args: Any, **kwargs: Any) -> Any:
             should_cache = kwargs.pop("cache", True)
             force = kwargs.pop("force", False)
-            # callers may explicitly pass ``cache_timeout=None`` (eg, when a database
-            # has no custom metadata cache timeout configured), which should fall back
-            # to the default timeout rather than be forwarded to the cache backend.
+            # always popped, even when caching is skipped, so it is never forwarded
+            # to the decorated function as an unexpected keyword argument.
             cache_timeout = kwargs.pop("cache_timeout", None)
-            if cache_timeout is None:
-                cache_timeout = app.config["CACHE_DEFAULT_TIMEOUT"]
 
             if not should_cache:
                 return f(*args, **kwargs)
+
+            # callers may explicitly pass ``cache_timeout=None`` (eg, when a database
+            # has no custom metadata cache timeout configured), which should fall back
+            # to the default timeout rather than be forwarded to the cache backend.
+            # the config lookup happens here so the uncached path stays independent
+            # of the Flask app config.
+            if cache_timeout is None:
+                cache_timeout = app.config["CACHE_DEFAULT_TIMEOUT"]
 
             # format the key using args/kwargs passed to the decorated function
             signature = inspect.signature(f)

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -162,9 +162,12 @@ def memoized_func(key: str, cache: Cache = cache_manager.cache) -> Callable[...,
         def wrapped_f(*args: Any, **kwargs: Any) -> Any:
             should_cache = kwargs.pop("cache", True)
             force = kwargs.pop("force", False)
-            cache_timeout = kwargs.pop(
-                "cache_timeout", app.config["CACHE_DEFAULT_TIMEOUT"]
-            )
+            # callers may explicitly pass ``cache_timeout=None`` (eg, when a database
+            # has no custom metadata cache timeout configured), which should fall back
+            # to the default timeout rather than be forwarded to the cache backend.
+            cache_timeout = kwargs.pop("cache_timeout", None)
+            if cache_timeout is None:
+                cache_timeout = app.config["CACHE_DEFAULT_TIMEOUT"]
 
             if not should_cache:
                 return f(*args, **kwargs)

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -54,6 +54,72 @@ def test_memoized_func(mocker: MockerFixture) -> None:
     assert result == 43
 
 
+def test_memoized_func_none_cache_timeout(mocker: MockerFixture) -> None:
+    """
+    An explicit ``cache_timeout=None`` falls back to ``CACHE_DEFAULT_TIMEOUT``.
+
+    Databases without a custom metadata cache timeout pass ``None`` explicitly, and
+    forwarding it to the cache backend breaks backends that require an integer.
+    """
+    from superset.utils.cache import memoized_func
+
+    _patch_config(mocker)
+    cache = mocker.MagicMock()
+    cache.get.return_value = None
+
+    decorator = memoized_func("db:{self.id}:schema:{schema}:table_list", cache)
+    decorated = decorator(lambda self, schema: 42)
+
+    self = mocker.MagicMock()
+    self.id = 1
+
+    result = decorated(self, "public", cache_timeout=None)
+    assert result == 42
+    cache.set.assert_called_once_with("db:1:schema:public:table_list", 42, timeout=100)
+
+
+def test_memoized_func_custom_cache_timeout(mocker: MockerFixture) -> None:
+    """
+    An explicit ``cache_timeout`` takes precedence over ``CACHE_DEFAULT_TIMEOUT``.
+    """
+    from superset.utils.cache import memoized_func
+
+    _patch_config(mocker)
+    cache = mocker.MagicMock()
+    cache.get.return_value = None
+
+    decorator = memoized_func("db:{self.id}:schema:{schema}:table_list", cache)
+    decorated = decorator(lambda self, schema: 42)
+
+    self = mocker.MagicMock()
+    self.id = 1
+
+    result = decorated(self, "public", cache_timeout=42)
+    assert result == 42
+    cache.set.assert_called_once_with("db:1:schema:public:table_list", 42, timeout=42)
+
+
+def test_memoized_func_disabled_cache_timeout(mocker: MockerFixture) -> None:
+    """
+    A timeout of -1 (``CACHE_DISABLED_TIMEOUT``) skips the cache set.
+    """
+    from superset.utils.cache import memoized_func
+
+    _patch_config(mocker)
+    cache = mocker.MagicMock()
+    cache.get.return_value = None
+
+    decorator = memoized_func("db:{self.id}:schema:{schema}:table_list", cache)
+    decorated = decorator(lambda self, schema: 42)
+
+    self = mocker.MagicMock()
+    self.id = 1
+
+    result = decorated(self, "public", cache_timeout=-1)
+    assert result == 42
+    cache.set.assert_not_called()
+
+
 def _make_cache_instance(mocker: MockerFixture) -> MagicMock:
     """A cache instance whose ``.cache`` is not a ``NullCache``."""
     cache_instance = mocker.MagicMock()

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -120,6 +120,33 @@ def test_memoized_func_disabled_cache_timeout(mocker: MockerFixture) -> None:
     cache.set.assert_not_called()
 
 
+def test_memoized_func_skip_cache_pops_cache_timeout(mocker: MockerFixture) -> None:
+    """
+    ``cache=False`` skips caching without touching the config or the wrapped function.
+
+    ``cache_timeout`` must still be popped so it is not forwarded to the decorated
+    function, which does not accept it. Callers such as
+    ``get_all_table_names_in_schema`` pass ``cache`` and ``cache_timeout`` together.
+    """
+    from superset.utils.cache import memoized_func
+
+    mock_config = mocker.patch("superset.utils.cache.app.config", MagicMock())
+    cache = mocker.MagicMock()
+
+    decorator = memoized_func("db:{self.id}:schema:{schema}:table_list", cache)
+    decorated = decorator(lambda self, schema: 42)
+
+    self = mocker.MagicMock()
+    self.id = 1
+
+    result = decorated(self, "public", cache=False, cache_timeout=None)
+
+    assert result == 42
+    cache.get.assert_not_called()
+    cache.set.assert_not_called()
+    mock_config.__getitem__.assert_not_called()
+
+
 def _make_cache_instance(mocker: MockerFixture) -> MagicMock:
     """A cache instance whose ``.cache`` is not a ``NullCache``."""
     cache_instance = mocker.MagicMock()


### PR DESCRIPTION
When the schema and table cache timeout fields are left empty on a database, `table_cache_timeout` is None and `get_all_table_names_in_schema` passes `cache_timeout=None` explicitly. `memoized_func` popped that kwarg with the config default as the fallback, but the key was there, so None won and went straight to `cache.set`. Redis rejects None as a timeout, so SQL Lab got a 422 instead of the table list.

Now the pop defaults to None and CACHE_DEFAULT_TIMEOUT is applied after that, so an explicit None gets the default too. `set_and_log_cache` in the same file already works this way. The pop stays above the `should_cache` early return so the kwarg is never forwarded to the wrapped function, and the config read moved below it so the uncached path does not touch app config.

Tests are in tests/unit_tests/utils/cache_test.py: None falls back to the default, an explicit int still wins, -1 still skips the set, and cache=False still pops the kwarg. I could not run the suite locally, so please rely on CI.

Closes #42085
