### PR TITLE
feat(db_engine_specs): add metadata block to OdpsEngineSpec

### DIFF
--- a/superset/db_engine_specs/odps.py
+++ b/superset/db_engine_specs/odps.py
@@ -32,7 +32,11 @@ from superset.databases.utils import (
     get_foreign_keys_metadata,
     get_indexes_metadata,
 )
-from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
+from superset.db_engine_specs.base import (
+    BaseEngineSpec,
+    BasicParametersMixin,
+    DatabaseCategory,
+)
 from superset.sql.parse import Partition, SQLScript, Table
 from superset.superset_typing import ResultSetColumnType
 
@@ -64,6 +68,34 @@ class OdpsEngineSpec(BasicParametersMixin, OdpsBaseEngineSpec):
     engine = "odps"
     engine_name = "ODPS (MaxCompute)"
     default_driver = "odps"
+
+    metadata = {
+        "description": (
+            "Alibaba Cloud MaxCompute (formerly ODPS) is a fully managed, "
+            "multi-tenancy cloud data warehousing platform for large-scale "
+            "batch and streaming analytics."
+        ),
+        "homepage_url": "https://www.alibabacloud.com/product/maxcompute",
+        "categories": [
+            DatabaseCategory.CLOUD_DATA_WAREHOUSES,
+            DatabaseCategory.ANALYTICAL_DATABASES,
+            DatabaseCategory.PROPRIETARY,
+        ],
+        "pypi_packages": ["pyodps"],
+        "connection_string": (
+            "odps://{access_id}:{secret_access_key}@{project}/?endpoint={endpoint}"
+        ),
+        "parameters": {
+            "access_id": "Aliyun Access Key ID",
+            "secret_access_key": "Aliyun Access Key Secret",
+            "project": "MaxCompute project name",
+            "endpoint": "MaxCompute service endpoint URL",
+        },
+        "docs_url": "https://pyodps.readthedocs.io/",
+        "sqlalchemy_docs_url": (
+            "https://pyodps.readthedocs.io/en/latest/sqlalchemy.html"
+        ),
+    }
 
     @classmethod
     def get_table_metadata(

--- a/tests/unit_tests/db_engine_specs/test_odps.py
+++ b/tests/unit_tests/db_engine_specs/test_odps.py
@@ -172,3 +172,22 @@ def test_is_odps_partitioned_table_not_partitioned(
         result = DatabaseDAO.is_odps_partitioned_table(database, "my_table")
 
     assert result == (False, [])
+
+
+def test_odps_metadata_has_required_fields() -> None:
+    """Regression test for #42980: OdpsEngineSpec must expose the four
+    ``REQUIRED_FIELDS`` from ``lint_metadata.py`` so the DB picker renders
+    the driver with useful context (description, pypi package, connection
+    string template, categories).
+
+    Deliberately narrow — checks presence + the driver package name pinned
+    by the ``daos/database.py`` runtime warning for ``pyodps``. Does not
+    lock down description wording, URLs, or optional-field decisions.
+    """
+    metadata = getattr(OdpsEngineSpec, "metadata", None)
+    assert metadata is not None, "OdpsEngineSpec.metadata must be defined"
+    for field in ("description", "categories", "pypi_packages", "connection_string"):
+        assert field in metadata, (
+            f"OdpsEngineSpec.metadata missing required field: {field}"
+        )
+    assert "pyodps" in metadata["pypi_packages"]


### PR DESCRIPTION
### SUMMARY

Partial fix for #42980. Adds a `metadata = {...}` block on `OdpsEngineSpec` (ODPS / Alibaba MaxCompute), the ONE spec in @jethac's 12-item incomplete list where metadata is genuinely missing rather than deliberately consolidated in another class.

### WHY THIS IS A NARROW FIX

Verified against `superset/db_engine_specs/lint_metadata.py --json` on `master`: 12 specs still report `has_metadata: false`. Reading each, **11 of the 12 explicitly point their documentation to another class in the same driver family**:

| Spec | Docs live in |
|---|---|
| `ibmi::IBMiEngineSpec` | `db2.py`'s `Db2EngineSpec.metadata["compatible_databases"]` |
| `kusto::KustoKqlEngineSpec` | `kusto.py`'s `KustoSqlEngineSpec.metadata["drivers"]` |
| `elasticsearch::OpenDistroEngineSpec` | Docstring: *"consolidated in ElasticSearchEngineSpec"* |
| 3× `databricks` legacy specs | Comment: *"Primary metadata is in DatabricksPythonConnectorEngineSpec"* |
| 2× `aurora` DataAPI + 2× base variants | Docstring: *"in MySQLEngineSpec/PostgresEngineSpec's compatible_databases"* |
| `clickhouse::ClickHouseEngineSpec` (sqlalchemy) | Sibling `ClickHouseConnectEngineSpec` in same file |

Adding metadata to any of those 11 would **duplicate** existing info and break the single-source-of-truth invariant that pattern deliberately maintains.

**`OdpsEngineSpec` is the only leaf where no parent-consolidation exists** — users picking "ODPS (MaxCompute)" from Superset's database picker currently see zero description or docs. That's the case this PR fixes.

### VERIFICATION

- `description` — factual from Alibaba Cloud's public product page
- `categories` — three existing `DatabaseCategory` constants (`CLOUD_DATA_WAREHOUSES`, `ANALYTICAL_DATABASES`, `PROPRIETARY`) verified in `base.py:217, 222, 231`
- `pypi_packages: ["pyodps"]` matches the runtime warning at `superset/daos/database.py:279`
- `connection_string` matches the ODPS URI regex at `superset/daos/database.py:284` and the test fixtures in `tests/unit_tests/db_engine_specs/test_odps.py:102`
- `logo` / `default_port` intentionally omitted — no aliyun/maxcompute asset in `docs/static/img/databases/` (78 files, none Alibaba-related) and MaxCompute uses a URL endpoint rather than a fixed host:port. Both are `RECOMMENDED`, not `REQUIRED` — linter still passes.

### RESULT (verified locally)

Before:
```
{"total": 80, "with_metadata": 68, "all_required": 68, "average_score": 73.7}
```

After:
```
{"total": 80, "with_metadata": 69, "all_required": 69, "average_score": 74.6}
```

ODPS report after change: `has_metadata: true`, `missing_required: []`, `completeness_score: 71.8`.

### DEFENSIVE TEST

Small pytest in `tests/unit_tests/db_engine_specs/test_odps.py` pins the four `REQUIRED_FIELDS` + the `pyodps` package name so an accidental future removal of the metadata block trips a fast pytest failure, not just the standalone linter script (which isn't part of the CI test surface).

### IF YOU'D RATHER CLEAR ALL 12

Three follow-up options ready to open as a separate PR:

1. **F1 (recommended):** teach `lint_metadata.py` to detect the *"Documentation ... consolidated in X"* docstring pattern and mark those leaves as `consolidated` rather than `false`. Answers @jethac's own design question directly; ~40 LOC in one file; no metadata duplication.
2. **F2:** add a machine-readable `consolidated_metadata_in = "..."` class attribute on each consolidated leaf. 11 files touched (small change each); zero regex.
3. **F3 (last resort):** duplicate the metadata on every leaf. 11 files, ~150-250 LOC total, breaks single-source-of-truth. Not recommended — every future metadata change now has to be applied in multiple places.

Happy to open the follow-up in whichever shape you prefer. This PR ships the narrow ODPS fix first so at least the one genuine gap is closed.

### ADDITIONAL INFORMATION

- [x] Has associated issue: partial fix for #42980
- [x] Required feature flags: none
- [x] Changes UI: no (metadata surfaces in the DB picker; existing UI code just reads it)
- [x] Includes DB Migration: no
- [x] Includes CLI or Node.js commands: no
- [x] Breaking change: no (purely additive)