### PR TITLE
ci: declare top-level permissions on the remaining workflows

### DIFF
--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -21,6 +21,9 @@ on:
   #schedule:
   #  - cron: '0 0 * * *'  # Runs daily at midnight UTC
 
+permissions:
+  contents: read
+
 jobs:
   bump-python-package:
     runs-on: ubuntu-slim

--- a/.github/workflows/check-db-migration-confict.yml
+++ b/.github/workflows/check-db-migration-confict.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_db_migration_conflict:
     name: Check DB migration conflict

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-26.04

--- a/.github/workflows/enforce-single-migration-head.yml
+++ b/.github/workflows/enforce-single-migration-head.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   enforce-single-migration-head:
     runs-on: ubuntu-26.04

--- a/.github/workflows/issue-creation.yml
+++ b/.github/workflows/issue-creation.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   superbot-orglabel:
     runs-on: ubuntu-slim

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published] # This makes it run only when a new released is published
 
+permissions:
+  contents: read
+
 jobs:
   latest-release:
     name: Add/update tag to new release

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   lint-check:
     runs-on: ubuntu-slim

--- a/.github/workflows/showtime-cleanup.yml
+++ b/.github/workflows/showtime-cleanup.yml
@@ -17,6 +17,9 @@ env:
   GITHUB_ORG: ${{ github.repository_owner }}
   GITHUB_REPO: ${{ github.event.repository.name }}
 
+permissions:
+  contents: read
+
 jobs:
   cleanup-expired:
     name: Clean up expired showtime environments

--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -26,6 +26,9 @@ env:
   GITHUB_REPO: ${{ github.event.repository.name }}
   GITHUB_ACTOR: ${{ github.actor }}
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: 🎪 Sync PR to desired state

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-26.04

--- a/.github/workflows/superset-helm-release.yml
+++ b/.github/workflows/superset-helm-release.yml
@@ -27,6 +27,9 @@ concurrency:
   group: helm-release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-26.04

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-26.04

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-26.04

--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   supersetbot:
     runs-on: ubuntu-26.04

--- a/.github/workflows/welcome-new-users.yml
+++ b/.github/workflows/welcome-new-users.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   welcome:
     runs-on: ubuntu-slim


### PR DESCRIPTION
### SUMMARY

16 of the 47 workflows in `.github/workflows/` had no top-level `permissions:` block, so their `GITHUB_TOKEN` scope came from whatever the repository or organisation default grants — broader than any of these jobs needs, and invisible to anyone reading the workflow or reviewing a diff.

Each now declares `permissions: contents: read`, placed exactly where the other 31 workflows put it (after `env:`, before `jobs:`).

**This changes no effective privilege**, which is worth stating precisely since a restrictive top-level block *can* break a workflow that silently relied on default write:

- every job in all 16 files already declares its own `permissions:` block — audited by parsing the YAML, not by eyeballing;
- a job-level block **replaces** the top-level one rather than merging, so each job keeps exactly the scope it declares;
- none of the 16 are reusable-workflow callers (`jobs.<id>.uses`), which inherit differently.

So the win is reviewability and defence in depth: any job added later without its own block now starts read-only instead of inheriting the org default.

Files: `bump-python-package`, `check-db-migration-confict`, `codeql-analysis`, `enforce-single-migration-head`, `issue-creation`, `labeler`, `latest-release-tag`, `pr-lint`, `showtime-cleanup`, `showtime-trigger`, `superset-e2e`, `superset-helm-release`, `superset-playwright`, `superset-python-presto-hive`, `supersetbot`, `welcome-new-users`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — CI configuration.

### TESTING INSTRUCTIONS

```bash
npm install -g @action-validator/core@0.6.0 @action-validator/cli@0.6.0
for f in $(git diff --name-only origin/master); do action-validator "$f"; done
```

All 16 pass with **0 failures**, matching what `.github/workflows/github-action-validator.sh` runs in CI. Separately, all 47 workflows were parsed to confirm each now has a top-level `permissions` key and none broke.

The change is additive: 48 insertions, 0 deletions, 3 lines per file.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42986
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)