### PR TITLE
fix(embedded): honor can_view_query for guest users in the chart data API

### DIFF
--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -566,11 +566,22 @@ class ChartDataRestApi(ChartRestApi):
                     query["timing"] = query_result.timing.as_public_dict()
 
             if security_manager.is_guest_user():
+                # Engine errors and stacktraces can name internal tables,
+                # schemas or hosts, so they are never handed to an embedded
+                # viewer, whatever the guest role was granted.
                 for query in queries:
-                    query.pop("query", None)
                     query.pop("stacktrace", None)
                     if query.get("error"):
                         query["error"] = sanitize_error_message(query["error"])
+
+                # The generated SQL is withheld by default. Operators can opt a
+                # guest role in by granting it the same `can_view_query` on
+                # `Dashboard` permission that gates the "View query" menu item
+                # in the UI; without honoring it here the menu item is offered
+                # but always renders an empty query.
+                if not security_manager.can_access("can_view_query", "Dashboard"):
+                    for query in queries:
+                        query.pop("query", None)
 
             payload: dict[str, Any] = {"result": queries}
             if dashboard_filter_context is not None:

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -45,7 +45,7 @@ from superset.common.chart_data_timing import (
 from superset.connectors.sqla.models import SqlaTable, TableColumn
 from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.errors import SupersetErrorType
-from superset.extensions import async_query_manager_factory, db
+from superset.extensions import async_query_manager_factory, db, security_manager
 from superset.models.annotations import AnnotationLayer
 from superset.models.slice import Slice
 from superset.models.sql_lab import Query
@@ -1573,7 +1573,28 @@ class TestGetChartDataApi(BaseTestChartDataApi):
     def test_chart_data_as_guest_user(self, is_guest_user, has_guest_access):
         """
         Chart data API: Test response does not inlcude the SQL query for embedded
-        users.
+        users without the `can view query on Dashboard` permission.
+        """
+        g.user.rls = []
+        is_guest_user.return_value = True
+        has_guest_access.return_value = True
+
+        with self.deny_permission("can_view_query", "Dashboard"):
+            rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
+        data = json.loads(rv.data.decode("utf-8"))
+        result = data["result"]
+        excluded_key = "query"
+        assert all([excluded_key not in query for query in result])  # noqa: C419
+
+    @mock.patch("superset.security.manager.SupersetSecurityManager.has_guest_access")
+    @mock.patch("superset.security.manager.SupersetSecurityManager.is_guest_user")
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_chart_data_as_guest_user_with_view_query_permission(
+        self, is_guest_user, has_guest_access
+    ):
+        """
+        Chart data API: Test response includes the SQL query for embedded users
+        whose role was granted `can view query on Dashboard` (issue #43100).
         """
         g.user.rls = []
         is_guest_user.return_value = True
@@ -1581,9 +1602,28 @@ class TestGetChartDataApi(BaseTestChartDataApi):
 
         rv = self.client.post(CHART_DATA_URI, json=self.query_context_payload)
         data = json.loads(rv.data.decode("utf-8"))
-        result = data["result"]
-        excluded_key = "query"
-        assert all([excluded_key not in query for query in result])  # noqa: C419
+        assert all("query" in query for query in data["result"])
+
+    @staticmethod
+    @contextmanager
+    def deny_permission(permission_name: str, view_name: str):
+        """
+        Make a single FAB permission read as denied for the current request.
+
+        The guest-user tests mock `is_guest_user` on top of a logged in Admin
+        session, so the underlying role still holds every permission. This
+        narrows the denial to the permission under test and leaves every other
+        access check (datasource access, guest access, ...) intact.
+        """
+        original_can_access = security_manager.can_access
+
+        def can_access(requested_permission: str, requested_view: str) -> bool:
+            if (requested_permission, requested_view) == (permission_name, view_name):
+                return False
+            return original_can_access(requested_permission, requested_view)
+
+        with mock.patch.object(security_manager, "can_access", can_access):
+            yield
 
     def test_chart_data_table_chart_with_time_grain_filter(self):
         """

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -327,6 +327,10 @@ def test_send_chart_response_strips_guest_query_after_timing_projection(
                 "superset.charts.data.api.security_manager.is_guest_user",
                 return_value=True,
             ),
+            patch(
+                "superset.charts.data.api.security_manager.can_access",
+                return_value=False,
+            ),
         ):
             response = api._send_chart_response(result)
     finally:
@@ -354,6 +358,10 @@ def test_send_chart_response_redacts_guest_query_error(app: SupersetApp) -> None
         patch(
             "superset.charts.data.api.security_manager.is_guest_user",
             return_value=True,
+        ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=False,
         ),
     ):
         response = api._send_chart_response(result)
@@ -436,6 +444,75 @@ def test_get_data_response_redacts_a_real_engine_error_for_guests(
     assert json.loads(guest.get_data(as_text=True))["message"] == str(
         GENERIC_ERROR_MESSAGE
     )
+
+
+def test_send_chart_response_keeps_guest_query_with_view_query_perm(
+    app: SupersetApp,
+) -> None:
+    """
+    Regression test for issue #43100: "View query" on an embedded dashboard.
+
+    A guest (embedded) role that the operator granted ``can_view_query`` on
+    ``Dashboard`` -- the same permission that gates the "View query" menu item
+    in the UI -- must receive the generated SQL instead of a silently empty
+    payload.
+    """
+    query_payload = {"data": [{"col1": 1}], "query": "SELECT 1"}
+    result = _json_execution_result(query_payload, ChartDataResultType.QUERY)
+
+    api = ChartDataRestApi()
+    with (
+        app.test_request_context("/api/v1/chart/data"),
+        patch(
+            "superset.charts.data.api.security_manager.is_guest_user",
+            return_value=True,
+        ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ) as can_access,
+    ):
+        response = api._send_chart_response(result)
+
+    query = json.loads(response.get_data(as_text=True))["result"][0]
+    assert query["query"] == "SELECT 1"
+    can_access.assert_called_once_with("can_view_query", "Dashboard")
+
+
+def test_send_chart_response_still_redacts_errors_for_permitted_guest(
+    app: SupersetApp,
+) -> None:
+    """
+    Being allowed to read the SQL (issue #43100) does not unlock engine error
+    text or stacktraces, which can name internal tables, schemas or hosts.
+    """
+    result = _json_execution_result(
+        {
+            "error": "Table mydb.myschema.mytable was not found",
+            "stacktrace": "Traceback ...",
+            "query": "SELECT 1",
+        },
+        result_type=ChartDataResultType.QUERY,
+    )
+
+    api = ChartDataRestApi()
+    with (
+        app.test_request_context("/api/v1/chart/data"),
+        patch(
+            "superset.charts.data.api.security_manager.is_guest_user",
+            return_value=True,
+        ),
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ),
+    ):
+        response = api._send_chart_response(result)
+
+    query = json.loads(response.get_data(as_text=True))["result"][0]
+    assert query["query"] == "SELECT 1"
+    assert query["error"] == str(GENERIC_ERROR_MESSAGE)
+    assert "stacktrace" not in query
 
 
 def test_send_chart_response_pairs_each_timing_with_its_query(


### PR DESCRIPTION
### SUMMARY

On an embedded dashboard, **View query** opened a modal with a blank query and no error, even for an embedded role the operator had granted `can view query` on `Dashboard`.

The two ends disagreed:

- The menu item is rendered when `canExplore || canViewQuery`, where `canViewQuery` comes from `findPermission('can_view_query', 'Dashboard', user.roles)` (`SliceHeaderControls`, `usePermissions.ts:73`). For an embedded viewer, `user` is populated after the guest-token handshake by `GET /api/v1/me/roles/`, which returns the guest role's real permission tuples — so the item appears exactly when the operator granted that permission.
- `ChartDataRestApi._send_chart_response` popped `"query"` from every result for *any* guest user, unconditionally, with no permission check. The response was `{"result": [{"language": "sql"}]}` and the modal rendered empty.

This gates the SQL on the same permission that gates the menu item, mirroring the existing check on the neighbouring export path (`superset/charts/data/api.py:492`).

Deliberately kept separate from the gate: engine errors and stacktraces stay redacted for **every** guest regardless of the permission, since they can name internal tables, schemas or hosts. The guest block is split so that sanitization is unconditional and only the `query` pop is conditional.

Security posture — the default is unchanged and fail-closed. `GUEST_ROLE_NAME` defaults to `Public` (`superset/config.py:2901`) and `('can_view_query', 'Dashboard')` is not in `PUBLIC_ROLE_PERMISSIONS`, so out of the box a guest still gets no SQL. Exposing it is an explicit operator decision to grant a view-menu permission to the embedded role, which `SECURITY.md` lists as a supported deployment choice.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: **View query** on an embedded dashboard opens an empty modal.
After: the generated SQL is shown when the embedded role holds `can view query` on `Dashboard`; without it the SQL is still withheld.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/charts/test_chart_data_api.py
pytest tests/integration_tests/charts/data/api_tests.py -k guest
```

New coverage:

- a permitted guest keeps `query` in the payload;
- a permitted guest still gets its `error` sanitized and `stacktrace` stripped;
- a guest without the permission still has `query` removed (existing tests, now explicit about the permission state).

Manually: embed a dashboard with a guest token whose role has `can view query` on `Dashboard`, open a chart's ⋯ menu → **View query**, and confirm the SQL renders. Remove the permission and confirm the menu item disappears.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43100
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Note: the Python tests were not executed locally (no working Superset virtualenv on the authoring machine) and rely on CI; `ruff format` and `ruff check` are clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)