### PR TITLE
fix(histogram): render empty chart instead of crashing when no rows match

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -80,7 +80,7 @@ export default function transformProps(
 
   const percentFormatter = getPercentFormatter(NumberFormats.PERCENT_2_POINT);
   const groupbySet = new Set(groupby);
-  const xAxisData: string[] = Object.keys(data[0])
+  const xAxisData: string[] = Object.keys(data[0] || {})
     .filter(key => !groupbySet.has(key))
     .map(key => {
       const array = key.split(' - ').map(value => parseFloat(value));

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -80,7 +80,7 @@ export default function transformProps(
 
   const percentFormatter = getPercentFormatter(NumberFormats.PERCENT_2_POINT);
   const groupbySet = new Set(groupby);
-  const xAxisData: string[] = Object.keys(data[0] || {})
+  const xAxisData: string[] = Object.keys(data[0] ?? {})
     .filter(key => !groupbySet.has(key))
     .map(key => {
       const array = key.split(' - ').map(value => parseFloat(value));

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { BarSeriesOption } from 'echarts/charts';
+import transformProps from '../../src/Histogram/transformProps';
+import {
+  HistogramChartProps,
+  HistogramFormData,
+} from '../../src/Histogram/types';
+
+const formData: HistogramFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  viz_type: 'histogram',
+  column: 'price',
+  groupby: [],
+  bins: 2,
+  cumulative: false,
+  normalize: false,
+  sliceId: 1,
+  showLegend: true,
+  showValue: false,
+  xAxisFormat: '',
+  xAxisTitle: '',
+  yAxisFormat: '',
+  yAxisTitle: '',
+};
+
+const createChartProps = (
+  data: Record<string, unknown>[],
+  overrides: Partial<HistogramFormData> = {},
+) =>
+  new ChartProps({
+    formData: { ...formData, ...overrides },
+    width: 800,
+    height: 600,
+    queriesData: [{ data }],
+    theme: supersetTheme,
+  });
+
+test('transforms bin columns into an axis category and a bar series', () => {
+  const props = createChartProps([{ '0 - 5': 3, '5 - 10': 7 }]);
+  const transformed = transformProps(props as HistogramChartProps);
+  const { xAxis, series } = transformed.echartOptions as {
+    xAxis: { data: string[] };
+    series: BarSeriesOption[];
+  };
+
+  expect(xAxis.data).toHaveLength(2);
+  expect(series).toHaveLength(1);
+  expect(series[0].data).toEqual([3, 7]);
+});
+
+test('renders an empty chart when the query returns no rows', () => {
+  /**
+   * The histogram post-processor returns an empty frame when every value in
+   * the target column is NULL (`df.dropna(...)` leaves nothing), so
+   * `queriesData[0].data` arrives as `[]`. Reading the bin labels off
+   * `data[0]` then throws "Cannot convert undefined or null to object" and
+   * the chart crashes instead of rendering as empty. Radar already guards
+   * the same lookup with `data[0] || {}`.
+   */
+  const props = createChartProps([]);
+  const transformed = transformProps(props as HistogramChartProps);
+  const { xAxis, series } = transformed.echartOptions as {
+    xAxis: { data: string[] };
+    series: BarSeriesOption[];
+  };
+
+  expect(xAxis.data).toEqual([]);
+  expect(series).toEqual([]);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
@@ -74,8 +74,8 @@ test('renders an empty chart when the query returns no rows', () => {
    * the target column is NULL (`df.dropna(...)` leaves nothing), so
    * `queriesData[0].data` arrives as `[]`. Reading the bin labels off
    * `data[0]` then throws "Cannot convert undefined or null to object" and
-   * the chart crashes instead of rendering as empty. Radar already guards
-   * the same lookup with `data[0] || {}`.
+   * the chart crashes instead of rendering as empty. Guard the lookup with
+   * `data[0] ?? {}`.
    */
   const props = createChartProps([]);
   const transformed = transformProps(props as HistogramChartProps);


### PR DESCRIPTION
### SUMMARY

The Histogram chart throws `TypeError: Cannot convert undefined or null to object` and fails to render whenever its query comes back with no rows.

`transformProps` reads the bin labels straight off the first datum:

```ts
const xAxisData: string[] = Object.keys(data[0])
```

That datum does not always exist. The histogram post-processor drops NULLs in the target column and returns the empty frame as-is:

```python
# superset/utils/pandas_postprocessing/histogram.py
df = df.dropna(subset=[column])
if df.empty:
    return df
```

So an all-NULL numeric column, or a filter that matches nothing, sends `data: []` to the frontend and `Object.keys(undefined)` throws.

The fix is a nullish-coalescing guard on that lookup:

```ts
const xAxisData: string[] = Object.keys(data[0] ?? {})
```

With `data` empty everything downstream already degrades correctly — `data.map(...)` yields no series, the legend list is empty, and the tooltip formatter is never called — so the chart renders as an empty plot instead of crashing.

Also adds `test/Histogram/transformProps.test.ts`. This plugin had a `buildQuery` test but no `transformProps` coverage at all.

### TESTING INSTRUCTIONS

Automated:

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/Histogram   # 5 passed
npm run test -- plugins/plugin-chart-echarts                  # 85 suites, 895 passed
```

Reverting the one-line change makes the new test fail with the reported error:

```
● renders an empty chart when the query returns no rows
  TypeError: Cannot convert undefined or null to object
  at keys (plugins/plugin-chart-echarts/src/Histogram/transformProps.ts:83:38)
```

Manually:

1. Create a Histogram chart on any dataset with a numeric column.
2. Add a filter that matches no rows (or point it at a numeric column whose values are all NULL).
3. Before: the chart area shows "Unexpected error". After: it renders as an empty chart.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
