### PR TITLE
feat(native-filters): drive cascade dependencies from chart metadata

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartMetadata.ts
@@ -55,6 +55,11 @@ export interface ChartMetadataConfig {
   // suppressContextMenu: true hides the default context menu for the chart.
   // This is useful for viz plugins that define their own context menu.
   suppressContextMenu?: boolean;
+  // Whether a native filter can participate in cascade dependencies (parent
+  // or child). Unset falls back to Behavior.NativeFilter. Explicit false
+  // opts out — used by time grain/column filters, whose extraFormData is
+  // not safe to merge across datasets.
+  supportsCascadeDependencies?: boolean;
 }
 
 export default class ChartMetadata {
@@ -100,6 +105,8 @@ export default class ChartMetadata {
 
   suppressContextMenu?: boolean;
 
+  supportsCascadeDependencies?: boolean;
+
   constructor(config: ChartMetadataConfig) {
     const {
       name,
@@ -122,6 +129,7 @@ export default class ChartMetadata {
       dynamicQueryObjectCount = false,
       parseMethod = 'json-bigint',
       suppressContextMenu = false,
+      supportsCascadeDependencies,
     } = config;
 
     this.name = name;
@@ -153,6 +161,7 @@ export default class ChartMetadata {
     this.dynamicQueryObjectCount = dynamicQueryObjectCount;
     this.parseMethod = parseMethod;
     this.suppressContextMenu = suppressContextMenu;
+    this.supportsCascadeDependencies = supportsCascadeDependencies;
   }
 
   canBeAnnotationType(type: string): boolean {

--- a/superset-frontend/packages/superset-ui-core/test/chart/models/ChartMetadata.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/chart/models/ChartMetadata.test.ts
@@ -70,4 +70,24 @@ describe('ChartMetadata', () => {
       expect(metadata.thumbnail).toEqual(clone.thumbnail);
     });
   });
+  test('stores supportsCascadeDependencies without defaulting unset to false', () => {
+    const unset = new ChartMetadata({
+      name: 'unset',
+      thumbnail: 'test.png',
+    });
+    const optedOut = new ChartMetadata({
+      name: 'opted out',
+      thumbnail: 'test.png',
+      supportsCascadeDependencies: false,
+    });
+    const optedIn = new ChartMetadata({
+      name: 'opted in',
+      thumbnail: 'test.png',
+      supportsCascadeDependencies: true,
+    });
+    expect(unset.supportsCascadeDependencies).toBeUndefined();
+    expect(optedOut.supportsCascadeDependencies).toBe(false);
+    expect(optedIn.supportsCascadeDependencies).toBe(true);
+    expect(optedOut.clone().supportsCascadeDependencies).toBe(false);
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -94,7 +94,7 @@ import {
 } from 'src/dashboard/components/nativeFilters/utils';
 import { DatasetSelectLabel } from 'src/features/datasets/DatasetSelectLabel';
 import {
-  ALLOW_DEPENDENCIES as TYPES_SUPPORT_DEPENDENCIES,
+  filterSupportsDependencies,
   getFiltersConfigModalTestId,
 } from '../FiltersConfigModal';
 import { FilterRemoval, NativeFiltersForm } from '../types';
@@ -472,7 +472,7 @@ const FiltersConfigForm = (
     formFilter?.filterType,
   );
 
-  const canDependOnOtherFilters = TYPES_SUPPORT_DEPENDENCIES.includes(
+  const canDependOnOtherFilters = filterSupportsDependencies(
     formFilter?.filterType,
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigModal.tsx
@@ -49,7 +49,7 @@ import {
   useFilterOperations,
   useCustomizationOperations,
   useModalSaveLogic,
-  ALLOW_DEPENDENCIES,
+  filterSupportsDependencies,
 } from './hooks';
 import {
   getFilterIds,
@@ -62,7 +62,7 @@ import {
 import { ConfigModalContent } from './ConfigModalContent';
 import ConfigModalSidebar from './ConfigModalSidebar';
 
-export { ALLOW_DEPENDENCIES };
+export { filterSupportsDependencies };
 
 const StyledModalBody = styled(BaseModalBody)`
   .filters-list {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/NativeFiltersModal.test.tsx
@@ -41,9 +41,18 @@ jest.mock('@superset-ui/core', () => ({
         value: {
           datasourceCount: 1,
           behaviors: ['NATIVE_FILTER'],
+          supportsCascadeDependencies: true,
         },
       },
     },
+    get: (key: string) =>
+      key === 'filter_select'
+        ? {
+            datasourceCount: 1,
+            behaviors: ['NATIVE_FILTER'],
+            supportsCascadeDependencies: true,
+          }
+        : undefined,
   }),
 }));
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/index.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/index.ts
@@ -18,7 +18,10 @@
  */
 export { useItemStateManager } from './useItemStateManager';
 export type { ItemStateManager } from './useItemStateManager';
-export { useFilterOperations, ALLOW_DEPENDENCIES } from './useFilterOperations';
+export {
+  useFilterOperations,
+  filterSupportsDependencies,
+} from './useFilterOperations';
 export type {
   FilterOperations,
   FilterOperationsParams,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useFilterOperations.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useFilterOperations.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Behavior } from '@superset-ui/core';
+import { filterSupportsDependencies } from './useFilterOperations';
+
+const mockItems: Record<string, { value: Record<string, unknown> }> = {
+  filter_select: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+      supportsCascadeDependencies: true,
+    },
+  },
+  filter_range: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+      supportsCascadeDependencies: true,
+    },
+  },
+  filter_time: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+      supportsCascadeDependencies: true,
+    },
+  },
+  filter_timegrain: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+      supportsCascadeDependencies: false,
+    },
+  },
+  filter_timecolumn: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+      supportsCascadeDependencies: false,
+    },
+  },
+  filter_unspecified: {
+    value: {
+      behaviors: [Behavior.NativeFilter],
+    },
+  },
+  chart_only: {
+    value: {
+      behaviors: [Behavior.InteractiveChart],
+    },
+  },
+};
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  getChartMetadataRegistry: () => ({
+    get: (key: string) => mockItems[key]?.value,
+  }),
+}));
+
+test('filterSupportsDependencies opts in the core select/range/time filters', () => {
+  expect(filterSupportsDependencies('filter_select')).toBe(true);
+  expect(filterSupportsDependencies('filter_range')).toBe(true);
+  expect(filterSupportsDependencies('filter_time')).toBe(true);
+});
+
+test('filterSupportsDependencies keeps time grain and time column out of the cascade gate', () => {
+  expect(filterSupportsDependencies('filter_timegrain')).toBe(false);
+  expect(filterSupportsDependencies('filter_timecolumn')).toBe(false);
+});
+
+test('filterSupportsDependencies falls back to NativeFilter behavior when unset', () => {
+  expect(filterSupportsDependencies('filter_unspecified')).toBe(true);
+  expect(filterSupportsDependencies('chart_only')).toBe(false);
+});
+
+test('filterSupportsDependencies returns false for an unknown or missing filterType', () => {
+  expect(filterSupportsDependencies('unknown_type')).toBe(false);
+  expect(filterSupportsDependencies(undefined)).toBe(false);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useFilterOperations.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/hooks/useFilterOperations.ts
@@ -18,17 +18,39 @@
  */
 import { useCallback } from 'react';
 import { t } from '@apache-superset/core/translation';
-import { Filter, Divider, NativeFilterType } from '@superset-ui/core';
+import {
+  Behavior,
+  Filter,
+  Divider,
+  NativeFilterType,
+  getChartMetadataRegistry,
+} from '@superset-ui/core';
 import type { FormInstance } from '@superset-ui/core/components';
 import { NativeFiltersForm } from '../types';
 import { generateFilterId, hasCircularDependency } from '../utils';
 import type { ItemStateManager } from './useItemStateManager';
 
-export const ALLOW_DEPENDENCIES = [
-  'filter_range',
-  'filter_select',
-  'filter_time',
-];
+/**
+ * Whether a native filter can participate in cascade dependencies as a
+ * parent or as a child. Matches the old ALLOW_DEPENDENCIES allowlist for
+ * core filters: select/range/time in, time grain/column out.
+ *
+ * An explicit `supportsCascadeDependencies` on chart metadata wins. When
+ * the flag is unset, NativeFilter plugins stay cascade-capable so third-
+ * party filters that predate the flag keep working.
+ */
+export function filterSupportsDependencies(
+  filterType: string | undefined,
+): boolean {
+  if (!filterType) {
+    return false;
+  }
+  const metadata = getChartMetadataRegistry().get(filterType);
+  if (metadata?.supportsCascadeDependencies !== undefined) {
+    return metadata.supportsCascadeDependencies;
+  }
+  return metadata?.behaviors?.includes(Behavior.NativeFilter) ?? false;
+}
 
 interface AvailableFilterOption {
   label: string;
@@ -148,7 +170,7 @@ export function useFilterOperations({
       return (
         component &&
         'filterType' in component &&
-        ALLOW_DEPENDENCIES.includes(component.filterType)
+        filterSupportsDependencies(component.filterType)
       );
     },
     [filterConfigMap, form, filterState.removedItems],

--- a/superset-frontend/src/filters/components/Range/index.ts
+++ b/superset-frontend/src/filters/components/Range/index.ts
@@ -29,6 +29,7 @@ export default class RangeFilterPlugin extends ChartPlugin {
       name: t('Range filter'),
       description: t('Range filter plugin using AntD'),
       behaviors: [Behavior.InteractiveChart, Behavior.NativeFilter],
+      supportsCascadeDependencies: true,
       tags: [t('Experimental')],
       thumbnail,
     });

--- a/superset-frontend/src/filters/components/Select/index.ts
+++ b/superset-frontend/src/filters/components/Select/index.ts
@@ -30,6 +30,7 @@ export default class FilterSelectPlugin extends ChartPlugin {
       description: t('Select filter plugin using AntD'),
       behaviors: [Behavior.InteractiveChart, Behavior.NativeFilter],
       enableNoResults: false,
+      supportsCascadeDependencies: true,
       tags: [t('Experimental')],
       thumbnail,
     });

--- a/superset-frontend/src/filters/components/Time/index.ts
+++ b/superset-frontend/src/filters/components/Time/index.ts
@@ -28,6 +28,7 @@ export default class TimeFilterPlugin extends ChartPlugin {
       name: t('Time filter'),
       description: t('Custom time filter plugin'),
       behaviors: [Behavior.InteractiveChart, Behavior.NativeFilter],
+      supportsCascadeDependencies: true,
       thumbnail,
       tags: [t('Experimental')],
       datasourceCount: 0,

--- a/superset-frontend/src/filters/components/TimeColumn/index.ts
+++ b/superset-frontend/src/filters/components/TimeColumn/index.ts
@@ -29,6 +29,7 @@ export default class FilterTimeColumnPlugin extends ChartPlugin {
       name: t('Time column'),
       description: t('Time column filter plugin'),
       behaviors: [Behavior.InteractiveChart, Behavior.NativeFilter],
+      supportsCascadeDependencies: false,
       tags: [t('Experimental')],
       thumbnail,
     });

--- a/superset-frontend/src/filters/components/TimeGrain/index.ts
+++ b/superset-frontend/src/filters/components/TimeGrain/index.ts
@@ -29,6 +29,7 @@ export default class FilterTimeGrainPlugin extends ChartPlugin {
       name: t('Time grain'),
       description: t('Time grain filter plugin'),
       behaviors: [Behavior.InteractiveChart, Behavior.NativeFilter],
+      supportsCascadeDependencies: false,
       tags: [t('Experimental')],
       thumbnail,
     });


### PR DESCRIPTION
### SUMMARY

This is the registry-only slice @rusackas asked for on #40905. The original implementation is @ashah65's — I am landing just the part that was already called clean, as a new PR rather than pushing over that branch.

Dashboard cascade used to consult a hardcoded `ALLOW_DEPENDENCIES` list (`filter_select` / `filter_range` / `filter_time`). Third-party native filters could not join cascade without a core change. This replaces that list with `ChartMetadata.supportsCascadeDependencies`:

- Select, Range, and Time filters set the flag to `true`. Parent picker and child "Values are dependent on other filters" stay as they are today.
- Time column and Time grain set it to `false`. They stay out of **both** gates — I did not take the #40905 child-side widening that would have shown the dependency section on those types.
- If a plugin leaves the flag unset, we fall back to `Behavior.NativeFilter` so existing third-party filters keep working.

`isColumnSelect`, the divider change-tracking rewrite, and the ControlLabel work from #40905 are not in this PR. Those can come later if still wanted.

I do not think this needs a SIP. It is the same cascade feature, driven from plugin metadata instead of a list, and rusackas already said the core swap is clean.

Related: #40905, discussion #26084.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. Core filter UI is unchanged. Time column / time grain still do not offer the child dependency control.

### TESTING INSTRUCTIONS

```
cd superset-frontend && npm run test -- --testPathPatterns='FiltersConfigModal|useFilterOperations|getControlItemsMap|ChartMetadata.test'
```

On a dashboard:

1. Open **Manage filters**.
2. Add a Value (select) filter and a Range filter. Confirm "Values are dependent on other filters" still appears for those types, and that each can be chosen as a parent of the other.
3. Add a Time column or Time grain filter. Confirm they do **not** show that child control and cannot be selected as a cascade parent.
4. Save and confirm existing select/range/time cascade still applies on the dashboard.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
