### PR TITLE
fix(deckgl): give handlebars tooltips an opaque background

### DIFF
--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.test.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@testing-library/jest-dom';
+import { supersetTheme, ThemeProvider } from '@apache-superset/core/theme';
+import type { ReactElement } from 'react';
+import Tooltip from './Tooltip';
+
+const renderWithTheme = (component: ReactElement) =>
+  render(<ThemeProvider theme={supersetTheme}>{component}</ThemeProvider>);
+
+const tooltip = {
+  x: 10,
+  y: 20,
+  content: <span data-test="tooltip-content">Fremont: 42</span>,
+};
+
+test('renders an opaque, themed surface for the default variant', () => {
+  renderWithTheme(<Tooltip tooltip={tooltip} />);
+
+  const container = screen.getByTestId('tooltip-content').parentElement;
+  expect(container).toHaveStyle({
+    background: supersetTheme.colorBgElevated,
+    color: supersetTheme.colorText,
+  });
+});
+
+test('renders an opaque, themed surface for the custom (handlebars) variant, see #41154', () => {
+  renderWithTheme(<Tooltip tooltip={tooltip} variant="custom" />);
+
+  // Custom tooltip content comes from a user-supplied handlebars template, so
+  // the container must supply its own background instead of letting the map
+  // show through. See https://github.com/apache/superset/issues/41154
+  const container = screen.getByTestId('tooltip-content').parentElement;
+  expect(container).toHaveStyle({
+    background: supersetTheme.colorBgElevated,
+    color: supersetTheme.colorText,
+    'border-radius': `${supersetTheme.borderRadius}px`,
+    padding: `${supersetTheme.sizeUnit * 2}px`,
+  });
+});
+
+test('renders nothing without a tooltip', () => {
+  const { container } = renderWithTheme(<Tooltip tooltip={null} />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
+++ b/superset-frontend/plugins/preset-chart-deckgl/src/components/Tooltip.tsx
@@ -44,23 +44,15 @@ const StyledDiv = styled.div<{
     left: ${left}px;
     z-index: 9;
     pointer-events: none;
-    ${
-      variant === 'default'
-        ? `
-      padding: ${theme.sizeUnit * 2}px;
-      margin: ${theme.sizeUnit * 2}px;
-      background: ${theme.colorBgElevated};
-      color: ${theme.colorText};
-      max-width: 300px;
-      font-size: ${theme.fontSizeSM}px;
-      border: 1px solid ${theme.colorBorder};
-      border-radius: ${theme.borderRadius}px;
-      box-shadow: ${theme.boxShadowSecondary};
-    `
-        : `
-      margin: ${theme.sizeUnit * 3}px;
-    `
-    }
+    padding: ${theme.sizeUnit * 2}px;
+    margin: ${variant === 'default' ? theme.sizeUnit * 2 : theme.sizeUnit * 3}px;
+    background: ${theme.colorBgElevated};
+    color: ${theme.colorText};
+    max-width: 300px;
+    font-size: ${theme.fontSizeSM}px;
+    border: 1px solid ${theme.colorBorder};
+    border-radius: ${theme.borderRadius}px;
+    box-shadow: ${theme.boxShadowSecondary};
   `}
 `;
 


### PR DESCRIPTION
### SUMMARY

A handlebars tooltip template on a deck.gl chart renders text with no surface behind it — the map shows straight through, and the values are hard to read.

The cause is not in `plugin-chart-handlebars`; it is the deck.gl tooltip container. `preset-chart-deckgl/src/components/Tooltip.tsx` branched its styling on `variant`:

- `variant === 'default'` got the full themed surface — background, color, padding, border, radius, shadow;
- the `else` branch set **only** `margin`. No background, no border, no padding.

Handlebars tooltips always take that second branch:

- `utilities/tooltipUtils.tsx` wraps `HandlebarsRenderer` in `<div className="deckgl-tooltip" data-tooltip-type="custom">` when `formData.tooltip_template` is set;
- `DeckGLContainer.tsx:114-122` detects that marker and renders `<Tooltip … variant="custom" />`;
- `utilities/HandlebarsRenderer.tsx` emits the compiled template in a plain div with only sizing rules.

So nothing along the handlebars path ever painted a background. The default tooltip already has the correct chrome, which is why only custom templates are affected.

The fix applies the same themed surface to both variants; `variant` now only picks the offset margin (`sizeUnit * 2` default vs `sizeUnit * 3` custom, preserving existing spacing). All values are antd theme tokens — no literal colors, so `theme-colors/no-literal-colors` stays satisfied.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: handlebars tooltip text floats directly over the map with no background.
After: same opaque, bordered, elevated surface the default deck.gl tooltip already uses.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- plugins/preset-chart-deckgl/src/components/Tooltip plugins/preset-chart-deckgl/src/DeckGLContainer
```

**11 tests across 2 suites pass** (verified in a clean checkout). The component had no test file; this adds one asserting the custom variant's computed background/color/radius/padding, plus a default-variant regression test and a null-tooltip case.

Manually: a deck.gl chart with a handlebars **Tooltip template**, hovered over a light and a dark area of the basemap.

Not verified: no browser screenshot was taken. The change applies styling already used by the default tooltip in the same component.

Possible follow-up, left out to keep the diff minimal: `HandlebarsRenderer.tsx` still sets hardcoded `maxWidth: '300px'` and `fontSize: '12px'` inline, now duplicating the container's token-based values.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #41154
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)