### PR TITLE
fix(postprocessing): keep operation signatures visible through validate_column_args

### DIFF
--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from collections.abc import Sequence
-from functools import partial
+from functools import partial, wraps
 from typing import Any, Callable
 
 import numpy as np
@@ -122,6 +122,13 @@ def scalar_to_sequence(val: Any) -> Sequence[str]:
 
 def validate_column_args(*argnames: str) -> Callable[..., Any]:
     def wrapper(func: Callable[..., Any]) -> Callable[..., Any]:
+        # `wraps` carries over `__name__`, `__doc__` and, crucially, sets
+        # `__wrapped__`, so `inspect.signature` reports the decorated operation's
+        # own parameters rather than the wrapper's `(df, **options)`. Without it
+        # every decorated operation looks like it accepts arbitrary keywords,
+        # which hides the signature from any caller that wants to tell a
+        # supported option from one a stored query kept past its removal.
+        @wraps(func)
         def wrapped(df: DataFrame, **options: Any) -> Any:
             if _is_multi_index_on_columns(df):
                 # MultiIndex column validate first level

--- a/tests/unit_tests/utils/pandas_postprocessing/validate_column_args_tests.py
+++ b/tests/unit_tests/utils/pandas_postprocessing/validate_column_args_tests.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import inspect
+
+from superset.utils import pandas_postprocessing
+from superset.utils.pandas_postprocessing.utils import validate_column_args
+
+
+def test_decorated_operation_keeps_its_identity() -> None:
+    """
+    Stored query_context blobs can carry options an operation no longer accepts, and
+    telling those apart means introspecting the operation. `validate_column_args`
+    used to return a bare `wrapped(df, **options)`, so every decorated operation
+    advertised arbitrary keywords and its real signature was unreachable (#42926).
+    """
+    assert pandas_postprocessing.pivot.__name__ == "pivot"
+
+    parameters = inspect.signature(pandas_postprocessing.pivot).parameters
+    assert "index" in parameters
+    assert "aggregates" in parameters
+    # the wrapper's own catch-all is no longer what callers see
+    assert "options" not in parameters
+
+
+def test_removed_option_is_visible_as_unsupported() -> None:
+    """
+    `flatten_columns` and `reset_index` were removed from `pivot` when flattening
+    became its own operation. With the signature restored, a caller can see that a
+    stored option is no longer supported instead of only finding out via TypeError.
+    """
+    parameters = inspect.signature(pandas_postprocessing.pivot).parameters
+
+    assert "flatten_columns" not in parameters
+    assert "reset_index" not in parameters
+
+
+def test_validation_still_rejects_unknown_columns() -> None:
+    import pandas as pd
+    import pytest
+
+    from superset.exceptions import InvalidPostProcessingError
+
+    @validate_column_args("columns")
+    def operation(df: pd.DataFrame, **options: object) -> pd.DataFrame:
+        return df
+
+    df = pd.DataFrame({"present": [1]})
+
+    assert operation(df, columns=["present"]) is df
+    with pytest.raises(InvalidPostProcessingError):
+        operation(df, columns=["absent"])
+
+
+def test_docstring_is_preserved() -> None:
+    assert pandas_postprocessing.pivot.__doc__
+    assert "pivot operation" in pandas_postprocessing.pivot.__doc__


### PR DESCRIPTION
### SUMMARY

`validate_column_args` returned a bare `wrapped(df, **options)` without `functools.wraps`, so every decorated post-processing operation lost its `__name__`, `__doc__` and signature. `inspect.signature(pandas_postprocessing.pivot)` reported the wrapper's `(df, **options)` catch-all rather than `index`, `aggregates` and the rest — every operation looked like it accepts arbitrary keywords.

That matters beyond tidiness. As #42926 describes, a chart's stored `query_context` is never migrated, so it can carry options an operation has since dropped — `pivot` no longer takes `flatten_columns` or `reset_index` — and replaying one raises `TypeError` from deep inside pandas on every non-Explore path (chart data API, alerts and reports, thumbnails, cache warm-up, CSV/Excel export, MCP tools). Any attempt to spot a stale option by introspection needs the real signature to be reachable first, and the missing `wraps` is precisely what hides it.

**Scope:** this is the secondary defect called out in #42926. The missing `query_context` migration itself is *not* addressed here — that is a larger design question also tracked in #33152 and #31872 — so this says *Addresses* rather than *Fixes* and leaves the issue open.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

```python
>>> inspect.signature(pandas_postprocessing.pivot)
(df: DataFrame, **options: Any)                       # before
(df, index, aggregates, columns=None, metric_fill_value=None, ...)   # after
```

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/utils/pandas_postprocessing/validate_column_args_tests.py
pytest tests/unit_tests/pandas_postprocessing tests/unit_tests/utils/pandas_postprocessing
```

New tests assert the operation keeps its name and docstring, that its real parameters are introspectable, that the removed `flatten_columns` / `reset_index` are visibly absent, and that column validation still rejects unknown columns. Locally: 4 passed for the new file and **110 passed** across the post-processing suites.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Addresses #42926
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)