### PR TITLE
feat(tooltip): add Truncate labels control to timeseries charts

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/tooltip.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/tooltip.ts
@@ -19,19 +19,71 @@
 import { t } from '@apache-superset/core/translation';
 import { sanitizeHtml } from './html';
 
+export type TooltipTruncationMode = 'off' | 'end' | 'start' | 'middle';
+
+export const TRUNCATION_MAX_CHARS = 40;
+
 const TRUNCATION_STYLE = `
   max-width: 300px;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
+const NOWRAP_STYLE = `
+  white-space: nowrap;
+`;
+
+/**
+ * Shortens plain text so a tooltip label stays readable, placing the ellipsis
+ * where the caller asked for it.
+ *
+ * Only 'start' and 'middle' slice. 'end' is handled by CSS in tooltipHtml, and
+ * 'off' means no truncation at all, so both return the input untouched.
+ *
+ * The input must be plain text. Callers are responsible for truncating before
+ * any markup (such as the ECharts series marker) is prepended, and before
+ * sanitization — slicing a string that already contains markup would cut into
+ * a tag.
+ */
+export function truncateLabel(
+  text: string,
+  mode: TooltipTruncationMode = 'end',
+): string {
+  if (
+    (mode !== 'start' && mode !== 'middle') ||
+    text.length <= TRUNCATION_MAX_CHARS
+  ) {
+    return text;
+  }
+  const budget = TRUNCATION_MAX_CHARS - 1;
+  if (mode === 'start') {
+    return `…${text.slice(-budget)}`;
+  }
+  const head = Math.ceil(budget / 2);
+  const tail = Math.floor(budget / 2);
+  return `${text.slice(0, head)}…${text.slice(-tail)}`;
+}
+
+function getTruncationStyle(mode: TooltipTruncationMode): string {
+  if (mode === 'end') {
+    return TRUNCATION_STYLE;
+  }
+  if (mode === 'off') {
+    return '';
+  }
+  // 'start' and 'middle' are already sliced upstream; keep them on one line.
+  return NOWRAP_STYLE;
+}
+
 export function tooltipHtml(
   data: string[][],
   title?: string,
   focusedRow?: number,
+  truncation: TooltipTruncationMode = 'end',
 ) {
+  const truncationStyle = getTruncationStyle(truncation);
   const titleRow = title
-    ? `<span style="font-weight: 700;${TRUNCATION_STYLE}">${title}</span>`
+    ? `<span style="font-weight: 700;${truncationStyle}">${title}</span>`
     : '';
   return sanitizeHtml(`
     <div>
@@ -46,7 +98,7 @@ export function tooltipHtml(
                 const cellStyle = `
                   text-align: ${j > 0 ? 'right' : 'left'};
                   padding-left: ${j === 0 ? 0 : 16}px;
-                  ${TRUNCATION_STYLE}
+                  ${truncationStyle}
                 `;
                 return `<td style="${cellStyle}">${cell}</td>`;
               });

--- a/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
@@ -16,7 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { sanitizeHtml, tooltipHtml } from '@superset-ui/core';
+import {
+  sanitizeHtml,
+  tooltipHtml,
+  truncateLabel,
+  TRUNCATION_MAX_CHARS,
+} from '@superset-ui/core';
 
 const TITLE_STYLE =
   'style="font-weight: 700;max-width:300px;overflow:hidden;text-overflow:ellipsis;"';
@@ -181,4 +186,84 @@ test('should preserve table styling after sanitization (fixes ECharts tooltip fo
   expect(html).toContain('padding-left:0px');
   expect(html).toContain('padding-left:16px');
   expect(html).toContain('max-width:300px');
+});
+
+describe('truncateLabel', () => {
+  const long = 'prod-us-east-1-service-checkout-latency-p99'; // 43 chars
+
+  it('returns text unchanged for off and end', () => {
+    expect(truncateLabel(long, 'off')).toBe(long);
+    expect(truncateLabel(long, 'end')).toBe(long);
+  });
+
+  it('defaults to end, which does not slice', () => {
+    expect(truncateLabel(long)).toBe(long);
+  });
+
+  it('truncates the start, keeping the distinguishing suffix', () => {
+    expect(truncateLabel(long, 'start')).toBe(
+      '…-us-east-1-service-checkout-latency-p99',
+    );
+    expect(truncateLabel(long, 'start')).toHaveLength(TRUNCATION_MAX_CHARS);
+  });
+
+  it('truncates the middle, keeping both ends', () => {
+    expect(truncateLabel(long, 'middle')).toBe(
+      'prod-us-east-1-servi…heckout-latency-p99',
+    );
+    expect(truncateLabel(long, 'middle')).toHaveLength(TRUNCATION_MAX_CHARS);
+  });
+
+  it('leaves text at or under the limit untouched', () => {
+    const atLimit = 'x'.repeat(TRUNCATION_MAX_CHARS);
+    expect(truncateLabel(atLimit, 'start')).toBe(atLimit);
+    expect(truncateLabel(atLimit, 'middle')).toBe(atLimit);
+    expect(truncateLabel('short', 'start')).toBe('short');
+    expect(truncateLabel('', 'middle')).toBe('');
+  });
+
+  it('truncates text one character over the limit', () => {
+    const overLimit = 'x'.repeat(TRUNCATION_MAX_CHARS + 1);
+    expect(truncateLabel(overLimit, 'start')).toBe(
+      `…${'x'.repeat(TRUNCATION_MAX_CHARS - 1)}`,
+    );
+  });
+});
+
+describe('tooltipHtml truncation modes', () => {
+  const rows = [['label', 'value']];
+
+  it('emits the 300px cap for end and for the default', () => {
+    expect(tooltipHtml(rows, 'Title', undefined, 'end')).toContain(
+      'max-width: 300px',
+    );
+    expect(tooltipHtml(rows, 'Title')).toBe(
+      tooltipHtml(rows, 'Title', undefined, 'end'),
+    );
+  });
+
+  it('emits no truncation style for off', () => {
+    const html = tooltipHtml(rows, 'Title', undefined, 'off');
+    expect(html).not.toContain('max-width');
+    expect(html).not.toContain('text-overflow');
+    expect(html).not.toContain('white-space');
+  });
+
+  it.each(['start', 'middle'] as const)(
+    'emits nowrap instead of a cap for %s',
+    mode => {
+      const html = tooltipHtml(rows, 'Title', undefined, mode);
+      expect(html).toContain('white-space: nowrap');
+      expect(html).not.toContain('max-width');
+    },
+  );
+
+  it('never slices cell text itself, whatever the mode', () => {
+    const longCell = 'y'.repeat(TRUNCATION_MAX_CHARS + 20);
+    (['off', 'end', 'start', 'middle'] as const).forEach(mode => {
+      expect(tooltipHtml([[longCell]], undefined, undefined, mode)).toContain(
+        longCell,
+      );
+    });
+  });
 });

--- a/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/utils/tooltip.test.ts
@@ -191,30 +191,30 @@ test('should preserve table styling after sanitization (fixes ECharts tooltip fo
 describe('truncateLabel', () => {
   const long = 'prod-us-east-1-service-checkout-latency-p99'; // 43 chars
 
-  it('returns text unchanged for off and end', () => {
+  test('returns text unchanged for off and end', () => {
     expect(truncateLabel(long, 'off')).toBe(long);
     expect(truncateLabel(long, 'end')).toBe(long);
   });
 
-  it('defaults to end, which does not slice', () => {
+  test('defaults to end, which does not slice', () => {
     expect(truncateLabel(long)).toBe(long);
   });
 
-  it('truncates the start, keeping the distinguishing suffix', () => {
+  test('truncates the start, keeping the distinguishing suffix', () => {
     expect(truncateLabel(long, 'start')).toBe(
       '…-us-east-1-service-checkout-latency-p99',
     );
     expect(truncateLabel(long, 'start')).toHaveLength(TRUNCATION_MAX_CHARS);
   });
 
-  it('truncates the middle, keeping both ends', () => {
+  test('truncates the middle, keeping both ends', () => {
     expect(truncateLabel(long, 'middle')).toBe(
       'prod-us-east-1-servi…heckout-latency-p99',
     );
     expect(truncateLabel(long, 'middle')).toHaveLength(TRUNCATION_MAX_CHARS);
   });
 
-  it('leaves text at or under the limit untouched', () => {
+  test('leaves text at or under the limit untouched', () => {
     const atLimit = 'x'.repeat(TRUNCATION_MAX_CHARS);
     expect(truncateLabel(atLimit, 'start')).toBe(atLimit);
     expect(truncateLabel(atLimit, 'middle')).toBe(atLimit);
@@ -222,7 +222,7 @@ describe('truncateLabel', () => {
     expect(truncateLabel('', 'middle')).toBe('');
   });
 
-  it('truncates text one character over the limit', () => {
+  test('truncates text one character over the limit', () => {
     const overLimit = 'x'.repeat(TRUNCATION_MAX_CHARS + 1);
     expect(truncateLabel(overLimit, 'start')).toBe(
       `…${'x'.repeat(TRUNCATION_MAX_CHARS - 1)}`,
@@ -233,32 +233,37 @@ describe('truncateLabel', () => {
 describe('tooltipHtml truncation modes', () => {
   const rows = [['label', 'value']];
 
-  it('emits the 300px cap for end and for the default', () => {
-    expect(tooltipHtml(rows, 'Title', undefined, 'end')).toContain(
-      'max-width: 300px',
-    );
+  // sanitizeHtml normalizes spacing inside style attributes, and it does so
+  // differently across versions, so compare with whitespace stripped.
+  const styles = (
+    title: string | undefined,
+    truncation?: 'off' | 'end' | 'start' | 'middle',
+  ) => removeWhitespaces(tooltipHtml(rows, title, undefined, truncation));
+
+  test('emits the 300px cap for end and for the default', () => {
+    expect(styles('Title', 'end')).toContain('max-width:300px');
     expect(tooltipHtml(rows, 'Title')).toBe(
       tooltipHtml(rows, 'Title', undefined, 'end'),
     );
   });
 
-  it('emits no truncation style for off', () => {
-    const html = tooltipHtml(rows, 'Title', undefined, 'off');
+  test('emits no truncation style for off', () => {
+    const html = styles('Title', 'off');
     expect(html).not.toContain('max-width');
     expect(html).not.toContain('text-overflow');
     expect(html).not.toContain('white-space');
   });
 
-  it.each(['start', 'middle'] as const)(
+  test.each(['start', 'middle'] as const)(
     'emits nowrap instead of a cap for %s',
     mode => {
-      const html = tooltipHtml(rows, 'Title', undefined, mode);
-      expect(html).toContain('white-space: nowrap');
+      const html = styles('Title', mode);
+      expect(html).toContain('white-space:nowrap');
       expect(html).not.toContain('max-width');
     },
   );
 
-  it('never slices cell text itself, whatever the mode', () => {
+  test('never slices cell text itself, whatever the mode', () => {
     const longCell = 'y'.repeat(TRUNCATION_MAX_CHARS + 20);
     (['off', 'end', 'start', 'middle'] as const).forEach(mode => {
       expect(tooltipHtml([[longCell]], undefined, undefined, mode)).toContain(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -40,6 +40,7 @@ import {
   TimeseriesChartDataResponseResult,
   TimeseriesDataRecord,
   tooltipHtml,
+  truncateLabel,
   ValueFormatter,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
@@ -207,6 +208,7 @@ export default function transformProps(
     zoomable,
     richTooltip,
     tooltipSortByMetric,
+    tooltipTruncation,
     xAxisBounds,
     xAxisLabelRotation,
     xAxisLabelInterval,
@@ -907,13 +909,19 @@ export default function transformProps(
               formatter: primarySeries.has(key)
                 ? tooltipFormatter
                 : tooltipFormatterSecondary,
+              truncation: tooltipTruncation,
             });
             rows.push(row);
             if (key === focusedSeries) {
               focusedRow = rows.length - 1;
             }
           });
-        return tooltipHtml(rows, tooltipFormatter(xValue), focusedRow);
+        return tooltipHtml(
+          rows,
+          truncateLabel(tooltipFormatter(xValue), tooltipTruncation),
+          focusedRow,
+          tooltipTruncation,
+        );
       },
     },
     legend: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -24,6 +24,7 @@ import {
   ContributionType,
   TimeFormatter,
   AxisType,
+  TooltipTruncationMode,
 } from '@superset-ui/core';
 import {
   BaseChartProps,
@@ -59,6 +60,7 @@ export type EchartsMixedTimeseriesFormData = QueryFormData & {
   timeGrainSqla?: TimeGranularity;
   forceMaxInterval?: boolean;
   tooltipTimeFormat?: string;
+  tooltipTruncation?: TooltipTruncationMode;
   zoomable: boolean;
   richTooltip: boolean;
   showQueryIdentifiers?: boolean;
@@ -108,6 +110,7 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   yAxisFormatSecondary: TIMESERIES_DEFAULTS.yAxisFormat,
   yAxisTitleSecondary: DEFAULT_TITLE_FORM_DATA.yAxisTitle,
   tooltipTimeFormat: TIMESERIES_DEFAULTS.tooltipTimeFormat,
+  tooltipTruncation: TIMESERIES_DEFAULTS.tooltipTruncation,
   xAxisBounds: TIMESERIES_DEFAULTS.xAxisBounds,
   xAxisForceCategorical: TIMESERIES_DEFAULTS.xAxisForceCategorical,
   xAxisTimeFormat: TIMESERIES_DEFAULTS.xAxisTimeFormat,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -73,6 +73,7 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   seriesType: EchartsTimeseriesSeriesType.Line,
   stack: false,
   tooltipTimeFormat: 'smart_date',
+  tooltipTruncation: 'end',
   xAxisTimeFormat: 'smart_date',
   xAxisNumberFormat: 'SMART_NUMBER',
   truncateXAxis: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -30,6 +30,7 @@ import {
   DTTM_ALIAS,
   ensureIsArray,
   tooltipHtml,
+  truncateLabel,
   getCustomFormatter,
   getMetricLabel,
   getNumberFormatter,
@@ -303,6 +304,7 @@ export default function transformProps(
     tooltipSortByMetric,
     showTooltipTotal,
     showTooltipPercentage,
+    tooltipTruncation,
     truncateXAxis,
     truncateYAxis,
     xAxis: xAxisOrig,
@@ -1449,6 +1451,7 @@ export default function transformProps(
               seriesName: key,
               formatter,
               marker,
+              truncation: tooltipTruncation,
             });
 
             const annotationRow = annotationLayers.some(
@@ -1482,7 +1485,12 @@ export default function transformProps(
           }
           rows.push(totalRow);
         }
-        return tooltipHtml(rows, tooltipFormatter(xValue), focusedRow);
+        return tooltipHtml(
+          rows,
+          truncateLabel(tooltipFormatter(xValue), tooltipTruncation),
+          focusedRow,
+          tooltipTruncation,
+        );
       },
     },
     legend: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -25,6 +25,7 @@ import {
   QueryFormMetric,
   TimeFormatter,
   TimeGranularity,
+  TooltipTruncationMode,
 } from '@superset-ui/core';
 import {
   BaseChartProps,
@@ -82,6 +83,7 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   tooltipTimeFormat?: string;
   showTooltipTotal?: boolean;
   showTooltipPercentage?: boolean;
+  tooltipTruncation?: TooltipTruncationMode;
   truncateXAxis: boolean;
   truncateYAxis: boolean;
   yAxisFormat?: string;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/controls.tsx
@@ -315,6 +315,27 @@ const tooltipPercentageControl: ControlSetItem = {
   },
 };
 
+const tooltipTruncationControl: ControlSetItem = {
+  name: 'tooltipTruncation',
+  config: {
+    type: 'SelectControl',
+    freeForm: false,
+    label: t('Truncate labels'),
+    renderTrigger: true,
+    default: 'end',
+    clearable: false,
+    choices: [
+      ['off', t('Off')],
+      ['end', t('End')],
+      ['start', t('Start')],
+      ['middle', t('Middle')],
+    ],
+    description: t(
+      'Where to place the ellipsis when a tooltip label is too long. Choose Off to always show the full label, or Start when labels share a common prefix.',
+    ),
+  },
+};
+
 export const richTooltipSection: ControlSetRow[] = [
   [<ControlSubSectionHeader>{t('Tooltip')}</ControlSubSectionHeader>],
   [richTooltipControl],
@@ -322,6 +343,7 @@ export const richTooltipSection: ControlSetRow[] = [
   [tooltipPercentageControl],
   [tooltipSortByMetricControl],
   [tooltipTimeFormatControl],
+  [tooltipTruncationControl],
 ];
 
 const sortSeriesType: ControlSetItem = {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { DataRecord, DTTM_ALIAS, ValueFormatter } from '@superset-ui/core';
+import {
+  DataRecord,
+  DTTM_ALIAS,
+  truncateLabel,
+  TooltipTruncationMode,
+  ValueFormatter,
+} from '@superset-ui/core';
 import type { OptionName, SeriesOption } from 'echarts/types/src/util/types';
 import type { TooltipMarker } from 'echarts/types/src/util/format';
 import {
@@ -91,12 +97,16 @@ export const formatForecastTooltipSeries = ({
   forecastUpper,
   marker,
   formatter,
+  truncation = 'end',
 }: ForecastValue & {
   seriesName: string;
   marker: TooltipMarker;
   formatter: ValueFormatter;
+  truncation?: TooltipTruncationMode;
 }): string[] => {
-  const name = `${marker}${sanitizeHtml(seriesName)}`;
+  // Truncate before sanitizing and before the marker is prepended: slicing a
+  // string that already contains markup would cut into the marker's tag.
+  const name = `${marker}${sanitizeHtml(truncateLabel(seriesName, truncation))}`;
   let value = typeof observation === 'number' ? formatter(observation) : '';
   // Use finite-number checks rather than truthiness so that legitimate
   // zero values (e.g. a forecast that crosses zero, or a confidence bound of

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -27,6 +27,7 @@ import {
   VizType,
   ChartDataResponseResult,
   TimeGranularity,
+  TooltipTruncationMode,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import {
@@ -1299,17 +1300,20 @@ describe('EchartsMixedTimeseries tooltip truncation', () => {
   const longSeriesName = 'prod-us-east-1-service-checkout-latency-p99';
   const marker = '<span style="background-color:#1f77b4;"></span>';
 
-  const buildTooltip = (tooltipTruncation?: string) => {
-    const chartProps = new ChartProps({
-      ...chartPropsConfig,
+  const buildTooltip = (tooltipTruncation?: TooltipTruncationMode) => {
+    const chartProps = createEchartsTimeseriesTestChartProps<
+      EchartsMixedTimeseriesFormData,
+      EchartsMixedTimeseriesProps
+    >({
+      ...MIXED_TIMESERIES_CHART_PROPS_DEFAULTS,
+      defaultQueriesData: queriesData,
       formData: {
         ...formData,
         ...(tooltipTruncation ? { tooltipTruncation } : {}),
       },
+      queriesData,
     });
-    const { echartOptions } = transformProps(
-      chartProps as EchartsMixedTimeseriesProps,
-    );
+    const { echartOptions } = transformProps(chartProps);
     const { formatter } = echartOptions.tooltip as {
       formatter: (params: unknown) => string;
     };
@@ -1323,26 +1327,26 @@ describe('EchartsMixedTimeseries tooltip truncation', () => {
     });
   };
 
-  it('keeps full text with the CSS cap by default', () => {
+  test('keeps full text with the CSS cap by default', () => {
     const html = buildTooltip();
-    expect(html).toContain('max-width: 300px');
+    expect(html.replace(/\s/g, '')).toContain('max-width:300px');
     expect(html).toContain(longSeriesName);
   });
 
-  it('removes the cap and keeps full text when off', () => {
+  test('removes the cap and keeps full text when off', () => {
     const html = buildTooltip('off');
     expect(html).not.toContain('max-width');
     expect(html).toContain(longSeriesName);
   });
 
-  it('drops the shared prefix when truncating from the start', () => {
+  test('drops the shared prefix when truncating from the start', () => {
     const html = buildTooltip('start');
     expect(html).not.toContain('prod-us-east');
     expect(html).toContain('latency-p99');
     expect(html).toContain('background-color:#1f77b4');
   });
 
-  it('keeps both ends when truncating the middle', () => {
+  test('keeps both ends when truncating the middle', () => {
     const html = buildTooltip('middle');
     expect(html).toContain('prod-us-east-1-servi…heckout-latency-p99');
     expect(html).not.toContain(longSeriesName);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1295,3 +1295,56 @@ test('y-axis title position: non-Left sets nameLocation to end', () => {
   expect(yAxis[1].nameGap).toEqual(30);
   expect(yAxis[1].nameLocation).toEqual('end');
 });
+describe('EchartsMixedTimeseries tooltip truncation', () => {
+  const longSeriesName = 'prod-us-east-1-service-checkout-latency-p99';
+  const marker = '<span style="background-color:#1f77b4;"></span>';
+
+  const buildTooltip = (tooltipTruncation?: string) => {
+    const chartProps = new ChartProps({
+      ...chartPropsConfig,
+      formData: {
+        ...formData,
+        ...(tooltipTruncation ? { tooltipTruncation } : {}),
+      },
+    });
+    const { echartOptions } = transformProps(
+      chartProps as EchartsMixedTimeseriesProps,
+    );
+    const { formatter } = echartOptions.tooltip as {
+      formatter: (params: unknown) => string;
+    };
+    // richTooltip is false in this fixture, so the trigger is 'item' and the
+    // formatter receives a single param object rather than an array.
+    return formatter({
+      seriesId: longSeriesName,
+      seriesName: longSeriesName,
+      value: [599616000000, 1],
+      marker,
+    });
+  };
+
+  it('keeps full text with the CSS cap by default', () => {
+    const html = buildTooltip();
+    expect(html).toContain('max-width: 300px');
+    expect(html).toContain(longSeriesName);
+  });
+
+  it('removes the cap and keeps full text when off', () => {
+    const html = buildTooltip('off');
+    expect(html).not.toContain('max-width');
+    expect(html).toContain(longSeriesName);
+  });
+
+  it('drops the shared prefix when truncating from the start', () => {
+    const html = buildTooltip('start');
+    expect(html).not.toContain('prod-us-east');
+    expect(html).toContain('latency-p99');
+    expect(html).toContain('background-color:#1f77b4');
+  });
+
+  it('keeps both ends when truncating the middle', () => {
+    const html = buildTooltip('middle');
+    expect(html).toContain('prod-us-east-1-servi…heckout-latency-p99');
+    expect(html).not.toContain(longSeriesName);
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2437,3 +2437,92 @@ test('honors the snake_case flag the compare-chart migration stores in params', 
     [BASE_TIMESTAMP + 300000000, 2],
   ]);
 });
+describe('EchartsTimeseries tooltip truncation', () => {
+  const longSeriesName = 'prod-us-east-1-service-checkout-latency-p99';
+  const marker = '<span style="background-color:#1f77b4;"></span>';
+
+  const buildTooltip = (
+    tooltipTruncation?: string,
+    xValue: string | number = 599616000000,
+  ) => {
+    const chartProps = new ChartProps({
+      formData: {
+        colorScheme: 'bnbColors',
+        datasource: '3__table',
+        granularity_sqla: 'ds',
+        metric: 'sum__num',
+        groupby: ['foo'],
+        viz_type: 'my_viz',
+        ...(tooltipTruncation ? { tooltipTruncation } : {}),
+      } as SqlaFormData,
+      width: 800,
+      height: 600,
+      queriesData: [
+        {
+          data: [
+            { [longSeriesName]: 1, __timestamp: 599616000000 },
+            { [longSeriesName]: 3, __timestamp: 599916000000 },
+          ],
+        },
+      ],
+      theme: supersetTheme,
+    });
+    const { echartOptions } = transformProps(
+      chartProps as EchartsTimeseriesChartProps,
+    );
+    const { formatter } = echartOptions.tooltip as {
+      formatter: (params: unknown) => string;
+    };
+    return formatter([
+      {
+        seriesId: longSeriesName,
+        seriesName: longSeriesName,
+        value: [xValue, 1],
+        marker,
+      },
+    ]);
+  };
+
+  it('applies the CSS cap and keeps full text by default', () => {
+    const html = buildTooltip();
+    expect(html).toContain('max-width: 300px');
+    expect(html).toContain(longSeriesName);
+  });
+
+  it('removes the cap and keeps full text when off', () => {
+    const html = buildTooltip('off');
+    expect(html).not.toContain('max-width');
+    expect(html).toContain(longSeriesName);
+  });
+
+  it('drops the shared prefix when truncating from the start', () => {
+    const html = buildTooltip('start');
+    expect(html).not.toContain('prod-us-east');
+    expect(html).toContain('latency-p99');
+    expect(html).toContain('white-space: nowrap');
+  });
+
+  it('keeps both ends when truncating the middle', () => {
+    const html = buildTooltip('middle');
+    expect(html).toContain('prod-us-east-1-servi…heckout-latency-p99');
+    expect(html).not.toContain(longSeriesName);
+  });
+
+  it('preserves the echarts marker in every mode', () => {
+    (['off', 'end', 'start', 'middle'] as const).forEach(mode => {
+      expect(buildTooltip(mode)).toContain('background-color:#1f77b4');
+    });
+  });
+
+  it('truncates a long non-temporal x-axis title', () => {
+    const longCategory = 'prod-us-east-1-service-checkout-cohort-2026';
+    const html = buildTooltip('start', longCategory);
+    expect(html).not.toContain(longCategory);
+    expect(html).toContain('cohort-2026');
+  });
+
+  it('leaves a long title alone in the default mode', () => {
+    const longCategory = 'prod-us-east-1-service-checkout-cohort-2026';
+    expect(buildTooltip(undefined, longCategory)).toContain(longCategory);
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -32,6 +32,7 @@ import {
   TimeseriesAnnotationLayer,
   ChartDataResponseResult,
   TimeGranularity,
+  TooltipTruncationMode,
 } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import { supersetTheme } from '@apache-superset/core/theme';
@@ -2442,7 +2443,7 @@ describe('EchartsTimeseries tooltip truncation', () => {
   const marker = '<span style="background-color:#1f77b4;"></span>';
 
   const buildTooltip = (
-    tooltipTruncation?: string,
+    tooltipTruncation?: TooltipTruncationMode,
     xValue: string | number = 599616000000,
   ) => {
     const chartProps = new ChartProps({
@@ -2483,45 +2484,47 @@ describe('EchartsTimeseries tooltip truncation', () => {
     ]);
   };
 
-  it('applies the CSS cap and keeps full text by default', () => {
+  test('applies the CSS cap and keeps full text by default', () => {
     const html = buildTooltip();
-    expect(html).toContain('max-width: 300px');
     expect(html).toContain(longSeriesName);
+    // sanitizeHtml normalizes spacing inside style attributes, so compare with
+    // whitespace stripped rather than hard-coding one version's formatting.
+    expect(html.replace(/\s/g, '')).toContain('max-width:300px');
   });
 
-  it('removes the cap and keeps full text when off', () => {
+  test('removes the cap and keeps full text when off', () => {
     const html = buildTooltip('off');
     expect(html).not.toContain('max-width');
     expect(html).toContain(longSeriesName);
   });
 
-  it('drops the shared prefix when truncating from the start', () => {
+  test('drops the shared prefix when truncating from the start', () => {
     const html = buildTooltip('start');
     expect(html).not.toContain('prod-us-east');
     expect(html).toContain('latency-p99');
-    expect(html).toContain('white-space: nowrap');
+    expect(html.replace(/\s/g, '')).toContain('white-space:nowrap');
   });
 
-  it('keeps both ends when truncating the middle', () => {
+  test('keeps both ends when truncating the middle', () => {
     const html = buildTooltip('middle');
     expect(html).toContain('prod-us-east-1-servi…heckout-latency-p99');
     expect(html).not.toContain(longSeriesName);
   });
 
-  it('preserves the echarts marker in every mode', () => {
+  test('preserves the echarts marker in every mode', () => {
     (['off', 'end', 'start', 'middle'] as const).forEach(mode => {
       expect(buildTooltip(mode)).toContain('background-color:#1f77b4');
     });
   });
 
-  it('truncates a long non-temporal x-axis title', () => {
+  test('truncates a long non-temporal x-axis title', () => {
     const longCategory = 'prod-us-east-1-service-checkout-cohort-2026';
     const html = buildTooltip('start', longCategory);
     expect(html).not.toContain(longCategory);
     expect(html).toContain('cohort-2026');
   });
 
-  it('leaves a long title alone in the default mode', () => {
+  test('leaves a long title alone in the default mode', () => {
     const longCategory = 'prod-us-east-1-service-checkout-cohort-2026';
     expect(buildTooltip(undefined, longCategory)).toContain(longCategory);
   });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -431,36 +431,36 @@ describe('formatForecastTooltipSeries truncation', () => {
       ...(truncation ? { truncation } : {}),
     })[0];
 
-  it('leaves the name intact by default and for off/end', () => {
+  test('leaves the name intact by default and for off/end', () => {
     expect(format()).toContain(longName);
     expect(format('off')).toContain(longName);
     expect(format('end')).toContain(longName);
   });
 
-  it('slices the start of the name without harming the marker', () => {
+  test('slices the start of the name without harming the marker', () => {
     const cell = format('start');
     expect(cell).toContain(marker);
     expect(cell).toContain('…-us-east-1-service-checkout-latency-p99');
     expect(cell).not.toContain('prod-us-east');
   });
 
-  it('slices the middle of the name without harming the marker', () => {
+  test('slices the middle of the name without harming the marker', () => {
     const cell = format('middle');
     expect(cell).toContain(marker);
     expect(cell).toContain('prod-us-east-1-servi…heckout-latency-p99');
   });
 
-  it('measures the budget against the name, not the marker markup', () => {
+  test('measures the budget against the name, not the marker markup', () => {
     // The marker alone is far longer than the budget. If truncation were
     // applied to the concatenated cell, a short name would be mangled.
     expect(marker.length).toBeGreaterThan(TRUNCATION_MAX_CHARS);
-    const cell = formatForecastTooltipSeries({
+    const [cell] = formatForecastTooltipSeries({
       seriesName: 'cpu',
       observation: 1,
       marker,
       formatter: intFormatter,
       truncation: 'start',
-    })[0];
+    });
     expect(cell).toBe(`${marker}cpu`);
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -16,7 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getNumberFormatter, NumberFormats } from '@superset-ui/core';
+import {
+  getNumberFormatter,
+  NumberFormats,
+  TRUNCATION_MAX_CHARS,
+} from '@superset-ui/core';
 import { SeriesOption } from 'echarts';
 import {
   extractForecastSeriesContext,
@@ -410,4 +414,53 @@ test('formatForecastTooltipSeries should skip non-finite forecast values', () =>
       formatter,
     }),
   ).toEqual(['<img>qwerty', '10']);
+});
+
+describe('formatForecastTooltipSeries truncation', () => {
+  const marker =
+    '<span style="display:inline-block;width:10px;height:10px;background-color:#1f77b4;"></span>';
+  const longName = 'prod-us-east-1-service-checkout-latency-p99'; // 43 chars
+  const intFormatter = getNumberFormatter(NumberFormats.INTEGER);
+
+  const format = (truncation?: 'off' | 'end' | 'start' | 'middle') =>
+    formatForecastTooltipSeries({
+      seriesName: longName,
+      observation: 1,
+      marker,
+      formatter: intFormatter,
+      ...(truncation ? { truncation } : {}),
+    })[0];
+
+  it('leaves the name intact by default and for off/end', () => {
+    expect(format()).toContain(longName);
+    expect(format('off')).toContain(longName);
+    expect(format('end')).toContain(longName);
+  });
+
+  it('slices the start of the name without harming the marker', () => {
+    const cell = format('start');
+    expect(cell).toContain(marker);
+    expect(cell).toContain('…-us-east-1-service-checkout-latency-p99');
+    expect(cell).not.toContain('prod-us-east');
+  });
+
+  it('slices the middle of the name without harming the marker', () => {
+    const cell = format('middle');
+    expect(cell).toContain(marker);
+    expect(cell).toContain('prod-us-east-1-servi…heckout-latency-p99');
+  });
+
+  it('measures the budget against the name, not the marker markup', () => {
+    // The marker alone is far longer than the budget. If truncation were
+    // applied to the concatenated cell, a short name would be mangled.
+    expect(marker.length).toBeGreaterThan(TRUNCATION_MAX_CHARS);
+    const cell = formatForecastTooltipSeries({
+      seriesName: 'cpu',
+      observation: 1,
+      marker,
+      formatter: intFormatter,
+      truncation: 'start',
+    })[0];
+    expect(cell).toBe(`${marker}cpu`);
+  });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Chart tooltip labels are truncated with an ellipsis. When labels share a common prefix, truncation removes the only part that distinguishes them, so every row in the tooltip reads the same. This is a regression relative to 2.1.1, where tooltips were never truncated.

This is caused by `superset-ui-core/src/utils/tooltip.ts` stamps this **inline** on the tooltip title `<span>` and on every `<td>`:

```js
const TRUNCATION_STYLE = `
  max-width: 300px;
  overflow: hidden;
  text-overflow: ellipsis;
`;
```

Because the styles are inline, no deployment can override them with CSS or a theme.

This PR addressed the issue by adding a **Truncate labels** control in the Tooltip section, with four modes:

| Mode | Behavior |
|---|---|
| `end` (default) | Today's 300px CSS cap — unchanged |
| `off` | No truncation; full label |
| `start` | `…-us-east-1-service-checkout-latency-p99` |
| `middle` | `prod-us-east-1-servi…heckout-latency-p99` |

Available on the seven plugins that consume `richTooltipSection`: Line, Bar, Area, Step, SmoothLine, Scatter, MixedTimeseries.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
After:
<img width="337" height="1173" alt="Screenshot 2026-08-17 at 3 20 44 PM" src="https://github.com/user-attachments/assets/ed43869a-eb7b-4312-b7c8-259aebef5716" />
<img width="963" height="1164" alt="Screenshot 2026-08-17 at 3 25 27 PM" src="https://github.com/user-attachments/assets/a631ebd8-f797-47e0-9e21-000e0bff8b17" />
<img width="1061" height="578" alt="Screenshot 2026-08-17 at 3 25 40 PM" src="https://github.com/user-attachments/assets/f9e63f85-5624-4dcd-8e34-c873932cc381" />
<img width="1314" height="725" alt="Screenshot 2026-08-17 at 3 25 52 PM" src="https://github.com/user-attachments/assets/10fab05f-fc67-4ead-8544-371f00ae5b1e" />
<img width="1155" height="708" alt="Screenshot 2026-08-17 at 3 26 06 PM" src="https://github.com/user-attachments/assets/534a7c92-b11c-45cd-be50-f023937b5fb5" />



### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Added unit tests for this behavior and existing unit tests should cover other behavior 


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

