### PR TITLE
fix(chart-data): keep non-numeric columns out of contribution post-processing

### DIFF
--- a/superset/utils/pandas_postprocessing/contribution.py
+++ b/superset/utils/pandas_postprocessing/contribution.py
@@ -17,15 +17,55 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Any
 
 from flask_babel import gettext as _
 from pandas import DataFrame, MultiIndex
+from pandas.api.types import infer_dtype, is_bool_dtype, is_numeric_dtype
 
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.core import PostProcessingContributionOrientation, TIME_COMPARISON
 from superset.utils.pandas_postprocessing.utils import validate_column_args
+
+# Inferred value types of an object-dtype column that the contribution
+# arithmetic can consume. `decimal` covers columns holding `decimal.Decimal`
+# (how drivers such as psycopg2 return NUMERIC/DECIMAL metrics); `empty`
+# covers an all-null column, which contributes nothing but is harmless once
+# the nulls are filled with zeros.
+_ARITHMETIC_OBJECT_DTYPES = frozenset({"decimal", "empty"})
+
+
+def _select_arithmetic_columns(df: DataFrame) -> DataFrame:
+    """
+    Select the columns whose values the contribution arithmetic can divide.
+
+    Numeric dtypes qualify directly. `decimal.Decimal` values -- how drivers
+    such as psycopg2 hand back NUMERIC/DECIMAL metrics -- live in an
+    object-dtype column, which ``select_dtypes`` cannot address: handing it
+    ``Decimal`` resolves to plain ``object`` and so selects every string,
+    dict and list column as well, leaving the division below to raise
+    ``TypeError`` on any result set that carries a non-numeric column. The
+    inferred value type separates Decimal columns from those, so the
+    remaining object columns are classified that way instead.
+
+    :param df: DataFrame to select columns from.
+    :return: Subset of `df` holding only the columns safe to divide.
+    """
+
+    # Booleans are excluded because ``is_numeric_dtype`` accepts them while
+    # ``select_dtypes(include=["number"])`` does not, and dividing them was
+    # never part of the calculation. Columns are addressed by position rather
+    # than by label so that duplicate labels stay distinguishable.
+    def is_arithmetic(position: int, dtype: Any) -> bool:
+        if is_numeric_dtype(dtype) and not is_bool_dtype(dtype):
+            return True
+        return infer_dtype(df.iloc[:, position], skipna=True) in (
+            _ARITHMETIC_OBJECT_DTYPES
+        )
+
+    return df.iloc[
+        :, [is_arithmetic(position, dtype) for position, dtype in enumerate(df.dtypes)]
+    ]
 
 
 @validate_column_args("columns")
@@ -56,8 +96,10 @@ def contribution(
     :return: DataFrame with contributions.
     """
     contribution_df = df.copy()
-    numeric_df = contribution_df.select_dtypes(include=["number", Decimal])
-    numeric_df.fillna(0, inplace=True)
+    # Filled out of place: the selection is a slice of `contribution_df`, and
+    # an in-place fill on a slice warns under pandas 2 and is dropped outright
+    # under copy-on-write.
+    numeric_df = _select_arithmetic_columns(contribution_df).fillna(0)
     # verify column selections
     if columns:
         numeric_columns = numeric_df.columns.tolist()

--- a/tests/unit_tests/pandas_postprocessing/test_contribution.py
+++ b/tests/unit_tests/pandas_postprocessing/test_contribution.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
 from numpy import nan
@@ -157,3 +158,87 @@ def test_contribution_with_numeric_prefix_time_shifts():
     # "22 weeks ago" group: a=2,b=4 -> 1/3,2/3; a=4,b=2 -> 2/3,1/3
     assert_array_equal(processed_df["a__22 weeks ago"].tolist(), [1 / 3, 2 / 3])
     assert_array_equal(processed_df["b__22 weeks ago"].tolist(), [2 / 3, 1 / 3])
+
+
+def test_contribution_leaves_string_columns_untouched():
+    """A non-numeric column alongside the metrics must not break the division.
+
+    `select_dtypes(include=["number", Decimal])` resolved `Decimal` to plain
+    `object`, so every string column was treated as a metric and the
+    contribution arithmetic raised `TypeError: unsupported operand type(s)
+    for /: 'str' and 'str'` -- surfacing as a 500 rather than a chart.
+    """
+    df = DataFrame({"label": ["x", "y"], "a": [1.0, 3.0]})
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+    )
+    assert processed_df.columns.tolist() == ["label", "a"]
+    assert processed_df["label"].tolist() == ["x", "y"]
+    assert processed_df["a"].tolist() == [0.25, 0.75]
+
+
+def test_contribution_across_row_leaves_string_columns_untouched():
+    df = DataFrame({"label": ["x", "y"], "a": [1.0, 3.0], "b": [3.0, 1.0]})
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.ROW,
+    )
+    assert processed_df["label"].tolist() == ["x", "y"]
+    assert processed_df["a"].tolist() == [0.25, 0.75]
+    assert processed_df["b"].tolist() == [0.75, 0.25]
+
+
+def test_contribution_rejects_selected_string_column():
+    """Selecting a string column is a validation error, not a crash.
+
+    The "not numeric" guard was unreachable for string columns, because they
+    were themselves being collected as numeric.
+    """
+    df = DataFrame({"label": ["x", "y"], "a": [1.0, 3.0]})
+    with pytest.raises(InvalidPostProcessingError, match="not numeric"):
+        contribution(df, columns=["label"])
+
+
+def test_contribution_on_decimal_columns():
+    """`Decimal` metrics (e.g. a psycopg2 NUMERIC column) still contribute.
+
+    They are held in an object-dtype column, so they have to be recognised by
+    value rather than by dtype.
+    """
+    df = DataFrame(
+        {
+            "label": ["x", "y"],
+            "a": [Decimal("1"), Decimal("3")],
+        }
+    )
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+    )
+    assert processed_df["label"].tolist() == ["x", "y"]
+    assert processed_df["a"].tolist() == [0.25, 0.75]
+
+
+def test_contribution_ignores_columns_of_unsupported_objects():
+    """Object columns that are neither numeric nor Decimal are passed through."""
+    df = DataFrame({"payload": [{"k": 1}, {"k": 2}], "a": [1.0, 3.0]})
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+    )
+    assert processed_df["payload"].tolist() == [{"k": 1}, {"k": 2}]
+    assert processed_df["a"].tolist() == [0.25, 0.75]
+
+
+def test_contribution_keeps_all_null_object_columns():
+    """An all-null object column carries no values, so filling it with zeros
+    and dividing is harmless; keep it in the calculation as before."""
+    df = DataFrame({"a": [1.0, 3.0], "empty": [None, None]})
+    processed_df = contribution(
+        df,
+        orientation=PostProcessingContributionOrientation.COLUMN,
+    )
+    assert processed_df.columns.tolist() == ["a", "empty"]
+    assert processed_df["a"].tolist() == [0.25, 0.75]
+    assert_array_equal(processed_df["empty"].tolist(), [nan, nan])


### PR DESCRIPTION
### SUMMARY

`contribution` post-processing crashes with a `TypeError` — surfacing to the user
as an HTTP 500 — whenever the result set carries a non-numeric column, even
though its docstring states *"Non-numeric columns will be kept untouched."*

The cause is a single selector:

```python
numeric_df = contribution_df.select_dtypes(include=["number", Decimal])
```

`select_dtypes` resolves `Decimal` through `infer_dtype_from_object`, which maps
any unrecognised Python type to `numpy.object_`. So `include=["number", Decimal]`
is really `include=["number", "object"]`, and **every** string / dict / list
column is collected as if it were a metric. The division that follows then blows
up:

```
TypeError: unsupported operand type(s) for /: 'str' and 'str'      # orientation=column
TypeError: unsupported operand type(s) for +: 'float' and 'str'    # orientation=row
```

Reproducing on `master`:

```python
>>> from pandas import DataFrame
>>> from superset.utils.pandas_postprocessing import contribution
>>> contribution(DataFrame({"label": ["x", "y"], "a": [1.0, 3.0]}))
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

The same defect silently disables the function's own validation guard. Selecting
a string column is meant to raise `InvalidPostProcessingError` ("Column ... is
not numeric"), but the check tests membership against the very list that now
wrongly contains string columns, so it never fires and the request 500s instead
of returning a 400:

```python
>>> contribution(DataFrame({"label": ["x", "y"], "a": [1.0, 3.0]}), columns=["label"])
TypeError: unsupported operand type(s) for /: 'str' and 'str'   # expected: InvalidPostProcessingError
```

The intent behind naming `Decimal` was sound — drivers such as psycopg2 hand
back `NUMERIC`/`DECIMAL` metrics as `decimal.Decimal`, which lands in an
object-dtype column — but a dtype selector cannot express "object columns
holding Decimals". This PR classifies the remaining object columns by their
inferred *value* type instead, which separates Decimal from strings, dicts and
lists. Decimal metrics keep working; everything else is left untouched, as
documented.

Existing coverage missed this because `test_non_numeric_columns` uses
`__timestamp`, a `datetime64` column — already excluded correctly, since it is
not object dtype. No test exercised the Decimal path at all.

Two incidental notes:

* Booleans are explicitly excluded so the selection stays byte-for-byte
  equivalent to the previous `select_dtypes(include=["number"])` behaviour
  (`is_numeric_dtype` accepts `bool`; `select_dtypes("number")` does not).
* The `fillna` is no longer `inplace`. The selection is a slice of
  `contribution_df`, and an in-place fill on a slice raises
  `SettingWithCopyWarning` under pandas 2 and is dropped outright under
  copy-on-write.

A pre-existing `FutureWarning` ("Downcasting object dtype arrays on .fillna ...
is deprecated") is reproducible on `master` as well and is left alone here to
keep this change scoped to the crash.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only fix.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/pandas_postprocessing/test_contribution.py
```

Six regression tests are added. Five of them fail on `master` with the exact
`TypeError`s above and pass with this change:

| test | asserts |
| --- | --- |
| `test_contribution_leaves_string_columns_untouched` | string column passes through, metric still divided |
| `test_contribution_across_row_leaves_string_columns_untouched` | same for `orientation=row` |
| `test_contribution_rejects_selected_string_column` | selecting a string column raises `InvalidPostProcessingError` rather than 500ing |
| `test_contribution_on_decimal_columns` | `Decimal` metrics still contribute (previously untested) |
| `test_contribution_ignores_columns_of_unsupported_objects` | dict-valued column passes through |
| `test_contribution_keeps_all_null_object_columns` | pins the preserved behaviour for an all-null object column |

The sixth passes either way by design — it pins behaviour deliberately left
unchanged, so that an all-`NULL` object column keeps behaving like an all-`NaN`
float column.

Manually:

```python
from pandas import DataFrame
from decimal import Decimal
from superset.utils.pandas_postprocessing import contribution

# 500 on master, correct on this branch
contribution(DataFrame({"label": ["x", "y"], "a": [Decimal("1"), Decimal("3")]}))
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
