### PR TITLE
fix(charts): fix Bubble chart crash and correct example's time_range to a year with real data

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SqlaFormData } from '@superset-ui/core';
+import transformProps from './transformProps';
+import { EchartsBubbleChartProps } from './types';
+
+const baseFormData: SqlaFormData = {
+  datasource: '1__table',
+  viz_type: 'bubble_v2',
+  entity: 'customer_name',
+  x: 'price',
+  y: 'sales',
+  size: 'count',
+};
+
+const baseChartProps = {
+  width: 400,
+  height: 400,
+  hooks: {},
+  queriesData: [
+    {
+      data: [
+        { customer_name: 'A', price: 10, sales: 100, count: 5 },
+        { customer_name: 'B', price: 20, sales: 200, count: 8 },
+      ],
+    },
+  ],
+  theme: { colorText: '#000' },
+};
+
+test('nests xAxisLabelInterval under axisLabel rather than the axis itself', () => {
+  // Regression test: xAxis.interval forces echarts' IntervalScale into a
+  // fixed-tick-spacing mode that expects a number and crashes on the
+  // 'auto'/'0' strings this control actually produces (observed as an
+  // uncaught assertion deep in echarts' axis "nice" tick calculation,
+  // reproducing on every dashboard bubble chart). The interval belongs on
+  // axisLabel, where it only controls how many labels are skipped.
+  const { echartOptions } = transformProps({
+    ...baseChartProps,
+    formData: baseFormData,
+  } as unknown as EchartsBubbleChartProps);
+
+  expect((echartOptions.xAxis as any).interval).toBeUndefined();
+  expect((echartOptions.xAxis as any).axisLabel.interval).toBe('auto');
+});
+
+test('honors an explicit xAxisLabelInterval override', () => {
+  const { echartOptions } = transformProps({
+    ...baseChartProps,
+    formData: { ...baseFormData, xAxisLabelInterval: '0' },
+  } as unknown as EchartsBubbleChartProps);
+
+  expect((echartOptions.xAxis as any).axisLabel.interval).toBe('0');
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Bubble/transformProps.ts
@@ -212,13 +212,16 @@ export default function transformProps(chartProps: EchartsBubbleChartProps) {
   const echartOptions: EChartsCoreOption = {
     series,
     xAxis: {
-      axisLabel: { formatter: xAxisFormatter, rotate: xAxisLabelRotation },
+      axisLabel: {
+        formatter: xAxisFormatter,
+        rotate: xAxisLabelRotation,
+        interval: xAxisLabelInterval,
+      },
       splitLine: {
         lineStyle: {
           type: 'dashed',
         },
       },
-      interval: xAxisLabelInterval,
       scale: true,
       name: bubbleXAxisTitle,
       nameLocation: 'middle',

--- a/superset/examples/world_health/charts/Life_Expectancy_VS_Rural.yaml
+++ b/superset/examples/world_health/charts/Life_Expectancy_VS_Rural.yaml
@@ -59,7 +59,7 @@ params:
     expressionType: SIMPLE
     label: SUM(SP_POP_TOTL)
     optionName: metric_size_life_expectancy_vs_rural
-  time_range: '2014-01-01 : 2014-01-02'
+  time_range: '2011-01-01 : 2011-01-02'
   tooltipSizeFormat: SMART_NUMBER
   truncateXAxis: true
   viz_type: bubble_v2


### PR DESCRIPTION
### SUMMARY
#43152 got squash-merged at its first commit's SHA, so the second commit (the actual crash fix) never landed on `master`. This PR carries that commit forward, rebased cleanly on current `master`.

Two real bugs, both from following up on the Bubble example's viz_type migration:

- `Bubble/transformProps.ts` set `xAxis.interval` at the axis level instead of nesting it under `xAxis.axisLabel.interval`. `interval` on the axis itself forces echarts' `IntervalScale` (numeric-tick mode), which crashes for a non-numeric x-axis - i.e. every real `bubble_v2` chart. Added a regression test (there was none before).
- The `Life_Expectancy_VS_Rural` example's `time_range` pointed at 2014, which has zero non-null `SP_DYN_LE00_IN` data in this dataset - the chart rendered with no bubbles even once the crash was fixed. Moved it to 2011, which has real data.

### TESTING INSTRUCTIONS
Load examples, open the "Life Expectancy VS Rural %" chart in `world_health` - it should render bubbles instead of crashing/showing empty. `npm run test -- transformProps.test.ts` under `plugin-chart-echarts` for the regression test.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API