### PR TITLE
fix(mcp): align Jinja context across query preview and compile paths …

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -22,7 +22,7 @@ import re
 from datetime import datetime
 from typing import Any, Callable, TYPE_CHECKING
 
-from flask import current_app as app, g, make_response, request, Response
+from flask import current_app as app, make_response, request, Response
 from flask_appbuilder.api import expose, protect
 from flask_babel import gettext as _
 from marshmallow import ValidationError
@@ -37,6 +37,7 @@ from superset.charts.data.dashboard_filter_context import (
     DashboardFilterContext,
     get_dashboard_filter_context,
 )
+from superset.charts.data.form_data import set_form_data
 from superset.charts.data.query_context_cache_loader import QueryContextCacheLoader
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.commands.chart.data.create_async_job_command import (
@@ -214,7 +215,7 @@ class ChartDataRestApi(ChartRestApi):
         # templating pulls form data from the request globally, so this
         # fallback ensures it has the filters and extra_form_data applied
         # when used in get_sqla_query which constructs the final query.
-        g.form_data = json_body
+        set_form_data(json_body)
 
         try:
             query_context = self._create_query_context_from_form(json_body)
@@ -410,7 +411,7 @@ class ChartDataRestApi(ChartRestApi):
             cached_data = self._load_query_context_form_from_cache(cache_key)
             # Set form_data in Flask Global as it is used as a fallback
             # for async queries with jinja context
-            g.form_data = cached_data
+            set_form_data(cached_data)
             query_context = self._create_query_context_from_form(cached_data)
             command = ChartDataCommand(query_context)
             command.validate()

--- a/superset/charts/data/form_data.py
+++ b/superset/charts/data/form_data.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from flask import g
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
+    from superset.common.query_object import QueryObject
+
+
+def set_form_data(form_data: dict[str, Any]) -> None:
+    """Expose chart data request fields to Jinja template macros."""
+    g.form_data = form_data
+
+
+def _serialize_query(
+    query: QueryObject,
+    form_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Serialize query fields consumed by the Jinja form-data fallback."""
+    query_data = dict(query.to_dict())
+    query_data["filters"] = query.filter
+    if query.time_range is not None:
+        query_data["time_range"] = query.time_range
+    if url_params := form_data.get("url_params"):
+        query_data["url_params"] = url_params
+    return query_data
+
+
+def set_query_context_form_data(
+    query_context: QueryContext,
+    datasource_id: int | str,
+    datasource_type: str,
+) -> None:
+    """Expose a programmatically-created query like a chart data API request."""
+    form_data = query_context.form_data or {}
+    set_form_data(
+        {
+            "datasource": {"id": datasource_id, "type": datasource_type},
+            "queries": [
+                _serialize_query(query, form_data) for query in query_context.queries
+            ],
+            "form_data": form_data,
+        }
+    )

--- a/superset/mcp_service/chart/compile.py
+++ b/superset/mcp_service/chart/compile.py
@@ -111,6 +111,7 @@ def _compile_chart(
     Returns a :class:`CompileResult` with ``success=True`` when the
     query executes cleanly.
     """
+    from superset.charts.data.form_data import set_query_context_form_data
     from superset.commands.chart.data.get_data_command import ChartDataCommand
     from superset.commands.chart.exceptions import (
         ChartDataCacheLoadError,
@@ -151,6 +152,7 @@ def _compile_chart(
             form_data=form_data,
         )
 
+        set_query_context_form_data(query_context, dataset_id, "table")
         command = ChartDataCommand(query_context)
         command.validate()
         result = command.run()

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -65,6 +65,7 @@ def generate_preview_from_form_data(
     """
     try:
         # Execute query to get data
+        from superset.charts.data.form_data import set_query_context_form_data
         from superset.commands.chart.data.get_data_command import ChartDataCommand
         from superset.connectors.sqla.models import SqlaTable
         from superset.extensions import db
@@ -115,6 +116,7 @@ def generate_preview_from_form_data(
         )
 
         # Execute query
+        set_query_context_form_data(query_context_obj, dataset_id, "table")
         command = ChartDataCommand(query_context_obj)
         command.validate()
         result = command.run()

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -32,6 +32,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
@@ -42,6 +43,7 @@ from superset.mcp_service.chart.chart_helpers import (
     find_chart_by_identifier,
     get_cached_form_data,
     merge_extra_form_data_filters_into_query,
+    resolve_form_data_datasource,
 )
 from superset.mcp_service.chart.chart_utils import validate_chart_dataset
 from superset.mcp_service.chart.schemas import (
@@ -676,6 +678,12 @@ async def get_chart_data(  # noqa: C901
             if guest_dashboard_id is not None:
                 guest_scope.authorize_query(query_context, guest_dashboard_id, chart)
 
+            set_query_context_form_data(
+                query_context,
+                chart.datasource_id,
+                chart.datasource_type,
+            )
+
             # Execute the query
             with event_logger.log_context(action="mcp.get_chart_data.query_execution"):
                 command = ChartDataCommand(query_context)
@@ -988,13 +996,7 @@ async def _query_from_form_data(
     """
     from superset.commands.chart.data.get_data_command import ChartDataCommand
 
-    datasource_id = form_data.get("datasource_id")
-
-    # Handle combined datasource field (e.g., "1__table")
-    if not datasource_id and form_data.get("datasource"):
-        parts = str(form_data["datasource"]).split("__")
-        if len(parts) == 2:
-            datasource_id = parts[0]
+    datasource_id, datasource_type = resolve_form_data_datasource(form_data)
 
     if not datasource_id:
         logger.warning(
@@ -1025,6 +1027,7 @@ async def _query_from_form_data(
         )
 
         await ctx.report_progress(3, 4, "Executing data query")
+        set_query_context_form_data(query_context, datasource_id, datasource_type)
         with event_logger.log_context(action="mcp.get_chart_data.query_execution"):
             command = ChartDataCommand(query_context)
             command.validate()

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -26,6 +26,7 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import db, event_logger
@@ -280,6 +281,20 @@ class PreviewFormatStrategy:
         if (dashboard_id := guest_scope.guest_dashboard_id(self.chart)) is not None:
             guest_scope.authorize_query(query_context, dashboard_id, self.chart)
 
+    def _run_chart_data_command(self, query_context: Any) -> dict[str, Any]:
+        """Execute ChartDataCommand with the same Jinja context as get_chart_data."""
+        from superset.commands.chart.data.get_data_command import ChartDataCommand
+
+        self._authorize_guest_query(query_context)
+        set_query_context_form_data(
+            query_context,
+            self.chart.datasource_id,
+            self.chart.datasource_type,
+        )
+        command = ChartDataCommand(query_context)
+        command.validate()
+        return command.run()
+
 
 class URLPreviewStrategy(PreviewFormatStrategy):
     """Generate URL-based preview with explore link."""
@@ -304,7 +319,6 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
 
     def generate(self) -> ASCIIPreview | ChartError:
         try:
-            from superset.commands.chart.data.get_data_command import ChartDataCommand
             from superset.utils import json as utils_json
 
             form_data = utils_json.loads(self.chart.params) if self.chart.params else {}
@@ -332,10 +346,7 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
             if not _first_query_has_fields(query_context):
                 return _no_query_fields_error(self.chart)
 
-            self._authorize_guest_query(query_context)
-            command = ChartDataCommand(query_context)
-            command.validate()
-            result = command.run()
+            result = self._run_chart_data_command(query_context)
 
             data: list[Any] = []
             if result and "queries" in result and len(result["queries"]) > 0:
@@ -374,7 +385,6 @@ class TablePreviewStrategy(PreviewFormatStrategy):
 
     def generate(self) -> TablePreview | ChartError:
         try:
-            from superset.commands.chart.data.get_data_command import ChartDataCommand
             from superset.utils import json as utils_json
 
             form_data = utils_json.loads(self.chart.params) if self.chart.params else {}
@@ -397,10 +407,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
             if not _first_query_has_fields(query_context):
                 return _no_query_fields_error(self.chart)
 
-            self._authorize_guest_query(query_context)
-            command = ChartDataCommand(query_context)
-            command.validate()
-            result = command.run()
+            result = self._run_chart_data_command(query_context)
 
             data: list[Any] = []
             if result and "queries" in result and len(result["queries"]) > 0:
@@ -447,7 +454,6 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
         try:
             # Get chart data directly using the same logic as get_chart_data tool
             # but without calling the MCP tool wrapper
-            from superset.commands.chart.data.get_data_command import ChartDataCommand
             from superset.daos.chart import ChartDAO
             from superset.utils import json as utils_json
 
@@ -488,11 +494,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
                 force=self.request.force_refresh,
             )
 
-            # Execute the query
-            self._authorize_guest_query(query_context)
-            command = ChartDataCommand(query_context)
-            command.validate()
-            result = command.run()
+            result = self._run_chart_data_command(query_context)
 
             # Extract data from result
             chart_data = []

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -28,6 +28,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.exceptions import SupersetException, SupersetSecurityException
@@ -35,6 +36,7 @@ from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_helpers import (
     build_query_context_from_form_data,
     extract_x_axis_col,
+    resolve_form_data_datasource,
     resolve_groupby,
     resolve_metrics,
     resolve_metrics_and_groupby,
@@ -185,6 +187,11 @@ def _sql_from_saved_query_context(
         query_context = ChartDataQueryContextSchema().load(qc_json)
         query_context.result_type = ChartDataResultType.QUERY
 
+        set_query_context_form_data(
+            query_context,
+            chart.datasource_id,
+            chart.datasource_type,
+        )
         command = ChartDataCommand(query_context)
         command.validate()
         result = command.run()
@@ -254,6 +261,11 @@ def _sql_from_form_data(
     from superset.commands.chart.data.get_data_command import ChartDataCommand
 
     query_context = _build_query_context_from_form_data(form_data, chart)
+    datasource_id, datasource_type = resolve_form_data_datasource(form_data, chart)
+    if datasource_id is None:
+        datasource_id = query_context.datasource.id
+        datasource_type = str(query_context.datasource.type)
+    set_query_context_form_data(query_context, datasource_id, datasource_type)
     command = ChartDataCommand(query_context)
     command.validate()
     result = command.run()

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import joinedload, subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
@@ -280,6 +281,10 @@ async def query_dataset(  # noqa: C901
             "row_limit": request.row_limit,
             "order_desc": request.order_desc,
         }
+        # Jinja get_time_filter() reads QueryObject.time_range, not only
+        # the TEMPORAL_RANGE filter used for SQL execution.
+        if request.time_range:
+            query_dict["time_range"] = request.time_range
         if granularity:
             query_dict["granularity"] = granularity
         if request.order_by:
@@ -309,6 +314,8 @@ async def query_dataset(  # noqa: C901
                 force=not request.use_cache or request.force_refresh,
                 custom_cache_timeout=request.cache_timeout,
             )
+
+            set_query_context_form_data(query_context, dataset.id, "table")
 
             command = ChartDataCommand(query_context)
             command.validate()

--- a/superset/mcp_service/semantic_layer/tool/get_table.py
+++ b/superset/mcp_service/semantic_layer/tool/get_table.py
@@ -30,6 +30,7 @@ from fastmcp import Context
 from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
@@ -237,6 +238,10 @@ def _build_query_dict(
         "row_limit": request.row_limit,
         "order_desc": request.order_desc,
     }
+    # Jinja get_time_filter() reads QueryObject.time_range, not only
+    # the TEMPORAL_RANGE filter used for SQL execution.
+    if request.time_range:
+        query_dict["time_range"] = request.time_range
     if time_col:
         query_dict["granularity"] = time_col
     if request.order_by:
@@ -355,6 +360,7 @@ async def _run_get_table_query(
             form_data={},
             force=not request.use_cache or request.force_refresh,
         )
+        set_query_context_form_data(query_context, datasource_id, datasource_type)
         command = ChartDataCommand(query_context)
         command.validate()
         result = command.run()

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -21,10 +21,11 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 from celery.exceptions import SoftTimeLimitExceeded
-from flask import current_app, g
+from flask import current_app
 from flask_appbuilder.security.sqla.models import User
 from marshmallow import ValidationError
 
+from superset.charts.data.form_data import set_form_data
 from superset.charts.schemas import ChartDataQueryContextSchema
 from superset.exceptions import (
     SupersetErrorException,
@@ -45,10 +46,6 @@ logger = logging.getLogger(__name__)
 query_timeout = current_app.config[
     "SQLLAB_ASYNC_TIME_LIMIT_SEC"
 ]  # TODO: new config key
-
-
-def set_form_data(form_data: dict[str, Any]) -> None:
-    g.form_data = form_data
 
 
 def _create_query_context_from_form(form_data: dict[str, Any]) -> QueryContext:

--- a/tests/unit_tests/charts/data/form_data_test.py
+++ b/tests/unit_tests/charts/data/form_data_test.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+from typing import Any
+
+from flask import current_app, g
+
+from superset.charts.data.form_data import (
+    set_form_data,
+    set_query_context_form_data,
+)
+from superset.common.query_object import QueryObject
+from superset.jinja_context import ExtraCache, get_dataset_id_from_context
+
+
+def _jinja_query_context(
+    *,
+    filters: list[dict[str, Any]] | None = None,
+    time_range: str = "Last week",
+    url_params: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    """Build a QueryContext-shaped object from a real QueryObject."""
+    query = QueryObject(
+        filters=filters
+        or [{"col": "region", "op": "IN", "val": ["North"]}],
+        time_range=time_range,
+    )
+    return SimpleNamespace(
+        queries=[query],
+        form_data={"url_params": url_params or {"tenant": "acme"}},
+    )
+
+
+def assert_request_dependent_jinja_macros(
+    *,
+    expected_filter_col: str = "region",
+    expected_filter_val: str = "North",
+    expected_url_param: str | None = "tenant",
+    expected_url_value: str = "acme",
+    expected_time_range: str | None = "Last week",
+    expected_dataset_id: int = 7,
+) -> None:
+    """Assert Jinja macros resolve the same inputs as a chart-data API request."""
+    extra_cache = ExtraCache()
+    assert extra_cache.filter_values(expected_filter_col) == [expected_filter_val]
+    assert extra_cache.get_filters(expected_filter_col) == [
+        {"col": expected_filter_col, "op": "IN", "val": [expected_filter_val]}
+    ]
+    if expected_url_param is not None:
+        assert extra_cache.url_param(expected_url_param) == expected_url_value
+    if expected_time_range is not None:
+        assert extra_cache.get_time_filter().time_range == expected_time_range
+    # metric() without an explicit dataset ID performs this lookup.
+    assert get_dataset_id_from_context("count") == expected_dataset_id
+
+
+def test_set_form_data_exposes_payload_on_flask_global() -> None:
+    """The shared helper publishes form data for request-independent queries."""
+    payload: dict[str, Any] = {"queries": [{"filters": []}]}
+
+    with current_app.test_request_context():
+        set_form_data(payload)
+
+        assert g.form_data is payload
+
+
+def test_query_context_form_data_supports_request_dependent_jinja_macros() -> None:
+    """Chart queries expose filters, URL parameters, and the datasource to Jinja."""
+    query_context = _jinja_query_context()
+
+    with current_app.test_request_context():
+        set_query_context_form_data(query_context, 7, "table")
+        assert_request_dependent_jinja_macros()

--- a/tests/unit_tests/mcp_service/chart/test_compile.py
+++ b/tests/unit_tests/mcp_service/chart/test_compile.py
@@ -23,6 +23,7 @@ path so fast-path tools (``generate_explore_link``, ``update_chart_preview``)
 that only use Tier-1 validation are exercised end-to-end.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -478,7 +479,9 @@ def test_compile_chart_returns_database_error_when_wrapped_in_query_failed(
     from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
     from superset.mcp_service.chart.compile import _compile_chart
 
-    mock_factory.return_value.create.return_value = Mock()
+    mock_factory.return_value.create.return_value = SimpleNamespace(
+        queries=[], form_data={}
+    )
     mock_cmd_cls.return_value.validate.return_value = None
 
     # Real scenario: __cause__ is NOT set, error is just a string
@@ -529,7 +532,9 @@ def test_compile_chart_returns_database_error_on_raw_sqlalchemy_error(
 
     from superset.mcp_service.chart.compile import _compile_chart
 
-    mock_factory.return_value.create.return_value = Mock()
+    mock_factory.return_value.create.return_value = SimpleNamespace(
+        queries=[], form_data={}
+    )
     mock_cmd_cls.return_value.validate.return_value = None
     mock_cmd_cls.return_value.run.side_effect = OperationalError(
         "connection to server at '10.0.0.1', port 5432 failed: Connection timed out",
@@ -572,3 +577,59 @@ def test_valid_configs_pass_tier1(config_factory):
     ds = _orm_dataset()
     result = validate_and_compile(config_factory(), {}, ds, run_compile_check=False)
     assert result.success, result.error
+
+
+def test_compile_chart_exposes_jinja_context() -> None:
+    """Compile checks publish the same Jinja inputs used during chart execution."""
+    from flask import current_app
+
+    from superset.common.query_object import QueryObject
+    from superset.mcp_service.chart.compile import _compile_chart
+    from tests.unit_tests.charts.data.form_data_test import (
+        assert_request_dependent_jinja_macros,
+    )
+
+    query = QueryObject(
+        filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+        time_range="Last week",
+    )
+    query_context = SimpleNamespace(
+        queries=[query],
+        form_data={"url_params": {"tenant": "acme"}},
+    )
+    observed: dict[str, bool] = {}
+
+    class ChartDataCommand:
+        def __init__(self, qc: object) -> None:
+            self.query_context = qc
+
+        def validate(self) -> None:
+            pass
+
+        def run(self) -> dict:
+            assert_request_dependent_jinja_macros()
+            observed["ran"] = True
+            return {"queries": [{"data": [{"region": "North"}]}]}
+
+    with (
+        current_app.test_request_context(),
+        patch(
+            "superset.common.query_context_factory.QueryContextFactory.create",
+            return_value=query_context,
+        ),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand",
+            ChartDataCommand,
+        ),
+    ):
+        result = _compile_chart(
+            {
+                "metrics": ["count"],
+                "url_params": {"tenant": "acme"},
+                "time_range": "Last week",
+            },
+            dataset_id=7,
+        )
+
+    assert result.success is True
+    assert observed["ran"] is True

--- a/tests/unit_tests/mcp_service/chart/test_preview_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_preview_utils.py
@@ -23,6 +23,8 @@ import ast
 import inspect
 from pathlib import Path
 
+import pytest
+
 from superset.mcp_service.chart import preview_utils
 
 
@@ -209,3 +211,80 @@ def test_build_query_columns_empty_columns_key_keeps_groupby():
     assert preview_utils._build_query_columns(
         {"groupby": ["country"], "columns": []}
     ) == ["country"]
+
+
+def test_generate_preview_from_form_data_exposes_jinja_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsaved-chart previews expose the same Jinja inputs as execution."""
+    from types import SimpleNamespace
+    from typing import Any
+    from unittest.mock import MagicMock
+
+    from flask import current_app
+
+    from superset.common.query_object import QueryObject
+    from tests.unit_tests.charts.data.form_data_test import (
+        assert_request_dependent_jinja_macros,
+    )
+
+    query = QueryObject(
+        filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+        time_range="Last week",
+    )
+    query_context = SimpleNamespace(
+        queries=[query],
+        form_data={"url_params": {"tenant": "acme"}},
+    )
+    observed: dict[str, bool] = {}
+
+    class QueryContextFactory:
+        def create(self, **kwargs: Any) -> object:
+            return query_context
+
+    class ChartDataCommand:
+        def __init__(self, qc: object) -> None:
+            self.query_context = qc
+
+        def validate(self) -> None:
+            pass
+
+        def run(self) -> dict[str, Any]:
+            assert_request_dependent_jinja_macros()
+            observed["ran"] = True
+            return {
+                "queries": [
+                    {
+                        "data": [{"region": "North"}],
+                        "colnames": ["region"],
+                        "rowcount": 1,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(
+        "superset.common.query_context_factory.QueryContextFactory",
+        QueryContextFactory,
+    )
+    monkeypatch.setattr(
+        "superset.commands.chart.data.get_data_command.ChartDataCommand",
+        ChartDataCommand,
+    )
+    mock_db = MagicMock()
+    mock_db.session.get.return_value = MagicMock()
+    monkeypatch.setattr("superset.extensions.db", mock_db)
+
+    with current_app.test_request_context():
+        result = preview_utils.generate_preview_from_form_data(
+            {
+                "metrics": ["count"],
+                "groupby": ["region"],
+                "url_params": {"tenant": "acme"},
+                "time_range": "Last week",
+            },
+            dataset_id=7,
+            preview_format="table",
+        )
+
+    assert observed["ran"] is True
+    assert getattr(result, "error", None) is None

--- a/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
@@ -19,6 +19,7 @@
 Unit tests for MCP generate_chart tool
 """
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -352,7 +353,9 @@ class TestCompileChart:
     @patch("superset.common.query_context_factory.QueryContextFactory")
     def test_compile_chart_success(self, mock_factory_cls, mock_cmd_cls):
         """Test _compile_chart returns success when query executes cleanly."""
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
         mock_cmd_cls.return_value.run.return_value = {
             "queries": [{"data": [{"col": 1}, {"col": 2}]}]
         }
@@ -373,7 +376,9 @@ class TestCompileChart:
     @patch("superset.common.query_context_factory.QueryContextFactory")
     def test_compile_chart_query_error_in_payload(self, mock_factory_cls, mock_cmd_cls):
         """Test _compile_chart detects errors embedded in query results."""
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
         mock_cmd_cls.return_value.run.return_value = {
             "queries": [{"error": "column 'bad_col' does not exist"}]
         }
@@ -391,7 +396,9 @@ class TestCompileChart:
             ChartDataQueryFailedError,
         )
 
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
         mock_cmd_cls.return_value.run.side_effect = ChartDataQueryFailedError(
             "syntax error near FROM"
         )

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -394,7 +394,7 @@ class TestUnsavedChartDataQueryConstruction:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -475,7 +475,7 @@ class TestUnsavedChartDataQueryConstruction:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -540,6 +540,84 @@ class TestUnsavedChartDataQueryConstruction:
         assert queries[1]["columns"] == ["ds", "state"]
         assert queries[1]["metrics"] == ["sum__profit"]
         assert queries[1]["row_limit"] == 99
+
+    @pytest.mark.asyncio
+    async def test_form_data_key_path_exposes_jinja_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unsaved-chart execution publishes the same Jinja inputs as get_chart_data."""
+        from flask import current_app
+
+        from superset.common.query_object import QueryObject
+        from tests.unit_tests.charts.data.form_data_test import (
+            assert_request_dependent_jinja_macros,
+        )
+
+        chart_data_module = importlib.import_module(
+            "superset.mcp_service.chart.tool.get_chart_data"
+        )
+        get_data_command_module = importlib.import_module(
+            "superset.commands.chart.data.get_data_command"
+        )
+
+        query = QueryObject(
+            filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+            time_range="Last week",
+        )
+        query_context = SimpleNamespace(
+            queries=[query],
+            form_data={"url_params": {"tenant": "acme"}},
+        )
+        observed: dict[str, bool] = {}
+
+        class ChartDataCommand:
+            def __init__(self, qc: object) -> None:
+                self.query_context = qc
+
+            def validate(self) -> None:
+                pass
+
+            def run(self) -> dict[str, Any]:
+                assert_request_dependent_jinja_macros()
+                observed["ran"] = True
+                return {
+                    "queries": [
+                        {
+                            "data": [{"region": "North"}],
+                            "colnames": ["region"],
+                            "rowcount": 1,
+                        }
+                    ]
+                }
+
+        monkeypatch.setattr(
+            chart_data_module,
+            "build_query_context_from_form_data",
+            lambda *args, **kwargs: query_context,
+        )
+        monkeypatch.setattr(
+            get_data_command_module, "ChartDataCommand", ChartDataCommand
+        )
+        monkeypatch.setattr(
+            chart_data_module,
+            "event_logger",
+            SimpleNamespace(log_context=lambda **kwargs: nullcontext()),
+        )
+
+        with current_app.test_request_context():
+            await _query_from_form_data(
+                {
+                    "datasource_id": 7,
+                    "datasource_type": "table",
+                    "url_params": {"tenant": "acme"},
+                    "time_range": "Last week",
+                },
+                GetChartDataRequest(form_data_key="cached-key"),
+                _AsyncContext(),
+            )
+
+        assert observed["ran"] is True
 
 
 class TestWorldMapChartFallback:
@@ -1027,7 +1105,9 @@ class TestChartDataCommandValidation:
             ) as mock_factory,
         ):
             mock_db.session.get.return_value = mock_dataset
-            mock_factory.return_value.create.return_value = MagicMock()
+            mock_factory.return_value.create.return_value = SimpleNamespace(
+                queries=[], form_data={}
+            )
 
             from superset.mcp_service.chart.preview_utils import (
                 generate_preview_from_form_data,
@@ -1075,7 +1155,9 @@ class TestChartDataCommandValidation:
             ) as mock_factory,
         ):
             mock_db.session.get.return_value = mock_dataset
-            mock_factory.return_value.create.return_value = MagicMock()
+            mock_factory.return_value.create.return_value = SimpleNamespace(
+                queries=[], form_data={}
+            )
 
             from superset.mcp_service.chart.preview_utils import (
                 generate_preview_from_form_data,
@@ -1118,7 +1200,9 @@ class TestChartDataCommandValidation:
                 "superset.common.query_context_factory.QueryContextFactory"
             ) as mock_factory,
         ):
-            mock_factory.return_value.create.return_value = MagicMock()
+            mock_factory.return_value.create.return_value = SimpleNamespace(
+                queries=[], form_data={}
+            )
 
             from superset.mcp_service.chart.tool.generate_chart import _compile_chart
 
@@ -1159,7 +1243,9 @@ class TestChartDataCommandValidation:
                 "superset.common.query_context_factory.QueryContextFactory"
             ) as mock_factory,
         ):
-            mock_factory.return_value.create.return_value = MagicMock()
+            mock_factory.return_value.create.return_value = SimpleNamespace(
+                queries=[], form_data={}
+            )
 
             from superset.mcp_service.chart.tool.generate_chart import _compile_chart
 
@@ -1379,7 +1465,7 @@ class TestOAuthErrorRouting:
 
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class RaisingChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -1800,7 +1886,7 @@ class TestGuestScoping:
             ),
             patch(
                 "superset.charts.schemas.ChartDataQueryContextSchema.load",
-                lambda self, data: object(),
+                lambda self, data: SimpleNamespace(queries=[], form_data={}),
             ),
         ):
             async with Client(mcp_server) as client:
@@ -1926,7 +2012,7 @@ class TestGuestScoping:
             ),
             patch(
                 "superset.charts.schemas.ChartDataQueryContextSchema.load",
-                lambda self, data: object(),
+                lambda self, data: SimpleNamespace(queries=[], form_data={}),
             ),
         ):
             async with Client(mcp_server) as client:
@@ -1953,7 +2039,7 @@ async def test_query_from_form_data_zero_row_limit_falls_back_to_default(
 
     def fake_build(form_data: Any, **kwargs: Any) -> Any:
         captured["row_limit"] = kwargs.get("row_limit")
-        return object()
+        return SimpleNamespace(queries=[], form_data={})
 
     class _Command:
         def __init__(self, query_context: Any) -> None: ...
@@ -1994,7 +2080,7 @@ async def test_query_from_form_data_string_row_limit_is_coerced(
 
     def fake_build(form_data: Any, **kwargs: Any) -> Any:
         captured["row_limit"] = kwargs.get("row_limit")
-        return object()
+        return SimpleNamespace(queries=[], form_data={})
 
     class _Command:
         def __init__(self, query_context: Any) -> None: ...

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -304,7 +304,7 @@ class TestGetChartPreview:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -366,6 +366,90 @@ class TestGetChartPreview:
         assert query["filters"] == [{"col": "gender", "op": "==", "val": "boy"}]
         assert "adhoc_filters" not in query
 
+    def test_table_preview_exposes_jinja_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Chart preview queries expose the same Jinja inputs as get_chart_data."""
+        from flask import current_app
+
+        from superset.common.query_object import QueryObject
+        from tests.unit_tests.charts.data.form_data_test import (
+            assert_request_dependent_jinja_macros,
+        )
+
+        get_data_command_module = importlib.import_module(
+            "superset.commands.chart.data.get_data_command"
+        )
+        query = QueryObject(
+            filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+            time_range="Last week",
+            columns=["region"],
+            metrics=["count"],
+        )
+        query_context = SimpleNamespace(
+            queries=[query],
+            form_data={"url_params": {"tenant": "acme"}},
+        )
+        observed: dict[str, bool] = {}
+
+        class ChartDataCommand:
+            def __init__(self, qc: object) -> None:
+                self.query_context = qc
+
+            def validate(self) -> None:
+                pass
+
+            def run(self) -> dict[str, Any]:
+                assert_request_dependent_jinja_macros()
+                observed["ran"] = True
+                return {
+                    "queries": [
+                        {
+                            "data": [{"region": "North"}],
+                            "colnames": ["region"],
+                            "rowcount": 1,
+                        }
+                    ]
+                }
+
+        preview_module = importlib.import_module(
+            "superset.mcp_service.chart.tool.get_chart_preview"
+        )
+        monkeypatch.setattr(
+            preview_module,
+            "build_query_context_from_form_data",
+            lambda *args, **kwargs: query_context,
+        )
+        monkeypatch.setattr(
+            get_data_command_module, "ChartDataCommand", ChartDataCommand
+        )
+
+        chart = SimpleNamespace(
+            id=1,
+            slice_name="Sales",
+            viz_type="table",
+            datasource_id=7,
+            datasource_type="table",
+            params=utils_json.dumps(
+                {
+                    "viz_type": "table",
+                    "metrics": ["count"],
+                    "groupby": ["region"],
+                    "url_params": {"tenant": "acme"},
+                    "time_range": "Last week",
+                }
+            ),
+        )
+        with current_app.test_request_context():
+            preview = TablePreviewStrategy(
+                chart,
+                GetChartPreviewRequest(identifier=1, format="table"),
+            ).generate()
+
+        assert isinstance(preview, TablePreview)
+        assert observed["ran"] is True
+
     def test_table_preview_uses_singular_metric(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -383,7 +467,7 @@ class TestGetChartPreview:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -454,7 +538,7 @@ class TestGetChartPreview:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -586,7 +670,7 @@ class TestGetChartPreview:
 
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:
@@ -672,7 +756,7 @@ class TestGetChartPreview:
         class QueryContextFactory:
             def create(self, **kwargs: Any) -> object:
                 captured_query_contexts.append(kwargs)
-                return object()
+                return SimpleNamespace(queries=[], form_data={})
 
         class ChartDataCommand:
             def __init__(self, query_context: object) -> None:

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -20,6 +20,8 @@ Unit tests for get_chart_sql MCP tool
 """
 
 import importlib
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -40,6 +42,8 @@ from superset.mcp_service.chart.tool.get_chart_sql import (
     _resolve_groupby,
     _resolve_metrics,
     _resolve_metrics_and_groupby,
+    _sql_from_form_data,
+    _sql_from_saved_query_context,
     get_chart_sql,
 )
 from superset.mcp_service.utils import sanitize_for_llm_context
@@ -206,6 +210,132 @@ class TestExtractSqlFromResult:
         assert output.chart_id is None
         assert output.chart_name is None
         assert output.datasource_name is None
+
+
+class TestChartSqlJinjaContext:
+    """SQL generation must expose the same Jinja inputs as chart data execution."""
+
+    def _command_observing_jinja(self, observed: dict[str, bool]) -> type:
+        from tests.unit_tests.charts.data.form_data_test import (
+            assert_request_dependent_jinja_macros,
+        )
+
+        class ChartDataCommand:
+            def __init__(self, query_context: object) -> None:
+                self.query_context = query_context
+
+            def validate(self) -> None:
+                pass
+
+            def run(self) -> dict[str, Any]:
+                assert_request_dependent_jinja_macros()
+                observed["ran"] = True
+                return {"queries": [{"query": "SELECT 1", "language": "sql"}]}
+
+        return ChartDataCommand
+
+    def test_sql_from_form_data_exposes_jinja_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The form_data SQL path publishes filters, time_range, and url_params."""
+        from flask import current_app
+
+        from superset.common.query_object import QueryObject
+
+        get_data_command_module = importlib.import_module(
+            "superset.commands.chart.data.get_data_command"
+        )
+        query = QueryObject(
+            filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+            time_range="Last week",
+        )
+        query_context = SimpleNamespace(
+            queries=[query],
+            form_data={"url_params": {"tenant": "acme"}},
+        )
+        observed: dict[str, bool] = {}
+        monkeypatch.setattr(
+            _get_chart_sql_mod,
+            "_build_query_context_from_form_data",
+            lambda *args, **kwargs: query_context,
+        )
+        monkeypatch.setattr(
+            get_data_command_module,
+            "ChartDataCommand",
+            self._command_observing_jinja(observed),
+        )
+
+        chart = SimpleNamespace(
+            id=1,
+            slice_name="Sales",
+            datasource_name="orders",
+            datasource_id=7,
+            datasource_type="table",
+        )
+        with current_app.test_request_context():
+            result = _sql_from_form_data(
+                {
+                    "datasource_id": 7,
+                    "datasource_type": "table",
+                    "url_params": {"tenant": "acme"},
+                    "time_range": "Last week",
+                },
+                chart,
+            )
+
+        assert isinstance(result, ChartSql)
+        assert observed["ran"] is True
+
+    def test_sql_from_saved_query_context_exposes_jinja_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Saved query_context SQL generation uses the shared Jinja helper."""
+        from flask import current_app
+
+        from superset.common.query_object import QueryObject
+
+        get_data_command_module = importlib.import_module(
+            "superset.commands.chart.data.get_data_command"
+        )
+        query = QueryObject(
+            filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+            time_range="Last week",
+        )
+        query_context = SimpleNamespace(
+            queries=[query],
+            form_data={"url_params": {"tenant": "acme"}},
+        )
+        observed: dict[str, bool] = {}
+
+        class FakeSchema:
+            def load(self, _data: object) -> SimpleNamespace:
+                return query_context
+
+        monkeypatch.setattr(
+            "superset.charts.schemas.ChartDataQueryContextSchema",
+            FakeSchema,
+        )
+        monkeypatch.setattr(
+            get_data_command_module,
+            "ChartDataCommand",
+            self._command_observing_jinja(observed),
+        )
+
+        chart = SimpleNamespace(
+            id=1,
+            slice_name="Sales",
+            datasource_name="orders",
+            datasource_id=7,
+            datasource_type="table",
+            query_context='{"datasource": {"id": 7, "type": "table"}, "queries": [{}]}',
+        )
+        with current_app.test_request_context():
+            result = _sql_from_saved_query_context(chart)
+
+        assert isinstance(result, ChartSql)
+        assert observed["ran"] is True
 
 
 class TestFindChartByIdentifier:

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import Generator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -137,6 +138,23 @@ def _mock_command_result(
     }
 
 
+def _query_context_from_factory_kwargs(
+    *_args: Any,
+    **kwargs: Any,
+) -> SimpleNamespace:
+    """Build a QueryContext-shaped object from QueryContextFactory.create args."""
+    from superset.common.query_object import QueryObject
+
+    query_dict = kwargs["queries"][0]
+    query = QueryObject(
+        filters=query_dict.get("filters"),
+        time_range=query_dict.get("time_range"),
+        columns=query_dict.get("columns"),
+        metrics=query_dict.get("metrics"),
+    )
+    return SimpleNamespace(queries=[query], form_data=kwargs.get("form_data") or {})
+
+
 @pytest.mark.asyncio
 async def test_query_dataset_success(mcp_server: FastMCP) -> None:
     """Happy path: metrics + columns returns data."""
@@ -158,7 +176,7 @@ async def test_query_dataset_success(mcp_server: FastMCP) -> None:
         ),
         patch(
             "superset.common.query_context_factory.QueryContextFactory.create",
-            return_value=MagicMock(),
+            return_value=SimpleNamespace(queries=[], form_data={}),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -179,6 +197,62 @@ async def test_query_dataset_success(mcp_server: FastMCP) -> None:
     assert data["row_count"] == 2
     assert len(data["data"]) == 2
     assert data["data"][0]["category"] == "Electronics"
+
+
+@pytest.mark.asyncio
+async def test_query_dataset_exposes_filters_to_jinja_macros(
+    mcp_server: FastMCP,
+) -> None:
+    """The MCP query path populates the form data read by dataset Jinja macros."""
+    from tests.unit_tests.charts.data.form_data_test import (
+        assert_request_dependent_jinja_macros,
+    )
+
+    dataset = _make_dataset(7, main_dttm_col="order_date")
+    observed: dict[str, bool] = {}
+
+    def run_query(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        # query_dataset has no url_params; skip that chart-only assertion.
+        assert_request_dependent_jinja_macros(expected_url_param=None)
+        observed["ran"] = True
+        return _mock_command_result()
+
+    with (
+        patch.object(query_dataset_module, "resolve_dataset", return_value=dataset),
+        patch(
+            "superset.common.query_context_factory.QueryContextFactory.create",
+            side_effect=_query_context_from_factory_kwargs,
+        ),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand.validate",
+        ),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand.run",
+            side_effect=run_query,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "query_dataset",
+                {
+                    "request": {
+                        "dataset_id": 7,
+                        "metrics": ["count"],
+                        "columns": ["region"],
+                        "filters": [
+                            {
+                                "col": "region",
+                                "op": "IN",
+                                "val": ["North"],
+                            }
+                        ],
+                        "time_range": "Last week",
+                    }
+                },
+            )
+
+    assert not result.is_error
+    assert observed["ran"] is True
 
 
 @pytest.mark.asyncio
@@ -288,7 +362,7 @@ async def test_query_dataset_with_time_range(mcp_server: FastMCP) -> None:
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(
@@ -374,7 +448,7 @@ async def test_query_dataset_with_filters(mcp_server: FastMCP) -> None:
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(
@@ -448,7 +522,7 @@ async def test_query_dataset_empty_results(mcp_server: FastMCP) -> None:
         ),
         patch(
             "superset.common.query_context_factory.QueryContextFactory.create",
-            return_value=MagicMock(),
+            return_value=SimpleNamespace(queries=[], form_data={}),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -489,7 +563,7 @@ async def test_query_dataset_by_uuid(mcp_server: FastMCP) -> None:
         ),
         patch(
             "superset.common.query_context_factory.QueryContextFactory.create",
-            return_value=MagicMock(),
+            return_value=SimpleNamespace(queries=[], form_data={}),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -528,7 +602,7 @@ async def test_query_dataset_permission_denied(mcp_server: FastMCP) -> None:
         ),
         patch(
             "superset.common.query_context_factory.QueryContextFactory.create",
-            return_value=MagicMock(),
+            return_value=SimpleNamespace(queries=[], form_data={}),
         ),
         patch(
             "superset.commands.chart.data.get_data_command.ChartDataCommand.validate",
@@ -565,7 +639,7 @@ async def test_query_dataset_order_by_valid(mcp_server: FastMCP) -> None:
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(
@@ -643,7 +717,7 @@ async def test_query_dataset_time_column_override(mcp_server: FastMCP) -> None:
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(
@@ -704,7 +778,7 @@ async def test_query_dataset_non_dttm_time_column_warns(mcp_server: FastMCP) -> 
         ),
         patch(
             "superset.common.query_context_factory.QueryContextFactory.create",
-            return_value=MagicMock(),
+            return_value=SimpleNamespace(queries=[], form_data={}),
         ),
     ):
         async with Client(mcp_server) as client:
@@ -1218,7 +1292,7 @@ async def test_query_dataset_bracket_year_resolves_without_parse_error(
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(
@@ -1289,7 +1363,7 @@ async def test_query_dataset_bracket_hour_resolves_without_parse_error(
 
     def capture_create(**kwargs):
         captured_queries.extend(kwargs.get("queries", []))
-        return MagicMock()
+        return SimpleNamespace(queries=[], form_data={})
 
     with (
         patch.object(

--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import Generator
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -140,7 +140,9 @@ async def test_get_table_builtin_happy_path(mcp_server: FastMCP) -> None:
         ) as mock_factory_cls,
     ):
         mock_command_cls.return_value.run.return_value = query_result
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -419,7 +421,9 @@ async def test_get_table_unknown_filter_operator_passes_through(
         ) as mock_factory_cls,
     ):
         mock_command_cls.return_value.run.return_value = query_result
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -472,7 +476,9 @@ async def test_get_table_unicode_filter_value_passes_through(
         ) as mock_factory_cls,
     ):
         mock_command_cls.return_value.run.return_value = query_result
-        mock_factory_cls.return_value.create.return_value = MagicMock()
+        mock_factory_cls.return_value.create.return_value = SimpleNamespace(
+            queries=[], form_data={}
+        )
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -638,3 +644,77 @@ class TestGetTableTemporalRangeFilterValidation:
             }
         )
         assert req.filters[0].val == "banana"
+
+
+@pytest.mark.asyncio
+async def test_get_table_exposes_filters_to_jinja_macros(
+    mcp_server: FastMCP,
+) -> None:
+    """get_table publishes the same Jinja inputs as other ChartDataCommand paths."""
+    from superset.common.query_object import QueryObject
+    from tests.unit_tests.charts.data.form_data_test import (
+        assert_request_dependent_jinja_macros,
+    )
+
+    mock_ds = _make_dataset(7)
+    observed: dict[str, bool] = {}
+
+    def fake_create(*_args: Any, **kwargs: Any) -> SimpleNamespace:
+        query_dict = kwargs["queries"][0]
+        query = QueryObject(
+            filters=query_dict.get("filters"),
+            time_range=query_dict.get("time_range"),
+            columns=query_dict.get("columns"),
+            metrics=query_dict.get("metrics"),
+        )
+        return SimpleNamespace(
+            queries=[query],
+            form_data=kwargs.get("form_data") or {},
+        )
+
+    def run_query(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        # get_table has no url_params; skip that chart-only assertion.
+        assert_request_dependent_jinja_macros(expected_url_param=None)
+        observed["ran"] = True
+        return {
+            "queries": [
+                {
+                    "data": [{"region": "North"}],
+                    "colnames": ["region"],
+                    "rowcount": 1,
+                }
+            ]
+        }
+
+    with (
+        patch("superset.daos.dataset.DatasetDAO.find_by_id", return_value=mock_ds),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand.validate",
+        ),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand.run",
+            side_effect=run_query,
+        ),
+        patch(
+            "superset.common.query_context_factory.QueryContextFactory.create",
+            side_effect=fake_create,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_table",
+                {
+                    "request": {
+                        "dataset_id": 7,
+                        "metrics": ["revenue"],
+                        "dimensions": ["region"],
+                        "filters": [
+                            {"col": "region", "op": "IN", "val": ["North"]},
+                        ],
+                        "time_range": "Last week",
+                    }
+                },
+            )
+
+    assert not result.is_error
+    assert observed["ran"] is True


### PR DESCRIPTION
### SUMMARY
Follow-up to #42822 / #43174. Chart execution could resolve request-dependent Jinja (`filter_values`, `get_filters`, `url_param`, `get_time_filter`, implicit `metric()` dataset lookup) while sibling MCP paths (`get_chart_sql`, preview, compile, `query_dataset`, `get_table`) still rendered fallbacks such as `No filter`, so displayed SQL could diverge from executed SQL.

This extracts a shared helper that serializes a real `QueryObject`/`QueryContext` onto `g.form_data` in the chart-data API shape, and applies it immediately before every MCP `ChartDataCommand` construction. `query_dataset` and `get_table` also copy `time_range` onto the query dict so `get_time_filter()` sees the same value as SQL execution. Guest `authorize_query` still runs first. Non-MCP `ChartDataCommand` sites are unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
1. Create a virtual dataset whose SQL uses `{{ filter_values('region') }}`, `{{ url_param('tenant') }}`, and `{{ get_time_filter().time_range }}`.
2. Build a chart on that dataset with a region filter, `url_params.tenant`, and a time range.
3. Call `get_chart_data` and confirm the macros resolve (not `No filter` / empty).
4. Call `get_chart_sql` and `get_chart_preview` on the same chart and confirm the rendered SQL matches the executed query.
5. Repeat with an unsaved chart via `form_data_key`.
6. Call `query_dataset` / `get_table` with filters and `time_range` and confirm `get_time_filter()` matches the request.
7. Confirm an embedded guest still cannot query a chart outside the guest dashboard scope.

```bash
pytest -q \
  tests/unit_tests/charts/data/form_data_test.py \
  tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py \
  tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py \
  tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py \
  tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py \
  tests/unit_tests/mcp_service/chart/test_preview_utils.py \
  tests/unit_tests/mcp_service/chart/test_compile.py \
  tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py \
  tests/unit_tests/mcp_service/chart/tool/test_generate_chart.py
```

### ADDITIONAL INFORMATION
- [X] Has associated issue: Fixes #43174
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
