### PR TITLE
fix(chart): stop contextmenu propagation in BigNumberViz

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.test.tsx
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+import { getNumberFormatter } from '@superset-ui/core';
+import { render, fireEvent } from '../../../../spec/helpers/testing-library';
+import BigNumberVis from './BigNumberViz';
+
 /**
  * Tests for the color threshold formatter logic in BigNumberViz.
  *
@@ -81,5 +85,35 @@ describe('BigNumberViz color formatters', () => {
     applyColorFormatters(undefined, [{ getColorFromValue }]);
 
     expect(getColorFromValue).not.toHaveBeenCalled();
+  });
+});
+
+describe('BigNumberViz context menu', () => {
+  test('invokes onContextMenu and stops the event bubbling to ancestor handlers', () => {
+    const onContextMenu = jest.fn();
+    const ancestorHandler = jest.fn();
+
+    const { container } = render(
+      <div onContextMenu={ancestorHandler}>
+        <BigNumberVis
+          width={200}
+          height={100}
+          bigNumber={42}
+          headerFormatter={getNumberFormatter()}
+          headerFontSize={0.3}
+          subheaderFontSize={0.125}
+          subtitleFontSize={0.125}
+          subtitle=""
+          refs={{}}
+          onContextMenu={onContextMenu}
+        />
+      </div>,
+    );
+
+    const headerLine = container.querySelector('.header-line');
+    fireEvent.contextMenu(headerLine!, { clientX: 10, clientY: 20 });
+
+    expect(onContextMenu).toHaveBeenCalledWith(10, 20);
+    expect(ancestorHandler).not.toHaveBeenCalled();
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BigNumber/BigNumberViz.tsx
@@ -224,6 +224,7 @@ function BigNumberVis({
     const handleContextMenu = (e: MouseEvent<HTMLDivElement>) => {
       if (onContextMenu) {
         e.preventDefault();
+        e.stopPropagation();
         onContextMenu(e.nativeEvent.clientX, e.nativeEvent.clientY);
       }
     };


### PR DESCRIPTION
### SUMMARY
The Big Number chart's contextmenu handler didn't call `stopPropagation()`, so the native event bubbled from the chart's header line up to `ChartRenderer`'s fallback handler, which re-invoked the menu-open logic within the same synchronous event dispatch (its `inContextMenu` guard reads stale React state). The duplicate call re-clicked the dropdown's hidden trigger, closing the context menu immediately after it opened.

Every other chart type with a context menu (Table, Pivot Table, deck.gl, ECharts canvas charts) already stops propagation here — Big Number was the outlier.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — not a visual change; before, right-clicking a Big Number chart opened and immediately closed the context menu.

### TESTING INSTRUCTIONS
1. Add a Big Number chart to a dashboard.
2. Right-click the chart.
3. Confirm the context menu opens and stays open (previously it closed immediately).

Also covered by a new Jest regression test in `BigNumberViz.test.tsx`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API