### PR TITLE
fix(plugin-chart-table): declare DataTable hooks before the early return

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -104,21 +104,19 @@ const sortTypes = {
 };
 
 // Prefer a stable identifier from original row data; otherwise use a deterministic
-// concatenation of visible values (keys sorted so column order changes are detected).
+// concatenation of visible values (keys sorted so the result does not depend on
+// column order).
 function stableRowKey<D extends object>(r: Row<D>): string {
   const orig = r.original as Record<string, unknown> | undefined;
   if (orig) {
-    const idLike =
-      (orig as any).id ??
-      (orig as any).ID ??
-      (orig as any).key ??
-      (orig as any).uuid;
+    const idLike = orig.id ?? orig.ID ?? orig.key ?? orig.uuid;
     if (idLike != null) return String(idLike);
   }
 
-  // Fallback: derive from row.values, but make it stable against column order changes.
+  // Fallback: derive from row.values, sorting the keys so that reordering the
+  // columns does not change the key.
   const v = r.values as Record<string, unknown>;
-  const keys = Object.keys(v).sort(); // detect column order changes
+  const keys = Object.keys(v).sort();
   return keys.map(k => String(v[k] ?? '')).join('|');
 }
 

--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -103,6 +103,44 @@ const sortTypes = {
   alphanumeric: sortAlphanumericCaseInsensitive,
 };
 
+// Prefer a stable identifier from original row data; otherwise use a deterministic
+// concatenation of visible values (keys sorted so column order changes are detected).
+function stableRowKey<D extends object>(r: Row<D>): string {
+  const orig = r.original as Record<string, unknown> | undefined;
+  if (orig) {
+    const idLike =
+      (orig as any).id ??
+      (orig as any).ID ??
+      (orig as any).key ??
+      (orig as any).uuid;
+    if (idLike != null) return String(idLike);
+  }
+
+  // Fallback: derive from row.values, but make it stable against column order changes.
+  const v = r.values as Record<string, unknown>;
+  const keys = Object.keys(v).sort(); // detect column order changes
+  return keys.map(k => String(v[k] ?? '')).join('|');
+}
+
+// Very small, fast hash for strings (no crypto dependency).
+function hashString(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i += 1) {
+    // oxlint-disable-next-line unicorn/prefer-math-trunc -- | 0 is intentional for 32-bit integer wrapping in hash
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return String(h);
+}
+
+function signatureOfRows<D extends object>(rs: Row<D>[]): string {
+  const keys = rs.map(stableRowKey);
+  const len = keys.length;
+  const first = keys[0] ?? '';
+  const last = keys[len - 1] ?? '';
+  const digest = hashString(keys.join('\u0001')); // non-printable separator to avoid collisions
+  return `${len}|${first}|${last}|${digest}`;
+}
+
 // Be sure to pass our updateMyData and the skipReset option
 export default typedMemo(function DataTable<D extends object>({
   tableClassName,
@@ -289,6 +327,46 @@ export default typedMemo(function DataTable<D extends object>({
     onFilteredDataChange(rowsRef.current, searchText);
   }, [filterValue, onFilteredDataChange, rowSignature]);
 
+  // Emit filtered rows to parent in client-side mode (debounced via RAF)
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const rafRef = useRef<number | null>(null);
+  const lastSigRef = useRef<string>('');
+
+  useEffect(() => {
+    if (serverPagination || typeof onFilteredRowsChange !== 'function') {
+      return;
+    }
+
+    const sig = signatureOfRows(rows);
+
+    if (sig !== lastSigRef.current) {
+      lastSigRef.current = sig;
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = requestAnimationFrame(() => {
+        if (isMountedRef.current) {
+          // Only emit originals when the signature truly changed
+          onFilteredRowsChange(rows.map(r => r.original as D));
+        }
+      });
+    }
+
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [rows, serverPagination, onFilteredRowsChange]);
+
   const handleSearchChange = useCallback(
     (query: string) => {
       if (manualSearch && onSearchChange) {
@@ -471,84 +549,6 @@ export default typedMemo(function DataTable<D extends object>({
     resultOnPageChange = (pageNumber: number) =>
       onServerPaginationChange(pageNumber, serverPageSize);
   }
-
-  // Emit filtered rows to parent in client-side mode (debounced via RAF)
-  const isMountedRef = useRef(true);
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  const rafRef = useRef<number | null>(null);
-  const lastSigRef = useRef<string>('');
-
-  // Prefer a stable identifier from original row data; otherwise use a deterministic
-  // concatenation of visible values (keys sorted so column order changes are detected).
-  function stableRowKey<D extends object>(r: Row<D>): string {
-    const orig = r.original as Record<string, unknown> | undefined;
-    if (orig) {
-      const idLike =
-        (orig as any).id ??
-        (orig as any).ID ??
-        (orig as any).key ??
-        (orig as any).uuid;
-      if (idLike != null) return String(idLike);
-    }
-
-    // Fallback: derive from row.values, but make it stable against column order changes.
-    const v = r.values as Record<string, unknown>;
-    const keys = Object.keys(v).sort(); // detect column order changes
-    return keys.map(k => String(v[k] ?? '')).join('|');
-  }
-
-  // Very small, fast hash for strings (no crypto dependency).
-  function hashString(s: string): string {
-    let h = 0;
-    for (let i = 0; i < s.length; i += 1) {
-      // oxlint-disable-next-line unicorn/prefer-math-trunc -- | 0 is intentional for 32-bit integer wrapping in hash
-      h = (h * 31 + s.charCodeAt(i)) | 0;
-    }
-    return String(h);
-  }
-
-  function signatureOfRows<D extends object>(rs: Row<D>[]): string {
-    const keys = rs.map(stableRowKey);
-    const len = keys.length;
-    const first = keys[0] ?? '';
-    const last = keys[len - 1] ?? '';
-    const digest = hashString(keys.join('\u0001')); // non-printable separator to avoid collisions
-    return `${len}|${first}|${last}|${digest}`;
-  }
-
-  useEffect(() => {
-    if (serverPagination || typeof onFilteredRowsChange !== 'function') {
-      return;
-    }
-
-    const sig = signatureOfRows(rows);
-
-    if (sig !== lastSigRef.current) {
-      lastSigRef.current = sig;
-      if (rafRef.current != null) {
-        cancelAnimationFrame(rafRef.current);
-      }
-      rafRef.current = requestAnimationFrame(() => {
-        if (isMountedRef.current) {
-          // Only emit originals when the signature truly changed
-          onFilteredRowsChange(rows.map(r => r.original as D));
-        }
-      });
-    }
-
-    return () => {
-      if (rafRef.current != null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [rows, serverPagination, onFilteredRowsChange]);
 
   return (
     <div

--- a/superset-frontend/plugins/plugin-chart-table/test/DataTable/DataTable.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/DataTable/DataTable.test.tsx
@@ -76,6 +76,8 @@ class RenderErrorBoundary extends Component<
 
   render() {
     if (this.state.hasError) {
+      // data-test is the configured testIdAttribute (see spec/helpers/setup.ts),
+      // so *ByTestId('render-error') resolves this node.
       return <div data-test="render-error">Render error</div>;
     }
 

--- a/superset-frontend/plugins/plugin-chart-table/test/DataTable/DataTable.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/DataTable/DataTable.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import '@testing-library/jest-dom';
+import { Component, type ReactNode } from 'react';
+import { render, screen } from '@superset-ui/core/spec';
+import { CellProps, Column, HeaderProps } from 'react-table';
+import DataTable from '../../src/DataTable/DataTable';
+import { ProviderWrapper } from '../testHelpers';
+
+type DataRow = {
+  city: string;
+  firstName: string;
+};
+
+interface RenderErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface RenderErrorBoundaryState {
+  hasError: boolean;
+}
+
+const columns: Column<DataRow>[] = [
+  {
+    Header: ({ column }: HeaderProps<DataRow>) => (
+      <th data-column-name={column.id}>First name</th>
+    ),
+    Cell: ({ value }: CellProps<DataRow>) => <td>{value}</td>,
+    id: 'firstName',
+    accessor: 'firstName' as never,
+  },
+  {
+    Header: ({ column }: HeaderProps<DataRow>) => (
+      <th data-column-name={column.id}>City</th>
+    ),
+    Cell: ({ value }: CellProps<DataRow>) => <td>{value}</td>,
+    id: 'city',
+    accessor: 'city' as never,
+  },
+];
+
+const data: DataRow[] = [
+  { firstName: 'Michael', city: 'Paris' },
+  { firstName: 'Jordan', city: 'London' },
+];
+
+// Turns a render-phase throw, such as a Rules of Hooks violation, into a
+// readable assertion instead of an unhandled error.
+class RenderErrorBoundary extends Component<
+  RenderErrorBoundaryProps,
+  RenderErrorBoundaryState
+> {
+  state: RenderErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div data-test="render-error">Render error</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+const renderDataTable = (tableColumns: Column<DataRow>[]) => (
+  <ProviderWrapper>
+    <RenderErrorBoundary>
+      <DataTable<DataRow>
+        columns={tableColumns}
+        data={data}
+        rowCount={data.length}
+        serverPagination={false}
+        serverPaginationData={{}}
+        onServerPaginationChange={jest.fn()}
+        handleSortByChange={jest.fn()}
+        sortByFromParent={[]}
+        onSearchColChange={jest.fn()}
+        searchOptions={[]}
+        onFilteredRowsChange={jest.fn()}
+        sticky={false}
+      />
+    </RenderErrorBoundary>
+  </ProviderWrapper>
+);
+
+test('keeps the hook order stable when the columns disappear', () => {
+  const { rerender } = render(renderDataTable(columns));
+
+  expect(screen.getByText('Michael')).toBeInTheDocument();
+
+  rerender(renderDataTable([]));
+
+  expect(screen.queryByTestId('render-error')).not.toBeInTheDocument();
+  expect(screen.getByText('No data found')).toBeInTheDocument();
+});
+
+test('keeps the hook order stable when the columns appear', () => {
+  const { rerender } = render(renderDataTable([]));
+
+  expect(screen.getByText('No data found')).toBeInTheDocument();
+
+  rerender(renderDataTable(columns));
+
+  expect(screen.queryByTestId('render-error')).not.toBeInTheDocument();
+  expect(screen.getByText('Michael')).toBeInTheDocument();
+});


### PR DESCRIPTION
DataTable returns early when it has no columns, but five hooks sit about 130 lines below that return: isMountedRef and its mount effect, rafRef, lastSigRef, and the effect that emits filtered rows through onFilteredRowsChange. A table chart that re-queries between a columns-less result and a populated one crosses that boundary, the hook count changes between renders, and React throws. The chart drops to an error boundary.

This moves the five hooks above the early return and lifts stableRowKey, hashString and signatureOfRows to module scope. No hook body, dependency array or emit condition changed. The one behaviour difference is that the emit effect now also runs with no columns, so onFilteredRowsChange gets one extra empty call. TableChart is the only caller in tree and it already pushes an empty result on mount.

The new test renders DataTable inside an error boundary and rerenders across the column boundary in both directions. I could not run the suite locally, so please rely on CI.

Closes #42978
