### PR TITLE
fix(ci): update vulnerable transitive nanoid

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -33246,9 +33246,9 @@
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -34955,9 +34955,9 @@
       }
     },
     "node_modules/react-checkbox-tree/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -415,6 +415,7 @@
     "minimatch@>=10": {
       "brace-expansion": ">=5.0.8"
     },
+    "nanoid@>=3 <4": "3.3.18",
     "nwsapi": "^2.2.13",
     "puppeteer": "^22.4.1",
     "tar": "^7.5.16",


### PR DESCRIPTION
### SUMMARY

Pin transitive Nanoid v3 dependencies to 3.3.18, the lowest release that resolves both active advisories, and refresh the two affected lockfile entries.

Dependabot's security updater could not raise the existing 3.3.12 and 3.3.16 transitive copies even though their parent ranges admit 3.3.18. The major-scoped npm override keeps Nanoid v1/v2 compatible and leaves the direct Nanoid v6 dependency unchanged.

This repairs the deterministic `security_update_not_possible` failure from [Dependabot run 31788627845](https://github.com/apache/superset/actions/runs/31788627845).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; dependency-only change.

### TESTING INSTRUCTIONS

From `superset-frontend` with Node 24.16.0 and npm 11.13.0:

```bash
npm ci --ignore-scripts --no-audit --no-fund
npm ls nanoid --all
npm ls --all --package-lock-only --depth=0 --json > /dev/null
npm test -- src/dashboard/components/filterscope/FilterScope.test.tsx --maxWorkers=2 --no-cache
```

Expected Nanoid tree: direct 6.0.1; PostCSS and react-checkbox-tree transitive copies both 3.3.18.

Also verified:

- `npm audit --json` contains no Nanoid advisory (the command still reports unrelated existing advisories).
- `npm run stylelint`
- `pre-commit run` on the changed files
- `pre-commit run --all-files` was executed; repository-wide baseline/tooling failures are unrelated to this two-file change (formatter/Ruff drift, missing local `yarn`/`helm-docs`, and unbuilt TypeScript project references).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
