### PR TITLE
fix(export): cap export filenames so archives extract on Windows

### DIFF
--- a/superset/utils/file.py
+++ b/superset/utils/file.py
@@ -23,6 +23,11 @@ from werkzeug.utils import secure_filename
 # SMTP headers, Content-Disposition filenames, and headless-browser document.title.
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
+# Cap for a single export filename, well under the 255-character limit a path
+# component has on Windows and Linux, leaving room for the directories and the
+# extension wrapped around it inside the archive.
+MAX_FILENAME_LENGTH = 200
+
 
 def sanitize_title(title: str) -> str:
     """Remove all C0/C1 control characters from a title string."""
@@ -32,5 +37,13 @@ def sanitize_title(title: str) -> str:
 def get_filename(model_name: str, model_id: int, skip_id: bool = False) -> str:
     model_name = sanitize_title(model_name)
     slug = secure_filename(model_name)
-    filename = slug if skip_id else f"{slug}_{model_id}"
-    return filename if slug else str(model_id)
+    suffix = "" if skip_id else f"_{model_id}"
+    # The name goes into a ZIP entry that already carries an
+    # `<asset>_export_<timestamp>/<type>/` prefix and a `.yaml` suffix, and the
+    # user's own extraction directory sits in front of all of it. A chart titled
+    # with a couple of hundred characters therefore produced an entry Windows
+    # refuses to extract, even though the archive itself was written fine. Trim
+    # the slug rather than the id: the id is what keeps two similarly titled
+    # assets from colliding inside one archive.
+    slug = slug[: max(MAX_FILENAME_LENGTH - len(suffix), 0)].rstrip("._-")
+    return f"{slug}{suffix}" if slug else str(model_id)

--- a/tests/unit_tests/utils/test_file.py
+++ b/tests/unit_tests/utils/test_file.py
@@ -16,7 +16,7 @@
 # under the License.
 import pytest
 
-from superset.utils.file import get_filename, sanitize_title
+from superset.utils.file import get_filename, MAX_FILENAME_LENGTH, sanitize_title
 
 
 @pytest.mark.parametrize(
@@ -44,6 +44,37 @@ def test_get_filename(
 ) -> None:
     original_filename = get_filename(model_name, model_id, skip_id)
     assert expected_filename == original_filename
+
+
+@pytest.mark.parametrize("skip_id", [False, True])
+def test_get_filename_is_capped(skip_id: bool) -> None:
+    """
+    A 250-character chart title produced a ZIP entry Windows refuses to extract,
+    even though the archive was written successfully (#42531).
+    """
+    filename = get_filename("A" * 250, 132, skip_id)
+
+    assert len(filename) <= MAX_FILENAME_LENGTH
+    assert filename.startswith("A")
+
+
+def test_get_filename_keeps_the_id_when_truncating() -> None:
+    """The id disambiguates similarly titled assets, so it must survive."""
+    filename = get_filename("A" * 250, 132)
+
+    assert filename.endswith("_132")
+    assert len(filename) <= MAX_FILENAME_LENGTH
+
+
+def test_get_filename_does_not_end_on_a_separator() -> None:
+    """Truncation must not leave a trailing separator before the extension."""
+    filename = get_filename("A" * 199 + "._-" + "B" * 50, 7, skip_id=True)
+
+    assert not filename.endswith((".", "_", "-"))
+
+
+def test_get_filename_leaves_short_names_alone() -> None:
+    assert get_filename("Energy Sankey", 132) == "Energy_Sankey_132"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

Exporting a chart whose title is a couple of hundred characters long produces a ZIP that Windows cannot extract. The archive itself is written fine — which is why the export appears to succeed and only fails at unzip time.

`get_filename` (`superset/utils/file.py`) builds `{slug}_{id}` from the full asset title with no length limit:

```python
slug = secure_filename(model_name)
filename = slug if skip_id else f"{slug}_{model_id}"
```

The resulting name goes into a ZIP entry that already carries an `<asset>_export_<timestamp>/<type>/` prefix and a `.yaml` suffix, with the user's own extraction directory in front of all of it.

This caps the name at 200 characters — comfortably under the 255-character limit a single path component has — leaving room for the directories and extension wrapped around it. The **slug** is trimmed, never the id: the id is what stops two similarly titled assets colliding inside one archive. Any separator left dangling at the cut (`.`, `_`, `-`) is stripped so the name doesn't run straight into the extension.

`get_filename` is the single chokepoint for chart, dashboard, database, dataset and theme exports, so one fix covers all of them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

For a 250-character chart title, entry name inside the archive:

| | length |
|---|---|
| before | 254 (+ prefix and `.yaml`) → extraction fails on Windows |
| after | 200, ending in `_132` |

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/utils/test_file.py
pytest tests/unit_tests/commands -k export
```

New cases cover the cap with and without the id, that the id survives truncation, that no separator is left trailing, and that short names are untouched. Locally: **27 passed** in `test_file.py` (was 22) and **70 passed** across the export command tests.

Note for reviewers: `test_get_filename[D:\Charts\Energy Sankey-...]` fails on a Windows dev machine both before and after this change — `secure_filename` treats `\` as a path separator there but not on Linux — so it is platform-dependent and untouched here.

Manually: name a chart ~250 characters, export it, and extract the ZIP on Windows.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42531
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)