### PR TITLE
fix(pivot-table): build conditional formatting scales from the rendered values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -35,7 +35,12 @@ import {
   ConditionalFormattingConfig,
   getColorFormatters,
 } from '@superset-ui/chart-controls';
-import { DateFormatter, PivotTableQueryFormData, QueryData } from '../types';
+import {
+  DateFormatter,
+  MetricsLayoutEnum,
+  PivotTableQueryFormData,
+  QueryData,
+} from '../types';
 import buildGroupbyCombinations, {
   additiveReducerFor,
   allMetricsAdditive,
@@ -219,9 +224,39 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
       config.colorScheme !== ColorSchemeEnum.Green &&
       config.colorScheme !== ColorSchemeEnum.Red,
   );
+  // Conditional formatting colors the values the pivot renders -- the leaf
+  // cells *and* every subtotal cell -- so the reference distribution a color
+  // scale is built from has to be that same set of values, not the raw rows of
+  // the response. Feeding it raw rows makes the scale disagree with the cells:
+  // the additive path returns leaf rows only, so subtotal cells fall outside
+  // the scale's [min, max] and end up with no color at all even though they
+  // are the largest values in their column, while the GROUPING SETS path
+  // returns every rollup level, so the grand total inflates the domain and
+  // squashes the leaf cells. Either way colors stop tracking value order
+  // within a column. `data` already holds one frame per rollup level, so use
+  // those frames -- minus the levels that only feed the "Total" row/column,
+  // which TableRenderers never color formats.
+  //
+  // The metric pseudo-dimension always occupies one axis, so it is the *other*
+  // axis that decides: a level whose prefix there is fully collapsed lands in
+  // the uncolored total row/column. A dimension list that is empty to begin
+  // with is itself the leaf level, so it still renders as value cells.
+  const displayRows = ensureIsArray(
+    transposePivot ? groupbyColumns : groupbyRows,
+  );
+  const displayColumns = ensureIsArray(
+    transposePivot ? groupbyRows : groupbyColumns,
+  );
+  const isColorFormattedLevel = ({ groupby }: QueryData) =>
+    metricsLayout === MetricsLayoutEnum.ROWS
+      ? groupby.columns.length > 0 || displayColumns.length === 0
+      : groupby.rows.length > 0 || displayRows.length === 0;
+  const colorFormattedValues = data
+    .filter(isColorFormattedLevel)
+    .flatMap(({ data: levelData }) => levelData);
   const metricColorFormatters = getColorFormatters(
     pivotConditionalFormatting,
-    mainQuery.data,
+    colorFormattedValues,
     theme,
   );
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -397,6 +397,94 @@ test('should map conditional formatting rules to metricColorFormatters with corr
   ).toEqual('#5ac189FF');
 });
 
+/**
+ * Color scales must be built from the values the pivot renders (leaf cells and
+ * subtotal cells alike), not from the raw response rows. See issue #43084:
+ * with the reference distribution taken from the leaf rows only, a subtotal
+ * cell -- the largest value in its column -- fell outside the scale's
+ * [min, max] and got no color at all, while smaller leaf cells were colored.
+ */
+const colorScaleChartProps = (conditionalFormatting: unknown[]) =>
+  new ChartProps<QueryFormData>({
+    formData: {
+      ...formData,
+      combineMetric: false,
+      transposePivot: false,
+      metricsLayout: MetricsLayoutEnum.ROWS,
+      groupbyRows: ['region', 'city'],
+      groupbyColumns: [],
+      rowSubTotals: true,
+      colTotals: true,
+      rowTotals: false,
+      conditionalFormatting,
+      metrics: [
+        {
+          expressionType: 'SIMPLE',
+          aggregate: 'SUM',
+          column: { column_name: 'v' },
+          label: 'v',
+        },
+      ],
+    } as unknown as QueryFormData,
+    width: 800,
+    height: 600,
+    queriesData: [
+      {
+        data: [
+          { region: 'A', city: 'A1', v: 10 },
+          { region: 'A', city: 'A2', v: 5 },
+          { region: 'B', city: 'B1', v: 3 },
+        ],
+        colnames: ['region', 'city', 'v'],
+        coltypes: [1, 1, 0],
+      },
+    ],
+    hooks: { setDataMask },
+    filterState: { selectedFilters: {} },
+    datasource: { verboseMap: {}, columnFormats: {} },
+    theme: supersetTheme,
+  });
+
+const alphaOf = (color: string | undefined) => {
+  expect(typeof color).toBe('string');
+  return parseInt((color as string).slice(-2), 16);
+};
+
+test('color scale covers subtotal cell values, not just leaf rows (#43084)', () => {
+  const result = transformProps(
+    colorScaleChartProps([
+      { colorScheme: '#FF0000', column: 'v', operator: 'None' },
+    ]),
+  );
+  const { getColorFromValue } = result.metricColorFormatters[0];
+  // Rendered cells: leaves 3/5/10, region subtotal A = 15, grand total 18.
+  const alphas = [3, 5, 10, 15, 18].map(value =>
+    alphaOf(getColorFromValue(value)),
+  );
+  expect(alphas).toEqual([...alphas].sort((a, b) => a - b));
+  // The subtotal is the darkest cell in the column, not an uncolored one.
+  expect(alphas[3]).toBeGreaterThan(alphas[2]);
+});
+
+test('bounded color scale gradient spans the rendered cell values (#43084)', () => {
+  const result = transformProps(
+    colorScaleChartProps([
+      { colorScheme: '#FF0000', column: 'v', operator: '>', targetValue: 0 },
+    ]),
+  );
+  const { getColorFromValue } = result.metricColorFormatters[0];
+  const alphas = [3, 5, 10, 15, 18].map(value =>
+    alphaOf(getColorFromValue(value)),
+  );
+  // Strictly increasing: no cell saturates early because the gradient's
+  // extreme is the largest rendered value rather than the largest leaf row.
+  alphas.forEach((alpha, i) => {
+    if (i > 0) {
+      expect(alpha).toBeGreaterThan(alphas[i - 1]);
+    }
+  });
+});
+
 test('additive metrics: synthesizes rollup levels from a single leaf query', () => {
   const additiveFormData = {
     ...formData,


### PR DESCRIPTION
### SUMMARY

Conditional formatting on a Pivot Table produced background colors that don't track value order within a column: some cells were darker than larger cells, and subtotal cells — the largest values in their column — often had no background at all.

The color scale was built from the **raw rows of the query response** rather than from the values the chart renders. `transformProps` passed `mainQuery.data` to `getColorFormatters`, which derives the reference distribution as `data.map(row => row[config.column])` and takes min/max from it (`getColorFormatters.ts:116-117`, `:325`). The rendered cells are the per-rollup-level pre-aggregated values, so the two sets disagree — and they disagree differently per query path:

- **additive fast path** — returns leaf rows only, so every subtotal cell sits outside `[min, max]` and `Comparator.None` returns `false` → the cell gets no color (`getColorFormatters.ts:118-120`);
- **GROUPING SETS path** — returns every rollup level, so the grand total inflates the domain and squashes the leaf cells into a narrow alpha band;
- **bounded comparators** (`>`, `<`, …) fail symmetrically: the gradient extreme is a leaf row, so every cell beyond it clamps to `MAX_OPACITY` (`:62-71`) and the cells become indistinguishable.

This is measurable in the reporter's screenshot. Pixel-sampling the colored cells gives alphas of 0.112 / 0.160 / 0.218 for −193k / −370k / −545k, which fits `0.05 + 0.95·|v|/3.06M` — the gradient extreme is −3.06M, a *subtotal* value present in the domain only because rollup rows were in the reference data, while those subtotal cells themselves render with no background.

The fix builds the distribution from the per-level frames the renderer consumes, excluding the levels that only feed the uncolored "Total" row/column. Which axis decides that depends on `metricsLayout`, since the metric pseudo-dimension always occupies one axis.

Checked and rejected as causes: formatter key matching (`keys = [...rowKey, ...colKey]` works because `METRIC_KEY` is part of the axis) and non-numeric values poisoning the domain (possible in theory, not what happens here).

**Scope:** this fixes only issue 1 (the formatting bug). Issue 2 in the same report — ellipsis truncation for long row labels — needs a new chart control plus styling and does not belong in a bug-fix PR, so the issue stays open for it. Hence *Addresses* rather than *Fixes*.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: subtotal cells uncolored while smaller leaf cells are shaded; alphas don't follow value order.
After: every rendered value is colored, and alpha increases with magnitude across leaf and subtotal cells alike.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-pivot-table
```

109 tests across 9 suites pass. Two new tests name #43084 and both were confirmed to **fail** on unpatched source: one asserts a `None` color scale colors every rendered value (leaves 3/5/10, subtotal 15, total 18) with non-decreasing alpha and the subtotal darkest; the other asserts a bounded (`>`) gradient is strictly increasing rather than saturating early (`Expected > 255, Received 255` before the fix).

Manually: build a Pivot Table with row subtotals enabled, add a conditional formatting rule on a metric column, and confirm the shading increases monotonically with the values, subtotals included.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Addresses #43084
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)