### PR TITLE
fix(bar-chart): show correct value labels per stack group with stackDimension

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -480,11 +480,57 @@ export default function transformProps(
       ? [minMarkerSize, maxMarkerSize]
       : [maxMarkerSize, minMarkerSize];
 
+  // When stackDimension is configured, each series is assigned to a separate
+  // ECharts stack group keyed by the dimension value. Compute this mapping
+  // before calling extractShowValueIndexes so each group's topmost series is
+  // tracked independently (fixing the bug where only the last series across
+  // all groups was flagged to show the total label).
+  const idxSelectedDimension =
+    stack === StackControlsValue.Stack &&
+    stackDimension &&
+    chartProps.rawFormData?.groupby
+      ? formData.metrics.length > 1
+        ? 1
+        : 0 + chartProps.rawFormData.groupby.indexOf(stackDimension)
+      : -1;
+
+  const seriesStackIds: string[] = rawSeries.map(entry => {
+    if (idxSelectedDimension >= 0 && entry.id) {
+      const dimensionValue = labelMap[entry.id]?.[idxSelectedDimension];
+      if (dimensionValue !== undefined) {
+        return String(dimensionValue);
+      }
+    }
+    return '__default__';
+  });
+
+  // Compute per-stack-group totalStackedValues so each group's "onlyTotal"
+  // label shows that group's own sum rather than the global sum across all
+  // groups. Group series by their stack group key and sum their data.
+  const perGroupTotalStackedValues: Record<string, number[]> = {};
+  if (stack && onlyTotal) {
+    rawSeries.forEach((entry, idx) => {
+      const group = seriesStackIds[idx];
+      if (!perGroupTotalStackedValues[group]) {
+        perGroupTotalStackedValues[group] = [];
+      }
+      const groupTotals = perGroupTotalStackedValues[group];
+      (entry.data as [any, number][] | undefined)?.forEach((datum, dataIndex) => {
+        if (entry.id && legendState && !legendState[entry.id]) return;
+        const val = isHorizontal ? datum[0] : datum[1];
+        if (typeof val === 'number') {
+          groupTotals[dataIndex] = (groupTotals[dataIndex] ?? 0) + val;
+        }
+      });
+    });
+  }
+
   const showValueIndexes = extractShowValueIndexes(rawSeries, {
     stack,
     onlyTotal,
     isHorizontal,
     legendState,
+    seriesStackIds,
   });
   const seriesContexts = extractForecastSeriesContexts(
     rawSeries.map(series => series.name as string),
@@ -543,7 +589,7 @@ export default function transformProps(
   let dataMax: number | undefined;
   let dataMin: number | undefined;
 
-  rawSeries.forEach(entry => {
+  rawSeries.forEach((entry, seriesIdx) => {
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
     // isDerivedSeries checks for time comparison series patterns:
@@ -670,8 +716,12 @@ export default function transformProps(
             ) ?? defaultFormatter),
         showValue,
         onlyTotal,
-        totalStackedValues: sortedTotalValues,
+        totalStackedValues:
+          onlyTotal && Object.keys(perGroupTotalStackedValues).length > 0
+            ? perGroupTotalStackedValues
+            : sortedTotalValues,
         showValueIndexes,
+        stackGroup: seriesStackIds[seriesIdx],
         thresholdValues,
         richTooltip,
         sliceId,
@@ -831,10 +881,6 @@ export default function transformProps(
     stackDimension &&
     chartProps.rawFormData.groupby
   ) {
-    const idxSelectedDimension =
-      formData.metrics.length > 1
-        ? 1
-        : 0 + chartProps.rawFormData.groupby.indexOf(stackDimension);
     for (const s of series) {
       if (s.id) {
         const columnsArr = labelMap[s.id];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -518,13 +518,15 @@ export default function transformProps(
         perGroupTotalStackedValues[group] = [];
       }
       const groupTotals = perGroupTotalStackedValues[group];
-      (entry.data as [any, number][] | undefined)?.forEach((datum, dataIndex) => {
-        if (entry.id && legendState && !legendState[entry.id]) return;
-        const val = isHorizontal ? datum[0] : datum[1];
-        if (typeof val === 'number') {
-          groupTotals[dataIndex] = (groupTotals[dataIndex] ?? 0) + val;
-        }
-      });
+      (entry.data as [any, number][] | undefined)?.forEach(
+        (datum, dataIndex) => {
+          if (entry.id && legendState && !legendState[entry.id]) return;
+          const val = isHorizontal ? datum[0] : datum[1];
+          if (typeof val === 'number') {
+            groupTotals[dataIndex] = (groupTotals[dataIndex] ?? 0) + val;
+          }
+        },
+      );
     });
   }
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -485,13 +485,16 @@ export default function transformProps(
   // before calling extractShowValueIndexes so each group's topmost series is
   // tracked independently (fixing the bug where only the last series across
   // all groups was flagged to show the total label).
+  // When metrics.length > 1 the label-map tuple is [metric, dim0, dim1, ...],
+  // so the stackDimension sits at offset 1 + groupby.indexOf(stackDimension).
+  // When there is a single metric the tuple is [dim0, dim1, ...] with no
+  // metric prefix, so the offset is just groupby.indexOf(stackDimension).
   const idxSelectedDimension =
     stack === StackControlsValue.Stack &&
     stackDimension &&
     chartProps.rawFormData?.groupby
-      ? formData.metrics.length > 1
-        ? 1
-        : 0 + chartProps.rawFormData.groupby.indexOf(stackDimension)
+      ? (formData.metrics.length > 1 ? 1 : 0) +
+        chartProps.rawFormData.groupby.indexOf(stackDimension)
       : -1;
 
   const seriesStackIds: string[] = rawSeries.map(entry => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -493,7 +493,7 @@ export default function transformProps(
     stack === StackControlsValue.Stack &&
     stackDimension &&
     chartProps.rawFormData?.groupby
-      ? (formData.metrics.length > 1 ? 1 : 0) +
+      ? (formData.metrics && formData.metrics.length > 1 ? 1 : 0) +
         chartProps.rawFormData.groupby.indexOf(stackDimension)
       : -1;
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformers.ts
@@ -240,8 +240,9 @@ export function transformSeries(
     onlyTotal?: boolean;
     legendState?: LegendState;
     formatter?: ValueFormatter;
-    totalStackedValues?: number[];
-    showValueIndexes?: number[];
+    totalStackedValues?: number[] | Record<string, number[]>;
+    showValueIndexes?: Record<string, number[]>;
+    stackGroup?: string;
     thresholdValues?: number[];
     richTooltip?: boolean;
     seriesKey?: OptionName;
@@ -276,7 +277,8 @@ export function transformSeries(
     formatter,
     legendState,
     totalStackedValues = [],
-    showValueIndexes = [],
+    showValueIndexes = {},
+    stackGroup,
     thresholdValues = [],
     richTooltip,
     seriesKey,
@@ -466,6 +468,21 @@ export function transformSeries(
         if (!stack && isSelectedLegend) {
           return formatter(numericValue);
         }
+        // Resolve per-stack-group index array and totals. When stackDimension
+        // creates separate ECharts stacks, each group has its own topmost-
+        // series index so the label appears on the correct bar segment.
+        const DEFAULT_STACK_GROUP = '__default__';
+        const resolvedStackGroup = stackGroup ?? DEFAULT_STACK_GROUP;
+        const stackShowValueIndexes = Array.isArray(showValueIndexes)
+          ? showValueIndexes
+          : (showValueIndexes[resolvedStackGroup] ??
+            showValueIndexes[DEFAULT_STACK_GROUP] ??
+            []);
+        const resolvedTotalStackedValues = Array.isArray(totalStackedValues)
+          ? totalStackedValues
+          : (totalStackedValues[resolvedStackGroup] ??
+            totalStackedValues[DEFAULT_STACK_GROUP] ??
+            []);
         if (!onlyTotal) {
           if (
             numericValue >=
@@ -475,8 +492,10 @@ export function transformSeries(
           }
           return '';
         }
-        if (seriesIndex === showValueIndexes[dataIndex]) {
-          return formatter(isAreaExpand ? 1 : totalStackedValues[dataIndex]);
+        if (seriesIndex === stackShowValueIndexes[dataIndex]) {
+          return formatter(
+            isAreaExpand ? 1 : resolvedTotalStackedValues[dataIndex],
+          );
         }
         return '';
       },

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -417,6 +417,26 @@ export function extractDataTotalValues(
   };
 }
 
+const DEFAULT_STACK_GROUP = '__default__';
+
+/**
+ * Computes, per stack group, which series index is the "topmost" (i.e. the
+ * series that should display the value label) for each data point.
+ *
+ * When a stackDimension splits bars into separate ECharts stack groups the
+ * computation must be done independently per group, otherwise only the
+ * globally-last series is flagged and all other groups miss their label.
+ *
+ * @param series      The raw series array (parallel to the rendered series).
+ * @param opts.stack           Whether stacking is active.
+ * @param opts.onlyTotal       Whether to show only the stack total.
+ * @param opts.isHorizontal    Whether the chart is horizontal.
+ * @param opts.legendState     Active legend state (hidden series are skipped).
+ * @param opts.seriesStackIds  Optional per-series stack-group key (parallel to
+ *                             `series`). Defaults to a single shared group.
+ * @returns A `Record<stackGroupKey, number[]>` where each inner array maps
+ *          `dataIndex → seriesIndex` of the topmost series in that group.
+ */
 export function extractShowValueIndexes(
   series: SeriesOption[],
   opts: {
@@ -424,35 +444,43 @@ export function extractShowValueIndexes(
     onlyTotal?: boolean;
     isHorizontal?: boolean;
     legendState?: LegendState;
+    seriesStackIds?: string[];
   },
-): number[] {
-  const showValueIndexes: number[] = [];
-  const { legendState, stack, isHorizontal, onlyTotal } = opts;
-  if (stack) {
-    series.forEach((entry, seriesIndex) => {
-      const { data = [] } = entry;
-      (data as [any, number][]).forEach((datum, dataIndex) => {
-        if (entry.id && legendState && !legendState[entry.id]) {
-          return;
-        }
-        if (!onlyTotal && datum[isHorizontal ? 0 : 1] !== null) {
+): Record<string, number[]> {
+  const result: Record<string, number[]> = {};
+  const { legendState, stack, isHorizontal, onlyTotal, seriesStackIds } = opts;
+  if (!stack) {
+    return result;
+  }
+
+  series.forEach((entry, seriesIndex) => {
+    const stackGroup = seriesStackIds?.[seriesIndex] ?? DEFAULT_STACK_GROUP;
+    if (!result[stackGroup]) {
+      result[stackGroup] = [];
+    }
+    const showValueIndexes = result[stackGroup];
+
+    const { data = [] } = entry;
+    (data as [any, number][]).forEach((datum, dataIndex) => {
+      if (entry.id && legendState && !legendState[entry.id]) {
+        return;
+      }
+      const numericValue = datum[isHorizontal ? 0 : 1];
+      if (!onlyTotal && numericValue !== null) {
+        showValueIndexes[dataIndex] = seriesIndex;
+      }
+      if (onlyTotal) {
+        if (numericValue > 0) {
           showValueIndexes[dataIndex] = seriesIndex;
         }
-        if (onlyTotal) {
-          if (datum[isHorizontal ? 0 : 1] > 0) {
-            showValueIndexes[dataIndex] = seriesIndex;
-          }
-          if (
-            !showValueIndexes[dataIndex] &&
-            datum[isHorizontal ? 0 : 1] !== null
-          ) {
-            showValueIndexes[dataIndex] = seriesIndex;
-          }
+        if (!showValueIndexes[dataIndex] && numericValue !== null) {
+          showValueIndexes[dataIndex] = seriesIndex;
         }
-      });
+      }
     });
-  }
-  return showValueIndexes;
+  });
+
+  return result;
 }
 
 export function sortAndFilterSeries(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -629,6 +629,7 @@ describe('Does transformProps transform series correctly', () => {
     label: { show: boolean; formatter: labelFormatterType };
     data: seriesDataType[];
     name: string;
+    stack?: string;
   };
 
   const formData: SqlaFormData = {
@@ -825,6 +826,107 @@ describe('Does transformProps transform series correctly', () => {
       'foo1, bar1': ['foo1', 'bar1'],
       'foo2, bar2': ['foo2', 'bar2'],
     });
+  });
+
+  test('should correctly assign stack and compute onlyTotal labels for multi-metric and multi-groupby charts with stackDimension', () => {
+    const multiMetricFormData: Partial<EchartsTimeseriesFormData> = {
+      viz_type: 'my_viz',
+      colorScheme: 'bnbColors',
+      datasource: '3__table',
+      granularity_sqla: 'ds',
+      metrics: ['sales', 'profit'],
+      groupby: ['dept', 'region'],
+      stackDimension: 'region',
+      stack: StackControlsValue.Stack,
+      onlyTotal: true,
+      showValue: true,
+    };
+
+    const multiMetricQueriesData: ChartDataResponseResult[] = [
+      createTestQueryData(
+        [
+          {
+            __timestamp: BASE_TIMESTAMP,
+            'sales, HR, East': 10,
+            'profit, Sales, East': 20,
+            'sales, HR, West': 100,
+            'profit, Sales, West': 200,
+          },
+        ],
+        {
+          colnames: [
+            '__timestamp',
+            'sales, HR, East',
+            'profit, Sales, East',
+            'sales, HR, West',
+            'profit, Sales, West',
+          ],
+          coltypes: [
+            GenericDataType.Temporal,
+            GenericDataType.Numeric,
+            GenericDataType.Numeric,
+            GenericDataType.Numeric,
+            GenericDataType.Numeric,
+          ],
+          label_map: {
+            'sales, HR, East': ['sales', 'HR', 'East'],
+            'profit, Sales, East': ['profit', 'Sales', 'East'],
+            'sales, HR, West': ['sales', 'HR', 'West'],
+            'profit, Sales, West': ['profit', 'Sales', 'West'],
+          },
+        },
+      ),
+    ];
+
+    const chartProps = createTestChartProps({
+      formData: multiMetricFormData,
+      queriesData: multiMetricQueriesData,
+    });
+
+    const transformedSeries = transformProps(chartProps).echartOptions
+      .series as seriesType[];
+
+    // Assert that each series has its stack property assigned to the stackDimension ('region')
+    // and NOT to the first groupby dimension ('dept')
+    const eastSeries = transformedSeries.filter(s => s.name?.includes('East'));
+    const westSeries = transformedSeries.filter(s => s.name?.includes('West'));
+
+    expect(eastSeries).toHaveLength(2);
+    expect(westSeries).toHaveLength(2);
+
+    eastSeries.forEach(s => {
+      expect(s.stack).toBe('East');
+    });
+    westSeries.forEach(s => {
+      expect(s.stack).toBe('West');
+    });
+
+    // Assert that each stack group's topmost series displays that group's total:
+    // East group total: 10 + 20 = 30
+    // West group total: 100 + 200 = 300
+    // If the multi-metric offset were missing, groups would be split by 'dept',
+    // producing totals 110 ('HR') and 220 ('Sales') instead of 30 and 300.
+    const eastLabels = eastSeries.map(s => {
+      const sIndex = transformedSeries.indexOf(s);
+      return s.label.formatter({
+        value: s.data[0],
+        dataIndex: 0,
+        seriesIndex: sIndex,
+      });
+    });
+    expect(eastLabels).toContain('30');
+    expect(eastLabels).toContain('');
+
+    const westLabels = westSeries.map(s => {
+      const sIndex = transformedSeries.indexOf(s);
+      return s.label.formatter({
+        value: s.data[0],
+        dataIndex: 0,
+        seriesIndex: sIndex,
+      });
+    });
+    expect(westLabels).toContain('300');
+    expect(westLabels).toContain('');
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -759,7 +759,9 @@ describe('extractShowValueIndexes', () => {
         ],
         { stack: true, onlyTotal: false, isHorizontal: false },
       ),
-    ).toEqual([undefined, 1, 0, 1, undefined, 2, 1, 1, undefined, 1]);
+    ).toEqual({
+      __default__: [undefined, 1, 0, 1, undefined, 2, 1, 1, undefined, 1],
+    });
   });
 
   test('should handle the negative numbers for total only', () => {
@@ -817,7 +819,53 @@ describe('extractShowValueIndexes', () => {
         ],
         { stack: true, onlyTotal: true, isHorizontal: false },
       ),
-    ).toEqual([undefined, 1, 0, 2, undefined, 1, 1, 2, undefined, 1]);
+    ).toEqual({
+      __default__: [undefined, 1, 0, 2, undefined, 1, 1, 2, undefined, 1],
+    });
+  });
+
+  test('should track topmost series independently per stack group (stackDimension)', () => {
+    // Simulates 2 stack groups: 'groupA' (series indices 0, 1) and 'groupB' (series index 2).
+    // With onlyTotal, each group's topmost positive series should be flagged independently.
+    expect(
+      extractShowValueIndexes(
+        [
+          {
+            id: 'A-cat1',
+            name: 'A-cat1',
+            data: [
+              ['Jan', 10],
+              ['Feb', 5],
+            ],
+          },
+          {
+            id: 'A-cat2',
+            name: 'A-cat2',
+            data: [
+              ['Jan', 20],
+              ['Feb', 15],
+            ],
+          },
+          {
+            id: 'B-cat1',
+            name: 'B-cat1',
+            data: [
+              ['Jan', 30],
+              ['Feb', 25],
+            ],
+          },
+        ],
+        {
+          stack: true,
+          onlyTotal: true,
+          isHorizontal: false,
+          seriesStackIds: ['groupA', 'groupA', 'groupB'],
+        },
+      ),
+    ).toEqual({
+      groupA: [1, 1], // series index 1 is top of groupA for both data points
+      groupB: [2, 2], // series index 2 is top of groupB for both data points
+    });
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -303,7 +303,7 @@ test('sortRows by max ascending', () => {
       sortData,
       totalStackedValues,
       'my_x_axis',
-      SortSeriesType.Min,
+      SortSeriesType.Max,
       true,
     ),
   ).toEqual([
@@ -319,7 +319,7 @@ test('sortRows by max descending', () => {
       sortData,
       totalStackedValues,
       'my_x_axis',
-      SortSeriesType.Min,
+      SortSeriesType.Max,
       false,
     ),
   ).toEqual([


### PR DESCRIPTION
## Summary
Fixes #33882

When "Split stack by" (`stackDimension`) is configured on a stacked bar chart,
ECharts creates separate stack groups per x-axis position.

Previously, `extractShowValueIndexes` tracked a single global "topmost series"
index across ALL groups, so with "Only Total" enabled only ONE label appeared
for the entire cluster instead of one per stack group.

## Changes
- `extractShowValueIndexes` now returns `Record<string, number[]>` keyed by
  stack group (defaults to `__default__` for non-split charts — backward compatible)
- `transformSeries` resolves per-group index array and totals in the label formatter
- `transformProps` computes `seriesStackIds[]` and `perGroupTotalStackedValues`
  before calling `extractShowValueIndexes`

## Before / After
**Before:** Only 1 label for the entire bar cluster with `onlyTotal`  
<img width="1462" height="693" alt="image" src="https://github.com/user-attachments/assets/8dda003f-3a71-4d89-bc51-4d756fe9fd9f" />


**After:** Each stack group shows its own total label ✅

<img width="1920" height="887" alt="image" src="https://github.com/user-attachments/assets/fafb80c0-af9e-4675-851f-2aa386a6798b" />


## Testing
- All 101 existing unit tests pass ✅
- New unit test added for multi-group stackDimension case ✅
