### PR TITLE
fix(examples): migrate Life Expectancy VS Rural % example off the removed legacy bubble viz_type

### DIFF
--- a/superset/examples/world_health/charts/Life_Expectancy_VS_Rural.yaml
+++ b/superset/examples/world_health/charts/Life_Expectancy_VS_Rural.yaml
@@ -41,27 +41,44 @@ params:
     filterOptionName: 2745eae5
     operator: NOT IN
     subject: country_code
-  compare_lag: '10'
-  compare_suffix: o10Y
-  country_fieldtype: cca3
+  color_scheme: supersetColors
   entity: country_name
   granularity_sqla: year
-  groupby: []
-  limit: 0
-  markup_type: markdown
+  legendOrientation: top
+  legendType: scroll
   max_bubble_size: '50'
-  row_limit: 50000
+  opacity: 0.6
+  order_desc: true
+  row_limit: 500
   series: region
-  show_bubbles: true
-  since: '2011-01-01'
-  size: sum__SP_POP_TOTL
+  show_legend: true
+  size:
+    aggregate: SUM
+    column:
+      column_name: SP_POP_TOTL
+    expressionType: SIMPLE
+    label: SUM(SP_POP_TOTL)
+    optionName: metric_size_life_expectancy_vs_rural
   time_range: '2014-01-01 : 2014-01-02'
-  until: '2011-01-02'
-  viz_type: bubble
-  x: sum__SP_RUR_TOTL_ZS
-  y: sum__SP_DYN_LE00_IN
+  tooltipSizeFormat: SMART_NUMBER
+  truncateXAxis: true
+  viz_type: bubble_v2
+  x:
+    aggregate: SUM
+    column:
+      column_name: SP_RUR_TOTL_ZS
+    expressionType: SIMPLE
+    label: SUM(SP_RUR_TOTL_ZS)
+    optionName: metric_x_life_expectancy_vs_rural
+  y:
+    aggregate: SUM
+    column:
+      column_name: SP_DYN_LE00_IN
+    expressionType: SIMPLE
+    label: SUM(SP_DYN_LE00_IN)
+    optionName: metric_y_life_expectancy_vs_rural
 query_context: null
 slice_name: Life Expectancy VS Rural %
 uuid: c18faec9-ec43-4d36-8b66-4c8b1372020f
 version: 1.0.0
-viz_type: bubble
+viz_type: bubble_v2


### PR DESCRIPTION
## SUMMARY

#41714 removed the legacy nvd3 chart pipeline and documented that saved
nvd3 Bubble charts auto-migrate to the ECharts Bubble Chart (`bubble_v2`).
That auto-migration runs against existing rows in an already-populated
metadata database (`superset/migrations/shared/migrate_viz/processors.py`,
`MigrateBubbleChart`), not against the example YAML fixtures loaded fresh
by `superset load-examples` -- so `Life Expectancy VS Rural %` (on the
"World Bank's Data" example dashboard) was left with `viz_type: bubble`,
which has had zero registered plugin since #41714 landed. Every fresh
install running `load-examples` gets a broken chart there.

This migrates the chart's params to `bubble_v2`'s shape: adhoc-metric
`x`/`y`/`size` objects instead of the legacy `sum__<column>` shorthand
strings, dropping legacy-only fields (`compare_lag`, `compare_suffix`,
`country_fieldtype`, `since`/`until`, etc.), matching the working
`bubble_v2` example already in `featured_charts/charts/Bubble.yaml`.

I also audited all 103 example chart YAMLs under `superset/examples/`
for any other `viz_type` without a currently-registered plugin (checked
against the full `VizType` enum plus deck.gl layer types) -- this was
the only one.

### TESTING INSTRUCTIONS

1. `superset load-examples` on this branch.
2. Open the "World Bank's Data" dashboard and confirm "Life Expectancy VS
   Rural %" renders as a bubble chart instead of erroring.

Also verified the new params validate against `ImportV1ChartSchema` and
import cleanly through a full `superset db upgrade` + fresh metadata DB.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API