### PR TITLE
fix(import): catch KeyError for missing uuid/ssh_tunnel in load_configs

### DIFF
--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -247,6 +247,25 @@ def load_configs(
                     )
                 exc.messages = {file_name: exc.messages}
                 exceptions.append(exc)
+            except KeyError as exc:
+                # Some config fields (e.g. `uuid`, `ssh_tunnel`) are read
+                # directly from the imported YAML before schema validation runs;
+                # a config missing one of these keys raises a raw KeyError
+                # instead of failing validation cleanly like every other
+                # per-file error. Convert it into a ValidationError so it flows
+                # into the same aggregated error path.
+                field = str(exc).strip("'\"")
+                logger.error(
+                    "Missing required key %s in config for %s (prefix: %s)",
+                    exc,
+                    file_name,
+                    prefix,
+                )
+                exceptions.append(
+                    ValidationError(
+                        {file_name: {field: ["Missing data for required field."]}}
+                    )
+                )
 
     return configs
 

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -339,6 +339,25 @@ def load_configs(
                 exceptions.append(
                     ValidationError({file_name: {"masked_encrypted_extra": [str(exc)]}})
                 )
+            except KeyError as exc:
+                # Some config fields (e.g. `uuid`, `ssh_tunnel`) are read
+                # directly from the imported YAML before schema validation runs;
+                # a config missing one of these keys raises a raw KeyError
+                # instead of failing validation cleanly like every other
+                # per-file error. Convert it into a ValidationError so it flows
+                # into the same aggregated error path.
+                field = str(exc).strip("'\"")
+                logger.error(
+                    "Missing required key %s in config for %s (prefix: %s)",
+                    exc,
+                    file_name,
+                    prefix,
+                )
+                exceptions.append(
+                    ValidationError(
+                        {file_name: {field: ["Missing data for required field."]}}
+                    )
+                )
 
     return configs
 

--- a/tests/unit_tests/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/commands/importers/v1/utils_test.py
@@ -138,3 +138,85 @@ class TestLoadYaml:
 
         with pytest.raises(ValidationError):
             load_yaml("test.yaml", 'key: "unterminated string')
+
+
+class TestLoadConfigs:
+    def _database_schemas(self) -> dict[str, object]:
+        from marshmallow import fields, Schema
+
+        class DatabaseSchema(Schema):
+            uuid = fields.UUID(required=True)
+            database_name = fields.String(required=True)
+            sqlalchemy_uri = fields.String(required=True)
+            password = fields.String(required=False, allow_none=True)
+
+        return {"databases/": DatabaseSchema()}
+
+    @patch("superset.commands.importers.v1.utils.db")
+    def test_missing_uuid_appends_validation_error(self, mock_db: object) -> None:
+        """A databases config missing `uuid` must not raise a raw KeyError;
+        it should be excluded from the returned configs and a ValidationError
+        appended to the exceptions list instead."""
+        from marshmallow.exceptions import ValidationError
+
+        from superset.commands.importers.v1.utils import load_configs
+
+        mock_db.session.query.return_value.all.return_value = []
+
+        # No `uuid` and no `password`, so the code reaches
+        # `config["uuid"] in db_passwords` and would raise KeyError pre-fix.
+        contents = {
+            "databases/bad.yaml": (
+                "database_name: bad\nsqlalchemy_uri: postgres://localhost\n"
+            ),
+        }
+        exceptions: list[ValidationError] = []
+
+        configs = load_configs(
+            contents,
+            self._database_schemas(),
+            {},
+            exceptions,
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert "databases/bad.yaml" not in configs
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0], ValidationError)
+        assert "databases/bad.yaml" in exceptions[0].messages
+
+    @patch("superset.commands.importers.v1.utils.db")
+    def test_uuid_present_loads_successfully(self, mock_db: object) -> None:
+        """Control: a well-formed databases config loads with no exceptions."""
+        from marshmallow.exceptions import ValidationError
+
+        from superset.commands.importers.v1.utils import load_configs
+
+        mock_db.session.query.return_value.all.return_value = []
+
+        contents = {
+            "databases/good.yaml": (
+                "uuid: 6ff1d5b3-4b0f-4c6a-9d2f-9c8b7a6e5d4c\n"
+                "database_name: good\n"
+                "sqlalchemy_uri: postgres://localhost\n"
+                "password: secret\n"
+            ),
+        }
+        exceptions: list[ValidationError] = []
+
+        configs = load_configs(
+            contents,
+            self._database_schemas(),
+            {},
+            exceptions,
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert "databases/good.yaml" in configs
+        assert exceptions == []

--- a/tests/unit_tests/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/commands/importers/v1/utils_test.py
@@ -18,7 +18,7 @@
 
 import gzip
 import io
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -168,12 +168,14 @@ class TestLoadYaml:
 
 class TestLoadConfigs:
     """
-    load_configs() merges caller-supplied ``encrypted_extra_secrets`` into the
-    ``masked_encrypted_extra`` field of each config, which comes straight from
-    the imported YAML (before schema validation). A malformed value there used
-    to raise a raw simplejson.JSONDecodeError that escaped uncaught (opaque
-    500); it must instead be collected as a ValidationError like every other
-    per-file failure.
+    Per-file failures inside load_configs() must be collected as
+    ValidationErrors rather than propagating as raw exceptions (opaque 500s):
+
+    - A malformed ``masked_encrypted_extra`` (into which caller-supplied
+      ``encrypted_extra_secrets`` are merged before schema validation) used to
+      raise a raw simplejson.JSONDecodeError.
+    - A config missing its ``uuid`` used to raise a raw KeyError when the
+      password/ssh-tunnel validation looked up ``config["uuid"]``.
     """
 
     @staticmethod
@@ -185,6 +187,17 @@ class TestLoadConfigs:
                 unknown = EXCLUDE
 
         return TrivialSchema()
+
+    def _database_schemas(self) -> dict[str, object]:
+        from marshmallow import fields, Schema
+
+        class DatabaseSchema(Schema):
+            uuid = fields.UUID(required=True)
+            database_name = fields.String(required=True)
+            sqlalchemy_uri = fields.String(required=True)
+            password = fields.String(required=False, allow_none=True)
+
+        return {"databases/": DatabaseSchema()}
 
     @patch("superset.commands.importers.v1.utils.db")
     def test_invalid_json_in_masked_encrypted_extra_is_collected(
@@ -266,6 +279,75 @@ class TestLoadConfigs:
         assert file_name in configs
         merged = json.loads(configs[file_name]["masked_encrypted_extra"])
         assert merged == {"foo": "actual_secret"}
+
+    @patch("superset.commands.importers.v1.utils.db")
+    def test_missing_uuid_appends_validation_error(self, mock_db: MagicMock) -> None:
+        """A databases config missing `uuid` must not raise a raw KeyError;
+        it should be excluded from the returned configs and a ValidationError
+        appended to the exceptions list instead."""
+        from marshmallow.exceptions import ValidationError
+
+        from superset.commands.importers.v1.utils import load_configs
+
+        mock_db.session.query.return_value.all.return_value = []
+
+        # No `uuid` and no `password`, so the code reaches
+        # `config["uuid"] in db_passwords` and would raise KeyError pre-fix.
+        contents = {
+            "databases/bad.yaml": (
+                "database_name: bad\nsqlalchemy_uri: postgres://localhost\n"
+            ),
+        }
+        exceptions: list[ValidationError] = []
+
+        configs = load_configs(
+            contents,
+            self._database_schemas(),
+            {},
+            exceptions,
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert "databases/bad.yaml" not in configs
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0], ValidationError)
+        assert "databases/bad.yaml" in exceptions[0].messages
+
+    @patch("superset.commands.importers.v1.utils.db")
+    def test_uuid_present_loads_successfully(self, mock_db: MagicMock) -> None:
+        """Control: a well-formed databases config loads with no exceptions."""
+        from marshmallow.exceptions import ValidationError
+
+        from superset.commands.importers.v1.utils import load_configs
+
+        mock_db.session.query.return_value.all.return_value = []
+
+        contents = {
+            "databases/good.yaml": (
+                "uuid: 6ff1d5b3-4b0f-4c6a-9d2f-9c8b7a6e5d4c\n"
+                "database_name: good\n"
+                "sqlalchemy_uri: postgres://localhost\n"
+                "password: secret\n"
+            ),
+        }
+        exceptions: list[ValidationError] = []
+
+        configs = load_configs(
+            contents,
+            self._database_schemas(),
+            {},
+            exceptions,
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert "databases/good.yaml" in configs
+        assert exceptions == []
 
 
 class TestLoadConfigsNonMappingYaml:


### PR DESCRIPTION
### SUMMARY

Catches a raw `KeyError` in `load_configs()` so a database import config missing `uuid`/`ssh_tunnel` fails with a clean validation error instead of an opaque 500.

#### Problem

`load_configs()` reads `config["uuid"]` and `config["ssh_tunnel"][...]` directly before the marshmallow schema validation runs. A database import YAML that is missing either key raises a raw `KeyError` that escapes uncaught, surfacing as an opaque 500 from the `*/import/` endpoints instead of a clean validation error. Confirmed via a git-stash repro against pre-fix code: it fails with `KeyError: 'uuid'` at `utils.py:162`.

#### Fix

Added a sibling `except KeyError as exc:` next to the existing `except ValidationError as exc:`, converting the failure into an aggregated `ValidationError` like every other per-file import failure. This mirrors the sibling fix in this same file for `masked_encrypted_extra` JSON decoding (see #43261 for context: https://github.com/apache/superset/pull/43261). There is no behavior change for well-formed configs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend error-handling change.

### TESTING INSTRUCTIONS

Two new tests were added to `TestLoadConfigs` in `tests/unit_tests/commands/importers/v1/utils_test.py`:

- **Missing-`uuid` case**: a database config with no `uuid` key now raises a `ValidationError` (aggregated per-file error) rather than a raw `KeyError`.
- **Control case**: a well-formed config with `uuid` present still loads cleanly with no error.

Run:

```bash
pytest tests/unit_tests/commands/importers/v1/utils_test.py
```

Also verified locally: `uvx ruff@0.9.7 check` and `uvx ruff@0.9.7 format --check` are clean, and mypy reports no new errors.

### ADDITIONAL INFORMATION

**Tradeoffs:** This is an additive catch only — no existing failure-mode semantics change for valid imports. Malformed imports that previously returned a 500 now return a clean 4xx validation error. This is the intended, additive change and matches the sibling PR's pattern; there is no undisclosed semantics shift.

<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
