### PR TITLE
fix(db): isolate malformed dialect entry points

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -162,9 +162,9 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:  # noq
     for ep in entry_points(group="sqlalchemy.dialects"):
         try:
             dialect = ep.load()
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.debug("Unable to load SQLAlchemy dialect %s: %s", ep.name, ex)
-        else:
+            # Third-party entry points may load an object that does not satisfy
+            # the SQLAlchemy dialect contract. Keep contract validation inside
+            # the plugin boundary so one malformed package cannot break startup.
             backend = dialect.name
             if isinstance(backend, bytes):
                 backend = backend.decode()
@@ -173,6 +173,9 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:  # noq
             driver = getattr(dialect, "driver", dialect.name)
             if isinstance(driver, bytes):
                 driver = driver.decode()
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.warning("Unable to load SQLAlchemy dialect %s: %s", ep.name, ex)
+        else:
             drivers[backend].add(driver)
 
     dbs_denylist = app.config["DBS_AVAILABLE_DENYLIST"]

--- a/tests/unit_tests/db_engine_specs/test_init.py
+++ b/tests/unit_tests/db_engine_specs/test_init.py
@@ -16,6 +16,8 @@
 # under the License.
 
 
+import logging
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -23,15 +25,37 @@ from superset.db_engine_specs import get_available_engine_specs
 
 
 def test_malformed_dialect_entry_point_does_not_break_bootstrap(
-    app, mocker: MockerFixture
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A broken third-party entry point must only disable that connector."""
-    malformed = mocker.Mock(name="exa")
-    malformed.load.return_value = mocker.Mock(spec=[])
-    mocker.patch("superset.db_engine_specs.entry_points", return_value=[malformed])
-    mocker.patch("superset.db_engine_specs.load_engine_specs", return_value=iter([]))
+    from superset.db_engine_specs.sqlite import SqliteEngineSpec
 
-    assert get_available_engine_specs() == {}
+    # loads successfully but violates the dialect contract: no `name`
+    malformed = mocker.Mock()
+    malformed.name = "malformed"
+    malformed.load.return_value = mocker.Mock(spec=[])
+
+    healthy = mocker.Mock()
+    healthy.name = "sqlite"
+    healthy.load.return_value = mocker.Mock(spec=["name", "driver"])
+    healthy.load.return_value.name = "sqlite"
+    healthy.load.return_value.driver = "pysqlite"
+
+    mocker.patch(
+        "superset.db_engine_specs.entry_points",
+        return_value=[malformed, healthy],
+    )
+    mocker.patch(
+        "superset.db_engine_specs.load_engine_specs",
+        return_value=iter([SqliteEngineSpec]),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="superset.db_engine_specs"):
+        available = get_available_engine_specs()
+
+    assert available == {SqliteEngineSpec: {"pysqlite"}}
+    assert "Unable to load SQLAlchemy dialect malformed" in caplog.text
 
 
 def test_get_available_engine_specs(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/db_engine_specs/test_init.py
+++ b/tests/unit_tests/db_engine_specs/test_init.py
@@ -22,6 +22,18 @@ from pytest_mock import MockerFixture
 from superset.db_engine_specs import get_available_engine_specs
 
 
+def test_malformed_dialect_entry_point_does_not_break_bootstrap(
+    app, mocker: MockerFixture
+) -> None:
+    """A broken third-party entry point must only disable that connector."""
+    malformed = mocker.Mock(name="exa")
+    malformed.load.return_value = mocker.Mock(spec=[])
+    mocker.patch("superset.db_engine_specs.entry_points", return_value=[malformed])
+    mocker.patch("superset.db_engine_specs.load_engine_specs", return_value=iter([]))
+
+    assert get_available_engine_specs() == {}
+
+
 def test_get_available_engine_specs(mocker: MockerFixture) -> None:
     """
     get_available_engine_specs should return all engine specs


### PR DESCRIPTION
## Why

Third-party SQLAlchemy dialect entry points are discovered during database engine-spec enumeration. An entry point can load successfully while returning an object that does not satisfy the dialect contract, such as an object without `.name`. That exception currently escapes the plugin boundary and can break application bootstrap for every user rather than disabling only the malformed connector.

## What

Validate and normalize the loaded dialect's `name` and `driver` inside the existing third-party entry-point exception boundary. Malformed plugins are logged and skipped. A regression test models an entry point that loads an object without `.name`, alongside a well-formed entry point that must still register its driver.

## Blast radius

Only database connector discovery is affected. Valid SQLAlchemy dialects follow the same path as before; malformed optional plugins now degrade in isolation.

## How to test

* `pytest tests/unit_tests/db_engine_specs/test_init.py` — 3 passed. Reverting only `superset/db_engine_specs/__init__.py` to master makes `test_malformed_dialect_entry_point_does_not_break_bootstrap` fail with the escaping `AttributeError`, so it is a true regression test.
* The test asserts both halves of the contract: the malformed entry point is skipped with a warning, and the healthy dialect in the same scan still resolves to `{SqliteEngineSpec: {"pysqlite"}}`.
* `PRE_COMMIT_HOME=/tmp/pre-commit-superset uvx pre-commit run --files superset/db_engine_specs/__init__.py tests/unit_tests/db_engine_specs/test_init.py` — all applicable hooks pass (ruff, ruff-format, mypy). The `pylint` hook cannot run in this sandbox (`pylint: command not found`); it is covered by the `pre-commit` CI job.

## Risk & rollback

Low risk: the change broadens the existing plugin isolation boundary and changes the failed-plugin log from debug to warning. Revert this commit to restore the previous behavior.

## Review guidance

Please review the exception boundary in `superset/db_engine_specs/__init__.py` first, then the malformed-contract regression fixture.
