### PR TITLE
fix(echarts): emit no cross-filter for clicks that are not categories

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eventHandlers.ts
@@ -47,12 +47,23 @@ const getCrossFilterDataMask =
   ) =>
   (value: string) => {
     const selected = Object.values(selectedValues);
-    let values: string[];
-    if (selected.includes(value)) {
-      values = selected.filter(v => v !== value);
-    } else {
-      values = [value];
+    const isCurrentValueSelected = selected.includes(value);
+
+    // Not every click lands on a real category. A pie renders its total as a
+    // graphic text when showTotal is on, rolls small sectors into an
+    // aggregated "Other" slice, and a sector can have an empty name -- none of
+    // which has a labelMap entry. Building a data mask from one produced
+    // filters with no values, and since `[].every(...)` is true, every groupby
+    // column came out as `IS NULL`, so downstream charts filtered on nothing.
+    // Emit no cross-filter at all for those, matching what
+    // contextMenuEventHandler already does when labelMap has no entry.
+    if (!value || (!isCurrentValueSelected && !labelMap[value])) {
+      return undefined;
     }
+
+    const values = isCurrentValueSelected
+      ? selected.filter(v => v !== value)
+      : [value];
 
     const groupbyValues = values
       .map(value => labelMap[value])
@@ -62,7 +73,7 @@ const getCrossFilterDataMask =
       dataMask: {
         extraFormData: {
           filters:
-            values.length === 0
+            values.length === 0 || groupbyValues.length === 0
               ? []
               : groupby.map((col, idx) => {
                   const val = groupbyValues.map(v => {
@@ -86,7 +97,7 @@ const getCrossFilterDataMask =
           selectedValues: values.length ? values : null,
         },
       },
-      isCurrentValueSelected: selected.includes(value),
+      isCurrentValueSelected,
     };
   };
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/eventHandlers.test.ts
@@ -180,3 +180,79 @@ test('cross-filter does nothing when emitCrossFilters is false', () => {
 
   expect(setDataMask).not.toHaveBeenCalled();
 });
+
+test('cross-filter ignores a click on a name absent from labelMap (#42340)', () => {
+  // The pie's Total graphic text and its aggregated "Other" slice are not
+  // categories, so they have no labelMap entry. Building a mask from one left
+  // every groupby column as `IS NULL`, because `[].every(...)` is true.
+  const setDataMask = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: { cancellations: ['cancellations'] },
+    selectedValues: {},
+    setDataMask,
+  });
+
+  const handlers = allEventHandlers(props);
+  handlers.click({ name: 'Total: 1234' });
+  handlers.click({ name: 'Other' });
+
+  expect(setDataMask).not.toHaveBeenCalled();
+});
+
+test('cross-filter ignores a click with an empty name (#42340)', () => {
+  const setDataMask = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: { cancellations: ['cancellations'] },
+    selectedValues: {},
+    setDataMask,
+  });
+
+  const handlers = allEventHandlers(props);
+  handlers.click({ name: '' });
+
+  expect(setDataMask).not.toHaveBeenCalled();
+});
+
+test('context menu offers no cross-filter for an unresolvable name (#42340)', () => {
+  const onContextMenu = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: { cancellations: ['cancellations'] },
+    selectedValues: {},
+    onContextMenu,
+  });
+
+  const handlers = allEventHandlers(props);
+  handlers.contextmenu({
+    name: 'Total: 1234',
+    event: {
+      stop: jest.fn(),
+      event: { clientX: 1, clientY: 2 } as unknown as PointerEvent,
+    },
+  });
+
+  // contextMenuEventHandler already bails out before opening the menu
+  expect(onContextMenu).not.toHaveBeenCalled();
+});
+
+test('cross-filter still clears when the last selected value is deselected (#42340)', () => {
+  const setDataMask = jest.fn();
+  const props = buildProps({
+    groupby: ['topics'],
+    labelMap: { cancellations: ['cancellations'] },
+    selectedValues: { 0: 'cancellations' },
+    setDataMask,
+  });
+
+  const handlers = allEventHandlers(props);
+  handlers.click({ name: 'cancellations' });
+
+  expect(setDataMask).toHaveBeenCalledWith(
+    expect.objectContaining({
+      extraFormData: { filters: [] },
+      filterState: { value: null, selectedValues: null },
+    }),
+  );
+});


### PR DESCRIPTION
### SUMMARY

Clicking a pie's **Total** text, its aggregated **Other** slice, or an unnamed sector emitted a cross-filter with no dimension values, so downstream charts filtered on nothing.

`getCrossFilterDataMask` built a mask from whatever name was clicked. For a name with no `labelMap` entry:

```ts
const groupbyValues = values.map(value => labelMap[value]).filter(Boolean);
```

`groupbyValues` came out empty while `values` stayed non-empty, so the `values.length === 0` guard never fired. The mask was still built, and since `[].every(...)` is `true`, **every** groupby column was emitted as `IS NULL`.

The fix returns `undefined` when the clicked name is empty, or absent from `labelMap` and not currently selected. That is already how `contextMenuEventHandler` behaves when `labelMap` has no entry, and `crossFilter` is an optional field on `ContextMenuFilters`, so `undefined` is the shape callers expect — `clickEventHandler` already guards with `?.dataMask`.

Deselection is untouched: a value present in `selectedValues` was resolvable when it was selected, so it still takes the deselect path. The filter branch additionally treats empty `groupbyValues` as "no filters", so a stale selection cannot rebuild the same bogus mask.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: clicking **Total** applied `IS NULL` on every groupby column to the dashboard.
After: the click is inert; only real sectors emit filters.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test
```

**776 tests across 69 suites pass.** Four new cases name #42340; two of them fail on unpatched source (`Total: 1234` and `Other` clicks, and the empty-name click). The other two — the context-menu path and clearing the last selected value — already behaved correctly and are included as regression guards so the new early return cannot break them.

Manually: dashboard with cross-filtering on, a Pie chart with **Show Total** (and optionally **Threshold for Other**), plus a second chart. Click the total text and the Other slice; no filter should be applied, while clicking a real sector still filters.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42340
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)