### PR TITLE
fix(users): show password validation errors

### DIFF
--- a/superset-frontend/src/features/users/UserListModal.test.tsx
+++ b/superset-frontend/src/features/users/UserListModal.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Actions } from 'src/constants';
+import { handleUserError } from './UserListModal';
+
+test('shows the password validation message from a 400 response', async () => {
+  const error = new Response(
+    JSON.stringify({
+      message: {
+        password: ['Password must be at least 8 characters long.'],
+      },
+    }),
+    { status: 400 },
+  );
+  const addDangerToast = jest.fn();
+
+  await expect(
+    handleUserError(error, Actions.CREATE, addDangerToast),
+  ).rejects.toBe(error);
+  expect(addDangerToast).toHaveBeenCalledWith(
+    'Password must be at least 8 characters long.',
+  );
+});
+
+test('keeps the duplicate username message for a 422 response', async () => {
+  const error = new Response(
+    JSON.stringify({
+      message:
+        'duplicate key value violates unique constraint "ab_user_username_key"',
+    }),
+    { status: 422 },
+  );
+  const addDangerToast = jest.fn();
+
+  await expect(
+    handleUserError(error, Actions.CREATE, addDangerToast),
+  ).rejects.toBe(error);
+  expect(addDangerToast).toHaveBeenCalledWith(
+    'This username is already taken. Please choose another one.',
+  );
+});

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -31,7 +31,12 @@ import {
 import { Group, Role, UserObject } from 'src/pages/UsersList/types';
 import { Actions } from 'src/constants';
 import { BaseUserListModalProps, FormValues } from './types';
-import { createUser, updateUser, atLeastOneRoleOrGroup } from './utils';
+import {
+  createUser,
+  updateUser,
+  atLeastOneRoleOrGroup,
+  handleUserError,
+} from './utils';
 
 export interface UserModalProps extends BaseUserListModalProps {
   roles: Role[];
@@ -39,48 +44,6 @@ export interface UserModalProps extends BaseUserListModalProps {
   user?: UserObject;
   groups: Group[];
 }
-
-type AddDangerToast = (message: string) => void;
-
-export const handleUserError = async (
-  err: Response,
-  action: Actions.CREATE | Actions.UPDATE,
-  addDangerToast: AddDangerToast,
-): Promise<never> => {
-  let errorMessage =
-    action === Actions.CREATE
-      ? t('There was an error creating the user. Please, try again.')
-      : t('There was an error updating the user. Please, try again.');
-
-  if (err.status === 400 || err.status === 422) {
-    const { message }: { message?: unknown } = await err.json();
-
-    if (err.status === 400 && message && typeof message === 'object') {
-      const validationMessages = Object.values(message).flat();
-      const detail = validationMessages.find(
-        validationMessage => typeof validationMessage === 'string',
-      );
-      if (detail) {
-        errorMessage = detail;
-      }
-    } else if (err.status === 422 && typeof message === 'string') {
-      if (message.includes('duplicate key value')) {
-        if (message.includes('ab_user_username_key')) {
-          errorMessage = t(
-            'This username is already taken. Please choose another one.',
-          );
-        } else if (message.includes('ab_user_email_key')) {
-          errorMessage = t(
-            'This email is already associated with an account. Please choose another one.',
-          );
-        }
-      }
-    }
-  }
-
-  addDangerToast(errorMessage);
-  throw err;
-};
 
 function UserListModal({
   show,

--- a/superset-frontend/src/features/users/UserListModal.tsx
+++ b/superset-frontend/src/features/users/UserListModal.tsx
@@ -40,6 +40,48 @@ export interface UserModalProps extends BaseUserListModalProps {
   groups: Group[];
 }
 
+type AddDangerToast = (message: string) => void;
+
+export const handleUserError = async (
+  err: Response,
+  action: Actions.CREATE | Actions.UPDATE,
+  addDangerToast: AddDangerToast,
+): Promise<never> => {
+  let errorMessage =
+    action === Actions.CREATE
+      ? t('There was an error creating the user. Please, try again.')
+      : t('There was an error updating the user. Please, try again.');
+
+  if (err.status === 400 || err.status === 422) {
+    const { message }: { message?: unknown } = await err.json();
+
+    if (err.status === 400 && message && typeof message === 'object') {
+      const validationMessages = Object.values(message).flat();
+      const detail = validationMessages.find(
+        validationMessage => typeof validationMessage === 'string',
+      );
+      if (detail) {
+        errorMessage = detail;
+      }
+    } else if (err.status === 422 && typeof message === 'string') {
+      if (message.includes('duplicate key value')) {
+        if (message.includes('ab_user_username_key')) {
+          errorMessage = t(
+            'This username is already taken. Please choose another one.',
+          );
+        } else if (message.includes('ab_user_email_key')) {
+          errorMessage = t(
+            'This email is already associated with an account. Please choose another one.',
+          );
+        }
+      }
+    }
+  }
+
+  addDangerToast(errorMessage);
+  throw err;
+};
+
 function UserListModal({
   show,
   onHide,
@@ -51,36 +93,6 @@ function UserListModal({
 }: UserModalProps) {
   const { addDangerToast, addSuccessToast } = useToasts();
   const handleFormSubmit = async (values: FormValues) => {
-    const handleError = async (
-      err: any,
-      action: Actions.CREATE | Actions.UPDATE,
-    ) => {
-      let errorMessage =
-        action === Actions.CREATE
-          ? t('There was an error creating the user. Please, try again.')
-          : t('There was an error updating the user. Please, try again.');
-
-      if (err.status === 422) {
-        const errorData = await err.json();
-        const detail = errorData?.message || '';
-
-        if (detail.includes('duplicate key value')) {
-          if (detail.includes('ab_user_username_key')) {
-            errorMessage = t(
-              'This username is already taken. Please choose another one.',
-            );
-          } else if (detail.includes('ab_user_email_key')) {
-            errorMessage = t(
-              'This email is already associated with an account. Please choose another one.',
-            );
-          }
-        }
-      }
-
-      addDangerToast(errorMessage);
-      throw err;
-    };
-
     if (isEditMode) {
       if (!user) {
         throw new Error('User is required in edit mode');
@@ -89,14 +101,14 @@ function UserListModal({
         await updateUser(user.id, values);
         addSuccessToast(t('The user has been updated successfully.'));
       } catch (err) {
-        await handleError(err, Actions.UPDATE);
+        await handleUserError(err as Response, Actions.UPDATE, addDangerToast);
       }
     } else {
       try {
         await createUser(values);
         addSuccessToast(t('The user has been created successfully.'));
       } catch (err) {
-        await handleError(err, Actions.CREATE);
+        await handleUserError(err as Response, Actions.CREATE, addDangerToast);
       }
     }
   };

--- a/superset-frontend/src/features/users/utils.test.ts
+++ b/superset-frontend/src/features/users/utils.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Actions } from 'src/constants';
-import { handleUserError } from './UserListModal';
+import { handleUserError } from './utils';
 
 test('shows the password validation message from a 400 response', async () => {
   const error = new Response(
@@ -53,5 +53,20 @@ test('keeps the duplicate username message for a 422 response', async () => {
   ).rejects.toBe(error);
   expect(addDangerToast).toHaveBeenCalledWith(
     'This username is already taken. Please choose another one.',
+  );
+});
+
+test('shows the generic message when a 400 response is not JSON', async () => {
+  const error = new Response('<html>Bad request</html>', {
+    status: 400,
+    headers: { 'Content-Type': 'text/html' },
+  });
+  const addDangerToast = jest.fn();
+
+  await expect(
+    handleUserError(error, Actions.CREATE, addDangerToast),
+  ).rejects.toBe(error);
+  expect(addDangerToast).toHaveBeenCalledWith(
+    'There was an error creating the user. Please, try again.',
   );
 });

--- a/superset-frontend/src/features/users/utils.test.ts
+++ b/superset-frontend/src/features/users/utils.test.ts
@@ -38,6 +38,21 @@ test('shows the password validation message from a 400 response', async () => {
   );
 });
 
+test('shows a plain string message from a 400 response', async () => {
+  const error = new Response(
+    JSON.stringify({ message: 'User must have at least one role or group!' }),
+    { status: 400 },
+  );
+  const addDangerToast = jest.fn();
+
+  await expect(
+    handleUserError(error, Actions.UPDATE, addDangerToast),
+  ).rejects.toBe(error);
+  expect(addDangerToast).toHaveBeenCalledWith(
+    'User must have at least one role or group!',
+  );
+});
+
 test('keeps the duplicate username message for a 422 response', async () => {
   const error = new Response(
     JSON.stringify({
@@ -53,6 +68,18 @@ test('keeps the duplicate username message for a 422 response', async () => {
   ).rejects.toBe(error);
   expect(addDangerToast).toHaveBeenCalledWith(
     'This username is already taken. Please choose another one.',
+  );
+});
+
+test('shows the generic message when a 422 response has no message', async () => {
+  const error = new Response(JSON.stringify({ foo: 'bar' }), { status: 422 });
+  const addDangerToast = jest.fn();
+
+  await expect(
+    handleUserError(error, Actions.CREATE, addDangerToast),
+  ).rejects.toBe(error);
+  expect(addDangerToast).toHaveBeenCalledWith(
+    'There was an error creating the user. Please, try again.',
   );
 });
 

--- a/superset-frontend/src/features/users/utils.ts
+++ b/superset-frontend/src/features/users/utils.ts
@@ -38,11 +38,11 @@ export const handleUserError = async (
     const errorData = await getClientErrorObject(err);
     const message: unknown = errorData.message;
 
-    if (err.status === 400 && message && typeof message === 'object') {
+    if (err.status === 400 && message && errorData.error) {
       errorMessage = errorData.error;
     } else if (
       err.status === 422 &&
-      errorData.error.includes('duplicate key value')
+      errorData.error?.includes('duplicate key value')
     ) {
       if (errorData.error.includes('ab_user_username_key')) {
         errorMessage = t(

--- a/superset-frontend/src/features/users/utils.ts
+++ b/superset-frontend/src/features/users/utils.ts
@@ -17,9 +17,48 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
-import { SupersetClient } from '@superset-ui/core';
+import { getClientErrorObject, SupersetClient } from '@superset-ui/core';
 import { SelectOption } from 'src/components/ListView';
+import { Actions } from 'src/constants';
 import { FormValues } from './types';
+
+type AddDangerToast = (message: string) => void;
+
+export const handleUserError = async (
+  err: Response,
+  action: Actions.CREATE | Actions.UPDATE,
+  addDangerToast: AddDangerToast,
+): Promise<never> => {
+  let errorMessage =
+    action === Actions.CREATE
+      ? t('There was an error creating the user. Please, try again.')
+      : t('There was an error updating the user. Please, try again.');
+
+  if (err.status === 400 || err.status === 422) {
+    const errorData = await getClientErrorObject(err);
+    const message: unknown = errorData.message;
+
+    if (err.status === 400 && message && typeof message === 'object') {
+      errorMessage = errorData.error;
+    } else if (
+      err.status === 422 &&
+      errorData.error.includes('duplicate key value')
+    ) {
+      if (errorData.error.includes('ab_user_username_key')) {
+        errorMessage = t(
+          'This username is already taken. Please choose another one.',
+        );
+      } else if (errorData.error.includes('ab_user_email_key')) {
+        errorMessage = t(
+          'This email is already associated with an account. Please choose another one.',
+        );
+      }
+    }
+  }
+
+  addDangerToast(errorMessage);
+  throw err;
+};
 
 export const createUser = async (values: FormValues) => {
   const { confirmPassword: _confirmPassword, ...payload } = values;


### PR DESCRIPTION
### SUMMARY

Surface field-level validation messages returned by the user API for HTTP 400 responses. Flask-AppBuilder uses 400 for Marshmallow validation errors such as password-complexity failures, while duplicate username/email database errors remain 422 and retain their existing friendly messages.

This keeps the API's established status-code contract intact rather than changing a shared Flask-AppBuilder endpoint. Client-side password-complexity checks are intentionally not duplicated because minimum length and blocklists are operator-configurable server policy.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Submitting a password shorter than the configured minimum showed the generic red toast: “There was an error creating the user. Please, try again.”

**After:** The same submission shows the server-provided reason in the red toast: “Password must be at least 8 characters long.” (The number follows the server's configured policy.)

### TESTING INSTRUCTIONS

1. Open **Settings → List Users → + User** as an administrator.
2. Complete the required fields and submit matching passwords shorter than the configured minimum.
3. Confirm the toast displays the specific minimum-length validation message and the user is not created.
4. Try creating a user with an existing username and confirm the existing friendly duplicate-username toast remains unchanged.

Automated test:

```bash
cd superset-frontend
npm run test -- src/features/users/utils.test.ts
```

The focused Jest suite passes (3 tests). Pre-commit formatting, linting, custom rules, and style checks pass. The targeted type-check hook cannot complete in this fresh worktree because generated `packages/*/lib` declarations have not been built; its reported errors are in unrelated existing files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

