### PR TITLE
fix(docker): install the frontend from the lockfile in docker-frontend.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,24 @@ services:
         required: true
       - path: docker/.env-local # optional override
         required: false
-    volumes: *superset-volumes
+    # Same shared bind mounts as the other services (repeated rather than
+    # aliased so an anonymous volume can be added over node_modules, keeping
+    # it container-managed). docker-frontend.sh now runs `npm ci`, which
+    # deletes node_modules before reinstalling; without this the delete+
+    # recreate lands directly on the host's bind-mounted directory, and this
+    # container has no `user: *superset-user` override (unlike
+    # superset-init/superset/superset-worker*), so it runs as the image's
+    # default root user and leaves the host copy root-owned.
+    volumes:
+      - ./docker:/app/docker
+      - ./superset:/app/superset
+      - ./superset-core:/app/superset-core
+      - ./superset-frontend:/app/superset-frontend
+      - /app/superset-frontend/node_modules
+      - superset_home:/app/superset_home
+      - ./tests:/app/tests
+      - superset_data:/app/data
+      - ./local_extensions:/app/local_extensions
 
   superset-worker:
     build:

--- a/docker/docker-frontend.sh
+++ b/docker/docker-frontend.sh
@@ -32,8 +32,10 @@ if [ "$BUILD_SUPERSET_FRONTEND_IN_DOCKER" = "true" ]; then
         npm run prune
     fi
 
-    echo "Running \"npm install\""
-    npm install
+    # Install from the committed lockfile so a dev image build resolves the same
+    # versions that were reviewed, matching the `npm ci` used in the Dockerfile.
+    echo "Running \"npm ci\""
+    npm ci
 
     echo "Start webpack dev server"
     # start the webpack dev server, serving dynamically at http://localhost:9000


### PR DESCRIPTION
### SUMMARY

`docker/docker-frontend.sh` installed the frontend with a bare `npm install`. When `package.json` and `package-lock.json` disagree, `npm install` re-resolves versions and rewrites the lockfile, so a dev image can be built against dependency versions that were never reviewed — and the repository has no `.npmrc` cooldown backing the lockfile up.

This switches that install to `npm ci`, which installs exactly what the lockfile pins and fails loudly when the lockfile is out of sync with `package.json`. The `Dockerfile` already uses `npm ci` for the equivalent install, so the two paths are now consistent.

Trade-off worth noting for reviewers: `npm ci` removes `node_modules` before installing, so with the dev bind mount the first container start after this change reinstalls from scratch. `NPM_RUN_PRUNE` (the existing knob for that directory) is unaffected.

Fixes #42979

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — build script change.

### TESTING INSTRUCTIONS

1. Set `BUILD_SUPERSET_FRONTEND_IN_DOCKER=true` in `docker/.env-local`.
2. `docker compose up --detach`.
3. The frontend container logs `Running "npm ci"` and the dev server comes up on http://localhost:9000.
4. To see the guard work, edit a dependency version in `superset-frontend/package.json` without updating the lockfile and restart: the install now fails with npm's lockfile-out-of-sync error instead of silently resolving a different version.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #42979
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
