### PR TITLE
fix(app-root): serve unprefixed /static/ paths under a non-root app root

### DIFF
--- a/docker/nginx/templates/superset.conf.template
+++ b/docker/nginx/templates/superset.conf.template
@@ -37,7 +37,15 @@ server {
         proxy_set_header Host $host;
     }
 
-    location ${SUPERSET_APP_ROOT}/static {
+    # Webpack bakes the /static/assets/ publicPath into the bundle (see
+    # AppRootMiddleware in superset/app.py), so lazily loaded chunks and the
+    # assets they reference are always requested unprefixed even when the app
+    # root mounts the app under a subpath. Match both the app-root-prefixed
+    # and the bare /static/ path so neither 404s; the optional group also
+    # covers the default app root of a single slash, where concatenating it
+    # onto /static would otherwise render as a double-slash path that matches
+    # nothing.
+    location ~ ^(?:${SUPERSET_APP_ROOT})?/static(?:/|$) {
         proxy_pass http://host.docker.internal:9000;  # Proxy to superset-node
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/superset/app.py
+++ b/superset/app.py
@@ -242,4 +242,12 @@ class AppRootMiddleware:
             environ["PATH_INFO"] = original_path_info[len(self.app_root) :]
             environ["SCRIPT_NAME"] = self.app_root
             return self.wsgi_app(environ, start_response)
+        if original_path_info == "/static" or original_path_info.startswith("/static/"):
+            # Webpack bakes `/static/assets/` into the bundle as its publicPath,
+            # so lazily loaded chunks and the assets they reference are always
+            # requested without the app-root prefix. Serve those unprefixed
+            # paths as-is instead of 404ing them; the app root is left off
+            # PATH_INFO and SCRIPT_NAME because the static route is registered
+            # at `/static/...` on the unprefixed app.
+            return self.wsgi_app(environ, start_response)
         return NotFound()(environ, start_response)

--- a/tests/unit_tests/middleware/test_app_root_middleware.py
+++ b/tests/unit_tests/middleware/test_app_root_middleware.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Path-rewriting behavior of ``AppRootMiddleware``.
+
+The middleware mounts the app under a prefix, so it decides three things for
+every inbound request: strip the prefix, pass an unprefixed ``/static/`` path
+through untouched (webpack bakes ``/static/assets/`` into the bundle at build
+time), or 404. A synthetic inner WSGI app records the environ it is handed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from werkzeug.test import EnvironBuilder
+
+from superset.app import AppRootMiddleware
+
+
+def _call(path: str, app_root: str = "/analytics"):
+    """Run ``path`` through the middleware, returning (environ, status).
+
+    ``environ`` is ``None`` when the inner app was never reached.
+    """
+    seen: dict[str, object] = {}
+    status: list[str] = []
+
+    def inner_app(environ, start_response):
+        seen.update(environ)
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        return [b"INNER_APP_REACHED"]
+
+    def start_response(response_status, _headers, *args):
+        status.append(response_status)
+        return lambda _chunk: None
+
+    middleware = AppRootMiddleware(inner_app, app_root)
+    list(middleware(EnvironBuilder(path).get_environ(), start_response))
+    return (seen or None), status[0]
+
+
+@pytest.mark.parametrize(
+    "path,expected_path_info",
+    [
+        ("/analytics", ""),
+        ("/analytics/", "/"),
+        ("/analytics/dashboard/list/", "/dashboard/list/"),
+    ],
+)
+def test_prefixed_path_is_stripped(path, expected_path_info):
+    environ, status = _call(path)
+    assert status == "200 OK"
+    assert environ["PATH_INFO"] == expected_path_info
+    assert environ["SCRIPT_NAME"] == "/analytics"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/static",
+        "/static/assets/images/superset-logo-horiz.png",
+        "/static/assets/chunk.1a2b3c.entry.js",
+    ],
+)
+def test_unprefixed_static_path_passes_through(path):
+    """Webpack requests ``/static/assets/...`` without the app root."""
+    environ, status = _call(path)
+    assert status == "200 OK"
+    # Neither stripped nor remounted: the static route lives at /static/... on
+    # the unprefixed app.
+    assert environ["PATH_INFO"] == path
+    assert environ.get("SCRIPT_NAME") == ""
+
+
+def test_prefixed_static_path_is_still_stripped():
+    """STATIC_ASSETS_PREFIX defaults to the app root, so both forms work."""
+    environ, status = _call("/analytics/static/assets/main.js")
+    assert status == "200 OK"
+    assert environ["PATH_INFO"] == "/static/assets/main.js"
+    assert environ["SCRIPT_NAME"] == "/analytics"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/dashboard/list/",
+        # Shares a string prefix with the app root but not a segment boundary.
+        "/analyticsfoo/dashboard/list/",
+        # A path that merely contains "/static/" further along is not a
+        # static asset request.
+        "/other/static/assets/main.js",
+    ],
+)
+def test_unmatched_path_returns_404(path):
+    environ, status = _call(path)
+    assert environ is None
+    assert "404" in status
+
+
+def test_trailing_slash_in_app_root_is_normalized():
+    environ, status = _call("/analytics/dashboard/list/", app_root="/analytics/")
+    assert status == "200 OK"
+    assert environ["PATH_INFO"] == "/dashboard/list/"
+    assert environ["SCRIPT_NAME"] == "/analytics"


### PR DESCRIPTION
### SUMMARY

`AppRootMiddleware.__call__` returned `NotFound()` for any request whose `PATH_INFO` did not start with the configured app root. Webpack compiles the frontend with `/static/assets/` as its `publicPath`, which is baked into the bundle at build time, so lazily loaded chunks and the assets they reference are requested **without** the app-root prefix. Under `SUPERSET_APP_ROOT=/analytics` those requests were rejected with a 404, so the logo, CSS and JS chunks failed to load.

`STATIC_ASSETS_PREFIX` defaults to the app root, which covers the URLs Superset generates server-side, but it cannot affect paths webpack already hard-coded into the bundle.

This adds a passthrough branch for unprefixed `/static/` paths. `PATH_INFO` and `SCRIPT_NAME` are deliberately left untouched there, because the static route is registered at `/static/...` on the unprefixed app. The app-root branch is still checked first, so `/analytics/static/assets/...` continues to be stripped and remounted as before. Paths that merely contain `/static/` further along (`/other/static/assets/main.js`) or that only share a string prefix with the app root (`/analyticsfoo/...`) still 404.

Scope note: only static assets are reachable through the new branch, and they are already served publicly at the prefixed path — no application route becomes reachable without the prefix.

The matching docs note (a reverse proxy fronting a prefixed deployment must forward `/static` as well as the prefix) is kept out of this PR so it does not pull in the docs workflow, which is already red on `master` over 12 pre-existing bare relative links in files unrelated to this change.

Fixes #39429

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no visual change beyond assets loading instead of 404ing.

### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/middleware/test_app_root_middleware.py
```

The new test module pins all three behaviors of the middleware: prefix stripping, `/static/` passthrough, and 404 for everything else.

Manual:

1. Start Superset with `SUPERSET_APP_ROOT=/analytics`.
2. Request `http://localhost:8088/static/assets/images/superset-logo-horiz.png` — 200 on this branch, 404 on `master`.
3. Request `http://localhost:8088/analytics/static/assets/images/superset-logo-horiz.png` — still 200 (unchanged).
4. Request `http://localhost:8088/dashboard/list/` — still 404 (unchanged).
5. Load `http://localhost:8088/analytics` and confirm no `/static/assets/*` 404s in the browser network tab.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #39429
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
