### PR TITLE
fix(db_engine_specs): cast VARCHAR before Postgres DATE_TRUNC

### DIFF
--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -292,17 +292,32 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         time_grain: str | None,
     ) -> TimestampExpression:
         """
-        Construct a timestamp expression while preserving pure ``DATE`` semantics.
+        Construct a timestamp expression for Postgres temporal columns.
 
         Applying ``DATE_TRUNC`` to a ``DATE`` column implicitly casts the value to
         ``TIMESTAMP``, which can trigger unwanted timezone conversion on the client
         and shift the displayed date by a day. To avoid this, the truncated value is
         cast back to ``DATE`` when the source column is a pure ``DATE`` type.
 
+        String columns explicitly marked as temporal are cast to ``TIMESTAMP`` before
+        applying a time grain because Postgres does not implicitly cast strings for
+        ``DATE_TRUNC`` or ``EXTRACT``.
+
         See https://github.com/apache/superset/issues/42254.
+        See https://github.com/apache/superset/issues/42386.
         """
         expr = super().get_timestamp_expr(col, pdf, time_grain)
         col_type = getattr(col, "type", None)
+        if (
+            time_grain
+            and isinstance(col_type, String)
+            and pdf not in ("epoch_s", "epoch_ms")
+        ):
+            expr = TimestampExpression(
+                expr.name.replace("{col}", "CAST({col} AS TIMESTAMP)"),
+                col,
+                type_=DateTime(),
+            )
         # ``DateTime``/``TIMESTAMP`` are distinct SQLAlchemy types (not subclasses
         # of ``Date``), so this only matches pure ``DATE`` columns.
         if time_grain and isinstance(col_type, Date):

--- a/superset/db_engine_specs/postgres.py
+++ b/superset/db_engine_specs/postgres.py
@@ -267,17 +267,32 @@ class PostgresBaseEngineSpec(BaseEngineSpec):
         time_grain: str | None,
     ) -> TimestampExpression:
         """
-        Construct a timestamp expression while preserving pure ``DATE`` semantics.
+        Construct a timestamp expression for Postgres temporal columns.
 
         Applying ``DATE_TRUNC`` to a ``DATE`` column implicitly casts the value to
         ``TIMESTAMP``, which can trigger unwanted timezone conversion on the client
         and shift the displayed date by a day. To avoid this, the truncated value is
         cast back to ``DATE`` when the source column is a pure ``DATE`` type.
 
+        String columns explicitly marked as temporal are cast to ``TIMESTAMP`` before
+        applying a time grain because Postgres does not implicitly cast strings for
+        ``DATE_TRUNC`` or ``EXTRACT``.
+
         See https://github.com/apache/superset/issues/42254.
+        See https://github.com/apache/superset/issues/42386.
         """
         expr = super().get_timestamp_expr(col, pdf, time_grain)
         col_type = getattr(col, "type", None)
+        if (
+            time_grain
+            and isinstance(col_type, String)
+            and pdf not in ("epoch_s", "epoch_ms")
+        ):
+            expr = TimestampExpression(
+                expr.name.replace("{col}", "CAST({col} AS TIMESTAMP)"),
+                col,
+                type_=DateTime(),
+            )
         # ``DateTime``/``TIMESTAMP`` are distinct SQLAlchemy types (not subclasses
         # of ``Date``), so this only matches pure ``DATE`` columns.
         if time_grain and isinstance(col_type, Date):

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -419,6 +419,44 @@ def test_get_timestamp_expr_datetime_column_not_cast() -> None:
     assert _compile(expr) == "DATE_TRUNC('day', event_ts)"
 
 
+def test_get_timestamp_expr_string_column_casts_to_timestamp() -> None:
+    """DB Eng Specs (postgres): temporal string columns are cast before truncation."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, "P1D")
+    assert (
+        _compile(expr)
+        == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
+    )
+
+
+def test_get_timestamp_expr_string_column_without_grain_not_cast() -> None:
+    """DB Eng Specs (postgres): strings without a time grain remain unchanged."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, None)
+    assert _compile(expr) == "event_timestamp"
+
+
+def test_get_timestamp_expr_epoch_string_column_not_cast() -> None:
+    """DB Eng Specs (postgres): epoch conversion handles strings before truncation."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, "epoch_s", "P1D")
+    assert _compile(expr) == (
+        "DATE_TRUNC('day', "
+        "(timestamp 'epoch' + event_timestamp * interval '1 second'))"
+    )
+
+
+def test_get_timestamp_expr_string_column_casts_every_grain_reference() -> None:
+    """DB Eng Specs (postgres): compound grains cast every string reference."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, "PT5S")
+    assert _compile(expr) == (
+        "DATE_TRUNC('minute', CAST(event_timestamp AS TIMESTAMP)) "
+        "+ INTERVAL '5 seconds' * "
+        "FLOOR(EXTRACT(SECOND FROM CAST(event_timestamp AS TIMESTAMP)) / 5)"
+    )
+
+
 def test_get_timestamp_expr_date_column_without_grain_not_cast() -> None:
     """
     DB Eng Specs (postgres): without a time grain there is no DATE_TRUNC, so the

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -423,10 +423,7 @@ def test_get_timestamp_expr_string_column_casts_to_timestamp() -> None:
     """DB Eng Specs (postgres): temporal string columns are cast before truncation."""
     col = column("event_timestamp", type_=types.String())
     expr = spec.get_timestamp_expr(col, None, "P1D")
-    assert (
-        _compile(expr)
-        == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
-    )
+    assert _compile(expr) == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
 
 
 def test_get_timestamp_expr_string_column_without_grain_not_cast() -> None:
@@ -441,8 +438,7 @@ def test_get_timestamp_expr_epoch_string_column_not_cast() -> None:
     col = column("event_timestamp", type_=types.String())
     expr = spec.get_timestamp_expr(col, "epoch_s", "P1D")
     assert _compile(expr) == (
-        "DATE_TRUNC('day', "
-        "(timestamp 'epoch' + event_timestamp * interval '1 second'))"
+        "DATE_TRUNC('day', (timestamp 'epoch' + event_timestamp * interval '1 second'))"
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -422,10 +422,7 @@ def test_get_timestamp_expr_string_column_casts_to_timestamp() -> None:
     """DB Eng Specs (postgres): temporal string columns are cast before truncation."""
     col = column("event_timestamp", type_=types.String())
     expr = spec.get_timestamp_expr(col, None, "P1D")
-    assert (
-        _compile(expr)
-        == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
-    )
+    assert _compile(expr) == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
 
 
 def test_get_timestamp_expr_string_column_without_grain_not_cast() -> None:
@@ -440,8 +437,7 @@ def test_get_timestamp_expr_epoch_string_column_not_cast() -> None:
     col = column("event_timestamp", type_=types.String())
     expr = spec.get_timestamp_expr(col, "epoch_s", "P1D")
     assert _compile(expr) == (
-        "DATE_TRUNC('day', "
-        "(timestamp 'epoch' + event_timestamp * interval '1 second'))"
+        "DATE_TRUNC('day', (timestamp 'epoch' + event_timestamp * interval '1 second'))"
     )
 
 

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -418,6 +418,44 @@ def test_get_timestamp_expr_datetime_column_not_cast() -> None:
     assert _compile(expr) == "DATE_TRUNC('day', event_ts)"
 
 
+def test_get_timestamp_expr_string_column_casts_to_timestamp() -> None:
+    """DB Eng Specs (postgres): temporal string columns are cast before truncation."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, "P1D")
+    assert (
+        _compile(expr)
+        == "DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))"
+    )
+
+
+def test_get_timestamp_expr_string_column_without_grain_not_cast() -> None:
+    """DB Eng Specs (postgres): strings without a time grain remain unchanged."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, None)
+    assert _compile(expr) == "event_timestamp"
+
+
+def test_get_timestamp_expr_epoch_string_column_not_cast() -> None:
+    """DB Eng Specs (postgres): epoch conversion handles strings before truncation."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, "epoch_s", "P1D")
+    assert _compile(expr) == (
+        "DATE_TRUNC('day', "
+        "(timestamp 'epoch' + event_timestamp * interval '1 second'))"
+    )
+
+
+def test_get_timestamp_expr_string_column_casts_every_grain_reference() -> None:
+    """DB Eng Specs (postgres): compound grains cast every string reference."""
+    col = column("event_timestamp", type_=types.String())
+    expr = spec.get_timestamp_expr(col, None, "PT5S")
+    assert _compile(expr) == (
+        "DATE_TRUNC('minute', CAST(event_timestamp AS TIMESTAMP)) "
+        "+ INTERVAL '5 seconds' * "
+        "FLOOR(EXTRACT(SECOND FROM CAST(event_timestamp AS TIMESTAMP)) / 5)"
+    )
+
+
 def test_get_timestamp_expr_date_column_without_grain_not_cast() -> None:
     """
     DB Eng Specs (postgres): without a time grain there is no DATE_TRUNC, so the

--- a/tests/unit_tests/db_engine_specs/test_postgres.py
+++ b/tests/unit_tests/db_engine_specs/test_postgres.py
@@ -434,7 +434,7 @@ def test_get_timestamp_expr_string_column_without_grain_not_cast() -> None:
 
 
 def test_get_timestamp_expr_epoch_string_column_not_cast() -> None:
-    """DB Eng Specs (postgres): epoch conversion handles strings before truncation."""
+    """DB Eng Specs (postgres): timestamp casts are not added to epoch expressions."""
     col = column("event_timestamp", type_=types.String())
     expr = spec.get_timestamp_expr(col, "epoch_s", "P1D")
     assert _compile(expr) == (


### PR DESCRIPTION
### SUMMARY
Fixes #42386

PostgreSQL `DATE_TRUNC` / `EXTRACT` do not accept `character varying`. A physical `VARCHAR` column marked `is_dttm` therefore generated invalid SQL such as `DATE_TRUNC('day', event_timestamp)` and failed at query time.

This change wraps string columns in `CAST({col} AS TIMESTAMP)` inside `PostgresBaseEngineSpec.get_timestamp_expr` when a time grain is applied. `DATE`, `DateTime`, and `epoch_s` / `epoch_ms` paths are unchanged. Marking VARCHAR as temporal remains supported (Hive/Presto partition dates); the fix is Postgres-specific, matching Presto/Athena which already CAST in their grain expressions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (SQL generation change)

* **Before SQL:** `DATE_TRUNC('day', event_timestamp)` → `function date_trunc(unknown, character varying) does not exist`
* **After SQL:** `DATE_TRUNC('day', CAST(event_timestamp AS TIMESTAMP))`

### TESTING INSTRUCTIONS
1. Create a PostgreSQL table with a `VARCHAR` timestamp-like column (see #42386).
2. Create a physical dataset and set **Is temporal** on that column.
3. In Explore, pick it as the time column with Time Grain **Day** and a metric.
4. Confirm the generated SQL uses `CAST(... AS TIMESTAMP)` and the chart loads.
5. Unit tests: `pytest tests/unit_tests/db_engine_specs/test_postgres.py -k get_timestamp_expr`

### ADDITIONAL INFORMATION
- [x] Has associated issue: #42386
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API