### PR TITLE
fix(api): align sort and prophet option schemas with their operations

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1443,9 +1443,14 @@
             "minimum": 0.0,
             "type": "number"
           },
-          "monthly_seasonality": {
-            "description": "Should monthly seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
+          "daily_seasonality": {
+            "description": "Should daily seasonality be applied. An integer value will specify Fourier order of seasonality, `None` will automatically detect seasonality.",
             "example": false
+          },
+          "index": {
+            "description": "Name of the column holding the x-axis data. Defaults to `__timestamp`.",
+            "example": "__timestamp",
+            "type": "string"
           },
           "periods": {
             "description": "Time periods (in units of `time_grain`) to predict into the future",
@@ -2672,31 +2677,20 @@
       },
       "ChartDataSortOptionsSchema": {
         "properties": {
-          "aggregates": {
-            "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
-            "example": {
-              "first_quantile": {
-                "column": "my_col",
-                "operator": "percentile",
-                "options": {
-                  "q": 0.25
-                }
-              }
-            },
-            "type": "object"
+          "ascending": {
+            "description": "Sort ascending (the default) or descending. A list of booleans may be given to set the direction per entry in `by`.",
+            "example": true
           },
-          "columns": {
-            "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.",
-            "example": {
-              "country": true,
-              "gender": false
-            },
-            "type": "object"
+          "by": {
+            "description": "Name, or list of names, of the columns to sort by. Ignored when `is_sort_index` is set.",
+            "example": "country"
+          },
+          "is_sort_index": {
+            "description": "Whether to sort by the index rather than by column values.",
+            "example": true,
+            "type": "boolean"
           }
         },
-        "required": [
-          "columns"
-        ],
         "type": "object"
       },
       "ChartDataTiming": {

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -677,15 +677,28 @@ class ChartDataSortOptionsSchema(ChartDataPostProcessingOperationOptionsSchema):
     Sort operation config.
     """
 
-    columns = fields.Dict(
+    is_sort_index = fields.Boolean(
         metadata={
-            "description": "columns by by which to sort. The key specifies the column "
-            "name, value specifies if sorting in ascending order.",
-            "example": {"country": True, "gender": False},
+            "description": "Whether to sort by the index rather than by column values.",
+            "example": True,
         },
-        required=True,
     )
-    aggregates = ChartDataAggregateConfigField()
+    by = fields.Raw(
+        # TODO: add correct union type once supported by Marshmallow
+        metadata={
+            "description": "Name, or list of names, of the columns to sort by. "
+            "Ignored when `is_sort_index` is set.",
+            "example": "country",
+        },
+    )
+    ascending = fields.Raw(
+        # TODO: add correct union type once supported by Marshmallow
+        metadata={
+            "description": "Sort ascending (the default) or descending. A list of "
+            "booleans may be given to set the direction per entry in `by`.",
+            "example": True,
+        },
+    )
 
 
 class ChartDataContributionOptionsSchema(ChartDataPostProcessingOperationOptionsSchema):
@@ -765,13 +778,20 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "example": False,
         },
     )
-    monthly_seasonality = fields.Raw(
+    daily_seasonality = fields.Raw(
         # TODO: add correct union type once supported by Marshmallow
         metadata={
-            "description": "Should monthly seasonality be applied. "
+            "description": "Should daily seasonality be applied. "
             "An integer value will specify Fourier order of seasonality, `None` will "
             "automatically detect seasonality.",
             "example": False,
+        },
+    )
+    index = fields.String(
+        metadata={
+            "description": "Name of the column holding the x-axis data. Defaults to "
+            "`__timestamp`.",
+            "example": "__timestamp",
         },
     )
 

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -760,15 +760,28 @@ class ChartDataSortOptionsSchema(ChartDataPostProcessingOperationOptionsSchema):
     Sort operation config.
     """
 
-    columns = fields.Dict(
+    is_sort_index = fields.Boolean(
         metadata={
-            "description": "columns by by which to sort. The key specifies the column "
-            "name, value specifies if sorting in ascending order.",
-            "example": {"country": True, "gender": False},
+            "description": "Whether to sort by the index rather than by column values.",
+            "example": True,
         },
-        required=True,
     )
-    aggregates = ChartDataAggregateConfigField()
+    by = fields.Raw(
+        # TODO: add correct union type once supported by Marshmallow
+        metadata={
+            "description": "Name, or list of names, of the columns to sort by. "
+            "Ignored when `is_sort_index` is set.",
+            "example": "country",
+        },
+    )
+    ascending = fields.Raw(
+        # TODO: add correct union type once supported by Marshmallow
+        metadata={
+            "description": "Sort ascending (the default) or descending. A list of "
+            "booleans may be given to set the direction per entry in `by`.",
+            "example": True,
+        },
+    )
 
 
 class ChartDataContributionOptionsSchema(ChartDataPostProcessingOperationOptionsSchema):
@@ -848,13 +861,20 @@ class ChartDataProphetOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "example": False,
         },
     )
-    monthly_seasonality = fields.Raw(
+    daily_seasonality = fields.Raw(
         # TODO: add correct union type once supported by Marshmallow
         metadata={
-            "description": "Should monthly seasonality be applied. "
+            "description": "Should daily seasonality be applied. "
             "An integer value will specify Fourier order of seasonality, `None` will "
             "automatically detect seasonality.",
             "example": False,
+        },
+    )
+    index = fields.String(
+        metadata={
+            "description": "Name of the column holding the x-axis data. Defaults to "
+            "`__timestamp`.",
+            "example": "__timestamp",
         },
     )
 

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -497,6 +497,10 @@ def test_post_processing_option_schemas_match_their_functions(
     `aggregates` field, neither of which `sort()` accepts, and
     `ChartDataProphetOptionsSchema` documented `monthly_seasonality` where
     `prophet()` takes `daily_seasonality`.
+
+    Only this direction is asserted. A parameter the schema omits is a
+    documentation gap that still works when sent; a field the schema adds is
+    a 500.
     """
     import inspect
 
@@ -505,19 +509,35 @@ def test_post_processing_option_schemas_match_their_functions(
     from superset.charts import schemas as chart_schemas
     from superset.utils import pandas_postprocessing
 
+    # Keyed without underscores so that, say, `ChartDataGeohashDecodeOptionsSchema`
+    # reaches `geohash_decode`. Resolving by a bare `getattr` on the lowercased
+    # class name would miss every underscored operation, and missing ones would
+    # be skipped silently rather than reported.
+    operations = {
+        name.replace("_", ""): name
+        for name, _ in inspect.getmembers(pandas_postprocessing, inspect.isfunction)
+    }
+
     mismatches = {}
+    unresolved = []
     for name, schema_cls in vars(chart_schemas).items():
         if not (
             inspect.isclass(schema_cls)
             and issubclass(schema_cls, Schema)
             and name.startswith("ChartData")
             and name.endswith("OptionsSchema")
+            # the base class the per-operation schemas derive from
+            and schema_cls
+            is not chart_schemas.ChartDataPostProcessingOperationOptionsSchema  # noqa: E501
         ):
             continue
-        operation = name[len("ChartData") : -len("OptionsSchema")].lower()
-        function = getattr(pandas_postprocessing, operation, None)
-        if function is None:
+        operation = operations.get(
+            name[len("ChartData") : -len("OptionsSchema")].lower()
+        )
+        if operation is None:
+            unresolved.append(name)
             continue
+        function = getattr(pandas_postprocessing, operation)
         # `validate_column_args` wraps the operation; the signature worth
         # checking is the wrapped function's, not the decorator's `**options`.
         wrapped = function
@@ -528,6 +548,10 @@ def test_post_processing_option_schemas_match_their_functions(
         if undocumented := sorted(set(schema_cls().fields) - accepted):
             mismatches[f"{name} -> {operation}()"] = undocumented
 
+    assert not unresolved, (
+        "option schemas that could not be matched to a post-processing "
+        f"operation, so they went unchecked: {unresolved}"
+    )
     assert not mismatches, (
         "schema fields that the post-processing function does not accept "
         f"(each is a 500 for any client following the OpenAPI spec): {mismatches}"

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -478,3 +478,57 @@ def test_chart_data_extras_rejects_system_sampling(app_context: None) -> None:
     with pytest.raises(ValidationError) as exc_info:
         ChartDataExtrasSchema().load({"system_sampling": True})
     assert "system_sampling" in exc_info.value.messages
+
+
+def test_post_processing_option_schemas_match_their_functions(
+    app_context: None,
+) -> None:
+    """Every documented post-processing option must be a real parameter.
+
+    `QueryObject.exec_post_processing` dispatches with
+    `getattr(pandas_postprocessing, operation)(df, **options)`, and the
+    per-operation `options` dict is passed through unvalidated. So a field
+    that appears in one of these schemas but not in the corresponding
+    function signature is published in the OpenAPI spec as a valid option
+    while raising `TypeError: <op>() got an unexpected keyword argument` --
+    an HTTP 500 -- for any client that sends it.
+
+    `ChartDataSortOptionsSchema` documented a required `columns` dict and an
+    `aggregates` field, neither of which `sort()` accepts, and
+    `ChartDataProphetOptionsSchema` documented `monthly_seasonality` where
+    `prophet()` takes `daily_seasonality`.
+    """
+    import inspect
+
+    from marshmallow import Schema
+
+    from superset.charts import schemas as chart_schemas
+    from superset.utils import pandas_postprocessing
+
+    mismatches = {}
+    for name, schema_cls in vars(chart_schemas).items():
+        if not (
+            inspect.isclass(schema_cls)
+            and issubclass(schema_cls, Schema)
+            and name.startswith("ChartData")
+            and name.endswith("OptionsSchema")
+        ):
+            continue
+        operation = name[len("ChartData") : -len("OptionsSchema")].lower()
+        function = getattr(pandas_postprocessing, operation, None)
+        if function is None:
+            continue
+        # `validate_column_args` wraps the operation; the signature worth
+        # checking is the wrapped function's, not the decorator's `**options`.
+        wrapped = function
+        for cell in function.__closure__ or ():
+            if inspect.isfunction(cell.cell_contents):
+                wrapped = cell.cell_contents
+        accepted = set(inspect.signature(wrapped).parameters) - {"df"}
+        if undocumented := sorted(set(schema_cls().fields) - accepted):
+            mismatches[f"{name} -> {operation}()"] = undocumented
+
+    assert not mismatches, (
+        "schema fields that the post-processing function does not accept "
+        f"(each is a 500 for any client following the OpenAPI spec): {mismatches}"
+    )

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -683,3 +683,57 @@ def test_prophet_accepts_every_mapped_grain(app_context: None, grain: str) -> No
         {"time_grain": grain, "periods": 7, "confidence_interval": 0.8}
     )
     assert result["time_grain"] == grain
+
+
+def test_post_processing_option_schemas_match_their_functions(
+    app_context: None,
+) -> None:
+    """Every documented post-processing option must be a real parameter.
+
+    `QueryObject.exec_post_processing` dispatches with
+    `getattr(pandas_postprocessing, operation)(df, **options)`, and the
+    per-operation `options` dict is passed through unvalidated. So a field
+    that appears in one of these schemas but not in the corresponding
+    function signature is published in the OpenAPI spec as a valid option
+    while raising `TypeError: <op>() got an unexpected keyword argument` --
+    an HTTP 500 -- for any client that sends it.
+
+    `ChartDataSortOptionsSchema` documented a required `columns` dict and an
+    `aggregates` field, neither of which `sort()` accepts, and
+    `ChartDataProphetOptionsSchema` documented `monthly_seasonality` where
+    `prophet()` takes `daily_seasonality`.
+    """
+    import inspect
+
+    from marshmallow import Schema
+
+    from superset.charts import schemas as chart_schemas
+    from superset.utils import pandas_postprocessing
+
+    mismatches = {}
+    for name, schema_cls in vars(chart_schemas).items():
+        if not (
+            inspect.isclass(schema_cls)
+            and issubclass(schema_cls, Schema)
+            and name.startswith("ChartData")
+            and name.endswith("OptionsSchema")
+        ):
+            continue
+        operation = name[len("ChartData") : -len("OptionsSchema")].lower()
+        function = getattr(pandas_postprocessing, operation, None)
+        if function is None:
+            continue
+        # `validate_column_args` wraps the operation; the signature worth
+        # checking is the wrapped function's, not the decorator's `**options`.
+        wrapped = function
+        for cell in function.__closure__ or ():
+            if inspect.isfunction(cell.cell_contents):
+                wrapped = cell.cell_contents
+        accepted = set(inspect.signature(wrapped).parameters) - {"df"}
+        if undocumented := sorted(set(schema_cls().fields) - accepted):
+            mismatches[f"{name} -> {operation}()"] = undocumented
+
+    assert not mismatches, (
+        "schema fields that the post-processing function does not accept "
+        f"(each is a 500 for any client following the OpenAPI spec): {mismatches}"
+    )

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -702,6 +702,10 @@ def test_post_processing_option_schemas_match_their_functions(
     `aggregates` field, neither of which `sort()` accepts, and
     `ChartDataProphetOptionsSchema` documented `monthly_seasonality` where
     `prophet()` takes `daily_seasonality`.
+
+    Only this direction is asserted. A parameter the schema omits is a
+    documentation gap that still works when sent; a field the schema adds is
+    a 500.
     """
     import inspect
 
@@ -710,19 +714,35 @@ def test_post_processing_option_schemas_match_their_functions(
     from superset.charts import schemas as chart_schemas
     from superset.utils import pandas_postprocessing
 
+    # Keyed without underscores so that, say, `ChartDataGeohashDecodeOptionsSchema`
+    # reaches `geohash_decode`. Resolving by a bare `getattr` on the lowercased
+    # class name would miss every underscored operation, and missing ones would
+    # be skipped silently rather than reported.
+    operations = {
+        name.replace("_", ""): name
+        for name, _ in inspect.getmembers(pandas_postprocessing, inspect.isfunction)
+    }
+
     mismatches = {}
+    unresolved = []
     for name, schema_cls in vars(chart_schemas).items():
         if not (
             inspect.isclass(schema_cls)
             and issubclass(schema_cls, Schema)
             and name.startswith("ChartData")
             and name.endswith("OptionsSchema")
+            # the base class the per-operation schemas derive from
+            and schema_cls
+            is not chart_schemas.ChartDataPostProcessingOperationOptionsSchema  # noqa: E501
         ):
             continue
-        operation = name[len("ChartData") : -len("OptionsSchema")].lower()
-        function = getattr(pandas_postprocessing, operation, None)
-        if function is None:
+        operation = operations.get(
+            name[len("ChartData") : -len("OptionsSchema")].lower()
+        )
+        if operation is None:
+            unresolved.append(name)
             continue
+        function = getattr(pandas_postprocessing, operation)
         # `validate_column_args` wraps the operation; the signature worth
         # checking is the wrapped function's, not the decorator's `**options`.
         wrapped = function
@@ -733,6 +753,10 @@ def test_post_processing_option_schemas_match_their_functions(
         if undocumented := sorted(set(schema_cls().fields) - accepted):
             mismatches[f"{name} -> {operation}()"] = undocumented
 
+    assert not unresolved, (
+        "option schemas that could not be matched to a post-processing "
+        f"operation, so they went unchecked: {unresolved}"
+    )
     assert not mismatches, (
         "schema fields that the post-processing function does not accept "
         f"(each is a 500 for any client following the OpenAPI spec): {mismatches}"


### PR DESCRIPTION
### SUMMARY

Two post-processing option schemas document fields that the operations they
describe do not accept. Because `options` is passed through unvalidated, a
client that follows the OpenAPI spec gets an HTTP 500.

`QueryObject.exec_post_processing` dispatches with:

```python
df = getattr(pandas_postprocessing, operation)(df, **options)
```

and `ChartDataPostProcessingOperationSchema.options` is a bare `fields.Dict`.
The per-operation schemas are therefore documentation only — nothing validates
against them — so a field they publish but the function does not accept becomes
`TypeError: <op>() got an unexpected keyword argument`.

**`ChartDataSortOptionsSchema` is entirely out of sync with `sort()`.** It
documents a `columns` dict — marked `required=True` — plus `aggregates`:

```python
columns = fields.Dict(..., required=True)
aggregates = ChartDataAggregateConfigField()
```

while the function signature is:

```python
def sort(df, is_sort_index=False, by=None, ascending=True) -> DataFrame:
```

So sending exactly what the spec marks as required fails, and the three real
parameters are undocumented:

```python
>>> sort(df, columns={"country": True})
TypeError: sort() got an unexpected keyword argument 'columns'
```

The frontend `sortOperator` already sends `{is_sort_index, ascending}` or
`{by, ascending}`, confirming which side is correct.

**`ChartDataProphetOptionsSchema` documents `monthly_seasonality`**, which
`prophet()` does not take — it takes `daily_seasonality`, which was undocumented,
along with `index`:

```python
>>> prophet(df, periods=2, confidence_interval=0.8, time_grain="P1D",
...         monthly_seasonality=True)
TypeError: prophet() got an unexpected keyword argument 'monthly_seasonality'
```

The frontend `prophetOperator` sends `daily_seasonality` and `index`, and never
sends `monthly_seasonality`.

This PR corrects both schemas to match their functions, and adds a test that
walks every `ChartData*OptionsSchema`, resolves the operation it describes, and
asserts each declared field is a real parameter — so the two cannot drift apart
again silently.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — the change is to the OpenAPI schema definitions.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/charts/test_schemas.py
```

`test_post_processing_option_schemas_match_their_functions` is added. Restoring
either pre-fix field makes it fail with:

```
schema fields that the post-processing function does not accept (each is a 500
for any client following the OpenAPI spec):
{'ChartDataSortOptionsSchema -> sort()': ['aggregates', 'columns'],
 'ChartDataProphetOptionsSchema -> prophet()': ['monthly_seasonality']}
```

To see the spec change, start Superset and open `/swagger/v1`, then compare the
`ChartDataSortOptions` and `ChartDataProphetOptions` definitions.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### CHECKLIST

- [ ] CI checks pass
- [x] Tests added/updated
- [ ] Documentation updated
- [x] PR title follows conventions
