### PR TITLE
fix(docker): keep C toolchain headers out of the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -194,14 +194,17 @@ COPY scripts/check-env.py scripts/
 # keeping for backward compatibility
 COPY --chmod=755 ./docker/entrypoints/run-server.sh /usr/bin/
 
-# Some debian libs
+# Some debian libs. Only runtime shared libraries belong here: the matching
+# `-dev` packages drag in a full C toolchain (libc6-dev, linux-libc-dev,
+# libssl-dev, ...) that no final image needs. Stages that compile native Python
+# extensions install the headers they require themselves.
 RUN /app/docker/apt-install.sh \
       curl \
-      libsasl2-dev \
+      libsasl2-2 \
       libsasl2-modules-gssapi-mit \
-      libpq-dev \
-      libecpg-dev \
-      libldap2-dev
+      libpq5 \
+      libecpg6 \
+      libldap2
 
 # Create data directory for DuckDB examples database
 # The database file will be created at runtime when examples are loaded from Parquet files
@@ -250,11 +253,17 @@ USER superset
 ######################################################################
 FROM python-common AS dev
 
-# Debian libs needed for dev
+# Debian libs needed for dev, including the headers required to build the
+# native extensions in requirements/development.txt (python-ldap needs
+# libldap2-dev/libsasl2-dev, mysqlclient needs default-libmysqlclient-dev) and
+# to let contributors build source distributions such as psycopg2.
 RUN /app/docker/apt-install.sh \
     git \
     pkg-config \
-    default-libmysqlclient-dev
+    default-libmysqlclient-dev \
+    libsasl2-dev \
+    libldap2-dev \
+    libpq-dev
 
 # Copy development requirements and install them
 COPY requirements/*.txt requirements/


### PR DESCRIPTION
### SUMMARY

The `lean` runtime image shipped a full set of C development packages. `python-common` — the shared ancestor of `lean`, `dev`, `ci` and `showtime` — installed `libsasl2-dev`, `libpq-dev`, `libldap2-dev` and `libecpg-dev`; `apt-mark showmanual` inside the built `lean` image confirms those four are the only manually installed offenders, with `libc6-dev`, `libc-dev-bin`, `libcrypt-dev`, `linux-libc-dev`, `libssl-dev` and `libldap-dev` arriving as their auto-deps. `pip-install.sh` already purges `build-essential`, but never touched these.

Each `-dev` package is replaced with its runtime shared library in `python-common`, and the headers move to the `dev` stage, which is where native extensions are actually compiled:

| Package | Verdict | Action |
|---|---|---|
| `libsasl2-dev` | build-only (headers for `python-ldap`) | → `libsasl2-2`; `-dev` moved to `dev` |
| `libpq-dev` | build-only (the `postgres` extra is `psycopg2-binary`, which bundles libpq) | → `libpq5`; `-dev` moved to `dev` |
| `libldap2-dev` | build-only (headers for `python-ldap`, `development.txt` only) | → `libldap2`; `-dev` moved to `dev` |
| `libecpg-dev` | build-only (no Python driver links ECPG) | → `libecpg6`; not re-added |
| `libc6-dev`, `libc-dev-bin`, `libcrypt-dev`, `linux-libc-dev`, `libssl-dev`, `libldap-dev` | build-only, transitive auto-deps of the above | dropped automatically |
| `libsasl2-modules-gssapi-mit` | **runtime-required** (Kerberos/GSSAPI SASL plugin) | kept |
| `curl` | **runtime-required** (healthcheck) | kept |

Four packages from the report — `libpython3.11-dev`, `python3.11-dev`, `zlib1g-dev`, `libexpat1-dev` — are **not present** in a current `master` `lean` build. The base image builds CPython from source, so Debian's `python3.11-dev` isn't in the tree at all; those entries most likely come from an older base image or a Chromium/Playwright-enabled build. No action taken rather than a speculative one.

On the npm side: `devlop` is a genuine **production** dependency (22 dependents in `package-lock.json` — `react-markdown`, `micromark`, `mdast-util-*`), and `preact-devtools` does not exist in the lock file at all, almost certainly a scanner mis-attribution of the `preact/devtools` submodule path. Worth noting for the reporter: `node_modules` is never copied into a final image — `python-common` takes only `superset/static/assets`, `service-worker.js` and `superset/translations` from the node stage — so those names can reach an SBOM through bundled JS, not as installed packages.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

`--target lean`, built locally on amd64:

| | before | after |
|---|---|---|
| `-dev`/`dev-bin` packages | 10 | **0** |
| total packages | 126 | 114 |
| image size | 1.21 GB | 1.14 GB |

No `gcc`, `cc`, `make` or `ld` in either. `libpq5`, `libldap2`, `libsasl2-2`, `libsasl2-modules-gssapi-mit`, `libecpg6`, `libssl3t64` and `zlib1g` are all still installed.

### TESTING INSTRUCTIONS

```bash
docker build --target lean -t superset-lean .
docker run --rm superset-lean bash -lc "dpkg -l | grep -E '\-dev|dev-bin'"   # no output
docker run --rm superset-lean bash -lc "superset version"
```

Verified locally (Docker 29.6.1, builds used `--build-arg DEV_MODE=true` to skip webpack, which touches no apt layer):

- `lean` runtime: `import superset, flask, sqlalchemy` and `import ssl, zlib, sqlite3` all fine; `superset version` prints, exercising the full app import path.
- `ci` target builds; `psycopg2 2.9.12` and `duckdb 1.5.5` import, and a real `duckdb:///:memory:` SQLAlchemy query returns.
- `dev` target builds; `ldap 3.4.7`, `MySQLdb`, `psycopg2` and `superset` all import — so `python-ldap` and `mysqlclient` still compile against the headers in their new location.

Not verified: `linux/arm64` (only the local amd64 platform was built); a full `DEV_MODE=false` frontend build, so the emitted `static/assets` were not scanned for `devlop`/`preact` strings — that conclusion rests on lock-file dependency flags and the `COPY --from=superset-node` scope. The `showtime` target wasn't built, but it is `lean` + `.[duckdb]`, a strict subset of the `ci` target that was.

One honest side effect: installing `libssl-dev` used to incidentally upgrade `libssl3t64` from the base image's `3.5.4` to `3.5.6`. Without it the image keeps the pinned base image's `3.5.4`. That is the ordinary consequence of not pulling in extra packages and resolves whenever `PY_VER` is bumped, but a scanner diffing before/after will see that one version move backwards.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43002
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)