### PR TITLE
fix(chart): map the remaining time grains for Prophet forecasting

### DIFF
--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -86,16 +86,24 @@ ALLOWLIST_CUMULATIVE_FUNCTIONS = (
 
 PROPHET_TIME_GRAIN_MAP: dict[str, str] = {
     TimeGrain.SECOND: "s",
+    TimeGrain.FIVE_SECONDS: "5s",
+    TimeGrain.THIRTY_SECONDS: "30s",
     TimeGrain.MINUTE: "min",
     TimeGrain.FIVE_MINUTES: "5min",
     TimeGrain.TEN_MINUTES: "10min",
     TimeGrain.FIFTEEN_MINUTES: "15min",
     TimeGrain.THIRTY_MINUTES: "30min",
+    # An alternate ISO-8601 spelling of THIRTY_MINUTES that a number of engine
+    # specs expose instead; the two denote the same interval.
+    TimeGrain.HALF_HOUR: "30min",
     TimeGrain.HOUR: "h",
+    TimeGrain.SIX_HOURS: "6h",
     TimeGrain.DAY: "D",
     TimeGrain.WEEK: "W",
     TimeGrain.MONTH: "ME" if _PANDAS_VERSION >= (2, 2) else "M",
     TimeGrain.QUARTER: "QE" if _PANDAS_VERSION >= (2, 2) else "Q",
+    # An alternate ISO-8601 spelling of QUARTER, as with HALF_HOUR above.
+    TimeGrain.QUARTER_YEAR: "QE" if _PANDAS_VERSION >= (2, 2) else "Q",
     TimeGrain.YEAR: "YE" if _PANDAS_VERSION >= (2, 2) else "A",
     TimeGrain.WEEK_STARTING_SUNDAY: "W-SUN",
     TimeGrain.WEEK_STARTING_MONDAY: "W-MON",

--- a/tests/unit_tests/pandas_postprocessing/test_prophet.py
+++ b/tests/unit_tests/pandas_postprocessing/test_prophet.py
@@ -374,3 +374,49 @@ def test_prophet_does_not_clamp_yhat_below_zero_for_negative_actuals():
     forecast_periods = 2
     forecast_yhat = result["balance__yhat"].iloc[-forecast_periods:]
     assert (forecast_yhat < 0).any()
+
+
+def test_prophet_every_time_grain_is_mapped():
+    """No `TimeGrain` may be missing from `PROPHET_TIME_GRAIN_MAP`.
+
+    Engine specs offer these grains in the Time Grain control, and the
+    `ChartDataProphetOptionsSchema.time_grain` field advertises them in the
+    OpenAPI spec, so an unmapped grain surfaces as "Unsupported time grain"
+    on a value the UI and the API both present as valid.
+    """
+    from superset.constants import TimeGrain
+    from superset.utils.pandas_postprocessing.utils import PROPHET_TIME_GRAIN_MAP
+
+    unmapped = [
+        grain.name for grain in TimeGrain if grain not in PROPHET_TIME_GRAIN_MAP
+    ]
+    assert not unmapped, f"TimeGrain values missing a pandas frequency: {unmapped}"
+
+
+@pytest.mark.parametrize(
+    "time_grain",
+    ["PT5S", "PT30S", "PT0.5H", "PT6H", "P0.25Y"],
+)
+def test_prophet_previously_unmapped_time_grains(time_grain):
+    """These five grains raised "Unsupported time grain" despite being offered
+    by engine specs such as Postgres, SQLite, Presto and Druid."""
+    df = prophet(
+        df=prophet_df, time_grain=time_grain, periods=3, confidence_interval=0.9
+    )
+    assert {"a__yhat", "a__yhat_upper", "a__yhat_lower"} <= set(df.columns)
+
+
+def test_prophet_alias_time_grains_match_their_canonical_form():
+    """`HALF_HOUR`/`QUARTER_YEAR` are alternate ISO-8601 spellings of
+    `THIRTY_MINUTES`/`QUARTER` and must resolve to the same frequency."""
+    from superset.constants import TimeGrain
+    from superset.utils.pandas_postprocessing.utils import PROPHET_TIME_GRAIN_MAP
+
+    assert (
+        PROPHET_TIME_GRAIN_MAP[TimeGrain.HALF_HOUR]
+        == PROPHET_TIME_GRAIN_MAP[TimeGrain.THIRTY_MINUTES]
+    )
+    assert (
+        PROPHET_TIME_GRAIN_MAP[TimeGrain.QUARTER_YEAR]
+        == PROPHET_TIME_GRAIN_MAP[TimeGrain.QUARTER]
+    )


### PR DESCRIPTION
<!-- PR TITLE: fix(chart): map the remaining time grains for Prophet forecasting -->
### SUMMARY

Enabling **Forecast** (Advanced Analytics → Predictive Analytics) fails with
`Unsupported time grain` for five time grains that Superset itself offers in
the Time Grain control.

`PROPHET_TIME_GRAIN_MAP` covered 16 of the 21 `TimeGrain` values. `prophet()`
rejects anything missing from it:

```python
if time_grain not in PROPHET_TIME_GRAIN_MAP:
    raise InvalidPostProcessingError(_("Unsupported time grain: %(time_grain)s", ...))
```

The five gaps, and how reachable each is — every one is exposed by real engine
specs through their `_time_grain_expressions`:

| TimeGrain | ISO | engine specs offering it |
| --- | --- | --- |
| `FIVE_SECONDS` | `PT5S` | 40 (Postgres, CockroachDB, SQLite, DataFusion, …) |
| `THIRTY_SECONDS` | `PT30S` | 42 (Postgres, CockroachDB, SQLite, DataFusion, …) |
| `HALF_HOUR` | `PT0.5H` | 15 (SQLite, Presto, GSheets, Kusto, …) |
| `SIX_HOURS` | `PT6H` | 15 (SQLite, Presto, Druid, GSheets, …) |
| `QUARTER_YEAR` | `P0.25Y` | 10 (SQLite, Shillelagh, GSheets, Ocient, …) |

Three of them are also advertised as valid by the API contract:
`ChartDataProphetOptionsSchema.time_grain` validates with
`validate.OneOf(choices=get_time_grain_choices())`, and `PT5S`, `PT30S` and
`PT6H` are all in `builtin_time_grains`. So the OpenAPI spec publishes them as
accepted values for the forecast operation, and the request then fails.

Two of the five are simply alternate ISO-8601 spellings of grains that already
work — `PT0.5H` is `PT30M`, `P0.25Y` is `P3M` — so picking one spelling
forecasts and the other errors, for the same interval.

Reproducing on `master`:

```python
>>> prophet(df=prophet_df, time_grain="PT6H", periods=3, confidence_interval=0.9)
InvalidPostProcessingError: Unsupported time grain: PT6H
```

This PR maps all five to their pandas frequency aliases (`5s`, `30s`, `30min`,
`6h`, and the same quarter alias `QUARTER` already uses). No `TimeGrain` value
is left unmapped.

Related but distinct: #42145 fixed `prophet()` being called with a *missing* `time_grain`. This fixes grains that are present and valid but unmapped.

Also a prerequisite for #43356, the operator-configured `TIME_GRAIN_ADDONS`
half of the same contract gap. The agreed fix there is to derive
`time_grain`'s `OneOf` from `PROPHET_TIME_GRAIN_MAP` so the schema advertises
only what `prophet()` can resolve. That has to land after this PR: on `master`
the map holds 16 keys against 19 built-ins, so doing it first would un-advertise
`PT5S`, `PT30S` and `PT6H` until this PR restored them. With this merged the map
is a strict superset of the built-ins, so nothing is lost.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend-only fix.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/pandas_postprocessing/test_prophet.py
```

Three tests are added:

| test | asserts |
| --- | --- |
| `test_prophet_previously_unmapped_time_grains` | all five grains now produce a forecast (parametrized; fails on `master`) |
| `test_prophet_every_time_grain_is_mapped` | no `TimeGrain` is missing from the map, so this cannot regress |
| `test_prophet_alias_time_grains_match_their_canonical_form` | `HALF_HOUR`/`QUARTER_YEAR` resolve identically to `THIRTY_MINUTES`/`QUARTER` |

Manually: on a Postgres or SQLite dataset, build a time-series chart, set Time
Grain to **6 hour** (or **5 second** / **30 second**), then enable Forecast
under Advanced Analytics. On `master` the chart errors with "Unsupported time
grain"; with this change it forecasts.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43356 (related; this PR is a prerequisite, it does not close it)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### CHECKLIST

- [ ] CI checks pass
- [x] Tests added/updated
- [ ] Documentation updated
- [x] PR title follows conventions
