### PR TITLE
fix(pandas_postprocessing): pass string aggregator names to GroupBy.agg to silence FutureWarning

### DIFF
--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -61,6 +61,15 @@ _PANDAS_STRING_AGGREGATORS: frozenset[str] = frozenset(
     {"max", "mean", "median", "min", "prod", "std", "sum", "var"}
 )
 
+# Reverse lookup from the numpy callables above to their pandas string name, so a
+# bare callable operator (e.g. np.median) can be swapped for the string form before
+# reaching GroupBy.agg and avoid the same FutureWarning.
+_STRING_AGGREGATOR_BY_CALLABLE: dict[Callable[..., Any], str] = {
+    func: name
+    for name, func in NUMPY_FUNCTIONS.items()
+    if name in _PANDAS_STRING_AGGREGATORS
+}
+
 DENYLIST_ROLLING_FUNCTIONS = (
     "count",
     "corr",
@@ -185,7 +194,11 @@ def _get_aggregate_funcs(
             )
         operator = agg_obj["operator"]
         if callable(operator):
-            aggfunc: str | Callable[..., Any] = operator
+            # A bare numpy callable (e.g. np.median) that pandas maps to its own
+            # GroupBy method triggers a FutureWarning; use the string name instead.
+            aggfunc: str | Callable[..., Any] = _STRING_AGGREGATOR_BY_CALLABLE.get(
+                operator, operator
+            )
         else:
             func = NUMPY_FUNCTIONS.get(operator)
             if not func:

--- a/superset/utils/pandas_postprocessing/utils.py
+++ b/superset/utils/pandas_postprocessing/utils.py
@@ -61,6 +61,15 @@ _PANDAS_STRING_AGGREGATORS: frozenset[str] = frozenset(
     {"max", "mean", "median", "min", "prod", "std", "sum", "var"}
 )
 
+# Reverse lookup from the numpy callables above to their pandas string name, so a
+# bare callable operator (e.g. np.median) can be swapped for the string form before
+# reaching GroupBy.agg and avoid the same FutureWarning.
+_STRING_AGGREGATOR_BY_CALLABLE: dict[Callable[..., Any], str] = {
+    func: name
+    for name, func in NUMPY_FUNCTIONS.items()
+    if name in _PANDAS_STRING_AGGREGATORS
+}
+
 DENYLIST_ROLLING_FUNCTIONS = (
     "count",
     "corr",
@@ -173,7 +182,11 @@ def _get_aggregate_funcs(
             )
         operator = agg_obj["operator"]
         if callable(operator):
-            aggfunc: str | Callable[..., Any] = operator
+            # A bare numpy callable (e.g. np.median) that pandas maps to its own
+            # GroupBy method triggers a FutureWarning; use the string name instead.
+            aggfunc: str | Callable[..., Any] = _STRING_AGGREGATOR_BY_CALLABLE.get(
+                operator, operator
+            )
         else:
             func = NUMPY_FUNCTIONS.get(operator)
             if not func:

--- a/tests/unit_tests/pandas_postprocessing/test_aggregate.py
+++ b/tests/unit_tests/pandas_postprocessing/test_aggregate.py
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
+
+import numpy as np
+
 from superset.utils.pandas_postprocessing import aggregate
 from tests.unit_tests.fixtures.dataframes import categories_df
 from tests.unit_tests.pandas_postprocessing.utils import series_to_list
@@ -54,6 +58,23 @@ def test_aggregate_string_operators():
     assert series_to_list(df["asc median"])[0] == 50.0
     assert series_to_list(df["asc max"])[0] == 100
     assert series_to_list(df["asc min"])[0] == 0
+
+
+def test_aggregate_callable_operator_avoids_future_warning():
+    """A bare numpy callable operator (e.g. np.median) that pandas maps to its own
+    GroupBy method must be swapped for the string form so GroupBy.agg does not raise
+    a FutureWarning, while producing the same result as the string operator."""
+    aggregates = {
+        "asc median": {"column": "asc_idx", "operator": np.median},
+        "asc mean": {"column": "asc_idx", "operator": np.mean},
+        "asc sum": {"column": "asc_idx", "operator": np.sum},
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        df = aggregate(df=categories_df, groupby=["constant"], aggregates=aggregates)
+    assert series_to_list(df["asc median"])[0] == 50.0
+    assert series_to_list(df["asc mean"])[0] == 50.0
+    assert series_to_list(df["asc sum"])[0] == 5050
 
 
 def test_aggregate_count_includes_nulls():


### PR DESCRIPTION
## Decisions made that were not in the instructions

- The string-operator path and the boxplot callers were **already fixed on `master`** (PRs #41025 and #42272 introduced `_PANDAS_STRING_AGGREGATORS` and switched boxplot to string operators). The one remaining source of this warning is the *callable-operator* branch of `_get_aggregate_funcs`, so this fix targets that branch (mapping bare numpy callables → string names). It's the same call site (`aggregate.py:46`) and the same warning class the report describes. No new mapping structures were introduced — the existing `NUMPY_FUNCTIONS` and `_PANDAS_STRING_AGGREGATORS` are reused.

### SUMMARY

A live production `FutureWarning` was surfaced via Datadog at `superset/utils/pandas_postprocessing/aggregate.py:46`:

```
FutureWarning: The provided callable <function median at 0x...> is currently using SeriesGroupBy.median. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "median" instead.
```

`_get_aggregate_funcs` has two operator branches. The string-operator branch already maps common operators to pandas string names (`_PANDAS_STRING_AGGREGATORS`) to avoid this warning, but the **callable-operator** branch forwarded a bare numpy callable (e.g. `np.median`) straight through to `GroupBy.agg`, where pandas maps it to its own `SeriesGroupBy.median` and raises the `FutureWarning`.

This PR adds a reverse lookup (`_STRING_AGGREGATOR_BY_CALLABLE`), built by filtering the existing `NUMPY_FUNCTIONS` down to the callables whose names are in `_PANDAS_STRING_AGGREGATORS`, and swaps such callables for their string name before calling `.agg()`.

### BEFORE/AFTER

- **Before:** a bare-callable operator such as `np.median` / `np.mean` / `np.sum` emits the `FutureWarning`.
- **After:** no warning; identical aggregation results and dtypes.

**No behavior change:** only the *representation* of the aggregator changes (numpy callable → its equivalent pandas string). The mapped strings produce identical values and dtypes (verified for `median`, `mean`, `sum`, `min`, `max`, `std`, `var`, `prod`). Non-mapped callables (closures, `np.ma.count`), string operators, and the `partial(func, **options)` path are all left untouched.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/pandas_postprocessing/test_aggregate.py
```

Adds `test_aggregate_callable_operator_avoids_future_warning`, which runs under `warnings.simplefilter("error", FutureWarning)` (so the previously-emitted warning would fail the test) and asserts unchanged values for `np.median`, `np.mean`, and `np.sum` operators.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
