### PR TITLE
fix(uploads): set catalog on datasets created by file upload

### DIFF
--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -220,7 +220,7 @@ class UploadCommand(BaseCommand):
                 editors=editors,
                 schema=self._schema,
                 # Ensure catalog is set
-                catalog=self._model.get_default_catalog()
+                catalog=self._model.get_default_catalog(),
             )
             db.session.add(sqla_table)
 

--- a/superset/commands/database/uploaders/base.py
+++ b/superset/commands/database/uploaders/base.py
@@ -219,6 +219,8 @@ class UploadCommand(BaseCommand):
                 database_id=self._model_id,
                 editors=editors,
                 schema=self._schema,
+                # Ensure catalog is set
+                catalog=self._model.get_default_catalog()
             )
             db.session.add(sqla_table)
 

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -145,6 +145,7 @@ def test_csv_upload_dataset():
     assert dataset is not None
     assert user_is_editor(security_manager.find_user("admin"), dataset)
 
+
 @only_postgresql
 @pytest.mark.usefixtures("setup_csv_upload_with_context_schema")
 def test_csv_upload_dataset_catalog():
@@ -173,6 +174,7 @@ def test_csv_upload_dataset_catalog():
     assert dataset.schema_perm == (
         f"[{upload_database.database_name}].[{catalog}].[public]"
     )
+
 
 @pytest.mark.usefixtures("setup_csv_upload_with_context")
 def test_csv_upload_with_index():

--- a/tests/integration_tests/databases/commands/upload_test.py
+++ b/tests/integration_tests/databases/commands/upload_test.py
@@ -145,6 +145,34 @@ def test_csv_upload_dataset():
     assert dataset is not None
     assert user_is_editor(security_manager.find_user("admin"), dataset)
 
+@only_postgresql
+@pytest.mark.usefixtures("setup_csv_upload_with_context_schema")
+def test_csv_upload_dataset_catalog():
+    admin_user = security_manager.find_user(username="admin")
+    upload_database = get_upload_db()
+
+    with override_user(admin_user):
+        UploadCommand(
+            upload_database.id,
+            CSV_UPLOAD_TABLE_W_SCHEMA,
+            create_csv_file(CSV_FILE_1),
+            "public",
+            CSVReader({}),
+        ).run()
+
+    dataset = (
+        db.session.query(SqlaTable)
+        .filter_by(
+            database_id=upload_database.id,
+            table_name=CSV_UPLOAD_TABLE_W_SCHEMA,
+        )
+        .one()
+    )
+    catalog = upload_database.get_default_catalog()
+    assert dataset.catalog == catalog
+    assert dataset.schema_perm == (
+        f"[{upload_database.database_name}].[{catalog}].[public]"
+    )
 
 @pytest.mark.usefixtures("setup_csv_upload_with_context")
 def test_csv_upload_with_index():


### PR DESCRIPTION
### SUMMARY
Fixes #43300 

In UploadCommand.run() when creating the SqlaTable record, it never set catalog before:

```
sqla_table = SqlaTable(
    table_name=self._table_name,
    database=self._model,
    database_id=self._model_id,
    owners=[get_user()],
    schema=self._schema,
    # ← catalog is never set
)
```

So, set catalog=self._model.get_default_catalog() when constructing the SqlaTable, mirroring what CreateDatasetCommand already does. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no UI changes.

### TESTING INSTRUCTIONS

Automated: `test_csv_upload_dataset_catalog` in `tests/integration_tests/databases/commands/upload_test.py`

Manual:

1. Connect a PostgreSQL database, enable **Allow file uploads to database** and
   allow the `public` schema.
2. Create a role with `can_upload` on `Database` plus `schema_access` on
   `public`, and assign it to a non-admin user.
3. As that user, upload a CSV into `public`.
4. Confirm the new dataset appears in the **Datasets** list, and that a chart
   created from it appears in the **Charts** list.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43300 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API