### PR TITLE
fix(api): restore three schema fields disabled by a stray trailing comma

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -2582,7 +2582,7 @@
           "columns": {
             "description": "columns on which to perform rolling, mapping source column to target column. For instance, `{'y': 'y'}` will replace the column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add a column `y2` based on rolling values calculated from `y`, leaving the original column `y` unchanged.",
             "example": {
-              "weekly_rolling_sales": "sales"
+              "sales": "weekly_rolling_sales"
             },
             "type": "object"
           },

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1047,8 +1047,18 @@
               }
             },
             "type": "object"
+          },
+          "groupby": {
+            "items": {
+              "description": "Columns by which to group by",
+              "type": "string"
+            },
+            "type": "array"
           }
         },
+        "required": [
+          "groupby"
+        ],
         "type": "object"
       },
       "ChartDataAsyncResponseSchema": {
@@ -1383,6 +1393,14 @@
             "description": "Do not include columns whose entries are all missing (default: `true`).",
             "type": "boolean"
           },
+          "index": {
+            "description": "Columns to group by on the table index (=rows)",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
           "marginal_distribution_name": {
             "description": "Name of marginal distribution row/column. (default: `All`)",
             "type": "string"
@@ -1396,6 +1414,9 @@
             "type": "number"
           }
         },
+        "required": [
+          "index"
+        ],
         "type": "object"
       },
       "ChartDataPostProcessingOperation": {
@@ -2558,6 +2579,13 @@
             "example": false,
             "type": "boolean"
           },
+          "columns": {
+            "description": "columns on which to perform rolling, mapping source column to target column. For instance, `{'y': 'y'}` will replace the column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add a column `y2` based on rolling values calculated from `y`, leaving the original column `y` unchanged.",
+            "example": {
+              "weekly_rolling_sales": "sales"
+            },
+            "type": "object"
+          },
           "min_periods": {
             "description": "The minimum amount of periods required for a row to be included in the result set.",
             "example": 7,
@@ -2626,6 +2654,7 @@
           }
         },
         "required": [
+          "columns",
           "rolling_type",
           "window"
         ],

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -515,10 +515,11 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
             allow_none=False,
             metadata={"description": "Columns by which to group by"},
         ),
-        # `minLength` as metadata neither validates a list nor is the right
-        # OpenAPI keyword for one -- arrays use `minItems`. A validator both
-        # enforces the bound and emits the correct constraint.
-        validate=Length(min=1),
+        # No lower bound: `aggregate()` reads an empty `groupby` as the
+        # global-aggregation case, grouping the frame as a whole, and the
+        # frontend's `aggregateOperator` emits exactly `groupby: []` for it.
+        # A `minItems` constraint here would document that request as invalid.
+        # The parameter has no default, though, so it is still required.
         required=True,
     )
     aggregates = ChartDataAggregateConfigField()
@@ -538,6 +539,9 @@ class ChartDataRollingOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "original column `y` unchanged.",
             "example": {"weekly_rolling_sales": "sales"},
         },
+        # `rolling()` takes `columns` positionally with no default, exactly as
+        # it takes `rolling_type`, which this schema already marks required.
+        required=True,
     )
     rolling_type = fields.String(
         metadata={

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -515,7 +515,10 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
             allow_none=False,
             metadata={"description": "Columns by which to group by"},
         ),
-        metadata={"minLength": 1},
+        # `minLength` as metadata neither validates a list nor is the right
+        # OpenAPI keyword for one -- arrays use `minItems`. A validator both
+        # enforces the bound and emits the correct constraint.
+        validate=Length(min=1),
         required=True,
     )
     aggregates = ChartDataAggregateConfigField()
@@ -858,8 +861,12 @@ class ChartDataPivotOptionsSchema(ChartDataPostProcessingOperationOptionsSchema)
         fields.String(allow_none=False),
         metadata={
             "description": "Columns to group by on the table index (=rows)",
-            "minLength": 1,
         },
+        # `pivot()` rejects an empty index ("Pivot operation requires at least
+        # one index"), so the schema has to say so. The previous `minLength`
+        # metadata did neither: it is not a validator, and arrays use
+        # `minItems` in OpenAPI.
+        validate=Length(min=1),
         required=True,
     )
     columns = fields.List(

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -510,15 +510,13 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
     Aggregate operation config.
     """
 
-    groupby = (
-        fields.List(
-            fields.String(
-                allow_none=False,
-                metadata={"description": "Columns by which to group by"},
-            ),
-            metadata={"minLength": 1},
-            required=True,
+    groupby = fields.List(
+        fields.String(
+            allow_none=False,
+            metadata={"description": "Columns by which to group by"},
         ),
+        metadata={"minLength": 1},
+        required=True,
     )
     aggregates = ChartDataAggregateConfigField()
 
@@ -528,17 +526,15 @@ class ChartDataRollingOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
     Rolling operation config.
     """
 
-    columns = (
-        fields.Dict(
-            metadata={
-                "description": "columns on which to perform rolling, mapping source "
-                "column to target column. For instance, `{'y': 'y'}` will replace the "
-                "column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add "  # noqa: E501
-                "a column `y2` based on rolling values calculated from `y`, leaving the "  # noqa: E501
-                "original column `y` unchanged.",
-                "example": {"weekly_rolling_sales": "sales"},
-            },
-        ),
+    columns = fields.Dict(
+        metadata={
+            "description": "columns on which to perform rolling, mapping source "
+            "column to target column. For instance, `{'y': 'y'}` will replace the "
+            "column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add "
+            "a column `y2` based on rolling values calculated from `y`, leaving the "
+            "original column `y` unchanged.",
+            "example": {"weekly_rolling_sales": "sales"},
+        },
     )
     rolling_type = fields.String(
         metadata={
@@ -858,15 +854,13 @@ class ChartDataPivotOptionsSchema(ChartDataPostProcessingOperationOptionsSchema)
     Pivot operation config.
     """
 
-    index = (
-        fields.List(
-            fields.String(allow_none=False),
-            metadata={
-                "description": "Columns to group by on the table index (=rows)",
-                "minLength": 1,
-            },
-            required=True,
-        ),
+    index = fields.List(
+        fields.String(allow_none=False),
+        metadata={
+            "description": "Columns to group by on the table index (=rows)",
+            "minLength": 1,
+        },
+        required=True,
     )
     columns = fields.List(
         fields.String(allow_none=False),

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -598,10 +598,11 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
             allow_none=False,
             metadata={"description": "Columns by which to group by"},
         ),
-        # `minLength` as metadata neither validates a list nor is the right
-        # OpenAPI keyword for one -- arrays use `minItems`. A validator both
-        # enforces the bound and emits the correct constraint.
-        validate=Length(min=1),
+        # No lower bound: `aggregate()` reads an empty `groupby` as the
+        # global-aggregation case, grouping the frame as a whole, and the
+        # frontend's `aggregateOperator` emits exactly `groupby: []` for it.
+        # A `minItems` constraint here would document that request as invalid.
+        # The parameter has no default, though, so it is still required.
         required=True,
     )
     aggregates = ChartDataAggregateConfigField()
@@ -621,6 +622,9 @@ class ChartDataRollingOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "original column `y` unchanged.",
             "example": {"weekly_rolling_sales": "sales"},
         },
+        # `rolling()` takes `columns` positionally with no default, exactly as
+        # it takes `rolling_type`, which this schema already marks required.
+        required=True,
     )
     rolling_type = fields.String(
         metadata={

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -620,7 +620,7 @@ class ChartDataRollingOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
             "column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add "
             "a column `y2` based on rolling values calculated from `y`, leaving the "
             "original column `y` unchanged.",
-            "example": {"weekly_rolling_sales": "sales"},
+            "example": {"sales": "weekly_rolling_sales"},
         },
         # `rolling()` takes `columns` positionally with no default, exactly as
         # it takes `rolling_type`, which this schema already marks required.

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -593,15 +593,13 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
     Aggregate operation config.
     """
 
-    groupby = (
-        fields.List(
-            fields.String(
-                allow_none=False,
-                metadata={"description": "Columns by which to group by"},
-            ),
-            metadata={"minLength": 1},
-            required=True,
+    groupby = fields.List(
+        fields.String(
+            allow_none=False,
+            metadata={"description": "Columns by which to group by"},
         ),
+        metadata={"minLength": 1},
+        required=True,
     )
     aggregates = ChartDataAggregateConfigField()
 
@@ -611,17 +609,15 @@ class ChartDataRollingOptionsSchema(ChartDataPostProcessingOperationOptionsSchem
     Rolling operation config.
     """
 
-    columns = (
-        fields.Dict(
-            metadata={
-                "description": "columns on which to perform rolling, mapping source "
-                "column to target column. For instance, `{'y': 'y'}` will replace the "
-                "column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add "  # noqa: E501
-                "a column `y2` based on rolling values calculated from `y`, leaving the "  # noqa: E501
-                "original column `y` unchanged.",
-                "example": {"weekly_rolling_sales": "sales"},
-            },
-        ),
+    columns = fields.Dict(
+        metadata={
+            "description": "columns on which to perform rolling, mapping source "
+            "column to target column. For instance, `{'y': 'y'}` will replace the "
+            "column `y` with the rolling value in `y`, while `{'y': 'y2'}` will add "
+            "a column `y2` based on rolling values calculated from `y`, leaving the "
+            "original column `y` unchanged.",
+            "example": {"weekly_rolling_sales": "sales"},
+        },
     )
     rolling_type = fields.String(
         metadata={
@@ -941,15 +937,13 @@ class ChartDataPivotOptionsSchema(ChartDataPostProcessingOperationOptionsSchema)
     Pivot operation config.
     """
 
-    index = (
-        fields.List(
-            fields.String(allow_none=False),
-            metadata={
-                "description": "Columns to group by on the table index (=rows)",
-                "minLength": 1,
-            },
-            required=True,
-        ),
+    index = fields.List(
+        fields.String(allow_none=False),
+        metadata={
+            "description": "Columns to group by on the table index (=rows)",
+            "minLength": 1,
+        },
+        required=True,
     )
     columns = fields.List(
         fields.String(allow_none=False),

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -598,7 +598,10 @@ class ChartDataAggregateOptionsSchema(ChartDataPostProcessingOperationOptionsSch
             allow_none=False,
             metadata={"description": "Columns by which to group by"},
         ),
-        metadata={"minLength": 1},
+        # `minLength` as metadata neither validates a list nor is the right
+        # OpenAPI keyword for one -- arrays use `minItems`. A validator both
+        # enforces the bound and emits the correct constraint.
+        validate=Length(min=1),
         required=True,
     )
     aggregates = ChartDataAggregateConfigField()
@@ -941,8 +944,12 @@ class ChartDataPivotOptionsSchema(ChartDataPostProcessingOperationOptionsSchema)
         fields.String(allow_none=False),
         metadata={
             "description": "Columns to group by on the table index (=rows)",
-            "minLength": 1,
         },
+        # `pivot()` rejects an empty index ("Pivot operation requires at least
+        # one index"), so the schema has to say so. The previous `minLength`
+        # metadata did neither: it is not a validator, and arrays use
+        # `minItems` in OpenAPI.
+        validate=Length(min=1),
         required=True,
     )
     columns = fields.List(

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -15,12 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import inspect
+
 import pytest
 from flask import current_app
-from marshmallow import ValidationError
+from marshmallow import fields as marshmallow_fields, Schema, ValidationError
 
+from superset.charts import schemas as chart_schemas
 from superset.charts.schemas import (
+    ChartDataAggregateOptionsSchema,
     ChartDataExtrasSchema,
+    ChartDataPivotOptionsSchema,
     ChartDataProphetOptionsSchema,
     ChartDataQueryObjectSchema,
     ChartDataResponseResult,
@@ -193,7 +198,10 @@ def test_chart_data_rolling_options_schema_window_range(
 ) -> None:
     """`window` must be a bounded positive integer."""
     schema = ChartDataRollingOptionsSchema()
-    base = {"rolling_type": "mean"}
+    # `columns` is required alongside `rolling_type`; both are parameters of
+    # `rolling()` that have no default. This test is about `window`, so the
+    # base payload just has to be otherwise valid.
+    base = {"rolling_type": "mean", "columns": {"y": "y"}}
 
     # Valid value passes
     assert schema.load({**base, "window": 7})["window"] == 7
@@ -492,12 +500,6 @@ def test_schema_attributes_are_fields_not_tuples(app_context: None) -> None:
     `ChartDataPivotOptionsSchema.index` -- each of them the parameter its
     post-processing operation cannot run without.
     """
-    import inspect
-
-    from marshmallow import fields as marshmallow_fields, Schema
-
-    from superset.charts import schemas as chart_schemas
-
     disabled: dict[str, list[str]] = {}
     for name, schema_cls in vars(chart_schemas).items():
         if not (inspect.isclass(schema_cls) and issubclass(schema_cls, Schema)):
@@ -521,47 +523,46 @@ def test_required_post_processing_options_are_documented(app_context: None) -> N
     default; a client cannot call them successfully without it, so it has to
     appear in the spec.
     """
-    from superset.charts.schemas import (
-        ChartDataAggregateOptionsSchema,
-        ChartDataPivotOptionsSchema,
-        ChartDataRollingOptionsSchema,
-    )
-
     assert "groupby" in ChartDataAggregateOptionsSchema().fields
     assert ChartDataAggregateOptionsSchema().fields["groupby"].required
 
     assert "index" in ChartDataPivotOptionsSchema().fields
     assert ChartDataPivotOptionsSchema().fields["index"].required
 
-    # `rolling()` requires `columns`, though the schema has always declared it
-    # optional; the field simply has to exist.
     assert "columns" in ChartDataRollingOptionsSchema().fields
+    assert ChartDataRollingOptionsSchema().fields["columns"].required
 
 
-def test_pivot_and_aggregate_reject_an_empty_column_list(app_context: None) -> None:
-    """An empty `index`/`groupby` must be rejected at the schema boundary.
+def test_pivot_rejects_an_empty_index(app_context: None) -> None:
+    """An empty `index` must be rejected at the schema boundary.
 
     `metadata={"minLength": 1}` is inert: metadata is not a validator, and
     `minLength` is the OpenAPI keyword for strings, not arrays (`minItems`).
     So the schema accepted `index=[]` while `pivot()` raises "Pivot operation
     requires at least one index".
     """
-    from marshmallow import ValidationError
-
-    from superset.charts.schemas import (
-        ChartDataAggregateOptionsSchema,
-        ChartDataPivotOptionsSchema,
-    )
-
     with pytest.raises(ValidationError) as exc_info:
         ChartDataPivotOptionsSchema().load({"index": [], "aggregates": {}})
     assert "index" in exc_info.value.messages
-
-    with pytest.raises(ValidationError) as exc_info:
-        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})
-    assert "groupby" in exc_info.value.messages
 
     # a non-empty list still loads
     assert ChartDataPivotOptionsSchema().load(
         {"index": ["__timestamp"], "aggregates": {}}
     )["index"] == ["__timestamp"]
+
+
+def test_aggregate_accepts_an_empty_groupby(app_context: None) -> None:
+    """`groupby: []` is the global-aggregation case, not a malformed request.
+
+    `aggregate()` branches on it explicitly -- an empty `groupby` groups the
+    frame as a whole via `df.groupby(lambda _: True)` -- and the frontend's
+    `aggregateOperator` emits `groupby: []` verbatim for every non-`LAST_VALUE`
+    aggregation. A lower bound on this field would publish `minItems: 1` and
+    so document Superset's own request as invalid.
+    """
+    assert (
+        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})[
+            "groupby"
+        ]
+        == []
+    )

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -478,3 +478,61 @@ def test_chart_data_extras_rejects_system_sampling(app_context: None) -> None:
     with pytest.raises(ValidationError) as exc_info:
         ChartDataExtrasSchema().load({"system_sampling": True})
     assert "system_sampling" in exc_info.value.messages
+
+
+def test_schema_attributes_are_fields_not_tuples(app_context: None) -> None:
+    """A trailing comma must not silently disable a field declaration.
+
+    `groupby = (fields.List(...),)` is a one-element tuple, not a `Field`.
+    Marshmallow only collects `Field` instances, so such an attribute is
+    dropped from the schema entirely: it never reaches the OpenAPI spec and
+    its `required=True` is never applied. Three declarations in this module
+    had picked up that stray comma -- `ChartDataAggregateOptionsSchema.groupby`,
+    `ChartDataRollingOptionsSchema.columns` and
+    `ChartDataPivotOptionsSchema.index` -- each of them the parameter its
+    post-processing operation cannot run without.
+    """
+    import inspect
+
+    from marshmallow import fields as marshmallow_fields, Schema
+
+    from superset.charts import schemas as chart_schemas
+
+    disabled: dict[str, list[str]] = {}
+    for name, schema_cls in vars(chart_schemas).items():
+        if not (inspect.isclass(schema_cls) and issubclass(schema_cls, Schema)):
+            continue
+        for attribute, value in vars(schema_cls).items():
+            if isinstance(value, tuple) and any(
+                isinstance(item, marshmallow_fields.Field) for item in value
+            ):
+                disabled.setdefault(name, []).append(attribute)
+
+    assert not disabled, (
+        "schema attributes wrapped in a tuple, so marshmallow ignores them "
+        f"and they never reach the OpenAPI spec: {disabled}"
+    )
+
+
+def test_required_post_processing_options_are_documented(app_context: None) -> None:
+    """The parameters these operations cannot run without must be published.
+
+    `aggregate()`, `rolling()` and `pivot()` each take a parameter with no
+    default; a client cannot call them successfully without it, so it has to
+    appear in the spec.
+    """
+    from superset.charts.schemas import (
+        ChartDataAggregateOptionsSchema,
+        ChartDataPivotOptionsSchema,
+        ChartDataRollingOptionsSchema,
+    )
+
+    assert "groupby" in ChartDataAggregateOptionsSchema().fields
+    assert ChartDataAggregateOptionsSchema().fields["groupby"].required
+
+    assert "index" in ChartDataPivotOptionsSchema().fields
+    assert ChartDataPivotOptionsSchema().fields["index"].required
+
+    # `rolling()` requires `columns`, though the schema has always declared it
+    # optional; the field simply has to exist.
+    assert "columns" in ChartDataRollingOptionsSchema().fields

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -536,3 +536,32 @@ def test_required_post_processing_options_are_documented(app_context: None) -> N
     # `rolling()` requires `columns`, though the schema has always declared it
     # optional; the field simply has to exist.
     assert "columns" in ChartDataRollingOptionsSchema().fields
+
+
+def test_pivot_and_aggregate_reject_an_empty_column_list(app_context: None) -> None:
+    """An empty `index`/`groupby` must be rejected at the schema boundary.
+
+    `metadata={"minLength": 1}` is inert: metadata is not a validator, and
+    `minLength` is the OpenAPI keyword for strings, not arrays (`minItems`).
+    So the schema accepted `index=[]` while `pivot()` raises "Pivot operation
+    requires at least one index".
+    """
+    from marshmallow import ValidationError
+
+    from superset.charts.schemas import (
+        ChartDataAggregateOptionsSchema,
+        ChartDataPivotOptionsSchema,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChartDataPivotOptionsSchema().load({"index": [], "aggregates": {}})
+    assert "index" in exc_info.value.messages
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})
+    assert "groupby" in exc_info.value.messages
+
+    # a non-empty list still loads
+    assert ChartDataPivotOptionsSchema().load(
+        {"index": ["__timestamp"], "aggregates": {}}
+    )["index"] == ["__timestamp"]

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -741,3 +741,32 @@ def test_required_post_processing_options_are_documented(app_context: None) -> N
     # `rolling()` requires `columns`, though the schema has always declared it
     # optional; the field simply has to exist.
     assert "columns" in ChartDataRollingOptionsSchema().fields
+
+
+def test_pivot_and_aggregate_reject_an_empty_column_list(app_context: None) -> None:
+    """An empty `index`/`groupby` must be rejected at the schema boundary.
+
+    `metadata={"minLength": 1}` is inert: metadata is not a validator, and
+    `minLength` is the OpenAPI keyword for strings, not arrays (`minItems`).
+    So the schema accepted `index=[]` while `pivot()` raises "Pivot operation
+    requires at least one index".
+    """
+    from marshmallow import ValidationError
+
+    from superset.charts.schemas import (
+        ChartDataAggregateOptionsSchema,
+        ChartDataPivotOptionsSchema,
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChartDataPivotOptionsSchema().load({"index": [], "aggregates": {}})
+    assert "index" in exc_info.value.messages
+
+    with pytest.raises(ValidationError) as exc_info:
+        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})
+    assert "groupby" in exc_info.value.messages
+
+    # a non-empty list still loads
+    assert ChartDataPivotOptionsSchema().load(
+        {"index": ["__timestamp"], "aggregates": {}}
+    )["index"] == ["__timestamp"]

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -683,3 +683,61 @@ def test_prophet_accepts_every_mapped_grain(app_context: None, grain: str) -> No
         {"time_grain": grain, "periods": 7, "confidence_interval": 0.8}
     )
     assert result["time_grain"] == grain
+
+
+def test_schema_attributes_are_fields_not_tuples(app_context: None) -> None:
+    """A trailing comma must not silently disable a field declaration.
+
+    `groupby = (fields.List(...),)` is a one-element tuple, not a `Field`.
+    Marshmallow only collects `Field` instances, so such an attribute is
+    dropped from the schema entirely: it never reaches the OpenAPI spec and
+    its `required=True` is never applied. Three declarations in this module
+    had picked up that stray comma -- `ChartDataAggregateOptionsSchema.groupby`,
+    `ChartDataRollingOptionsSchema.columns` and
+    `ChartDataPivotOptionsSchema.index` -- each of them the parameter its
+    post-processing operation cannot run without.
+    """
+    import inspect
+
+    from marshmallow import fields as marshmallow_fields, Schema
+
+    from superset.charts import schemas as chart_schemas
+
+    disabled: dict[str, list[str]] = {}
+    for name, schema_cls in vars(chart_schemas).items():
+        if not (inspect.isclass(schema_cls) and issubclass(schema_cls, Schema)):
+            continue
+        for attribute, value in vars(schema_cls).items():
+            if isinstance(value, tuple) and any(
+                isinstance(item, marshmallow_fields.Field) for item in value
+            ):
+                disabled.setdefault(name, []).append(attribute)
+
+    assert not disabled, (
+        "schema attributes wrapped in a tuple, so marshmallow ignores them "
+        f"and they never reach the OpenAPI spec: {disabled}"
+    )
+
+
+def test_required_post_processing_options_are_documented(app_context: None) -> None:
+    """The parameters these operations cannot run without must be published.
+
+    `aggregate()`, `rolling()` and `pivot()` each take a parameter with no
+    default; a client cannot call them successfully without it, so it has to
+    appear in the spec.
+    """
+    from superset.charts.schemas import (
+        ChartDataAggregateOptionsSchema,
+        ChartDataPivotOptionsSchema,
+        ChartDataRollingOptionsSchema,
+    )
+
+    assert "groupby" in ChartDataAggregateOptionsSchema().fields
+    assert ChartDataAggregateOptionsSchema().fields["groupby"].required
+
+    assert "index" in ChartDataPivotOptionsSchema().fields
+    assert ChartDataPivotOptionsSchema().fields["index"].required
+
+    # `rolling()` requires `columns`, though the schema has always declared it
+    # optional; the field simply has to exist.
+    assert "columns" in ChartDataRollingOptionsSchema().fields

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -15,19 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import inspect
+
 import pandas as pd
 import pytest
 from flask import current_app
 from jsonschema import validate as validate_json_schema
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
-from marshmallow import ValidationError
+from marshmallow import fields as marshmallow_fields, Schema, ValidationError
 from marshmallow.validate import OneOf
 from pytest_mock import MockerFixture
 
+from superset.charts import schemas as chart_schemas
 from superset.charts.schemas import (
     chart_get_list_schema,
     ChartDataAdhocMetricSchema,
+    ChartDataAggregateOptionsSchema,
     ChartDataExtrasSchema,
+    ChartDataPivotOptionsSchema,
     ChartDataPostProcessingOperationSchema,
     ChartDataProphetOptionsSchema,
     ChartDataQueryObjectSchema,
@@ -242,7 +247,10 @@ def test_chart_data_rolling_options_schema_window_range(
 ) -> None:
     """`window` must be a bounded positive integer."""
     schema = ChartDataRollingOptionsSchema()
-    base = {"rolling_type": "mean"}
+    # `columns` is required alongside `rolling_type`; both are parameters of
+    # `rolling()` that have no default. This test is about `window`, so the
+    # base payload just has to be otherwise valid.
+    base = {"rolling_type": "mean", "columns": {"y": "y"}}
 
     # Valid value passes
     assert schema.load({**base, "window": 7})["window"] == 7
@@ -697,12 +705,6 @@ def test_schema_attributes_are_fields_not_tuples(app_context: None) -> None:
     `ChartDataPivotOptionsSchema.index` -- each of them the parameter its
     post-processing operation cannot run without.
     """
-    import inspect
-
-    from marshmallow import fields as marshmallow_fields, Schema
-
-    from superset.charts import schemas as chart_schemas
-
     disabled: dict[str, list[str]] = {}
     for name, schema_cls in vars(chart_schemas).items():
         if not (inspect.isclass(schema_cls) and issubclass(schema_cls, Schema)):
@@ -726,47 +728,46 @@ def test_required_post_processing_options_are_documented(app_context: None) -> N
     default; a client cannot call them successfully without it, so it has to
     appear in the spec.
     """
-    from superset.charts.schemas import (
-        ChartDataAggregateOptionsSchema,
-        ChartDataPivotOptionsSchema,
-        ChartDataRollingOptionsSchema,
-    )
-
     assert "groupby" in ChartDataAggregateOptionsSchema().fields
     assert ChartDataAggregateOptionsSchema().fields["groupby"].required
 
     assert "index" in ChartDataPivotOptionsSchema().fields
     assert ChartDataPivotOptionsSchema().fields["index"].required
 
-    # `rolling()` requires `columns`, though the schema has always declared it
-    # optional; the field simply has to exist.
     assert "columns" in ChartDataRollingOptionsSchema().fields
+    assert ChartDataRollingOptionsSchema().fields["columns"].required
 
 
-def test_pivot_and_aggregate_reject_an_empty_column_list(app_context: None) -> None:
-    """An empty `index`/`groupby` must be rejected at the schema boundary.
+def test_pivot_rejects_an_empty_index(app_context: None) -> None:
+    """An empty `index` must be rejected at the schema boundary.
 
     `metadata={"minLength": 1}` is inert: metadata is not a validator, and
     `minLength` is the OpenAPI keyword for strings, not arrays (`minItems`).
     So the schema accepted `index=[]` while `pivot()` raises "Pivot operation
     requires at least one index".
     """
-    from marshmallow import ValidationError
-
-    from superset.charts.schemas import (
-        ChartDataAggregateOptionsSchema,
-        ChartDataPivotOptionsSchema,
-    )
-
     with pytest.raises(ValidationError) as exc_info:
         ChartDataPivotOptionsSchema().load({"index": [], "aggregates": {}})
     assert "index" in exc_info.value.messages
-
-    with pytest.raises(ValidationError) as exc_info:
-        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})
-    assert "groupby" in exc_info.value.messages
 
     # a non-empty list still loads
     assert ChartDataPivotOptionsSchema().load(
         {"index": ["__timestamp"], "aggregates": {}}
     )["index"] == ["__timestamp"]
+
+
+def test_aggregate_accepts_an_empty_groupby(app_context: None) -> None:
+    """`groupby: []` is the global-aggregation case, not a malformed request.
+
+    `aggregate()` branches on it explicitly -- an empty `groupby` groups the
+    frame as a whole via `df.groupby(lambda _: True)` -- and the frontend's
+    `aggregateOperator` emits `groupby: []` verbatim for every non-`LAST_VALUE`
+    aggregation. A lower bound on this field would publish `minItems: 1` and
+    so document Superset's own request as invalid.
+    """
+    assert (
+        ChartDataAggregateOptionsSchema().load({"groupby": [], "aggregates": {}})[
+            "groupby"
+        ]
+        == []
+    )


### PR DESCRIPTION
<!-- PR TITLE: fix(api): restore three schema fields disabled by a stray trailing comma -->
### SUMMARY

Three field declarations in `superset/charts/schemas.py` are wrapped in
parentheses with a trailing comma, which makes them one-element **tuples**
rather than `Field` instances:

```python
groupby = (
    fields.List(
        fields.String(allow_none=False, metadata={...}),
        metadata={"minLength": 1},
        required=True,
    ),          # <-- this comma makes the whole thing a tuple
)
```

Marshmallow collects only `Field` instances into a schema, so an attribute
like this is dropped entirely: it never appears in the OpenAPI spec, and its
`required=True` is never applied.

The three affected declarations are each the parameter its post-processing
operation cannot run without:

| Schema | Field | Signature |
| --- | --- | --- |
| `ChartDataAggregateOptionsSchema` | `groupby` | `aggregate(df, groupby, aggregates)` |
| `ChartDataRollingOptionsSchema` | `columns` | `rolling(df, rolling_type, columns, ...)` |
| `ChartDataPivotOptionsSchema` | `index` | `pivot(df, index, aggregates, ...)` |

All three are parameters with no default, and the frontend operators send all
three (`pivotOperator` sends `index`, `rollingWindowOperator` sends `columns`).
So `/swagger/v1` currently documents `pivot` without `index` and `aggregate`
without `groupby` — the one option each caller must provide.

Confirmed before and after:

```
# master
ChartDataAggregateOptionsSchema: fields=['aggregates']
ChartDataPivotOptionsSchema:     fields=['aggregates', 'column_fill_value', 'columns', ...]   # no 'index'

# this branch
ChartDataAggregateOptionsSchema: fields=['aggregates', 'groupby']   groupby: required=True
ChartDataPivotOptionsSchema:     fields=[..., 'index', ...]         index:   required=True
```

**No runtime behaviour changes.** These schemas are documentation only —
`ChartDataPostProcessingOperationSchema.options` is a bare `fields.Dict`, so
nothing validates against them; they are registered solely for OpenAPI spec
generation. The only place any of them is `.load()`ed is a unit test for
`rolling`, whose payload does not include `columns`, and `columns` stays
optional.

I scanned the whole `superset/` tree for the pattern; these three are the only
occurrences.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — the change is to the OpenAPI schema definitions.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/charts/test_schemas.py
```

Two tests are added:

| test | asserts |
| --- | --- |
| `test_schema_attributes_are_fields_not_tuples` | no attribute on any schema in the module is a tuple wrapping a `Field` — a general guard against this typo recurring anywhere |
| `test_required_post_processing_options_are_documented` | `groupby`, `index` and `columns` are present, and the two `required=True` ones are marked required |

Re-introducing the trailing comma on any one of the three makes both fail.

To see the spec change, start Superset, open `/swagger/v1` and compare the
`ChartDataAggregateOptions`, `ChartDataRollingOptions` and
`ChartDataPivotOptions` definitions.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### CHECKLIST

- [ ] CI checks pass
- [x] Tests added/updated
- [ ] Documentation updated
- [x] PR title follows conventions
