### PR TITLE
fix(db2): Use DATE_TRUNC to improve timegrain expressions

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -53,6 +53,9 @@ Scheduled report and alert captures require chart readiness to remain stable
 immediately before Chromium captures the image. A capture that re-enters a loading
 state during that window fails instead of delivering a screenshot with spinners.
 
+### Improve Db2 Time Grain Expressions
+The Db2 engine specification's for time grains has been streamlined with DATE_TRUNC scalar functions supported in Db2 11.1.0 or higher. As part of this change, the `WEEK` time grain also shifts the first day of the week to Monday according to ISO 8601 standards.
+
 ### Resample "Fill the entire time range"
 
 Charts with Resample can enable **Fill the entire time range** so gap-filling

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -54,7 +54,10 @@ immediately before Chromium captures the image. A capture that re-enters a loadi
 state during that window fails instead of delivering a screenshot with spinners.
 
 ### Improve Db2 Time Grain Expressions
-The Db2 engine specification's for time grains has been streamlined with DATE_TRUNC scalar functions supported in Db2 11.1.0 or higher. As part of this change, the `WEEK` time grain also shifts the first day of the week to Monday according to ISO 8601 standards.
+The Db2 engine spec has been streamlined by using the DATE_TRUNC scalar function, which requires Db2 11.1.0 or higher. Per the ISO 8601 standards, the `WEEK` time grain now shifts the first day of the week to Monday as part of this change.
+
+### Update IBM Db2 for i Time Grain Expressions'
+IBM Db2 for i inherits its engine spec from Db2 but does not support the DATE_TRUNC scalar function, so it will use the previous arithmetic expressions defined for Db2. Its `WEEK` time grain now uses `DAYOFWEEK_ISO` to align with the Db2 change.
 
 ### Resample "Fill the entire time range"
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -54,10 +54,14 @@ immediately before Chromium captures the image. A capture that re-enters a loadi
 state during that window fails instead of delivering a screenshot with spinners.
 
 ### Improve Db2 Time Grain Expressions
-The Db2 engine spec has been streamlined by using the DATE_TRUNC scalar function, which requires Db2 11.1.0 or higher. Per the ISO 8601 standards, the `WEEK` time grain now shifts the first day of the week to Monday as part of this change.
+The Db2 engine spec has been streamlined by using the DATE_TRUNC scalar function,
+which requires Db2 11.1.0 or higher. Per the ISO 8601 standards, the `WEEK` time
+grain now shifts the first day of the week to Monday as part of this change.
 
 ### Update IBM Db2 for i Time Grain Expressions'
-IBM Db2 for i inherits its engine spec from Db2 but does not support the DATE_TRUNC scalar function, so it will use the previous arithmetic expressions defined for Db2. Its `WEEK` time grain now uses `DAYOFWEEK_ISO` to align with the Db2 change.
+IBM Db2 for i inherits its engine spec from Db2 but does not support the DATE_TRUNC
+scalar function, so it will use the previous arithmetic expressions defined for Db2.
+Its `WEEK` time grain now uses `DAYOFWEEK_ISO` to align with the Db2 change.
 
 ### Resample "Fill the entire time range"
 

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -95,21 +95,14 @@ class Db2EngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
-        TimeGrain.SECOND: "CAST({col} as TIMESTAMP) - MICROSECOND({col}) MICROSECONDS",
-        TimeGrain.MINUTE: "CAST({col} as TIMESTAMP)"
-        " - SECOND({col}) SECONDS"
-        " - MICROSECOND({col}) MICROSECONDS",
-        TimeGrain.HOUR: "CAST({col} as TIMESTAMP)"
-        " - MINUTE({col}) MINUTES"
-        " - SECOND({col}) SECONDS"
-        " - MICROSECOND({col}) MICROSECONDS ",
-        TimeGrain.DAY: "DATE({col})",
-        TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
-        TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
-        TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"
-        " - (MONTH({col})-1) MONTHS"
-        " + ((QUARTER({col})-1) * 3) MONTHS",
-        TimeGrain.YEAR: "{col} - (DAY({col})-1) DAYS - (MONTH({col})-1) MONTHS",
+        TimeGrain.SECOND: "DATE_TRUNC('SECOND', {col})",
+        TimeGrain.MINUTE: "DATE_TRUNC('MINUTE', {col})",
+        TimeGrain.HOUR: "DATE_TRUNC('HOUR', {col})",
+        TimeGrain.DAY: "DATE_TRUNC('DAY', {col})",
+        TimeGrain.WEEK: "DATE_TRUNC('WEEK', {col})",
+        TimeGrain.MONTH: "DATE_TRUNC('MONTH', {col})",
+        TimeGrain.QUARTER: "DATE_TRUNC('QUARTER', {col})",
+        TimeGrain.YEAR: "DATE_TRUNC('YEAR', {col})",
     }
 
     @classmethod

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -57,7 +57,8 @@ class Db2EngineSpec(BaseEngineSpec):
                 "connection_string": "ibm_db_sa://{username}:{password}@{hostname}:{port}/{database}",
                 "is_recommended": False,
                 "notes": (
-                    "Db2 11.1.0 or higher is required to support SQL compatibility enhancements. " 
+                    "Db2 11.1.0 or higher is required to support SQL compatibility "
+                    "enhancements. "
                     "Use for older Db2 versions without LIMIT [n] syntax. "
                     "Recommended for SQL Lab."
                 ),

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -57,7 +57,7 @@ class Db2EngineSpec(BaseEngineSpec):
                 "connection_string": "ibm_db_sa://{username}:{password}@{hostname}:{port}/{database}",
                 "is_recommended": False,
                 "notes": (
-                    "Db2 11.1.0 or higher is required to support SQL compatibility enhancements."
+                    "Db2 11.1.0 or higher is required to support SQL compatibility enhancements. " 
                     "Use for older Db2 versions without LIMIT [n] syntax. "
                     "Recommended for SQL Lab."
                 ),

--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -57,7 +57,8 @@ class Db2EngineSpec(BaseEngineSpec):
                 "connection_string": "ibm_db_sa://{username}:{password}@{hostname}:{port}/{database}",
                 "is_recommended": False,
                 "notes": (
-                    "Use for older DB2 versions without LIMIT [n] syntax. "
+                    "Db2 11.1.0 or higher is required to support SQL compatibility enhancements."
+                    "Use for older Db2 versions without LIMIT [n] syntax. "
                     "Recommended for SQL Lab."
                 ),
             },

--- a/superset/db_engine_specs/ibmi.py
+++ b/superset/db_engine_specs/ibmi.py
@@ -41,7 +41,7 @@ class IBMiEngineSpec(Db2EngineSpec):
         " - SECOND({col}) SECONDS"
         " - MICROSECOND({col}) MICROSECONDS ",
         TimeGrain.DAY: "DATE({col})",
-        TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
+        TimeGrain.WEEK: "{col} - (DAYOFWEEK_ISO({col})-1) DAYS",
         TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
         TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"
         " - (MONTH({col})-1) MONTHS"

--- a/superset/db_engine_specs/ibmi.py
+++ b/superset/db_engine_specs/ibmi.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from superset.constants import TimeGrain
+
 from .db2 import Db2EngineSpec
 
 
@@ -27,6 +29,25 @@ class IBMiEngineSpec(Db2EngineSpec):
     engine = "ibmi"
     engine_name = "IBM Db2 for i"
     max_column_name_length = 128
+
+    _time_grain_expressions = {
+        None: "{col}",
+        TimeGrain.SECOND: "CAST({col} as TIMESTAMP) - MICROSECOND({col}) MICROSECONDS",
+        TimeGrain.MINUTE: "CAST({col} as TIMESTAMP)"
+        " - SECOND({col}) SECONDS"
+        " - MICROSECOND({col}) MICROSECONDS",
+        TimeGrain.HOUR: "CAST({col} as TIMESTAMP)"
+        " - MINUTE({col}) MINUTES"
+        " - SECOND({col}) SECONDS"
+        " - MICROSECOND({col}) MICROSECONDS ",
+        TimeGrain.DAY: "DATE({col})",
+        TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
+        TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
+        TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"
+        " - (MONTH({col})-1) MONTHS"
+        " + ((QUARTER({col})-1) * 3) MONTHS",
+        TimeGrain.YEAR: "{col} - (DAY({col})-1) DAYS - (MONTH({col})-1) MONTHS",
+    }
 
     @classmethod
     def epoch_to_dttm(cls) -> str:

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -109,33 +109,14 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
     ("grain", "expected_expression"),
     [
         (None, "my_col"),
-        (
-            TimeGrain.SECOND,
-            "CAST(my_col as TIMESTAMP) - MICROSECOND(my_col) MICROSECONDS",
-        ),
-        (
-            TimeGrain.MINUTE,
-            "CAST(my_col as TIMESTAMP)"
-            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS",
-        ),
-        (
-            TimeGrain.HOUR,
-            "CAST(my_col as TIMESTAMP)"
-            " - MINUTE(my_col) MINUTES"
-            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS ",
-        ),
-        (TimeGrain.DAY, "DATE(my_col)"),
-        (TimeGrain.WEEK, "my_col - (DAYOFWEEK(my_col)) DAYS"),
-        (TimeGrain.MONTH, "my_col - (DAY(my_col)-1) DAYS"),
-        (
-            TimeGrain.QUARTER,
-            "my_col - (DAY(my_col)-1) DAYS"
-            " - (MONTH(my_col)-1) MONTHS + ((QUARTER(my_col)-1) * 3) MONTHS",
-        ),
-        (
-            TimeGrain.YEAR,
-            "my_col - (DAY(my_col)-1) DAYS - (MONTH(my_col)-1) MONTHS",
-        ),
+        (TimeGrain.SECOND,"DATE_TRUNC('SECOND', my_col)"),
+        (TimeGrain.MINUTE,"DATE_TRUNC('MINUTE', my_col)"),
+        (TimeGrain.HOUR,"DATE_TRUNC('HOUR', my_col)"),
+        (TimeGrain.DAY, "DATE_TRUNC('DAY', my_col)"),
+        (TimeGrain.WEEK, "DATE_TRUNC('WEEK', my_col)"),
+        (TimeGrain.MONTH, "DATE_TRUNC('MONTH', my_col)"),
+        (TimeGrain.QUARTER,"DATE_TRUNC('QUARTER', my_col)"),
+        (TimeGrain.YEAR,"DATE_TRUNC('YEAR', my_col)"),
     ],
 )
 def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> None:

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -109,14 +109,14 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
     ("grain", "expected_expression"),
     [
         (None, "my_col"),
-        (TimeGrain.SECOND,"DATE_TRUNC('SECOND', my_col)"),
-        (TimeGrain.MINUTE,"DATE_TRUNC('MINUTE', my_col)"),
-        (TimeGrain.HOUR,"DATE_TRUNC('HOUR', my_col)"),
+        (TimeGrain.SECOND, "DATE_TRUNC('SECOND', my_col)"),
+        (TimeGrain.MINUTE, "DATE_TRUNC('MINUTE', my_col)"),
+        (TimeGrain.HOUR, "DATE_TRUNC('HOUR', my_col)"),
         (TimeGrain.DAY, "DATE_TRUNC('DAY', my_col)"),
         (TimeGrain.WEEK, "DATE_TRUNC('WEEK', my_col)"),
         (TimeGrain.MONTH, "DATE_TRUNC('MONTH', my_col)"),
-        (TimeGrain.QUARTER,"DATE_TRUNC('QUARTER', my_col)"),
-        (TimeGrain.YEAR,"DATE_TRUNC('YEAR', my_col)"),
+        (TimeGrain.QUARTER, "DATE_TRUNC('QUARTER', my_col)"),
+        (TimeGrain.YEAR, "DATE_TRUNC('YEAR', my_col)"),
     ],
 )
 def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> None:

--- a/tests/unit_tests/db_engine_specs/test_ibmi.py
+++ b/tests/unit_tests/db_engine_specs/test_ibmi.py
@@ -53,7 +53,7 @@ def test_epoch_to_dttm() -> None:
             " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS ",
         ),
         (TimeGrain.DAY, "DATE(my_col)"),
-        (TimeGrain.WEEK, "my_col - (DAYOFWEEK(my_col)) DAYS"),
+        (TimeGrain.WEEK, "my_col - (DAYOFWEEK_ISO(my_col)-1) DAYS"),
         (TimeGrain.MONTH, "my_col - (DAY(my_col)-1) DAYS"),
         (
             TimeGrain.QUARTER,

--- a/tests/unit_tests/db_engine_specs/test_ibmi.py
+++ b/tests/unit_tests/db_engine_specs/test_ibmi.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from superset.constants import TimeGrain
+
+
+def test_epoch_to_dttm() -> None:
+    """
+    Test the `epoch_to_dttm` method.
+    """
+    from superset.db_engine_specs.ibmi import IBMiEngineSpec
+
+    assert (
+        IBMiEngineSpec.epoch_to_dttm().format(col="epoch_dttm")
+        == "(DAYS(epoch_dttm) - DAYS('1970-01-01')) * 86400"
+        " + MIDNIGHT_SECONDS(epoch_dttm)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("grain", "expected_expression"),
+    [
+        (None, "my_col"),
+        (
+            TimeGrain.SECOND,
+            "CAST(my_col as TIMESTAMP) - MICROSECOND(my_col) MICROSECONDS",
+        ),
+        (
+            TimeGrain.MINUTE,
+            "CAST(my_col as TIMESTAMP)"
+            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS",
+        ),
+        (
+            TimeGrain.HOUR,
+            "CAST(my_col as TIMESTAMP)"
+            " - MINUTE(my_col) MINUTES"
+            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS ",
+        ),
+        (TimeGrain.DAY, "DATE(my_col)"),
+        (TimeGrain.WEEK, "my_col - (DAYOFWEEK(my_col)) DAYS"),
+        (TimeGrain.MONTH, "my_col - (DAY(my_col)-1) DAYS"),
+        (
+            TimeGrain.QUARTER,
+            "my_col - (DAY(my_col)-1) DAYS"
+            " - (MONTH(my_col)-1) MONTHS + ((QUARTER(my_col)-1) * 3) MONTHS",
+        ),
+        (
+            TimeGrain.YEAR,
+            "my_col - (DAY(my_col)-1) DAYS - (MONTH(my_col)-1) MONTHS",
+        ),
+    ],
+)
+def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> None:
+    """
+    Test that time grain expressions generate the expected SQL.
+    """
+    from superset.db_engine_specs.ibmi import IBMiEngineSpec
+
+    actual = IBMiEngineSpec._time_grain_expressions[grain].format(col="my_col")
+    assert actual == expected_expression


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The [DB2 time grain expressions](https://github.com/apache/superset/blob/master/superset/db_engine_specs/db2.py) currently rely on manual arithmetic by subtracting time grain components (e.g. MICROSECONDS, MINUTES, DAYS) to obtain the desired time granularity. While it is correct, the readability and maintainability can be improved.

The change uses the DB2 built-in [DATE_TRUNC](https://www.ibm.com/docs/en/db2/12.1.x?topic=functions-date-trunc) scalar function to delegate all the logic to obtain the time grain unit to the Db2 database engine.

Db2 change note:
1. Add note to specify Db2 requires Db2 11.1.0 or higher, this is needed to use the new Db2 scalar functions such as DATE_TRUNC.
2. Using the DATE_TRUNC function on the `WEEK` time grain shifts the first day of the week to Monday. This meets the ISO 8601 standards.

IBM Db2 for i change note:
1. IBM Db2 for i inherits its engine spec from Db2 but does not support the DATE_TRUNC scalar function. Therefore, it is set to use the old Db2 time grain expression to prevent incompatibility.
2. The `WEEK` time grain now shifts the first day of the week to Monday to align with the Db2 time grain by using the `DAYOFWEEK_ISO` rather than `DAYOFWEEK`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:
```
    _time_grain_expressions = {
        None: "{col}",
        TimeGrain.SECOND: "CAST({col} as TIMESTAMP) - MICROSECOND({col}) MICROSECONDS",
        TimeGrain.MINUTE: "CAST({col} as TIMESTAMP)"
        " - SECOND({col}) SECONDS"
        " - MICROSECOND({col}) MICROSECONDS",
        TimeGrain.HOUR: "CAST({col} as TIMESTAMP)"
        " - MINUTE({col}) MINUTES"
        " - SECOND({col}) SECONDS"
        " - MICROSECOND({col}) MICROSECONDS ",
        TimeGrain.DAY: "DATE({col})",
        TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
        TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
        TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"
        " - (MONTH({col})-1) MONTHS"
        " + ((QUARTER({col})-1) * 3) MONTHS",
        TimeGrain.YEAR: "{col} - (DAY({col})-1) DAYS - (MONTH({col})-1) MONTHS",
    }
```

After:
```
    _time_grain_expressions = {
        None: "{col}",
        TimeGrain.SECOND: "DATE_TRUNC('SECOND', {col})",
        TimeGrain.MINUTE: "DATE_TRUNC('MINUTE', {col})",
        TimeGrain.HOUR: "DATE_TRUNC('HOUR', {col})",
        TimeGrain.DAY: "DATE_TRUNC('DAY', {col})",
        TimeGrain.WEEK: "DATE_TRUNC('WEEK', {col})",
        TimeGrain.MONTH: "DATE_TRUNC('MONTH', {col})",
        TimeGrain.QUARTER: "DATE_TRUNC('QUARTER', {col})",
        TimeGrain.YEAR: "DATE_TRUNC('YEAR', {col})",
    }
```

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

#### Db2
Updated the @pytest.mark.parameterize for the Db2 time grain expressions in the unit test.
```
pytest tests/unit_tests/db_engine_specs/test_db2.py -v
```
#### IBM Db2 for i
Added the @pytest.mark.parametrize in a new unit test to test the IBM Db2 for i implementation.
```
pytest tests/unit_tests/db_engine_specs/test_ibmi.py -v
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #43231
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
