### PR TITLE
docs: give bare relative links an explicit extension

### DIFF
--- a/docs/developer_docs/extensions/overview.md
+++ b/docs/developer_docs/extensions/overview.md
@@ -47,14 +47,14 @@ Extension developers have access to pre-built UI components via `@apache-superse
 
 ## Next Steps
 
-- **[Quick Start](./quick-start)** - Build your first extension with a complete walkthrough
-- **[Architecture](./architecture)** - Design principles and system overview
-- **[Dependencies](./dependencies)** - Managing dependencies and understanding API stability
-- **[Contribution Types](./contribution-types)** - Available extension points
-- **[Development](./development)** - Project structure, APIs, and development workflow
-- **[Deployment](./deployment)** - Packaging and deploying extensions
-- **[MCP Integration](./mcp)** - Adding AI agent capabilities using extensions
-- **[Security](./security)** - Security considerations and best practices
-- **[Storage](./storage)** - Managed storage API for persisting extension data
-- **[Tasks](./tasks)** - Framework for creating and managing long running tasks
-- **[Community Extensions](./registry)** - Browse extensions shared by the community
+- **[Quick Start](./quick-start.md)** - Build your first extension with a complete walkthrough
+- **[Architecture](./architecture.md)** - Design principles and system overview
+- **[Dependencies](./dependencies.md)** - Managing dependencies and understanding API stability
+- **[Contribution Types](./contribution-types.md)** - Available extension points
+- **[Development](./development.md)** - Project structure, APIs, and development workflow
+- **[Deployment](./deployment.md)** - Packaging and deploying extensions
+- **[MCP Integration](./mcp.md)** - Adding AI agent capabilities using extensions
+- **[Security](./security.md)** - Security considerations and best practices
+- **[Storage](./storage.md)** - Managed storage API for persisting extension data
+- **[Tasks](./tasks.md)** - Framework for creating and managing long running tasks
+- **[Community Extensions](./registry.md)** - Browse extensions shared by the community

--- a/docs/docs/using-superset/number-formatting.mdx
+++ b/docs/docs/using-superset/number-formatting.mdx
@@ -89,4 +89,4 @@ Use these when a metric's underlying values are stored in meters or centimeters 
 
 ## Currency
 
-Some chart types also expose currency-specific formatting, including a dynamic mode that reads the currency from a column value. See [Dynamic Currency Formatting](./creating-your-first-dashboard#dynamic-currency-formatting) for details.
+Some chart types also expose currency-specific formatting, including a dynamic mode that reads the currency from a column value. See [Dynamic Currency Formatting](./creating-your-first-dashboard.mdx#dynamic-currency-formatting) for details.


### PR DESCRIPTION
### SUMMARY

`yarn lint:docs-links` fails on `master` with 12 findings, all in the "bare relative link" category:

```
docs/using-superset/number-formatting.mdx:92  ./creating-your-first-dashboard#dynamic-currency-formatting
developer_docs/extensions/overview.md:50-60   ./quick-start, ./architecture, ./dependencies,
                                              ./contribution-types, ./development, ./deployment,
                                              ./mcp, ./security, ./storage, ./tasks, ./registry
```

A link with no extension skips Docusaurus's file resolver: the href is emitted as written and the browser resolves it against the current page URL, which is the wrong directory for trailing-slash routes. `onBrokenLinks: 'throw'` cannot catch it, which is why the dedicated linter exists.

This adds the extension each target actually has on disk — `.md` for the eleven `developer_docs/extensions/*` pages, `.mdx` for `creating-your-first-dashboard` (the anchor is preserved). No link targets or link text change.

Because this check runs in the `Docs Testing` workflow, it currently fails on every PR that touches a `docs/` path, regardless of what that PR changed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:

```
$ yarn lint:docs-links
✗ lint-docs-links: found 12 broken internal link(s)
```

After:

```
$ yarn lint:docs-links
✓ lint-docs-links: no broken internal links found
```

### TESTING INSTRUCTIONS

```bash
cd docs
node scripts/lint-docs-links.mjs   # exits 0
```

The linter has no dependencies beyond node. Optionally also confirm the eleven "Next Steps" links on `developer_docs/extensions/overview.md` and the currency-formatting link on `using-superset/number-formatting.mdx` still navigate correctly in a docs build.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
