### PR TITLE
fix(dashboard): derive filter scope on read instead of serving a stale cache

### DIFF
--- a/superset-frontend/src/dashboard/actions/nativeFilters.ts
+++ b/superset-frontend/src/dashboard/actions/nativeFilters.ts
@@ -27,7 +27,7 @@ import {
 } from '@superset-ui/core';
 import { Dispatch } from 'redux';
 import { RootState } from 'src/dashboard/types';
-import { cloneDeep } from 'lodash-es';
+import { cloneDeep, omit } from 'lodash-es';
 import { setDataMaskForFilterChangesComplete } from 'src/dataMask/actions';
 import { HYDRATE_DASHBOARD } from './hydrate';
 import {
@@ -90,12 +90,20 @@ export const setFilterConfiguration =
     });
     try {
       const response = await updateFilters(filterChanges);
+      // chartsInScope/tabsInScope are derived from the live layout, and the
+      // response carries the persisted copy for every filter - including the
+      // ones this save never touched, whose copy is whatever was stored when
+      // the dashboard was last saved. Dropping them lets the reducers keep the
+      // scopes calculateScopes already computed for this session.
+      const savedFilters = response.result.map(
+        filter => omit(filter, ['chartsInScope', 'tabsInScope']) as Filter,
+      );
       dispatch({
         type: SET_NATIVE_FILTERS_CONFIG_COMPLETE,
-        filterChanges: response.result,
+        filterChanges: savedFilters,
         deletedIds: filterChanges.deleted,
       });
-      dispatch(nativeFiltersConfigChanged(response.result));
+      dispatch(nativeFiltersConfigChanged(savedFilters));
       dispatch(setDataMaskForFilterChangesComplete(filterChanges, oldFilters));
     } catch (err) {
       dispatch({

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -34,6 +34,7 @@ from superset.commands.dashboard.exceptions import (
     DashboardUpdateFailedError,
 )
 from superset.daos.base import BaseDAO, ColumnOperator, ColumnOperatorEnum
+from superset.dashboards.filter_scope import derive_metadata_scopes
 from superset.dashboards.filters import DashboardAccessFilter
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db
@@ -547,7 +548,9 @@ class DashboardDAO(BaseDAO[Dashboard]):
         cls, id: str
     ) -> dict[str, list[dict[str, Any]]]:
         dashboard = cls.get_by_id_or_slug(id)
-        metadata = json.loads(dashboard.json_metadata or "{}")
+        metadata = derive_metadata_scopes(
+            dashboard, json.loads(dashboard.json_metadata or "{}")
+        )
         native_filter_configuration = metadata.get("native_filter_configuration", [])
 
         tab_filters = defaultdict(list)
@@ -616,6 +619,13 @@ class DashboardDAO(BaseDAO[Dashboard]):
 
             metadata["native_filter_configuration"] = updated_configuration
             dashboard.json_metadata = json.dumps(metadata)
+
+            # The client rebuilds its in-scope state from this response, so hand
+            # back derived scopes rather than the stored caches, which are stale
+            # for every filter the caller did not touch.
+            updated_configuration = derive_metadata_scopes(dashboard, metadata)[
+                "native_filter_configuration"
+            ]
 
         return updated_configuration
 

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -91,6 +91,7 @@ from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.commands.purge import PurgeArchivedCommand, SoftDeleteBinding
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.dashboard import DashboardDAO, EmbeddedDashboardDAO
+from superset.dashboards.filter_scope import derive_json_metadata
 from superset.dashboards.filters import (
     DashboardAccessFilter,
     DashboardCertifiedFilter,
@@ -653,6 +654,12 @@ class DashboardRestApi(
             schema = self.dashboard_get_response_schema
 
         result = schema.dump(dash)
+        if json_metadata := result.get("json_metadata"):
+            # The stored scope caches (``chartsInScope``, ``tabsInScope``,
+            # ``chart_configuration``) go stale as soon as the layout changes;
+            # derive them so callers see the same document the dashboard client
+            # computes for itself.
+            result["json_metadata"] = derive_json_metadata(dash, json_metadata)
         if "charts" in result:
             # Only name the member charts the caller can access, consistent with
             # the per-object narrowing applied to the dashboard's datasets and

--- a/superset/dashboards/filter_scope.py
+++ b/superset/dashboards/filter_scope.py
@@ -1,0 +1,275 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Derive filter-scope caches in ``json_metadata`` from the dashboard layout.
+
+``chartsInScope`` / ``tabsInScope`` on a native filter, and the ``chartsInScope``
+lists inside ``chart_configuration`` / ``global_chart_configuration``, are
+denormalized caches of the authoritative ``scope`` plus ``position_json``. They
+are written when a dashboard is saved and are never revisited afterwards, so a
+dashboard that has charts added or removed - or that was seeded, exported or
+imported - carries scope arrays naming charts it does not contain.
+
+The dashboard client already ignores the stored values and recomputes them from
+the live layout on every load, which is why the JSON Metadata panel and
+``GET /api/v1/dashboard/{id}`` disagreed on a dashboard nobody had ever saved.
+Deriving them on read makes the API agree with the client and keeps integrations
+that read ``native_filter_configuration`` from receiving dangling chart ids.
+
+The rules mirror the client (``superset-frontend/src/dashboard/util``):
+``calculateScopes``, ``getChartIdsInFilterScope``, ``findTabsWithChartsInScope``
+and ``getCrossFiltersConfiguration``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, TYPE_CHECKING
+
+from superset.utils import json
+
+if TYPE_CHECKING:
+    from superset.models.dashboard import Dashboard
+
+CHART_TYPE = "CHART"
+TAB_TYPE = "TAB"
+NATIVE_FILTER_DIVIDER_PREFIX = "NATIVE_FILTER_DIVIDER-"
+DIVIDER_TYPES = frozenset({"DIVIDER", "CHART_CUSTOMIZATION_DIVIDER"})
+
+# ``chart-<chartId>-layer-<layerIndex>``, the per-layer scope keys a deck.gl
+# multi-layer chart contributes to ``scope.selectedLayers``.
+LAYER_SELECTION_RE = re.compile(r"^chart-(\d+)-layer-(\d+)$")
+
+ChartLayoutItems = dict[int, list[dict[str, Any]]]
+
+
+def build_chart_layout_items(position_data: dict[str, Any]) -> ChartLayoutItems:
+    """Map each chart id in the layout to the layout items that render it."""
+    chart_layout_items: ChartLayoutItems = {}
+    for item in position_data.values():
+        if not isinstance(item, dict) or item.get("type") != CHART_TYPE:
+            continue
+        chart_id = item.get("meta", {}).get("chartId")
+        if isinstance(chart_id, int):
+            chart_layout_items.setdefault(chart_id, []).append(item)
+    return chart_layout_items
+
+
+def get_chart_ids_in_scope(
+    scope: dict[str, Any],
+    chart_ids: list[int],
+    chart_layout_items: ChartLayoutItems,
+) -> list[int]:
+    """Charts covered by ``scope``, in ``chart_ids`` order."""
+    excluded = set(scope.get("excluded") or [])
+    root_path = set(scope.get("rootPath") or [])
+
+    def in_scope(chart_id: int) -> bool:
+        if chart_id in excluded:
+            return False
+        return any(
+            parent in root_path
+            for layout_item in chart_layout_items.get(chart_id, [])
+            for parent in layout_item.get("parents") or []
+        )
+
+    selected_layers = scope.get("selectedLayers") or []
+    if not selected_layers:
+        return [chart_id for chart_id in chart_ids if in_scope(chart_id)]
+
+    # A layer selection targets its chart directly, and suppresses the
+    # rootPath/excluded test for that chart.
+    charts_with_layer_selections = set()
+    targeted: list[int] = []
+    chart_id_set = set(chart_ids)
+    for selection_key in selected_layers:
+        if match := LAYER_SELECTION_RE.match(str(selection_key)):
+            chart_id = int(match.group(1))
+            charts_with_layer_selections.add(chart_id)
+            if chart_id in chart_id_set and chart_id not in targeted:
+                targeted.append(chart_id)
+
+    return targeted + [
+        chart_id
+        for chart_id in chart_ids
+        if chart_id not in charts_with_layer_selections
+        and chart_id not in targeted
+        and in_scope(chart_id)
+    ]
+
+
+def get_tabs_in_scope(
+    charts_in_scope: list[int],
+    chart_layout_items: ChartLayoutItems,
+) -> list[str]:
+    """Tabs holding at least one of ``charts_in_scope``."""
+    tabs_in_scope: list[str] = []
+    seen: set[str] = set()
+    for chart_id in charts_in_scope:
+        for layout_item in chart_layout_items.get(chart_id, []):
+            for parent in layout_item.get("parents") or []:
+                if parent.startswith(f"{TAB_TYPE}-") and parent not in seen:
+                    seen.add(parent)
+                    tabs_in_scope.append(parent)
+    return tabs_in_scope
+
+
+def _is_divider(item: dict[str, Any]) -> bool:
+    return (
+        str(item.get("id", "")).startswith(NATIVE_FILTER_DIVIDER_PREFIX)
+        or item.get("type") in DIVIDER_TYPES
+    )
+
+
+def _derive_item_scopes(
+    items: list[Any],
+    chart_ids: list[int],
+    chart_layout_items: ChartLayoutItems,
+) -> list[Any]:
+    """Restamp ``chartsInScope`` / ``tabsInScope`` on scoped config items.
+
+    Items without a usable ``scope`` are returned untouched: legacy chart
+    customizations target a chart directly and only gain a ``scope`` once the
+    client migrates them, so overwriting their cache here would drop targeting
+    the client still needs.
+    """
+    derived = []
+    for item in items:
+        if not isinstance(item, dict):
+            derived.append(item)
+            continue
+        if _is_divider(item):
+            derived.append({**item, "chartsInScope": [], "tabsInScope": []})
+            continue
+        scope = item.get("scope")
+        if not isinstance(scope, dict) or not isinstance(scope.get("excluded"), list):
+            derived.append(item)
+            continue
+        charts_in_scope = get_chart_ids_in_scope(scope, chart_ids, chart_layout_items)
+        derived.append(
+            {
+                **item,
+                "chartsInScope": charts_in_scope,
+                "tabsInScope": get_tabs_in_scope(charts_in_scope, chart_layout_items),
+            }
+        )
+    return derived
+
+
+def _derive_cross_filter_scopes(
+    metadata: dict[str, Any],
+    chart_ids: list[int],
+    chart_layout_items: ChartLayoutItems,
+) -> None:
+    global_config = metadata.get("global_chart_configuration")
+    global_charts_in_scope = chart_ids
+    if isinstance(global_config, dict) and isinstance(global_config.get("scope"), dict):
+        global_charts_in_scope = get_chart_ids_in_scope(
+            global_config["scope"], chart_ids, chart_layout_items
+        )
+        metadata["global_chart_configuration"] = {
+            **global_config,
+            "chartsInScope": global_charts_in_scope,
+        }
+
+    chart_configuration = metadata.get("chart_configuration")
+    if not isinstance(chart_configuration, dict):
+        return
+
+    derived_configuration = {}
+    for key, config in chart_configuration.items():
+        try:
+            chart_id = int(key)
+        except (TypeError, ValueError):
+            derived_configuration[key] = config
+            continue
+        # Config for a chart no longer on the dashboard is dead weight; the
+        # client drops it on load for the same reason.
+        if chart_id not in chart_layout_items:
+            continue
+        if not isinstance(config, dict):
+            derived_configuration[key] = config
+            continue
+        cross_filters = config.get("crossFilters")
+        if not isinstance(cross_filters, dict):
+            derived_configuration[key] = config
+            continue
+        scope = cross_filters.get("scope")
+        if isinstance(scope, dict):
+            charts_in_scope = get_chart_ids_in_scope(
+                scope, chart_ids, chart_layout_items
+            )
+        else:
+            # Anything that is not an explicit scope object points at the
+            # dashboard-wide scope, which never includes the emitting chart.
+            charts_in_scope = [cid for cid in global_charts_in_scope if cid != chart_id]
+        derived_configuration[key] = {
+            **config,
+            "crossFilters": {**cross_filters, "chartsInScope": charts_in_scope},
+        }
+
+    metadata["chart_configuration"] = derived_configuration
+
+
+def derive_scopes(
+    metadata: dict[str, Any],
+    position_data: dict[str, Any],
+    chart_ids: list[int],
+) -> dict[str, Any]:
+    """Return ``metadata`` with every derived scope cache recomputed.
+
+    ``chart_ids`` orders the resulting ``chartsInScope`` arrays and should be the
+    dashboard's chart ids as the client sees them, so that the API and the JSON
+    Metadata panel produce byte-identical documents.
+    """
+    derived = dict(metadata)
+    chart_layout_items = build_chart_layout_items(position_data)
+
+    for key in ("native_filter_configuration", "chart_customization_config"):
+        config = derived.get(key)
+        if isinstance(config, list):
+            derived[key] = _derive_item_scopes(config, chart_ids, chart_layout_items)
+
+    _derive_cross_filter_scopes(derived, chart_ids, chart_layout_items)
+    return derived
+
+
+def derive_metadata_scopes(
+    dashboard: Dashboard,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """``derive_scopes`` for a dashboard model's parsed ``json_metadata``."""
+    return derive_scopes(
+        metadata,
+        dashboard.position,
+        [slc.id for slc in dashboard.slices],
+    )
+
+
+def derive_json_metadata(dashboard: Dashboard, json_metadata: str) -> str:
+    """``derive_metadata_scopes`` over a raw ``json_metadata`` string.
+
+    Metadata that does not parse as a JSON object is handed back untouched -
+    reading a dashboard is not the place to start rejecting documents that have
+    always been served as-is.
+    """
+    try:
+        metadata = json.loads(json_metadata)
+    except (TypeError, ValueError):
+        return json_metadata
+    if not isinstance(metadata, dict):
+        return json_metadata
+    return json.dumps(derive_metadata_scopes(dashboard, metadata))

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -646,6 +646,65 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         db.session.delete(dashboard)
         db.session.commit()
 
+    def test_get_dashboard_derives_stale_filter_scope(self):
+        """
+        Dashboard API: ``chartsInScope`` is derived from the layout, not read
+        back from the stored cache (sc-116923).
+        """
+        admin = self.get_user("admin")
+        slices = db.session.query(Slice).limit(2).all()
+        positions = {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "parents": ["ROOT_ID"]},
+        }
+        for slc in slices:
+            positions[f"CHART-{slc.id}"] = {
+                "id": f"CHART-{slc.id}",
+                "type": "CHART",
+                "meta": {"chartId": slc.id},
+                "parents": ["ROOT_ID", "GRID_ID"],
+            }
+        # A scope naming charts the dashboard does not contain - the state every
+        # seeded and imported dashboard starts in.
+        stored_metadata = {
+            "native_filter_configuration": [
+                {
+                    "id": "NATIVE_FILTER-1",
+                    "name": "Region",
+                    "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+                    "chartsInScope": [90001, 90002],
+                    "tabsInScope": ["TAB-gone"],
+                }
+            ]
+        }
+        dashboard = self.insert_dashboard(
+            "scope-cache",
+            "scope-cache",
+            [admin.id],
+            slices=slices,
+            position_json=json.dumps(positions),
+            json_metadata=json.dumps(stored_metadata),
+        )
+
+        self.login(ADMIN_USERNAME)
+        rv = self.get_assert_metric(f"api/v1/dashboard/{dashboard.id}", "get")
+        assert rv.status_code == 200
+
+        response_metadata = json.loads(
+            json.loads(rv.data.decode("utf-8"))["result"]["json_metadata"]
+        )
+        native_filter = response_metadata["native_filter_configuration"][0]
+        assert sorted(native_filter["chartsInScope"]) == sorted(
+            slc.id for slc in slices
+        )
+        assert native_filter["tabsInScope"] == []
+        assert native_filter["name"] == "Region"
+        # Deriving is read-only; the stored document is left alone.
+        assert json.loads(dashboard.json_metadata) == stored_metadata
+
+        db.session.delete(dashboard)
+        db.session.commit()
+
     def test_get_dashboard_with_columns(self):
         """
         Dashboard API: Test get dashboard with column selection via q param

--- a/tests/unit_tests/dashboards/filter_scope_test.py
+++ b/tests/unit_tests/dashboards/filter_scope_test.py
@@ -1,0 +1,233 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from types import SimpleNamespace
+from typing import Any
+
+from superset.dashboards.filter_scope import (
+    derive_json_metadata,
+    derive_metadata_scopes,
+    derive_scopes,
+)
+from superset.utils import json
+
+# Two charts in a tab, one chart outside it.
+POSITION_DATA: dict[str, Any] = {
+    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+    "CHART-outside": {
+        "id": "CHART-outside",
+        "type": "CHART",
+        "meta": {"chartId": 1},
+        "parents": ["ROOT_ID", "GRID_ID"],
+    },
+    "CHART-in-tab": {
+        "id": "CHART-in-tab",
+        "type": "CHART",
+        "meta": {"chartId": 2},
+        "parents": ["ROOT_ID", "GRID_ID", "TABS-1", "TAB-1"],
+    },
+    "CHART-also-in-tab": {
+        "id": "CHART-also-in-tab",
+        "type": "CHART",
+        "meta": {"chartId": 3},
+        "parents": ["ROOT_ID", "GRID_ID", "TABS-1", "TAB-1"],
+    },
+    "MARKDOWN-1": {"id": "MARKDOWN-1", "type": "MARKDOWN", "parents": ["ROOT_ID"]},
+}
+CHART_IDS = [1, 2, 3]
+
+
+def test_stale_charts_in_scope_is_replaced() -> None:
+    """The reported symptom: a scope cache naming charts that are not present."""
+    metadata = {
+        "native_filter_configuration": [
+            {
+                "id": "NATIVE_FILTER-1",
+                "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+                "chartsInScope": [7, 17, 23],
+                "tabsInScope": ["TAB-gone"],
+            }
+        ]
+    }
+
+    derived = derive_scopes(metadata, POSITION_DATA, CHART_IDS)
+
+    assert derived["native_filter_configuration"][0]["chartsInScope"] == [1, 2, 3]
+    assert derived["native_filter_configuration"][0]["tabsInScope"] == ["TAB-1"]
+
+
+def test_scope_narrowed_to_a_tab() -> None:
+    metadata = {
+        "native_filter_configuration": [
+            {
+                "id": "NATIVE_FILTER-1",
+                "scope": {"rootPath": ["TAB-1"], "excluded": [3]},
+            }
+        ]
+    }
+
+    derived = derive_scopes(metadata, POSITION_DATA, CHART_IDS)
+
+    assert derived["native_filter_configuration"][0]["chartsInScope"] == [2]
+    assert derived["native_filter_configuration"][0]["tabsInScope"] == ["TAB-1"]
+
+
+def test_dividers_and_unscoped_items() -> None:
+    metadata = {
+        "native_filter_configuration": [
+            {"id": "NATIVE_FILTER_DIVIDER-1", "chartsInScope": [7], "tabsInScope": []},
+            {"id": "DIVIDER-1", "type": "DIVIDER", "chartsInScope": [7]},
+            # A legacy chart customization targets a chart directly and only
+            # gains a scope once the client migrates it.
+            {"id": "CHART_CUSTOMIZATION-1", "chartId": 7, "chartsInScope": [7]},
+        ]
+    }
+
+    config = derive_scopes(metadata, POSITION_DATA, CHART_IDS)[
+        "native_filter_configuration"
+    ]
+
+    assert config[0]["chartsInScope"] == []
+    assert config[1]["chartsInScope"] == []
+    assert config[2]["chartsInScope"] == [7]
+
+
+def test_chart_configuration_drops_charts_not_on_the_dashboard() -> None:
+    metadata = {
+        "global_chart_configuration": {
+            "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            "chartsInScope": [7, 17],
+        },
+        "chart_configuration": {
+            "1": {"id": 1, "crossFilters": {"scope": "global", "chartsInScope": [17]}},
+            "2": {
+                "id": 2,
+                "crossFilters": {
+                    "scope": {"rootPath": ["TAB-1"], "excluded": []},
+                    "chartsInScope": [23],
+                },
+            },
+            "84": {"id": 84, "crossFilters": {"scope": "global", "chartsInScope": [7]}},
+        },
+    }
+
+    derived = derive_scopes(metadata, POSITION_DATA, CHART_IDS)
+
+    assert derived["global_chart_configuration"]["chartsInScope"] == [1, 2, 3]
+    assert list(derived["chart_configuration"]) == ["1", "2"]
+    # A globally scoped chart emits to every other chart, never to itself.
+    assert derived["chart_configuration"]["1"]["crossFilters"]["chartsInScope"] == [
+        2,
+        3,
+    ]
+    assert derived["chart_configuration"]["2"]["crossFilters"]["chartsInScope"] == [
+        2,
+        3,
+    ]
+
+
+def test_selected_layers_target_their_chart_directly() -> None:
+    metadata = {
+        "native_filter_configuration": [
+            {
+                "id": "NATIVE_FILTER-1",
+                "scope": {
+                    "rootPath": ["TAB-1"],
+                    "excluded": [1],
+                    "selectedLayers": ["chart-1-layer-0"],
+                },
+            }
+        ]
+    }
+
+    derived = derive_scopes(metadata, POSITION_DATA, CHART_IDS)
+
+    # Chart 1 is excluded and outside the rootPath, but a layer selection wins.
+    assert derived["native_filter_configuration"][0]["chartsInScope"] == [1, 2, 3]
+
+
+def test_key_order_and_untouched_keys_are_kept() -> None:
+    metadata = {
+        "color_scheme": "supersetColors",
+        "native_filter_configuration": [
+            {
+                "id": "NATIVE_FILTER-1",
+                "chartsInScope": [7],
+                "name": "Region",
+                "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            }
+        ],
+        "refresh_frequency": 0,
+    }
+
+    derived = derive_scopes(metadata, POSITION_DATA, CHART_IDS)
+
+    assert list(derived) == list(metadata)
+    assert list(derived["native_filter_configuration"][0]) == [
+        "id",
+        "chartsInScope",
+        "name",
+        "scope",
+        "tabsInScope",
+    ]
+    assert derived["color_scheme"] == "supersetColors"
+    assert derived["refresh_frequency"] == 0
+
+
+def test_derive_metadata_scopes_orders_by_dashboard_charts() -> None:
+    dashboard = SimpleNamespace(
+        position=POSITION_DATA,
+        slices=[SimpleNamespace(id=3), SimpleNamespace(id=1), SimpleNamespace(id=2)],
+    )
+    metadata = {
+        "native_filter_configuration": [
+            {
+                "id": "NATIVE_FILTER-1",
+                "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+            }
+        ]
+    }
+
+    derived = derive_metadata_scopes(dashboard, metadata)  # type: ignore[arg-type]
+
+    assert derived["native_filter_configuration"][0]["chartsInScope"] == [3, 1, 2]
+
+
+def test_derive_json_metadata_round_trip() -> None:
+    dashboard = SimpleNamespace(position=POSITION_DATA, slices=[SimpleNamespace(id=1)])
+    stored = json.dumps(
+        {
+            "native_filter_configuration": [
+                {
+                    "id": "NATIVE_FILTER-1",
+                    "scope": {"rootPath": ["ROOT_ID"], "excluded": []},
+                    "chartsInScope": [61, 62],
+                }
+            ]
+        }
+    )
+
+    derived = json.loads(derive_json_metadata(dashboard, stored))  # type: ignore[arg-type]
+
+    assert derived["native_filter_configuration"][0]["chartsInScope"] == [1]
+
+
+def test_derive_json_metadata_passes_through_unparsable_metadata() -> None:
+    dashboard = SimpleNamespace(position={}, slices=[])
+
+    assert derive_json_metadata(dashboard, "not json") == "not json"  # type: ignore[arg-type]
+    assert derive_json_metadata(dashboard, "[]") == "[]"  # type: ignore[arg-type]


### PR DESCRIPTION
### SUMMARY

`chartsInScope` / `tabsInScope` on native filters, and the `chartsInScope` lists inside `chart_configuration` / `global_chart_configuration`, are denormalized caches of `scope` + `position_json`. They are stamped on save and never revisited, so seeded, imported and edited dashboards serve scope arrays naming charts they don't contain — on a seeded dashboard that was never saved, 9 of 11 entries pointed at nonexistent charts. The client already ignores them and recomputes from the live layout, which is why the JSON Metadata panel and `GET /api/v1/dashboard/{id}` returned different documents for the same dashboard with no save in between.

This derives them on read from the same rules the client uses (`calculateScopes` / `getChartIdsInFilterScope` / `getCrossFiltersConfiguration`), in `superset/dashboards/filter_scope.py`, wired into the three read paths that hand the caches to a caller: `GET /api/v1/dashboard/{id}`, `GET /api/v1/dashboard/{id}/tabs`, and the `PUT /api/v1/dashboard/{id}/filters` response. Storage is untouched — deriving is read-only.

The frontend change is the matching guard: `PUT /filters` returns the whole config, so before this the persisted scope of every *untouched* filter overwrote the correct in-session value, and `DashboardContainer`'s equality guard saw no change and never recomputed. Dropping the two derived keys from that response lets the reducers keep what `calculateScopes` computed.

One known remainder: the panel also lists default `chart_configuration` entries for cross-filter-capable charts that have never been scoped. The client materialises those from the viz-type registry, which has no backend equivalent, so the API cannot reproduce them. After this change both surfaces only ever name charts that exist.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — the change is in the API payload, not in any rendered surface.

### TESTING INSTRUCTIONS

1. Open a seeded dashboard with native filters (e.g. *Video Game Sales*) on a fresh load.
2. Edit properties → Advanced settings → JSON Metadata; copy the contents; close without saving.
3. In the console: `var r = await (await fetch('/api/v1/dashboard/{id}')).json(); JSON.parse(r.result.json_metadata)`.
4. `chartsInScope`, `tabsInScope` and the `chart_configuration` keys now match the panel and name only charts present in `position_json`.
5. Rename one filter via the filter-config modal and repeat — the other filters keep their computed scope instead of reverting.

`pytest tests/unit_tests/dashboards/filter_scope_test.py` and `tests/integration_tests/dashboards/api_tests.py -k derives_stale_filter_scope`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No — reported through Preset support.
- [ ] Required feature flags: None.
- [ ] Changes UI: No — backend read path plus one Redux action.
- [ ] Includes DB Migration: No — no schema or data change; stored `json_metadata` is left as-is.
- [ ] Introduces new feature or API: No.
- [ ] Removes existing feature or API: No. `GET /api/v1/dashboard/{id}` no longer returns `json_metadata` byte-identical to the stored column: the derived scope keys are corrected and `chart_configuration` entries for charts absent from the layout are dropped, matching what the client already does on load.