### PR TITLE
fix(embedded): honor "can view query" permission for guest users

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -566,8 +566,17 @@ class ChartDataRestApi(ChartRestApi):
                     query["timing"] = query_result.timing.as_public_dict()
 
             if security_manager.is_guest_user():
+                # Guests may see the generated SQL only when the role attached to
+                # their guest token has been granted "can view query on Dashboard",
+                # mirroring the permission the frontend uses to expose the
+                # "View query" action. Stacktraces and driver errors stay redacted
+                # regardless, as those leak details of the deployment itself.
+                can_view_query = security_manager.can_access(
+                    "can_view_query", "Dashboard"
+                )
                 for query in queries:
-                    query.pop("query", None)
+                    if not can_view_query:
+                        query.pop("query", None)
                     query.pop("stacktrace", None)
                     if query.get("error"):
                         query["error"] = sanitize_error_message(query["error"])

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -34,6 +34,7 @@ import pytest
 from flask import g, Response
 from flask.ctx import AppContext
 
+from superset import security_manager
 from superset.charts.data.api import ChartDataRestApi
 from superset.commands.chart.data.get_data_command import ChartDataCommand
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
@@ -96,6 +97,25 @@ INCOMPATIBLE_ADHOC_COLUMN_FIXTURE: AdhocColumn = {
     "label": "exciting_or_boring",
     "sqlExpression": "case when genre = 'Action' then 'Exciting' else 'Boring' end",
 }
+
+
+def _override_view_query_permission(granted: bool) -> Any:
+    """
+    Answer ("can_view_query", "Dashboard") with ``granted`` and let every other
+    permission check fall through to the real security manager, so the rest of
+    the request keeps its normal access rules.
+    """
+    real_can_access = security_manager.can_access
+
+    def can_access(permission_name: str, view_name: str) -> bool:
+        if (permission_name, view_name) == ("can_view_query", "Dashboard"):
+            return granted
+        return real_can_access(permission_name, view_name)
+
+    return mock.patch(
+        "superset.charts.data.api.security_manager.can_access",
+        side_effect=can_access,
+    )
 
 
 def _query_timing() -> QueryTiming:
@@ -1572,19 +1592,14 @@ class TestGetChartDataApi(BaseTestChartDataApi):
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_chart_data_as_guest_user(self, is_guest_user, has_guest_access):
         """
-        Chart data API: Test response does not inlcude the SQL query for embedded
+        Chart data API: Test response does not include the SQL query for embedded
         users whose role lacks "can view query on Dashboard".
         """
         g.user.rls = []
         is_guest_user.return_value = True
         has_guest_access.return_value = True
 
-        with mock.patch(
-            "superset.charts.data.api.security_manager.can_access",
-            side_effect=lambda permission, view: (
-                (permission, view) != ("can_view_query", "Dashboard")
-            ),
-        ):
+        with _override_view_query_permission(granted=False):
             rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
         data = json.loads(rv.data.decode("utf-8"))
         result = data["result"]
@@ -1605,10 +1620,7 @@ class TestGetChartDataApi(BaseTestChartDataApi):
         is_guest_user.return_value = True
         has_guest_access.return_value = True
 
-        with mock.patch(
-            "superset.charts.data.api.security_manager.can_access",
-            return_value=True,
-        ):
+        with _override_view_query_permission(granted=True):
             rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
         data = json.loads(rv.data.decode("utf-8"))
         result = data["result"]

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -1573,17 +1573,46 @@ class TestGetChartDataApi(BaseTestChartDataApi):
     def test_chart_data_as_guest_user(self, is_guest_user, has_guest_access):
         """
         Chart data API: Test response does not inlcude the SQL query for embedded
-        users.
+        users whose role lacks "can view query on Dashboard".
         """
         g.user.rls = []
         is_guest_user.return_value = True
         has_guest_access.return_value = True
 
-        rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
+        with mock.patch(
+            "superset.charts.data.api.security_manager.can_access",
+            side_effect=lambda permission, view: (
+                (permission, view) != ("can_view_query", "Dashboard")
+            ),
+        ):
+            rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
         data = json.loads(rv.data.decode("utf-8"))
         result = data["result"]
         excluded_key = "query"
         assert all([excluded_key not in query for query in result])  # noqa: C419
+
+    @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_chart_data_as_guest_user_allowed_to_view_query(
+        self, is_guest_user, has_guest_access
+    ):
+        """
+        Chart data API: Test response includes the SQL query for embedded users
+        whose role carries "can view query on Dashboard".
+        """
+        g.user.rls = []
+        is_guest_user.return_value = True
+        has_guest_access.return_value = True
+
+        with mock.patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ):
+            rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+        assert all("query" in query for query in result)
 
     def test_chart_data_table_chart_with_time_grain_filter(self):
         """

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -327,6 +327,10 @@ def test_send_chart_response_strips_guest_query_after_timing_projection(
                 "superset.charts.data.api.security_manager.is_guest_user",
                 return_value=True,
             ),
+            patch(
+                "superset.charts.data.api.security_manager.can_access",
+                return_value=False,
+            ),
         ):
             response = api._send_chart_response(result)
     finally:
@@ -336,6 +340,35 @@ def test_send_chart_response_strips_guest_query_after_timing_projection(
     assert "query" not in query
     assert "timing" in query
     assert "query" in query_payload
+
+
+def test_send_chart_response_keeps_guest_query_when_permitted(
+    app: SupersetApp,
+) -> None:
+    """
+    A guest whose role carries "can view query on Dashboard" must receive the
+    generated SQL, otherwise "View query" is empty on embedded dashboards.
+    """
+    query_payload = {"data": [{"col1": 1}], "query": "SELECT 1"}
+    result = _json_execution_result(query_payload)
+
+    api = ChartDataRestApi()
+    with (
+        app.test_request_context("/api/v1/chart/data"),
+        patch(
+            "superset.charts.data.api.security_manager.is_guest_user",
+            return_value=True,
+        ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ) as can_access,
+    ):
+        response = api._send_chart_response(result)
+
+    query = json.loads(response.get_data(as_text=True))["result"][0]
+    assert query["query"] == "SELECT 1"
+    can_access.assert_called_once_with("can_view_query", "Dashboard")
 
 
 def test_send_chart_response_redacts_guest_query_error(app: SupersetApp) -> None:
@@ -355,10 +388,50 @@ def test_send_chart_response_redacts_guest_query_error(app: SupersetApp) -> None
             "superset.charts.data.api.security_manager.is_guest_user",
             return_value=True,
         ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=False,
+        ),
     ):
         response = api._send_chart_response(result)
 
     query = json.loads(response.get_data(as_text=True))["result"][0]
+    assert query["error"] == str(GENERIC_ERROR_MESSAGE)
+    assert "stacktrace" not in query
+
+
+def test_send_chart_response_still_redacts_guest_errors_when_query_permitted(
+    app: SupersetApp,
+) -> None:
+    """
+    "can view query on Dashboard" only unlocks the generated SQL; stacktraces
+    and driver errors describe the deployment and stay redacted for guests.
+    """
+    result = _json_execution_result(
+        {
+            "error": "Table mydb.myschema.mytable was not found",
+            "stacktrace": "Traceback ...",
+            "query": "SELECT 1",
+        },
+        result_type=ChartDataResultType.QUERY,
+    )
+
+    api = ChartDataRestApi()
+    with (
+        app.test_request_context("/api/v1/chart/data"),
+        patch(
+            "superset.charts.data.api.security_manager.is_guest_user",
+            return_value=True,
+        ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ),
+    ):
+        response = api._send_chart_response(result)
+
+    query = json.loads(response.get_data(as_text=True))["result"][0]
+    assert query["query"] == "SELECT 1"
     assert query["error"] == str(GENERIC_ERROR_MESSAGE)
     assert "stacktrace" not in query
 


### PR DESCRIPTION
The chart data API dropped the `query` key from every response as soon as the requester was a guest user. There was no permission check first, so "View query" on an embedded dashboard came back empty even when the guest role had "can view query on Dashboard" granted. That is the same permission the frontend uses to show the action, so granting it did nothing.

Now the key is only removed when `can_access("can_view_query", "Dashboard")` is false. Stacktraces and driver errors are still stripped for guests either way, since those leak details about the deployment.

Worth testing on a real embedded dashboard both ways: a guest role with the permission should get the SQL back, one without it should not. Unit tests are in tests/unit_tests/charts/test_chart_data_api.py. I also updated the integration tests in tests/integration_tests/charts/data/api_tests.py, but that class is skipped in the repo so they did not run.

Closes #43100
