### PR TITLE
feat(semantic layers): optional metadata for metrics/dimensions

### DIFF
--- a/superset-core/src/superset_core/semantic_layers/types.py
+++ b/superset-core/src/superset_core/semantic_layers/types.py
@@ -18,8 +18,9 @@
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
+from typing import Any
 
 import isodate
 import pyarrow as pa
@@ -90,6 +91,8 @@ class Dimension:
     definition: str | None = None
     description: str | None = None
     grain: Grain | None = None
+    verbose_name: str | None = field(default=None, compare=False)
+    metadata: dict[str, Any] = field(default_factory=dict, compare=False)
 
 
 class AggregationType(str, enum.Enum):
@@ -121,6 +124,9 @@ class Metric:
     definition: str
     description: str | None = None
     aggregation: AggregationType | None = None
+    verbose_name: str | None = field(default=None, compare=False)
+    d3format: str | None = field(default=None, compare=False)
+    metadata: dict[str, Any] = field(default_factory=dict, compare=False)
 
 
 @dataclass(frozen=True)

--- a/superset-core/tests/semantic_layers/test_types.py
+++ b/superset-core/tests/semantic_layers/test_types.py
@@ -1,0 +1,81 @@
+import pyarrow as pa
+
+from superset_core.semantic_layers.types import Dimension, Metric
+
+
+def test_dimension_metadata_is_not_part_of_identity() -> None:
+    first = Dimension(
+        "sales.region",
+        "region",
+        pa.utf8(),
+        verbose_name="Region",
+        metadata={"display_name": "Region"},
+    )
+    second = Dimension(
+        "sales.region",
+        "region",
+        pa.utf8(),
+        verbose_name="Sales region",
+        metadata={"display_name": "Sales region"},
+    )
+
+    assert first == second
+    assert {first, second} == {first}
+
+
+def test_metric_metadata_is_not_part_of_identity() -> None:
+    first = Metric(
+        "sales.total_revenue",
+        "total_revenue",
+        pa.float64(),
+        "SUM(revenue)",
+        verbose_name="Total revenue",
+        d3format="$,.2f",
+        metadata={"unit": {"kind": "currency", "code": "USD"}},
+    )
+    second = Metric(
+        "sales.total_revenue",
+        "total_revenue",
+        pa.float64(),
+        "SUM(revenue)",
+        verbose_name="Revenue",
+        d3format=",.0f",
+        metadata={"unit": {"kind": "currency", "code": "EUR"}},
+    )
+
+    assert first == second
+    assert {first, second} == {first}
+
+
+def test_metric_accepts_superset_presentation_fields() -> None:
+    metric = Metric(
+        "sales.total_revenue",
+        "total_revenue",
+        pa.float64(),
+        "SUM(revenue)",
+        verbose_name="Total revenue",
+        d3format="$,.2f",
+    )
+
+    assert metric.verbose_name == "Total revenue"
+    assert metric.d3format == "$,.2f"
+
+
+def test_dimension_accepts_superset_presentation_fields() -> None:
+    dimension = Dimension(
+        "sales.region",
+        "region",
+        pa.utf8(),
+        verbose_name="Region",
+    )
+
+    assert dimension.verbose_name == "Region"
+
+
+def test_metadata_defaults_are_not_shared() -> None:
+    first = Metric("first", "first", pa.int64(), "COUNT(*)")
+    second = Metric("second", "second", pa.int64(), "COUNT(*)")
+
+    first.metadata["display_name"] = "First"
+
+    assert second.metadata == {}

--- a/superset-core/tests/semantic_layers/test_types.py
+++ b/superset-core/tests/semantic_layers/test_types.py
@@ -1,5 +1,21 @@
-import pyarrow as pa
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
+import pyarrow as pa
 from superset_core.semantic_layers.types import Dimension, Metric
 
 

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -378,19 +378,14 @@ class SemanticView(AuditMixinNullable, Model):
         dimensions = self._unique_dimensions
         metrics = list(self.implementation.get_metrics())
         verbose_map = {
-            **{
-                metric.name: metric.verbose_name or metric.name
-                for metric in metrics
-            },
+            **{metric.name: metric.verbose_name or metric.name for metric in metrics},
             **{
                 dimension.name: dimension.verbose_name or dimension.name
                 for dimension in dimensions
             },
         }
         column_formats = {
-            metric.name: metric.d3format
-            for metric in metrics
-            if metric.d3format
+            metric.name: metric.d3format for metric in metrics if metric.d3format
         }
 
         return {

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -324,7 +324,9 @@ class SemanticView(AuditMixinNullable, Model):
             MetricMetadata(
                 metric_name=metric.name,
                 expression=metric.definition,
+                verbose_name=metric.verbose_name,
                 description=metric.description,
+                d3format=metric.d3format,
             )
             for metric in self.implementation.get_metrics()
         ]
@@ -357,6 +359,7 @@ class SemanticView(AuditMixinNullable, Model):
                 is_dttm=pa.types.is_date(dimension.type)
                 or pa.types.is_time(dimension.type)
                 or pa.types.is_timestamp(dimension.type),
+                verbose_name=dimension.verbose_name,
                 description=dimension.description,
                 expression=None,
                 extra=json.dumps(
@@ -372,6 +375,24 @@ class SemanticView(AuditMixinNullable, Model):
 
     @property
     def data(self) -> ExplorableData:
+        dimensions = self._unique_dimensions
+        metrics = list(self.implementation.get_metrics())
+        verbose_map = {
+            **{
+                metric.name: metric.verbose_name or metric.name
+                for metric in metrics
+            },
+            **{
+                dimension.name: dimension.verbose_name or dimension.name
+                for dimension in dimensions
+            },
+        }
+        column_formats = {
+            metric.name: metric.d3format
+            for metric in metrics
+            if metric.d3format
+        }
+
         return {
             # core
             "id": self.id,
@@ -399,16 +420,16 @@ class SemanticView(AuditMixinNullable, Model):
                     "python_date_format": None,
                     "type": str(dimension.type),
                     "type_generic": get_column_type(dimension.type),
-                    "verbose_name": None,
+                    "verbose_name": dimension.verbose_name,
                     "warning_markdown": None,
                 }
-                for dimension in self._unique_dimensions
+                for dimension in dimensions
             ],
             "metrics": [
                 {
                     "certification_details": None,
                     "certified_by": None,
-                    "d3format": None,
+                    "d3format": metric.d3format,
                     "description": metric.description,
                     "expression": metric.definition,
                     "id": None,
@@ -417,14 +438,14 @@ class SemanticView(AuditMixinNullable, Model):
                     "metric_name": metric.name,
                     "warning_markdown": None,
                     "warning_text": None,
-                    "verbose_name": None,
+                    "verbose_name": metric.verbose_name,
                 }
-                for metric in self.implementation.get_metrics()
+                for metric in metrics
             ],
             "database": {},
             "parent": {"name": self.semantic_layer.name},
             # UI features
-            "verbose_map": {},
+            "verbose_map": verbose_map,
             "order_by_choices": [],
             "filter_select": True,
             "filter_select_enabled": True,
@@ -436,11 +457,11 @@ class SemanticView(AuditMixinNullable, Model):
             "description": self.description,
             "table_name": self.name,
             "column_types": [
-                get_column_type(dimension.type) for dimension in self._unique_dimensions
+                get_column_type(dimension.type) for dimension in dimensions
             ],
-            "column_names": [dimension.name for dimension in self._unique_dimensions],
+            "column_names": [dimension.name for dimension in dimensions],
             # rare
-            "column_formats": {},
+            "column_formats": column_formats,
             "datasource_name": self.name,
             "perm": self.perm,
             "offset": self.offset,

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -272,6 +272,7 @@ def mock_dimensions() -> list[Dimension]:
             definition="orders.order_date",
             description="Date of the order",
             grain=Grains.DAY,
+            verbose_name="Order date",
         ),
         Dimension(
             id="products.category",
@@ -280,6 +281,7 @@ def mock_dimensions() -> list[Dimension]:
             definition="products.category",
             description="Product category",
             grain=None,
+            verbose_name="Category",
         ),
     ]
 
@@ -294,6 +296,8 @@ def mock_metrics() -> list[Metric]:
             type=pa.float64(),
             definition="SUM(orders.amount)",
             description="Total revenue",
+            verbose_name="Total revenue",
+            d3format="$,.2f",
         ),
         Metric(
             id="orders.count",
@@ -301,6 +305,8 @@ def mock_metrics() -> list[Metric]:
             type=pa.int64(),
             definition="COUNT(*)",
             description="Number of orders",
+            verbose_name="Order count",
+            d3format=",.0f",
         ),
     ]
 
@@ -481,7 +487,9 @@ def test_semantic_view_metrics(
         assert len(metrics) == 2
         assert metrics[0].metric_name == "revenue"
         assert metrics[0].expression == "SUM(orders.amount)"
+        assert metrics[0].verbose_name == "Total revenue"
         assert metrics[0].description == "Total revenue"
+        assert metrics[0].d3format == "$,.2f"
         assert metrics[1].metric_name == "order_count"
 
 
@@ -502,10 +510,12 @@ def test_semantic_view_columns(
         assert columns[0].column_name == "order_date"
         assert columns[0].type == "date32[day]"
         assert columns[0].is_dttm is True
+        assert columns[0].verbose_name == "Order date"
         assert columns[0].description == "Date of the order"
         assert columns[1].column_name == "category"
         assert columns[1].type == "string"
         assert columns[1].is_dttm is False
+        assert columns[1].verbose_name == "Category"
 
 
 def test_semantic_view_column_names(
@@ -632,15 +642,32 @@ def test_semantic_view_data(
         assert data["columns"][0]["type"] == "date32[day]"
         assert data["columns"][0]["is_dttm"] is True
         assert data["columns"][0]["type_generic"] == GenericDataType.TEMPORAL
+        assert data["columns"][0]["verbose_name"] == "Order date"
         assert data["columns"][1]["column_name"] == "category"
         assert data["columns"][1]["type"] == "string"
         assert data["columns"][1]["type_generic"] == GenericDataType.STRING
+        assert data["columns"][1]["verbose_name"] == "Category"
 
         # Check metrics
         assert len(data["metrics"]) == 2
         assert data["metrics"][0]["metric_name"] == "revenue"
         assert data["metrics"][0]["expression"] == "SUM(orders.amount)"
+        assert data["metrics"][0]["verbose_name"] == "Total revenue"
+        assert data["metrics"][0]["d3format"] == "$,.2f"
         assert data["metrics"][1]["metric_name"] == "order_count"
+        assert data["metrics"][1]["verbose_name"] == "Order count"
+        assert data["metrics"][1]["d3format"] == ",.0f"
+
+        assert data["verbose_map"] == {
+            "revenue": "Total revenue",
+            "order_count": "Order count",
+            "order_date": "Order date",
+            "category": "Category",
+        }
+        assert data["column_formats"] == {
+            "revenue": "$,.2f",
+            "order_count": ",.0f",
+        }
 
         # Check column_types and column_names
         assert data["column_types"] == [


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Allow metrics and dimensions from semantic views to have metadata, including `d3format` for visualizations that use datasource `columnFormats`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

Added unit tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
