### PR TITLE
fix(echarts): stop labeling zero-value segments in stacked bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -467,6 +467,13 @@ export function transformSeries(
           return formatter(numericValue);
         }
         if (!onlyTotal) {
+          // A stacked segment with a value of zero has no height, so its label
+          // is anchored to the same pixel as the neighboring segment's label
+          // and the two render on top of each other. There is nothing visible
+          // to label, so skip it.
+          if (numericValue === 0) {
+            return '';
+          }
           if (
             numericValue >=
             (thresholdValues[dataIndex] || Number.MIN_SAFE_INTEGER)

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformers.test.ts
@@ -20,13 +20,14 @@ import {
   CategoricalColorScale,
   ChartProps,
   TimeGranularity,
+  getNumberFormatter,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { supersetTheme } from '@apache-superset/core/theme';
 import type { SeriesOption } from 'echarts';
 import type { ScatterSeriesOption } from 'echarts/charts';
 import { EchartsTimeseriesSeriesType } from '../../src';
-import { TIMESERIES_CONSTANTS } from '../../src/constants';
+import { StackControlsValue, TIMESERIES_CONSTANTS } from '../../src/constants';
 import {
   LegendOrientation,
   EchartsTimeseriesChartProps,
@@ -158,6 +159,50 @@ describe('transformSeries', () => {
 
     expect((result as ScatterSeriesOption).symbolSize).toBe(7);
   });
+});
+
+test('transformSeries suppresses stacked value labels for zero values to avoid overlapping the adjacent segment label (issue #42702)', () => {
+  type StackedLabelParams = {
+    value: [string, number];
+    dataIndex: number;
+    seriesIndex: number;
+    seriesName: string;
+  };
+
+  const result = transformSeries({ name: 'B', id: 'B' }, mockColorScale, 'B', {
+    seriesType: EchartsTimeseriesSeriesType.Bar,
+    stack: StackControlsValue.Stack,
+    showValue: true,
+    onlyTotal: false,
+    formatter: getNumberFormatter(),
+    // default `percentage_threshold` of 0 yields a zero threshold per row
+    thresholdValues: [0, 0],
+    totalStackedValues: [32, 40],
+    timeShiftColor: false,
+  });
+
+  const { formatter } = (
+    result as unknown as {
+      label: { formatter: (params: StackedLabelParams) => string };
+    }
+  ).label;
+
+  expect(
+    formatter({
+      value: ['1-3g', 0],
+      dataIndex: 0,
+      seriesIndex: 1,
+      seriesName: 'B',
+    }),
+  ).toBe('');
+  expect(
+    formatter({
+      value: ['4g', 8],
+      dataIndex: 1,
+      seriesIndex: 1,
+      seriesName: 'B',
+    }),
+  ).toBe('8');
 });
 
 describe('transformNegativeLabelsPosition', () => {


### PR DESCRIPTION
### SUMMARY

In a stacked Timeseries Bar chart with **Values** labels on, a series whose value is exactly `0` still rendered a label. A zero-value segment has no height, so its label is anchored to the same pixel as the neighboring segment's label and the two render on top of each other.

The mechanism is the threshold guard in `transformSeries`:

```ts
if (numericValue >= (thresholdValues[dataIndex] || Number.MIN_SAFE_INTEGER)) {
```

With `percentage_threshold` at its default of `0`, `extractDataTotalValues` pushes a per-row threshold of `0` — which is falsy, so the guard degrades to `numericValue >= Number.MIN_SAFE_INTEGER` and admits everything, zeros included.

The fix returns an empty label for `numericValue === 0` in that branch. It deliberately does *not* use `> 0`: negative stacked values render visible segments and are legitimately labeled today, so only the zero case — the one with nothing to anchor to — is suppressed. The guard sits after the `!stack` early return, so unstacked charts still label zeros as before. `MixedTimeseries` shares this code path and is fixed along with it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Minimal echarts repro isolating the label formatter's before/after behavior (two stacked series, one of which is `0` on the first category):

| Before | After |
|---|---|
| ![before: overlapping 24/0 labels](https://raw.githubusercontent.com/rusackas/superset/pr-43178-screenshots/before-zero-label-overlap.png) | ![after: clean single label](https://raw.githubusercontent.com/rusackas/superset/pr-43178-screenshots/after-zero-label-suppressed.png) |

Before: the zero series' `0` label sits on top of the adjacent segment's label (garbled text over the `1-3g` bar). After: no label is drawn for the zero-height segment; every other label is unchanged.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/Timeseries plugins/plugin-chart-echarts/test/MixedTimeseries
```

(295 tests across 17 suites pass, including the new case.)

Manually:

1. Build a Timeseries Bar chart with a dimension that produces a zero value for one series in a given bucket.
2. Set **Stacked Style** to *Stack*, enable **Show Values**, leave **Percentage threshold** at `0`.
3. Before this change the zero series' label overlaps its neighbor's; after it, only visible segments carry labels.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42702
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
