### PR TITLE
fix(clickhouse): add PT1S time grain

### DIFF
--- a/superset/db_engine_specs/README.md
+++ b/superset/db_engine_specs/README.md
@@ -83,7 +83,7 @@ The tables below (generated via `python superset/db_engine_specs/lib.py`) summar
 | Databricks (legacy) | 70 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | StarRocks | 69 | Supported | Partial | Supported | Partial | Partial | Partial |
 | SingleStore | 68 | Supported | Partial | Supported | Not supported | Partial | Not supported |
-| ClickHouse Connect (Superset) | 61 | Supported | Partial | Partial | Partial | Partial | Not supported |
+| ClickHouse Connect (Superset) | 62 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | Google Sheets | 61 | Supported | Partial | Supported | Supported | Partial | Partial |
 | Aurora MySQL (Data API) | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | MariaDB | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
@@ -91,7 +91,7 @@ The tables below (generated via `python superset/db_engine_specs/lib.py`) summar
 | OceanBase | 59 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | MotherDuck | 58 | Supported | Partial | Supported | Not supported | Partial | Not supported |
 | KustoSQL | 54 | Supported | Partial | Supported | Partial | Partial | Not supported |
-| ClickHouse | 51 | Supported | Partial | Partial | Partial | Partial | Not supported |
+| ClickHouse | 52 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | Databend | 51 | Supported | Partial | Supported | Partial | Partial | Not supported |
 | Apache Drill | 50 | Supported | Partial | Supported | Partial | Partial | Partial |
 | Apache Druid | 47 | Partial | Partial | Supported | Partial | Partial | Not supported |
@@ -293,8 +293,8 @@ The tables below (generated via `python superset/db_engine_specs/lib.py`) summar
 | Aurora MySQL (Data API) | True | True | True | True | True | True | True | True |
 | Aurora PostgreSQL (Data API) | True | True | True | True | True | True | True | True |
 | Azure Synapse | True | True | True | True | True | True | True | True |
-| ClickHouse | False | True | True | True | True | True | True | True |
-| ClickHouse Connect (Superset) | False | True | True | True | True | True | True | True |
+| ClickHouse | True | True | True | True | True | True | True | True |
+| ClickHouse Connect (Superset) | True | True | True | True | True | True | True | True |
 | CockroachDB | True | True | True | True | True | True | True | True |
 | Couchbase | True | True | True | True | False | True | True | True |
 | CrateDB | True | True | True | True | True | True | True | True |

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -112,7 +112,7 @@ class ClickHouseBaseEngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
-        "PT1S": "toStartOfSecond(toDateTime({col}))",
+        "PT1S": "toStartOfSecond(toDateTime64({col}, 3))",
         "PT1M": "toStartOfMinute(toDateTime({col}))",
         "PT5M": "toDateTime(intDiv(toUInt32(toDateTime({col})), 300)*300)",
         "PT10M": "toDateTime(intDiv(toUInt32(toDateTime({col})), 600)*600)",

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -112,6 +112,7 @@ class ClickHouseBaseEngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
+        "PT1S": "toStartOfSecond(toDateTime({col}))",
         "PT1M": "toStartOfMinute(toDateTime({col}))",
         "PT5M": "toDateTime(intDiv(toUInt32(toDateTime({col})), 300)*300)",
         "PT10M": "toDateTime(intDiv(toUInt32(toDateTime({col})), 600)*600)",

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -66,7 +66,7 @@ def test_convert_dttm(
     "time_grain,expected",
     [
         (None, "{col}"),
-        ("PT1S", "toStartOfSecond(toDateTime({col}))"),
+        ("PT1S", "toStartOfSecond(toDateTime64({col}, 3))"),
         ("PT1M", "toStartOfMinute(toDateTime({col}))"),
     ],
 )

--- a/tests/unit_tests/db_engine_specs/test_clickhouse.py
+++ b/tests/unit_tests/db_engine_specs/test_clickhouse.py
@@ -62,6 +62,20 @@ def test_convert_dttm(
     assert_convert_dttm(spec, target_type, expected_result, dttm)
 
 
+@pytest.mark.parametrize(
+    "time_grain,expected",
+    [
+        (None, "{col}"),
+        ("PT1S", "toStartOfSecond(toDateTime({col}))"),
+        ("PT1M", "toStartOfMinute(toDateTime({col}))"),
+    ],
+)
+def test_time_grain_expressions(time_grain: Optional[str], expected: str) -> None:
+    from superset.db_engine_specs.clickhouse import ClickHouseBaseEngineSpec
+
+    assert ClickHouseBaseEngineSpec._time_grain_expressions[time_grain] == expected
+
+
 def test_convert_dttm_normalizes_aware_datetime_to_utc() -> None:
     from superset.db_engine_specs.clickhouse import (
         ClickHouseEngineSpec as spec,  # noqa: N813


### PR DESCRIPTION
### SUMMARY

ClickHouse has had `toStartOfSecond()` since 20.5.0, but `ClickHouseBaseEngineSpec._time_grain_expressions` started at `PT1M`. The README (and the 6.1 docs snapshot) therefore marked SECOND as unsupported, even though the engine already uses the matching `toStartOf*` helpers for coarser grains.

This adds one key on `ClickHouseBaseEngineSpec` (both drivers inherit it):

```python
"PT1S": "toStartOfSecond(toDateTime64({col}, 3))"
```

The first draft used `toDateTime({col})`, matching `toStartOfMinute` / `toStartOfHour` / `toStartOfDay`. That is illegal SQL: on ClickHouse 26.7.3, `toStartOfSecond` raises Code 43 (`Illegal type DateTime of argument`). The function has been `DateTime64`-only since it landed in 20.5. Wrapping with `toDateTime64({col}, 3)` runs for both `DateTime` (promoted) and `DateTime64` (subseconds truncated). I did not add `PT5S` / `PT30S`, and I did not touch other engines.

The generated README table now marks SECOND as True, which also flips Common Time Grains from Partial to Supported.

This is a one-expression fill-in on an existing engine spec, not a new database or public API, so I did not file a SIP.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend SQL expression only.

### TESTING INSTRUCTIONS

```bash
pytest -q tests/unit_tests/db_engine_specs/test_clickhouse.py
```

84 passed locally. `pre-commit run` on the staged files is green.

Against a live ClickHouse 26.7.3:

```sql
-- fails (the sibling-grain wrap)
SELECT toStartOfSecond(toDateTime('2020-01-01 10:20:30'));
-- Code 43: Illegal type DateTime of argument for function toStartOfSecond

-- works (this PR)
SELECT toStartOfSecond(toDateTime64(toDateTime('2020-01-01 10:20:30'), 3));
SELECT toStartOfSecond(toDateTime64(toDateTime64('2020-01-01 10:20:30.999', 3), 3));
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
