### PR TITLE
fix(plugin-chart-table): keep the configured page size under server pagination

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/DataTable.tsx
@@ -464,8 +464,11 @@ export default typedMemo(function DataTable<D extends object>({
     const foundPageSizeIndex = pageSizeOptions.findIndex(
       ([option]) => option >= resultCurrentPageSize,
     );
-    if (foundPageSizeIndex === -1) {
-      resultCurrentPageSize = 0;
+    if (foundPageSizeIndex === -1 && pageSizeOptions.length > 0) {
+      // No option is large enough for the active page size: fall back to the
+      // largest available one instead of 0, which renders as an empty
+      // selection because it is not a valid server pagination page size.
+      resultCurrentPageSize = pageSizeOptions[pageSizeOptions.length - 1][0];
     }
     resultCurrentPage = serverPaginationData?.currentPage ?? 0;
     resultOnPageChange = (pageNumber: number) =>

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -462,13 +462,24 @@ export default function TableChart<D extends DataRecord = DataRecord>(
 
   // only take relevant page size options
   const pageSizeOptions = useMemo(() => {
-    const getServerPagination = (n: number) => n <= rowCount;
-    return (
-      serverPagination ? SERVER_PAGE_SIZE_OPTIONS : PAGE_SIZE_OPTIONS
-    ).filter(([n]) =>
-      serverPagination ? getServerPagination(n) : n <= 2 * data.length,
+    if (!serverPagination) {
+      return PAGE_SIZE_OPTIONS.filter(
+        ([n]) => n <= 2 * data.length,
+      ) as SizeOption[];
+    }
+    // The page size the chart is actually paginating with must always stay
+    // selectable, even when the result set is smaller than it.
+    const currentServerPageSize = serverPaginationData?.pageSize ?? pageSize;
+    return SERVER_PAGE_SIZE_OPTIONS.filter(
+      ([n]) => n <= rowCount || n === currentServerPageSize,
     ) as SizeOption[];
-  }, [data.length, rowCount, serverPagination]);
+  }, [
+    data.length,
+    pageSize,
+    rowCount,
+    serverPagination,
+    serverPaginationData?.pageSize,
+  ]);
 
   const getValueRange = useCallback(
     function getValueRange(key: string, alignPositiveNegative: boolean) {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2029,6 +2029,30 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(arrow as HTMLElement).zIndex).toBe('11');
       });
 
+      test('keeps the configured page size when rowCount is smaller (#42243)', () => {
+        // With server pagination and a result set smaller than the configured
+        // page size, the selector used to drop the configured size from the
+        // options and fall back to rendering 0.
+        const props = {
+          ...transformProps(testData.basic),
+          serverPagination: true,
+          rowCount: 12,
+          pageSize: 20,
+          serverPaginationData: { currentPage: 0, pageSize: 20 },
+        };
+        const { container } = render(
+          ProviderWrapper({
+            children: <TableChart {...props} sticky={false} />,
+          }),
+        );
+
+        const selected = container.querySelector(
+          '.dt-select-page-size .ant-select-content',
+        );
+        expect(selected).not.toBeNull();
+        expect(selected).toHaveTextContent('20');
+      });
+
       test('recalculates totals when user filters data', async () => {
         const formDataWithTotals = {
           ...testData.basic.formData,


### PR DESCRIPTION
### SUMMARY

With server pagination on and a result set smaller than the configured page size, the page-size selector rendered `0` and the configured size disappeared from the dropdown.

Two connected defects:

1. **`TableChart.tsx:465`** filtered every server option by the row count:
   ```ts
   const getServerPagination = (n: number) => n <= rowCount;
   ```
   With `rowCount = 12` and `SERVER_PAGE_SIZE_OPTIONS = [10, 20, 50, 100, 200]`, the list collapses to `[10]` — the configured size (say 20) is gone.

2. **`DataTable/DataTable.tsx:464-469`** then cannot find the active size among those options, so `findIndex` returns `-1` and it falls back to `0`:
   ```ts
   if (foundPageSizeIndex === -1) { resultCurrentPageSize = 0; }
   ```
   `0` is the *client* option list's "All" sentinel and is not a valid server page size, so the select receives a value with no matching option and renders empty.

The fix keeps the size actually being paginated with selectable (`n <= rowCount || n === currentServerPageSize`), and changes the `-1` fallback to clamp to the largest available option instead of `0`, leaving the value untouched when the options list is empty.

Note for reviewers: this does not overlap #43184, which hoists hooks near the top of `DataTable.tsx`; this change is inside the `if (serverPagination)` block further down.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: page-size selector shows `0`, dropdown offers only `10`.
After: the configured size stays selected and available.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-table
```

New test `keeps the configured page size when rowCount is smaller (#42243)`. Before the fix: **1 failed, 146 passed**. After: **147 passed across 7 suites** (verified in a clean checkout, not just the authoring worktree).

Manually: a Table chart with server pagination enabled, page size 20, against a query returning ~12 rows — the selector should read 20, not 0.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42243
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)