### PR TITLE
fix(echarts): drop the sort metric's time-shift column from timeseries series

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -367,9 +367,20 @@ export default function transformProps(
   // metric. extraMetricLabels must be mapped the same way, or a sort-only
   // metric with a verbose_name set would silently fail to match here (and in
   // extractSeries below, which has the same requirement).
-  const extraMetricLabels = extractExtraMetrics(chartProps.rawFormData)
-    .map(getMetricLabel)
-    .map(label => verboseMap[label] ?? label);
+  const rawExtraMetricLabels = extractExtraMetrics(chartProps.rawFormData).map(
+    getMetricLabel,
+  );
+  const timeCompareOffsets = ensureIsArray(timeCompare).map(String);
+  const extraMetricLabels = [
+    ...rawExtraMetricLabels.map(label => verboseMap[label] ?? label),
+    // Time comparison emits a derived column per query metric and sort-only
+    // metrics are part of the query, so the sort metric's shifted column has
+    // to be excluded as well. Those columns keep the raw label with an
+    // `__<offset>` suffix rather than the verbose name.
+    ...rawExtraMetricLabels.flatMap(label =>
+      timeCompareOffsets.map(offset => `${label}__${offset}`),
+    ),
+  ];
   const { totalStackedValues, thresholdValues } = extractDataTotalValues(
     rebasedData,
     {
@@ -433,7 +444,6 @@ export default function transformProps(
   // `<offset>|<dims>` key for a series name belonging to that metric, or
   // undefined if the name doesn't belong to it. Keying by offset pairs each
   // comparison value series with the size series from the same offset.
-  const timeCompareOffsets = ensureIsArray(timeCompare).map(String);
   const matchSeriesKey = (
     name: string,
     rawLabel: string,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -837,6 +837,59 @@ describe('Does transformProps transform series correctly', () => {
     expect(totalLabels).toEqual(['32']);
   });
 
+  test("should keep a sort-only metric's time-comparison column out of the stacked total (#43068)", () => {
+    // #42881 excluded the sort-only metric from the total by exact name, which
+    // leaves its `__<offset>` column matching nothing, so the shifted value was
+    // summed into the total (and into the thresholds derived from it).
+    const sortMetricVerboseMap = { sort_metric: 'Sort By Metric' };
+    const sortFormData: SqlaFormData = {
+      ...formData,
+      onlyTotal: true,
+      groupby: [],
+      metrics: ['San Francisco', 'New York', 'Boston'],
+      timeseries_limit_metric: 'sort_metric',
+      x_axis_sort: 'sort_metric',
+      timeCompare: ['1 year ago'],
+      time_compare: ['1 year ago'],
+      comparison_type: 'values',
+    };
+    const sortQueriesData: ChartDataResponseResult[] = [
+      createTestQueryData(
+        createTestData(
+          [
+            {
+              'San Francisco': 32,
+              'New York': 0,
+              Boston: 0,
+              'Sort By Metric': 2,
+              // the sort metric's shifted column: must not reach the total
+              'sort_metric__1 year ago': 1000,
+            },
+          ],
+          { intervalMs: 300000000 },
+        ),
+      ),
+    ];
+    const chartProps = createTestChartProps({
+      formData: sortFormData,
+      queriesData: sortQueriesData,
+      datasource: { verboseMap: sortMetricVerboseMap },
+    });
+
+    const transformedSeries = transformProps(chartProps).echartOptions
+      .series as seriesType[];
+
+    const totalLabels = transformedSeries
+      .flatMap((series, seriesIndex) =>
+        series.data.map((value, dataIndex) =>
+          series.label.formatter({ value, dataIndex, seriesIndex }),
+        ),
+      )
+      .filter(label => label !== '');
+
+    expect(totalLabels).toEqual(['32']);
+  });
+
   test("should exclude a sort-only metric's time-comparison column from the series (#43138)", () => {
     // A sort-only metric is part of the query, so time comparison emits a
     // derived column for it too. That column keeps the raw metric label with

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -837,6 +837,70 @@ describe('Does transformProps transform series correctly', () => {
     expect(totalLabels).toEqual(['32']);
   });
 
+  test("should exclude a sort-only metric's time-comparison column from the series (#43138)", () => {
+    // A sort-only metric is part of the query, so time comparison emits a
+    // derived column for it too. That column keeps the raw metric label with
+    // an `__<offset>` suffix, so resolving the base label through verboseMap
+    // is not enough to filter it out.
+    const sortMetricVerboseMap = { sort_metric: 'Sort By Metric' };
+    const sortFormData: SqlaFormData = {
+      ...formData,
+      groupby: [],
+      metrics: ['San Francisco', 'New York', 'Boston'],
+      timeseries_limit_metric: 'sort_metric',
+      x_axis_sort: 'sort_metric',
+      // ChartProps camelizes formData while leaving rawFormData snake_cased, and
+      // transformProps reads the offsets from both, so the test data carries the
+      // key under both spellings.
+      timeCompare: ['1 year ago'],
+      time_compare: ['1 year ago'],
+      comparison_type: 'values',
+    };
+    const sortQueriesData: ChartDataResponseResult[] = [
+      createTestQueryData(
+        createTestData(
+          [
+            {
+              'San Francisco': 32,
+              'New York': 8,
+              Boston: 4,
+              'Sort By Metric': 2,
+              'sort_metric__1 year ago': 1,
+              'San Francisco__1 year ago': 16,
+              'New York__1 year ago': 4,
+              'Boston__1 year ago': 2,
+            },
+          ],
+          { intervalMs: 300000000 },
+        ),
+      ),
+    ];
+    const chartProps = createTestChartProps({
+      formData: sortFormData,
+      queriesData: sortQueriesData,
+      datasource: { verboseMap: sortMetricVerboseMap },
+    });
+
+    const seriesNames = (
+      transformProps(chartProps).echartOptions.series as seriesType[]
+    ).map(series => series.name);
+
+    expect(seriesNames).not.toContain('sort_metric__1 year ago');
+    // the sort metric's own column stays excluded, and every displayed metric
+    // keeps both its base and its shifted series
+    expect(seriesNames).not.toContain('Sort By Metric');
+    expect(seriesNames).toEqual(
+      expect.arrayContaining([
+        'San Francisco',
+        'New York',
+        'Boston',
+        'San Francisco__1 year ago',
+        'New York__1 year ago',
+        'Boston__1 year ago',
+      ]),
+    );
+  });
+
   test('should show labels on values >= percentageThreshold if onlyTotal is false', () => {
     const chartProps = createTestChartProps({ formData, queriesData });
 


### PR DESCRIPTION
### SUMMARY

A sort-only metric — one set through `timeseries_limit_metric` / `x_axis_sort` that is not among the chart's metrics — is part of the query, so enabling time comparison makes the backend emit a derived column for it alongside the derived columns for the displayed metrics.

`transformProps` built `extraMetricLabels` from the sort metric's base label only, so the shifted column survived the filter in `sortAndFilterSeries` and rendered as an extra series named `<metric>__<offset>` — visible in the chart and the legend, and counted into the stacked totals.

Derived columns keep the *raw* metric label with an `__<offset>` suffix (verbose mapping applies to base columns only, see `rebaseForecastDatum`), so resolving the base label through `verboseMap` cannot match them. This adds one `<raw label>__<offset>` entry per configured offset to `extraMetricLabels`, and hoists `timeCompareOffsets` above its first use.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: series/legend include a `sort_metric__1 year ago` entry that was never asked for.
After: only the chart's own metrics and their shifted counterparts are rendered.

### TESTING INSTRUCTIONS

Unit test added next to the existing sort-only-metric coverage:

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
```

Manually, on a Time-series chart:

1. Pick one or more metrics, then set **Sort by** (`timeseries_limit_metric`) to a metric that is *not* in the metrics list.
2. Under Advanced Analytics, add a time shift (e.g. `1 year ago`) with comparison type `values`.
3. Run the query. Before this change the legend carries an extra `<sort metric>__1 year ago` series; after it, only the chosen metrics and their shifted series appear.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43138
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)