### PR TITLE
fix(histogram): compare groupby membership using column labels

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -79,7 +79,7 @@ export default function transformProps(
   const yAxisFormatter = formatter(yAxisFormat);
 
   const percentFormatter = getPercentFormatter(NumberFormats.PERCENT_2_POINT);
-  const groupbySet = new Set(groupby);
+  const groupbySet = new Set(groupby.map(getColumnLabel));
   const xAxisData: string[] = Object.keys(data[0])
     .filter(key => !groupbySet.has(key))
     .map(key => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { BarSeriesOption } from 'echarts/charts';
+import transformProps from '../../src/Histogram/transformProps';
+import {
+  HistogramChartProps,
+  HistogramFormData,
+} from '../../src/Histogram/types';
+
+const formData: HistogramFormData = {
+  datasource: '5__table',
+  granularity_sqla: 'ds',
+  viz_type: 'histogram',
+  column: 'price',
+  groupby: [],
+  bins: 2,
+  cumulative: false,
+  normalize: false,
+  sliceId: 1,
+  showLegend: true,
+  showValue: false,
+  xAxisFormat: '',
+  xAxisTitle: '',
+  yAxisFormat: '',
+  yAxisTitle: '',
+};
+
+const createChartProps = (
+  data: Record<string, unknown>[],
+  overrides: Partial<HistogramFormData> = {},
+) =>
+  new ChartProps({
+    formData: { ...formData, ...overrides },
+    width: 800,
+    height: 600,
+    queriesData: [{ data }],
+    theme: supersetTheme,
+  });
+
+const readChart = (props: ChartProps) => {
+  const transformed = transformProps(props as HistogramChartProps);
+  const { xAxis, series } = transformed.echartOptions as {
+    xAxis: { data: string[] };
+    series: BarSeriesOption[];
+  };
+  return { xAxis, series };
+};
+
+test('transforms bin columns into an axis category and a bar series', () => {
+  const { xAxis, series } = readChart(
+    createChartProps([{ '0 - 5': 3, '5 - 10': 7 }]),
+  );
+
+  expect(xAxis.data).toHaveLength(2);
+  expect(series).toHaveLength(1);
+  expect(series[0].data).toEqual([3, 7]);
+});
+
+test('keeps physical groupby columns off the x-axis', () => {
+  const { xAxis, series } = readChart(
+    createChartProps([{ region: 'WEST', '0 - 5': 3, '5 - 10': 7 }], {
+      groupby: ['region'],
+    }),
+  );
+
+  expect(xAxis.data).toHaveLength(2);
+  expect(xAxis.data.every(label => !label.includes('NaN'))).toBe(true);
+  expect(series[0].name).toBe('WEST');
+  expect(series[0].data).toEqual([3, 7]);
+});
+
+test('does not treat adhoc groupby labels as histogram bin edges', () => {
+  /**
+   * Query results key groupby columns by getColumnLabel(), but groupby
+   * membership was checked against the raw form-data entries. Adhoc columns
+   * are objects, so they fail that filter, get parsed as bin edges, and
+   * show up as a NaN bin label on the x-axis.
+   */
+  const adhocGroupby = {
+    expressionType: 'SQL' as const,
+    sqlExpression: 'UPPER(region)',
+    label: 'region_upper',
+  };
+  const { xAxis, series } = readChart(
+    createChartProps([{ region_upper: 'WEST', '0 - 5': 3, '5 - 10': 7 }], {
+      groupby: [adhocGroupby],
+    }),
+  );
+
+  expect(xAxis.data).toHaveLength(2);
+  expect(xAxis.data.every(label => !label.includes('NaN'))).toBe(true);
+  expect(series[0].name).toBe('WEST');
+  expect(series[0].data).toEqual([3, 7]);
+});


### PR DESCRIPTION
### SUMMARY

Follow-up to #43218 (empty query crash). This change does not include that guard.

Histogram `transformProps` builds the x-axis from every datum key that is not in `groupby`, then parses those leftover keys as `"low - high"` bin edges. Series names already look up groupby values with `getColumnLabel()`, but membership was checked against the raw form-data entries:

```ts
const groupbySet = new Set(groupby);
```

Adhoc groupby columns are objects (`{ sqlExpression, label, expressionType: 'SQL' }`), so `Set.has(datumKey)` is always false. The labeled column is treated as a bin, `parseFloat(label)` is `NaN`, and the x-axis grows an extra `"NaN - undefined"` category (or `"NaN - NaN"` with a numeric formatter). The series data array also picks up the groupby value.

Sibling plugins (BoxPlot, Radar, Pie) already map `groupby.map(getColumnLabel)` before comparing. This does the same, so physical string columns stay identity and adhoc labels match the keys the query actually returns.

### TESTING INSTRUCTIONS

Automated:

```bash
cd superset-frontend
npm run test -- plugins/plugin-chart-echarts/test/Histogram   # 6 passed
npm run test -- plugins/plugin-chart-echarts                  # 85 suites, 896 passed
```

Reverting the one-line change makes the new adhoc test fail:

```
● does not treat adhoc groupby labels as histogram bin edges
  Expected length: 2
  Received length: 3
  Received array:  ["NaN - undefined", "0 - 5", "5 - 10"]
```

Manually:

1. Create a Histogram chart with a numeric column and an adhoc groupby (SQL expression with a custom label).
2. Before: the x-axis includes a NaN bin and the groupby value is mixed into the series data.
3. After: the x-axis is only the numeric bins, and the series is named from the groupby value.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
