### PR TITLE
fix: remove a labeler glob that matches no files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,7 @@
 "dependencies:python":
 - changed-files:
   - any-glob-to-any-file:
-    - 'superset/requirements/**'
+    - 'requirements/**'
     - 'superset/translations/requirements.txt'
     - 'RELEASING/requirements.txt'
 


### PR DESCRIPTION
### SUMMARY
One glob in `.github/labeler.yml` never matched: `superset/requirements/**` (line 32). The requirements directory lives at the repository root, so the `dependencies:python` label was never applied by this entry. Resolving the stale reference:

Update labeler.yml line 32 to: `requirements/**`

### TESTING INSTRUCTIONS

    # the stale line
    sed -n '32p' .github/labeler.yml

    # tracked files under the referenced glob, 0 before this PR
    git ls-files -- 'requirements/**' | wc -l

### ADDITIONAL INFORMATION
I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.