### PR TITLE
fix(chart): accept quarter and day in end-of time ranges

### DIFF
--- a/superset/utils/date_parser.py
+++ b/superset/utils/date_parser.py
@@ -831,6 +831,19 @@ class EvalLastDayFunc:  # pylint: disable=too-few-public-methods
             return dttm.replace(
                 month=12, day=31, hour=0, minute=0, second=0, microsecond=0
             )
+        if unit == "quarter":
+            # Both arguments are passed to a single `replace` so the day is
+            # never briefly out of range for the new month (e.g. the 31st
+            # moving into a 30-day quarter-end month).
+            last_month = 3 * ((dttm.month - 1) // 3) + 3
+            return dttm.replace(
+                month=last_month,
+                day=calendar.monthrange(dttm.year, last_month)[1],
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
         if unit == "month":
             return dttm.replace(
                 day=calendar.monthrange(dttm.year, dttm.month)[1],
@@ -839,6 +852,11 @@ class EvalLastDayFunc:  # pylint: disable=too-few-public-methods
                 second=0,
                 microsecond=0,
             )
+        if unit == "day":
+            # The last day of a day is that same day. Truncating to midnight
+            # keeps the result consistent with every other unit here, which
+            # all return the final day at midnight rather than at its end.
+            return dttm.replace(hour=0, minute=0, second=0, microsecond=0)
         # unit == "week":
         mon = dttm - relativedelta(days=dttm.weekday())
         mon = mon.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -939,7 +957,12 @@ def datetime_parser() -> ParseResults:  # pylint: disable=too-many-locals
     lastday_func <<= (
         LASTDAY
         + lparen
-        + Group(date_expr + comma + (YEAR | MONTH | WEEK) + ppOptional(comma))
+        + Group(
+            date_expr
+            + comma
+            + (YEAR | QUARTER | MONTH | WEEK | DAY)
+            + ppOptional(comma)
+        )
         + rparen
     ).setParseAction(EvalLastDayFunc)
     holiday_func <<= (

--- a/tests/unit_tests/utils/date_parser_tests.py
+++ b/tests/unit_tests/utils/date_parser_tests.py
@@ -867,3 +867,67 @@ def test_datetime_eval_does_not_emit_parsedatetime_debug_logs(
         "flood production logs. Records: "
         + repr([(r.levelname, r.getMessage()) for r in parsedatetime_records])
     )
+
+
+def test_lastday_supports_quarter_and_day() -> None:
+    """`handle_end_of` emits LASTDAY for quarter and day, so the grammar must
+    accept them.
+
+    The `lastday` rule only matched `year | month | week`, so every "end of ...
+    quarter" and "end of ... day" range raised
+    `ValueError: Expected {'year' | 'month' | 'week'}` instead of resolving.
+    """
+    assert datetime_eval(
+        "LASTDAY(datetime('2026-08-12T15:30:45'), quarter)"
+    ) == datetime(2026, 9, 30)
+    assert datetime_eval("LASTDAY(datetime('2026-08-12T15:30:45'), day)") == datetime(
+        2026, 8, 12
+    )
+
+
+def test_lastday_quarter_boundaries() -> None:
+    """Every month resolves to the last day of the quarter containing it."""
+    expected = {
+        1: datetime(2026, 3, 31),
+        2: datetime(2026, 3, 31),
+        3: datetime(2026, 3, 31),
+        4: datetime(2026, 6, 30),
+        5: datetime(2026, 6, 30),
+        6: datetime(2026, 6, 30),
+        7: datetime(2026, 9, 30),
+        8: datetime(2026, 9, 30),
+        9: datetime(2026, 9, 30),
+        10: datetime(2026, 12, 31),
+        11: datetime(2026, 12, 31),
+        12: datetime(2026, 12, 31),
+    }
+    for month, last_day in expected.items():
+        assert (
+            datetime_eval("LASTDAY(datetime('2026-%02d-15'), quarter)" % month)
+            == last_day
+        )
+
+
+def test_lastday_quarter_from_a_longer_month() -> None:
+    """The 31st must survive a move into a 30-day quarter-end month."""
+    assert datetime_eval("LASTDAY(datetime('2026-08-31'), quarter)") == datetime(
+        2026, 9, 30
+    )
+    # Q1 of a leap year, where the source month is shorter than the target.
+    assert datetime_eval("LASTDAY(datetime('2024-02-15'), quarter)") == datetime(
+        2024, 3, 31
+    )
+
+
+@patch("superset.utils.date_parser.parse_human_datetime", mock_parse_human_datetime)
+def test_get_since_until_end_of_quarter_and_day() -> None:
+    """End-to-end: the "end of ..." time ranges these units feed."""
+    for time_range, expected_until in [
+        ("2020-01-01 : end of this quarter", datetime(2016, 12, 31)),
+        ("2020-01-01 : end of last quarter", datetime(2016, 9, 30)),
+        ("2020-01-01 : end of next quarter", datetime(2017, 3, 31)),
+        ("2020-01-01 : end of this day", datetime(2016, 11, 7)),
+        ("2020-01-01 : end of prior 3 days", datetime(2016, 11, 4)),
+    ]:
+        _, until = get_since_until(time_range)
+        assert until == expected_until, time_range


### PR DESCRIPTION
<!-- PR TITLE: fix(chart): accept quarter and day in end-of time ranges -->
### SUMMARY

Every `"end of ... quarter"` and `"end of ... day"` time range raises a
`ValueError` instead of resolving to a date.

`handle_end_of()` declares five valid units and emits a `LASTDAY(...)`
expression for each of them:

```python
def handle_end_of(base_expression: str, unit: str) -> str:
    valid_units = {"year", "quarter", "month", "week", "day"}
    if unit in valid_units:
        return f"LASTDAY({base_expression}, {unit})"
```

The `lastday` grammar rule that has to evaluate that expression only matched
three of them:

```python
Group(date_expr + comma + (YEAR | MONTH | WEEK) + ppOptional(comma))
```

So `quarter` and `day` are generated and then rejected by the very parser they
are generated for. `DATEADD` and `DATETRUNC` in the same grammar already accept
`YEAR | QUARTER | MONTH | WEEK | DAY | HOUR | MINUTE | SECOND`, which is why
`"start of this quarter"` works while `"end of this quarter"` does not.

Reproducing on `master`:

```python
>>> from superset.utils.date_parser import get_since_until
>>> get_since_until(time_range="2020-01-01 : end of this quarter")
ValueError: Expected {'year' | 'month' | 'week'}, found 'quarter'  (at char 27)
>>> get_since_until(time_range="2020-01-01 : end of this day")
ValueError: Expected {'year' | 'month' | 'week'}, found 'day'  (at char 27)
```

The `time_range_lookup` pattern that routes these strings explicitly accepts
both units, so they are reachable from any free-form time range — the Explore
Advanced frame, a dashboard native filter's `default_time_range`, a
`TEMPORAL_RANGE` filter comparator, and `get_time_filter()` in Jinja:

```python
r"^(start of|beginning of|end of)\s{1,5}"
r"(this|last|next|prior)\s{1,5}"
r"([0-9]+)?\s{0,5}"
r"(day|week|month|quarter|year)s?$"
```

All affected forms: `end of this|last|next|prior [N] quarter(s)` and
`end of this|last|next|prior [N] day(s)`.

This PR adds `QUARTER` and `DAY` to the `lastday` rule and implements both in
`EvalLastDayFunc`. Quarter resolves to the last day of the quarter containing
the date; day resolves to that same day. Both are returned at midnight, which
is what every other unit here already does — `LASTDAY(..., month)` returns the
final day at `00:00:00`, not at its end — so the convention is unchanged.

The quarter branch passes `month` and `day` to a single `replace()` call so the
day is never briefly out of range for the new month (e.g. the 31st moving into
a 30-day quarter-end month).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only fix.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/utils/date_parser_tests.py
```

Four tests are added, all failing on `master` with the `ValueError` above:

| test | asserts |
| --- | --- |
| `test_lastday_supports_quarter_and_day` | the two units the grammar rejected now evaluate |
| `test_lastday_quarter_boundaries` | all twelve months map to their quarter's last day |
| `test_lastday_quarter_from_a_longer_month` | `2026-08-31` → `2026-09-30`, and leap-year Q1 |
| `test_get_since_until_end_of_quarter_and_day` | end-to-end through `get_since_until` |

Manually, in Explore → Time Range → Advanced, enter `end of this quarter` as
the END value. On `master` the "Actual time range" preview errors; with this
change it resolves to the last day of the current quarter.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### CHECKLIST

- [ ] CI checks pass
- [x] Tests added/updated
- [ ] Documentation updated
- [x] PR title follows conventions
