### PR TITLE
docs(datasets): explain what marking a column temporal requires

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -2417,6 +2417,16 @@ function DatasourceEditor({
               filterTerm={columnSearchTerm}
               filterFields={['column_name']}
               onColumnsChange={cols => setColumns({ databaseColumns: cols })}
+              columnLabelTooltips={{
+                is_dttm: t(
+                  'Marks the column as a time column, so it can drive the ' +
+                    'time range filter and time grain. A column whose database ' +
+                    'type is not already a date or timestamp also needs a ' +
+                    'Datetime format below, otherwise a time grain builds SQL ' +
+                    'such as DATE_TRUNC() directly against the raw column and ' +
+                    'the query fails.',
+                ),
+              }}
             />
             {metadataLoading && <Loading />}
           </StyledTableTabWrapper>


### PR DESCRIPTION
### SUMMARY

Marking a `VARCHAR` column **Is temporal** is accepted silently. The first sign anything is wrong comes later, when a time grain builds `DATE_TRUNC()` against the raw column and PostgreSQL rejects it for a string argument — which reads as a query bug rather than a dataset misconfiguration.

The supported path already exists. `TableColumn.is_temporal` documents it:

> This usually happens during initial metadata fetching or when a column is manually set as temporal (**for this `python_date_format` needs to be set**).

Nothing in the UI communicates that. The **Is temporal** header has no tooltip at all, and the **Datetime format** field explains its own syntax at length without saying it is required in this case.

This adds that tooltip, using the `columnLabelTooltips` mechanism the metric and calculated-column tables already use.

**Guidance rather than enforcement, deliberately.** Rejecting the combination at save time would be the stronger fix, but some engines cast strings implicitly, so datasets that work today would start failing validation. If maintainers would prefer hard validation — or a warning surfaced when `is_dttm` is set on a non-temporal type with no format — I'm happy to follow up; I did not want to change save-time behavior for every engine on the strength of one PostgreSQL report.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: **Is temporal** column header, no explanation.
After: hovering it explains that a non-date/timestamp column also needs a **Datetime format**, and what happens if it doesn't.

### TESTING INSTRUCTIONS

```bash
cd superset-frontend
npm run test -- src/components/Datasource/components/DatasourceEditor
npx tsc --noEmit -p .
```

63 tests across 4 suites pass; no new type errors.

Manually: **Datasets → Edit dataset → Columns**, hover the **Is temporal** header.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Addresses #42386
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)