### PR TITLE
fix(ci): restore scheduled CI checks

### DIFF
--- a/.github/workflows/frontend-bundle-size-nightly.yml
+++ b/.github/workflows/frontend-bundle-size-nightly.yml
@@ -105,6 +105,7 @@ jobs:
           tool: customSmallerIsBetter
           output-file-path: bundle-size-summary.json
           external-data-json-path: bundle-size-history.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-alert: false
           summary-always: true
 

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -42,6 +42,7 @@ RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429})
 PATTERNS = {
     "python": [
         r"^\.github/workflows/.*python",
+        r"^\.github/workflows/frontend-bundle-size-nightly\.yml$",
         r"^\.github/workflows/scheduled-docker-image-refresh\.yml$",
         r"^docker-compose-image-tag\.yml$",
         r"^tests/",

--- a/superset-frontend/src/explore/components/controls/FixedOrMetricControl/FixedOrMetricControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FixedOrMetricControl/FixedOrMetricControl.test.tsx
@@ -22,10 +22,11 @@ import FixedOrMetricControl from '.';
 jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
-    ({ fileName }: { fileName: string }) => (
-      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
-      <span role="img" aria-label={fileName.replace('_', '-')} />
-    ),
+    ({ fileName }: { fileName: string }) =>
+      (
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
+        <span role="img" aria-label={fileName.replace('_', '-')} />
+      ),
 );
 
 const createProps = () => ({

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanel.test.tsx
@@ -38,10 +38,11 @@ import {
 jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
-    ({ fileName }: { fileName: string }) => (
-      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
-      <span role="img" aria-label={fileName.replace('_', '-')} />
-    ),
+    ({ fileName }: { fileName: string }) =>
+      (
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
+        <span role="img" aria-label={fileName.replace('_', '-')} />
+      ),
 );
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks

--- a/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanelWrapper.test.tsx
+++ b/superset-frontend/src/features/datasets/AddDataset/DatasetPanel/DatasetPanelWrapper.test.tsx
@@ -29,10 +29,11 @@ import DatasetPanelWrapper from 'src/features/datasets/AddDataset/DatasetPanel';
 jest.mock(
   '@superset-ui/core/components/Icons/AsyncIcon',
   () =>
-    ({ fileName }: { fileName: string }) => (
-      // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
-      <span role="img" aria-label={fileName.replace('_', '-')} />
-    ),
+    ({ fileName }: { fileName: string }) =>
+      (
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role -- mirrors AsyncIcon's real span+role="img" shape
+        <span role="img" aria-label={fileName.replace('_', '-')} />
+      ),
 );
 
 const errorMessageRegistry = getErrorMessageComponentRegistry();

--- a/tests/unit_tests/frontend_bundle_size_workflow_test.py
+++ b/tests/unit_tests/frontend_bundle_size_workflow_test.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts import change_detector
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github/workflows/frontend-bundle-size-nightly.yml"
+)
+
+
+def load_workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_scheduled_bundle_size_action_uses_read_only_token() -> None:
+    workflow = load_workflow()
+    job = workflow["jobs"]["refresh-baseline"]
+    steps = {step["name"]: step for step in job["steps"]}
+
+    benchmark_step = steps["Update bundle size baseline"]
+    assert benchmark_step["with"]["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert workflow["permissions"]["contents"] == "read"
+    effective_permissions = job.get("permissions", workflow["permissions"])
+    assert effective_permissions.get("contents") in {None, "read"}
+
+
+def test_scheduled_bundle_size_changes_trigger_python_tests() -> None:
+    assert change_detector.detect_changes(
+        [".github/workflows/frontend-bundle-size-nightly.yml"],
+        change_detector.PATTERNS["python"],
+    )


### PR DESCRIPTION
### SUMMARY

Restore two deterministic scheduled-CI regressions observed while walking master back to three consecutive green push commits:

- pass the read-only `GITHUB_TOKEN` to the nightly bundle-size benchmark action so schedule events can resolve the checked-out commit;
- commit the remaining Oxfmt 0.62 output for three frontend test mocks;
- add a workflow regression test and ensure workflow-only changes trigger that Python test.

This overlaps with #43251 for the bundle-size token and with the three formatter hunks incidentally included in #42939. This automation-owned, baseline-pinned PR is intentionally narrow and does not modify either contributor's branch.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; CI-only change.

### TESTING INSTRUCTIONS

- `PYTHONPATH=. uvx --with pyyaml pytest --noconftest -q tests/unit_tests/scripts/change_detector_test.py tests/unit_tests/frontend_bundle_size_workflow_test.py` (10 passed)
- targeted Jest suites for `FixedOrMetricControl`, `DatasetPanel`, and `DatasetPanelWrapper` (17 passed)
- Oxfmt 0.62 check and Oxlint on the three changed TypeScript files
- targeted pre-commit hooks: YAML, Ruff, and MyPy
- `git diff --check`
- `pre-commit run --all-files` was executed. Relevant hooks passed; unrelated repository-wide Ruff baseline findings, missing generated frontend declaration files/docs ESLint in the isolated checkout, and a local zizmor cache permission error prevented a fully green local all-files run.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
