### PR TITLE
fix(dataset): preserve legacy default dashboard URLs

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -1627,9 +1627,7 @@ function DatasourceEditor({
               {t(
                 'Default URL to redirect to when accessing from the dataset list page. Accepts relative URLs such as',
               )}{' '}
-              <Typography.Text code>
-                /superset/dashboard/{'{id}'}/
-              </Typography.Text>
+              <Typography.Text code>/dashboard/{'{id}'}/</Typography.Text>
             </>
           }
           control={<TextControl controlId="default_endpoint" />}

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
@@ -74,7 +74,7 @@ test('renders Tabs', async () => {
 test('recommends a registered client route for the default URL', async () => {
   await asyncRender(createProps());
 
-  userEvent.click(screen.getByTestId('collection-tab-Settings'));
+  userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
 
   expect(await screen.findByText('/dashboard/{id}/')).toBeInTheDocument();
   expect(

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx
@@ -71,6 +71,17 @@ test('renders Tabs', async () => {
   expect(screen.getByTestId('edit-dataset-tabs')).toBeInTheDocument();
 });
 
+test('recommends a registered client route for the default URL', async () => {
+  await asyncRender(createProps());
+
+  userEvent.click(screen.getByTestId('collection-tab-Settings'));
+
+  expect(await screen.findByText('/dashboard/{id}/')).toBeInTheDocument();
+  expect(
+    screen.queryByText('/superset/dashboard/{id}/'),
+  ).not.toBeInTheDocument();
+});
+
 test('can sync columns from source', async () => {
   const testProps = createProps();
   await asyncRender({

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -1157,6 +1157,34 @@ test('dataset links use internal routing when PREVENT_UNSAFE_DEFAULT_URLS_ON_DAT
   });
 });
 
+test('legacy dashboard default URLs use the registered client route', async () => {
+  const dataset = {
+    ...mockDatasets[0],
+    explore_url: '/superset/dashboard/123/?standalone=1#section',
+  };
+  mockDatasetListEndpoints({ result: [dataset], count: 1 });
+
+  renderDatasetList(
+    mockAdminUser,
+    {},
+    {
+      common: {
+        conf: {
+          PREVENT_UNSAFE_DEFAULT_URLS_ON_DATASET: true,
+        },
+      },
+    },
+  );
+
+  const datasetLink = await screen.findByRole('link', {
+    name: dataset.table_name,
+  });
+  expect(datasetLink).toHaveAttribute(
+    'href',
+    '/dashboard/123/?standalone=1#section',
+  );
+});
+
 // Note: These delete error tests verify that the modal doesn't open when fetching
 // related_objects fails. The component's openDatasetDeleteModal error handler
 // (index.tsx:262-268) returns a string but doesn't call addDangerToast(), so no

--- a/superset-frontend/src/pages/DatasetList/DatasetList.subdirectory.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.subdirectory.test.tsx
@@ -124,9 +124,13 @@ test('explore link is single-prefixed under a subdirectory deployment', async ()
 });
 
 test('legacy dashboard default URL uses the router basename once', async () => {
+  // A subdirectory user pastes the full browser path, so the saved value
+  // carries both the application root and the legacy `/superset` prefix.
+  // stripAppRoot removes the root and the legacy normalization removes the
+  // prefix, leaving the basename to re-add the root exactly once.
   const dataset = {
     ...mockDatasets[0],
-    explore_url: '/superset/dashboard/123/?standalone=1#section',
+    explore_url: `${APP_ROOT}/superset/dashboard/123/?standalone=1#section`,
   };
   mockDatasetListEndpoints({ result: [dataset], count: 1 });
 

--- a/superset-frontend/src/pages/DatasetList/DatasetList.subdirectory.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.subdirectory.test.tsx
@@ -54,10 +54,18 @@ import {
 
 const APP_ROOT = '/superset';
 
-const renderUnderSubdirectory = () => {
+const renderUnderSubdirectory = (preventUnsafeDefaultUrls = false) => {
+  const defaultState = createDefaultStoreState(mockAdminUser);
   const store = createMockStore({
-    ...createDefaultStoreState(mockAdminUser),
+    ...defaultState,
     user: mockAdminUser,
+    common: {
+      ...defaultState.common,
+      conf: {
+        ...defaultState.common?.conf,
+        PREVENT_UNSAFE_DEFAULT_URLS_ON_DATASET: preventUnsafeDefaultUrls,
+      },
+    },
   });
   return render(
     <Provider store={store}>
@@ -113,6 +121,27 @@ test('explore link is single-prefixed under a subdirectory deployment', async ()
     `${APP_ROOT}/explore/?datasource=1__table`,
   );
   expect(exploreLink.getAttribute('href')).not.toContain('/superset/superset');
+});
+
+test('legacy dashboard default URL uses the router basename once', async () => {
+  const dataset = {
+    ...mockDatasets[0],
+    explore_url: '/superset/dashboard/123/?standalone=1#section',
+  };
+  mockDatasetListEndpoints({ result: [dataset], count: 1 });
+
+  renderUnderSubdirectory(true);
+
+  const dashboardLink = await screen.findByRole('link', {
+    name: dataset.table_name,
+  });
+  expect(dashboardLink).toHaveAttribute(
+    'href',
+    `${APP_ROOT}/dashboard/123/?standalone=1#section`,
+  );
+  expect(dashboardLink.getAttribute('href')).not.toContain(
+    '/superset/superset',
+  );
 });
 
 test('external default_endpoint passes through unprefixed', async () => {

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -87,7 +87,6 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import { Icons } from '@superset-ui/core/components/Icons';
 import WarningIconWithTooltip from '@superset-ui/core/components/WarningIconWithTooltip';
 import { isUserEditorOrAdmin } from 'src/dashboard/util/permissionUtils';
-
 import {
   PAGE_SIZE,
   SORT_BY,
@@ -113,6 +112,10 @@ import type {
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 import type User from 'src/types/User';
+
+// Keep saved Default URLs compatible with the prefix-free SPA route.
+const normalizeLegacyDashboardUrl = (url: string) =>
+  url.replace(/^\/superset(?=\/dashboard(?:\/|$))/, '');
 
 const SEMANTIC_LAYERS_FLAG = 'SEMANTIC_LAYERS' as FeatureFlag;
 type DatasetExtra = {
@@ -722,7 +725,9 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
           // Router basename, which re-prefixes the root — so strip it here to
           // avoid a doubled `/superset/superset/...`. External
           // `default_endpoint` URLs pass through unchanged.
-          const exploreTo = stripAppRoot(exploreURL);
+          const exploreTo = normalizeLegacyDashboardUrl(
+            stripAppRoot(exploreURL),
+          );
           let titleLink: JSX.Element;
           if (PREVENT_UNSAFE_DEFAULT_URLS_ON_DATASET) {
             titleLink = (


### PR DESCRIPTION
### SUMMARY

The dataset editor recommended the legacy `/superset/dashboard/{id}/` path even though the frontend router registers `/dashboard/:idOrSlug/`. Update the example to the registered route and normalize existing saved legacy dashboard Default URLs before passing them to React Router, preserving query strings and fragments.

This intentionally handles the known legacy dashboard path rather than adding a global fallback for every unmatched frontend URL. A general fallback needs broader routing ownership and behavior decisions because the existing route detector does not pattern-match parameterized routes; it is better handled separately than expanded into this focused compatibility fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** following the Default URL help text and clicking the dataset name navigated to `/superset/dashboard/<id>/`, leaving only the persistent navigation bar and a blank page.

**After:** the help text recommends `/dashboard/{id}/`. Existing datasets saved with `/superset/dashboard/<id>/` are transparently routed to `/dashboard/<id>/`, so the dashboard renders instead of the blank shell.

### TESTING INSTRUCTIONS

1. Edit a dataset and open the Settings tab; verify Default URL recommends `/dashboard/{id}/`.
2. Save `/superset/dashboard/<valid-dashboard-id>/?standalone=1` as its Default URL.
3. From the Datasets list, click the dataset name.
4. Verify the dashboard loads at `/dashboard/<valid-dashboard-id>/?standalone=1`.
5. Run:
   - `npm test -- --runInBand src/pages/DatasetList/DatasetList.listview.test.tsx src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditor.test.tsx`

Regression coverage verifies both the canonical help text and navigation of a saved legacy URL, including its query string and fragment.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `PREVENT_UNSAFE_DEFAULT_URLS_ON_DATASET` (enabled by default)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
