### PR TITLE
fix(reports): humanize day-of-month + day-of-week crontabs as OR

### DIFF
--- a/superset/reports/models.py
+++ b/superset/reports/models.py
@@ -20,7 +20,6 @@ import logging
 from typing import Any, Optional
 
 import rison
-from cron_descriptor import get_description
 from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from sqlalchemy import (
@@ -44,6 +43,7 @@ from superset.models.helpers import AuditMixinNullable, ExtraJSONMixin
 from superset.models.slice import Slice
 from superset.reports.types import ReportScheduleExtra
 from superset.subjects.models import report_schedule_editors, Subject
+from superset.tasks.cron_util import get_cron_description
 from superset.utils.backports import StrEnum
 from superset.utils.core import MediumText
 
@@ -197,7 +197,7 @@ class ReportSchedule(AuditMixinNullable, ExtraJSONMixin, Model):
 
     @renders("crontab")
     def crontab_humanized(self) -> str:
-        return get_description(self.crontab)
+        return get_cron_description(self.crontab)
 
     def get_native_filters_params(self) -> tuple[str, list[str]]:
         """

--- a/superset/tasks/cron_util.py
+++ b/superset/tasks/cron_util.py
@@ -19,11 +19,56 @@ import logging
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 
+from cron_descriptor import ExpressionDescriptor, get_description
 from croniter import croniter, CroniterBadDateError
 from flask import current_app
 from pytz import timezone as pytz_timezone, UnknownTimeZoneError
 
 logger = logging.getLogger(__name__)
+
+# Field values that place no restriction on a cron field. ``?`` is the Quartz
+# spelling of "no specific value" and is accepted by ``cron_descriptor``.
+UNRESTRICTED_CRON_FIELDS = {"*", "?"}
+
+
+def get_cron_description(cron: str) -> str:
+    """
+    Build a human readable description of a cron expression.
+
+    ``cron_descriptor`` renders a restricted day-of-month next to a restricted
+    day-of-week as a single comma separated clause -- ``0 9 7-11 * 2`` becomes
+    "At 09:00 AM, on day 7 through 11 of the month, only on Tuesday" -- which
+    reads as an intersection. POSIX cron, and therefore ``croniter`` (which
+    picks the fire times in :func:`cron_schedule_window`), takes the *union* of
+    the two fields when both are restricted: the schedule fires on every
+    matching day of the month as well as on every matching day of the week.
+    Join the two clauses with "or" so the description matches when the job
+    really runs.
+    """
+    description = get_description(cron)
+
+    fields = cron.split()
+    if len(fields) != 5:
+        return description
+
+    day_of_month, day_of_week = fields[2], fields[4]
+    if (
+        day_of_month in UNRESTRICTED_CRON_FIELDS
+        or day_of_week in UNRESTRICTED_CRON_FIELDS
+    ):
+        # Only one of the two fields narrows the days, so the description is
+        # already unambiguous.
+        return description
+
+    day_of_week_clause = ExpressionDescriptor(cron).get_day_of_week_description()
+    if not day_of_week_clause.startswith(", ") or day_of_week_clause not in description:
+        return description
+
+    clause = day_of_week_clause[len(", ") :]
+    # "only on Tuesday" claims the day-of-week narrows the day-of-month clause;
+    # it is an alternative to it, not an extra filter.
+    clause = clause.removeprefix("only ")
+    return description.replace(day_of_week_clause, f", or {clause}", 1)
 
 
 def cron_schedule_window(

--- a/tests/unit_tests/tasks/test_cron_util.py
+++ b/tests/unit_tests/tasks/test_cron_util.py
@@ -17,9 +17,10 @@
 from datetime import datetime
 
 import pytest
+from croniter import croniter
 from freezegun.api import FakeDatetime
 
-from superset.tasks.cron_util import cron_schedule_window
+from superset.tasks.cron_util import cron_schedule_window, get_cron_description
 
 
 @pytest.mark.parametrize(
@@ -256,3 +257,56 @@ def test_cron_schedule_window_invalid_cron_date(
     assert (
         list(cron.strftime("%A, %d %B %Y, %H:%M:%S") for cron in datetimes) == expected  # noqa: C400
     )
+
+
+@pytest.mark.parametrize(
+    "cron, expected",
+    [
+        # only the day-of-month is restricted
+        (
+            "0 9 7-11,19-23 * *",
+            "At 09:00 AM, on day 7 through 11 and 19 through 23 of the month",
+        ),
+        # only the day-of-week is restricted
+        ("0 9 * * 2", "At 09:00 AM, only on Tuesday"),
+        ("0 9 ? * 2", "At 09:00 AM, only on Tuesday"),
+        # neither is restricted
+        ("0 9 * * *", "At 09:00 AM"),
+        # both are restricted: cron unions them, so the description must too
+        (
+            "0 9 7-11,19-23 * 2",
+            "At 09:00 AM, on day 7 through 11 and 19 through 23 of the month, "
+            "or on Tuesday",
+        ),
+        (
+            "0 9 1,15 * 1-5",
+            "At 09:00 AM, on day 1 and 15 of the month, or Monday through Friday",
+        ),
+        (
+            "0 9 15 3 2#1",
+            "At 09:00 AM, on day 15 of the month, or on the first Tuesday of the "
+            "month, only in March",
+        ),
+        ("0 9 L * 5", "At 09:00 AM, on the last day of the month, or on Friday"),
+    ],
+)
+def test_get_cron_description(cron: str, expected: str) -> None:
+    """
+    Test that the humanized cron matches the days the schedule actually fires on.
+    """
+
+    assert get_cron_description(cron) == expected
+
+
+def test_get_cron_description_matches_fire_times() -> None:
+    """
+    A restricted day-of-month and day-of-week are OR'ed, never AND'ed.
+    """
+
+    cron = "0 9 7-11,19-23 * 2"
+    # 2026-09-01 is a Tuesday that falls outside both day-of-month ranges, so
+    # an AND reading of the description would have skipped it
+    first_fire_time = croniter(cron, datetime(2026, 9, 1)).get_next(datetime)
+
+    assert first_fire_time == datetime(2026, 9, 1, 9, 0)
+    assert "or on Tuesday" in get_cron_description(cron)


### PR DESCRIPTION
### SUMMARY

The **Schedule** column on Alerts & Reports shows a human-readable rendering of the report's crontab, produced by `ReportSchedule.crontab_humanized` → `cron_descriptor.get_description()`. When a schedule restricts *both* the day-of-month and the day-of-week fields, that description is wrong.

`0 9 7-11,19-23 * 2` renders as:

> At 09:00 AM, on day 7 through 11 and 19 through 23 of the month, only on Tuesday

The comma plus "only on" reads as an intersection — "the 7th–11th and 19th–23rd, but only when that day is a Tuesday". POSIX cron does the opposite: when both fields are restricted they are **OR**'d. `croniter`, which selects the actual fire times in `superset/tasks/cron_util.py`, implements that correctly, so the report also fires on every Tuesday outside those two ranges. Verified against `croniter`: for the expression above the first fire time after 2026-09-01 is 2026-09-01 09:00 — a Tuesday that is in neither day-of-month range.

So the picker is right and the description is wrong. The frontend cron picker (`react-js-cron`, via `CronPicker`) already renders this correctly: its locale sets `prefixWeekDaysForMonthAndYearPeriod: 'or'`, so the builder shows "… on day 7-11,19-23 **or** Tuesday". Only the backend-generated text disagreed, which is exactly the mismatch users hit — they configure a schedule in the picker and then read a contradictory description in the list.

Rather than swapping out `cron_descriptor` (which is otherwise fine and handles `L`, `W`, `#n`, i18n, etc.), this adds a small `get_cron_description()` wrapper in `superset/tasks/cron_util.py` — the module that already owns cron interpretation via `croniter`. It only changes the output for the ambiguous case: when neither the day-of-month nor the day-of-week field is `*`/`?`, the day-of-week clause is rejoined with "or". Every other expression is passed through `cron_descriptor` untouched.

| crontab | before | after |
|---|---|---|
| `0 9 7-11,19-23 * 2` | …of the month, only on Tuesday | …of the month, **or on** Tuesday |
| `0 9 1,15 * 1-5` | …of the month, Monday through Friday | …of the month, **or** Monday through Friday |
| `0 9 L * 5` | on the last day of the month, only on Friday | on the last day of the month, **or on** Friday |
| `0 9 * * 2` | only on Tuesday | *(unchanged)* |
| `0 9 7-11 * *` | on day 7 through 11 of the month | *(unchanged)* |

Known limitations: the rewrite is applied to standard 5-field expressions only (what the picker and the API validator produce); 6-field expressions fall through to the unmodified `cron_descriptor` output because the field offsets are ambiguous. The "only " prefix strip is English-specific — `cron_descriptor` is invoked with its default `en_US` locale here, and if the prefix isn't present the clause is emitted verbatim, so a different locale degrades to ", or <clause>" rather than breaking.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No UI code changed — this is the text returned by the `crontab_humanized` field of `GET /api/v1/report/`, rendered verbatim in the Schedule column. The before/after strings are in the table above.

### TESTING INSTRUCTIONS

Regression tests in `tests/unit_tests/tasks/test_cron_util.py`:

- `test_get_cron_description` — parametrized over the ambiguous and unambiguous cases; the ambiguous rows fail on `master` (`assert '…of the month, only on Tuesday' == '…of the month, or on Tuesday'`).
- `test_get_cron_description_matches_fire_times` — pins the description against what `croniter` actually schedules, so the two can't drift apart again.

```
pytest tests/unit_tests/tasks/test_cron_util.py tests/unit_tests/reports/ -q
281 passed
```

Manually: create a report with schedule type "CRON Schedule" and crontab `0 9 7-11,19-23 * 2`, then look at the Schedule column on the Alerts & Reports list. It should read "At 09:00 AM, on day 7 through 11 and 19 through 23 of the month, or on Tuesday", matching what the recurring picker shows for the same expression.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
