### PR TITLE
fix(datasets): keep metric certified_by when certification details are typed next

### DIFF
--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorMetricCertification.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorMetricCertification.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { screen, userEvent, waitFor } from 'spec/helpers/testing-library';
+import {
+  createProps,
+  DATASOURCE_ENDPOINT,
+  setupDatasourceEditorMocks,
+  cleanupAsyncOperations,
+  fastRender,
+  dismissDatasourceWarning,
+} from './DatasourceEditor.test.utils';
+
+beforeEach(() => {
+  fetchMock.get(DATASOURCE_ENDPOINT, [], { name: DATASOURCE_ENDPOINT });
+  setupDatasourceEditorMocks();
+});
+
+afterEach(async () => {
+  await cleanupAsyncOperations();
+  fetchMock.clearHistory().removeRoutes();
+});
+
+// Certifying a metric fills two adjacent fields in one visit to the expanded
+// row. Both are committed through TextControl's debounce, so the second one
+// used to land on the item as it looked before the first had been applied,
+// leaving the saved metric with details but no certifier.
+test('certifying a metric keeps both certified_by and certification_details', async () => {
+  const testProps = createProps();
+  fastRender(testProps);
+  await dismissDatasourceWarning();
+
+  await userEvent.click(await screen.findByTestId('collection-tab-Metrics'));
+  const expandToggles = await screen.findAllByLabelText(/expand row/i);
+  await userEvent.click(expandToggles[0]);
+
+  await userEvent.type(
+    await screen.findByPlaceholderText('Certified by'),
+    'Metric Certifier',
+  );
+  await userEvent.type(
+    await screen.findByPlaceholderText('Certification details'),
+    'Metric cert details',
+  );
+
+  await waitFor(() => {
+    const { calls } = testProps.onChange.mock;
+    const savedMetrics = calls[calls.length - 1]?.[0]?.metrics ?? [];
+    const saved = savedMetrics.find(metric => metric.metric_name === 'count');
+    expect(saved).toEqual(
+      expect.objectContaining({
+        certified_by: 'Metric Certifier',
+        certification_details: 'Metric cert details',
+      }),
+    );
+  });
+});

--- a/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode, useCallback } from 'react';
+import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { Divider, Form, Typography } from '@superset-ui/core/components';
 import { css } from '@apache-superset/core/theme';
 import { recurseReactClone } from '../../utils';
@@ -39,14 +39,24 @@ export default function Fieldset({
   title = null,
   compact = false,
 }: FieldsetProps) {
+  // Controls report their edits asynchronously - TextControl debounces by
+  // FAST_DEBOUNCE - so the callback that eventually fires was built during an
+  // earlier render. Spreading that render's `item` rebuilds the whole record
+  // from a snapshot taken before a sibling field committed, dropping the value
+  // the user typed first. Reading off a ref merges into the latest commit.
+  const itemRef = useRef(item);
+  useEffect(() => {
+    itemRef.current = item;
+  }, [item]);
+
   const handleChange = useCallback(
     (fieldKey: fieldKeyType, val: any) => {
       onChange?.({
-        ...item,
+        ...itemRef.current,
         [fieldKey]: val,
       });
     },
-    [onChange, item],
+    [onChange],
   );
 
   const propExtender = (field: { props: { fieldKey: fieldKeyType } }) => ({


### PR DESCRIPTION
### SUMMARY

Certifying a metric in Edit dataset → Metrics saves the certification details but drops **Certified by**, so nobody can see who certified the metric.

`Fieldset` rebuilds the whole record on every field edit — `onChange({ ...item, [fieldKey]: val })` — where `item` is the value captured when that render was on screen. `TextControl` commits through a `FAST_DEBOUNCE` (250 ms) debounce, so when two adjacent fields are filled in one visit to the expanded row, the second field's callback was built before the first field's value had been applied. It rebuilds the metric from that older snapshot and the first field is gone. Certification is the visible case because it is the only pair of adjacent text fields users fill back to back; the saved `extra` came out as `{"certification":{"details":"Metric cert details"}}`.

Reading the item off a ref merges each edit into the latest committed record instead of a snapshot. `Fieldset` is shared, so the dataset column fieldsets get the same fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before / after, from the new test's `buildExtraJsonObject` output for the same keystrokes:

```
- {"certification":{"details":"Metric cert details"}}
+ {"certification":{"certified_by":"Metric Certifier","details":"Metric cert details"}}
```

### TESTING INSTRUCTIONS

1. Data → Datasets → Edit a dataset → Metrics tab → expand a metric.
2. Type into **Certified by**, then into **Certification details**, then Save.
3. Reopen the dataset and expand the same metric — both fields are still there.

Automated: `npm run test -- DatasourceEditorMetricCertification`. The new test drives the real editor and fails on master.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No — reported through Preset support.
- [ ] Required feature flags: None.
- [x] Changes UI: Only in that edits stop being dropped; no visual change.
- [ ] Includes DB Migration: No.
- [ ] Introduces new feature or API: No.
- [ ] Removes existing feature or API: No.