### PR TITLE
fix(i18n-es): correct case/number collapse in the semantic-layer labels

### DIFF
--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -3804,9 +3804,8 @@ msgstr "Radio de agrupación"
 msgid "Code"
 msgstr "Código"
 
-#, fuzzy
 msgid "Code Copied!"
-msgstr "SQL copiado"
+msgstr "¡Código copiado!"
 
 #, fuzzy
 msgid "Collapse"
@@ -4301,9 +4300,8 @@ msgstr "Controles etiquetados "
 msgid "Copied to clipboard!"
 msgstr "Copiado al portapapeles"
 
-#, fuzzy
 msgid "Copied!"
-msgstr "SQL copiado"
+msgstr "¡Copiado!"
 
 msgid "Copy"
 msgstr "Copiar"
@@ -4903,9 +4901,8 @@ msgstr "Con puntos"
 msgid "Data"
 msgstr "Datos"
 
-#, fuzzy
 msgid "Data Connections"
-msgstr "Conexiones de la base de datos"
+msgstr "Conexiones de datos"
 
 msgid "Data Export Options"
 msgstr "Opciones de exportación de datos"
@@ -4919,13 +4916,11 @@ msgstr "El URI de datos no está permitido."
 msgid "Data Zoom"
 msgstr "«Zoom» de datos"
 
-#, fuzzy
 msgid "Data connection"
-msgstr "Conexiones de la base de datos"
+msgstr "Conexión de datos"
 
-#, fuzzy
 msgid "Data connections"
-msgstr "Conexiones de la base de datos"
+msgstr "Conexiones de datos"
 
 msgid ""
 "Data could not be deserialized from the results backend. The storage "
@@ -5165,9 +5160,8 @@ msgstr ""
 "Se requiere el tipo de fuente de datos cuando se proporciona un ID de "
 "fuentes de datos"
 
-#, fuzzy
 msgid "Datasources"
-msgstr "Fuente de datos"
+msgstr "Fuentes de datos"
 
 msgid "Date Time Format"
 msgstr "Formato de fecha y hora"
@@ -9874,9 +9868,8 @@ msgstr "Error de red al intentar recuperar el recurso"
 msgid "Network error."
 msgstr "Error de red."
 
-#, fuzzy
 msgid "New"
-msgstr "Ahora"
+msgstr "Nuevo"
 
 #, -ERR:PROP-NOT-FOUND-
 msgid "New Semantic Layer"
@@ -19340,20 +19333,17 @@ msgstr "panel de control"
 msgid "dashboards"
 msgstr "Paneles de control"
 
-#, fuzzy
 msgid "data connection"
-msgstr "Conexiones de la base de datos"
+msgstr "conexión de datos"
 
-#, fuzzy
 msgid "data connections"
-msgstr "Conexiones de la base de datos"
+msgstr "conexiones de datos"
 
 msgid "database"
 msgstr "base de datos"
 
-#, fuzzy
 msgid "databases"
-msgstr "Bases de datos"
+msgstr "bases de datos"
 
 msgid "dataset"
 msgstr "conjunto de datos"
@@ -19361,17 +19351,14 @@ msgstr "conjunto de datos"
 msgid "dataset name"
 msgstr "nombre del conjunto de datos"
 
-#, fuzzy
 msgid "datasets"
-msgstr "Conjuntos de datos"
+msgstr "conjuntos de datos"
 
-#, fuzzy
 msgid "datasource"
-msgstr "Fuente de datos"
+msgstr "fuente de datos"
 
-#, fuzzy
 msgid "datasources"
-msgstr "Fuente de datos"
+msgstr "fuentes de datos"
 
 msgid "date"
 msgstr "fecha"


### PR DESCRIPTION
### SUMMARY

The Spanish catalog collapsed several families of labels that the source code
deliberately keeps distinct, so one Spanish string was serving four English
msgids differing only in case or number.

Two files — `superset-frontend/src/features/semanticLayers/label.ts` and
`superset/semantic_layers/labels.py` — do one job: swap vocabulary when the
`SEMANTIC_LAYERS` flag is on (*dataset* → *datasource*, *database* → *data
connection*). Between them they contain exactly **19** translatable strings, and
each is exported in a cased/numbered variant so labels read correctly both as
headings and mid-sentence:

```ts
datasetLabel()       = sl(t('Dataset'),   t('Datasource'))
datasetLabelLower()  = sl(t('dataset'),   t('datasource'))
datasetsLabel()      = sl(t('Datasets'),  t('Datasources'))
datasetsLabelLower() = sl(t('datasets'),  t('datasources'))
// same shape for the database / data connection family
```

**10 of those 19 were broken.** Six msgids all rendered "Conexiones de la base de
datos" — which is the legitimate translation of a seventh, the legacy menu label
`Database Connections`. Three all rendered "Fuente de datos". One was capitalised
where the source asks for lower case. The remaining 9 were already correct and are
untouched.

| msgid | Before | After |
| --- | --- | --- |
| `datasets` | Conjuntos de datos | conjuntos de datos |
| `datasource` | Fuente de datos | fuente de datos |
| `Datasources` | Fuente de datos | Fuentes de datos |
| `datasources` | Fuente de datos | fuentes de datos |
| `databases` | Bases de datos | bases de datos |
| `Data connection` | Conexiones de la base de datos | Conexión de datos |
| `data connection` | Conexiones de la base de datos | conexión de datos |
| `Data connections` | Conexiones de la base de datos | Conexiones de datos |
| `data connections` | Conexiones de la base de datos | conexiones de datos |
| `Data Connections` | Conexiones de la base de datos | Conexiones de datos |

**Proof a reviewer can check without reading Spanish:** the legacy half of the same
file already models the convention correctly — `Dataset` / `dataset` / `Datasets`
are "Conjunto de datos" / "conjunto de datos" / "Conjuntos de datos". This change
makes the semantic half follow the pattern the catalog itself already establishes.

`Data Connections` and `Data connections` both map to "Conexiones de datos". That is
intentional: Spanish does not title-case headings, so the English difference between
them is styling rather than meaning.

#### Scope

Three further entries are included because they are visibly wrong on the same
screens a reviewer will open to check the above. They are **not** part of the 19,
and are called out here rather than folded silently into the claim:

| msgid | Before | Literally | After |
| --- | --- | --- | --- |
| `New` | Ahora | "Now" | Nuevo |
| `Copied!` | SQL copiado | "SQL copied" | ¡Copiado! |
| `Code Copied!` | SQL copiado | "SQL copied" | ¡Código copiado! |

- `New` was a byte-copy of `Now`'s translation. It is a standalone button label at
  all five call sites (`DatasetList`, `DatabaseList`, `NewItemDropdown`), never
  composed with a following noun, so no agreement constraint applies.
- `Copied!` and `Code Copied!` both held "SQL copiado", whose own msgid is no longer
  in the catalog — both copies were orphaned. The catalog is inconsistent about
  whether to carry an English trailing `!`; these two keep it, in the full
  `¡…!` form Spanish requires.

Every one of the 13 msgids was checked tree-wide for its *call site*, not its bare
text, over `superset-frontend/{src,packages,plugins}` and `superset/` (5,210 files).
The ten label entries appear only in the two files named above.

`msgfmt` statistics move by exactly the entry count and nothing else:
**translated 3996 → 4009, fuzzy 913 → 900, untranslated unchanged at 197.**

### BEFORE/AFTER SCREENSHOTS 

Before
<img width="1502" height="812" alt="01-dataset-list" src="https://github.com/user-attachments/assets/9a37e5fb-3c7f-4bf1-b36a-1600bd83db23" />

After
<img width="1502" height="812" alt="01-dataset-list" src="https://github.com/user-attachments/assets/2600358a-fd64-41af-9aef-47f85908e98d" />

Before
<img width="1502" height="812" alt="02-database-list" src="https://github.com/user-attachments/assets/66211aed-ac88-481c-ba30-150e8dc5598c" />

After
<img width="1502" height="812" alt="02-database-list" src="https://github.com/user-attachments/assets/d02f3e7f-3dce-496e-85ec-49810dbd6315" />



### TESTING INSTRUCTIONS

Two of the entries (`datasets`, `databases`) render in a default install. The rest
need the `SEMANTIC_LAYERS` feature flag, which ships default-off — which is
precisely why these strings rotted unnoticed.

```python
FEATURE_FLAGS = {"SEMANTIC_LAYERS": True}
```

Switch the UI to Spanish, then:

1. **`/tablemodelview/list/`** — the nav item and page title read "Fuentes de datos"
   (were "Fuente de datos"); the create button reads "+ Nuevo" (was "+ Ahora"); the
   filter and column header read "Conexión de datos" (were "Conexiones de la base de
   datos"). Hovering the import icon shows "Importar fuentes de datos".
2. **`/databaseview/list/`** — the page title and the Settings → Data Connections menu
   link both read "Conexiones de datos".
3. **`/sqllab/`** — the connection selector placeholder reads "Selecciona conexión de
   datos o escribe para buscar conexiones de datos", exercising the singular and the
   plural in one sentence.
4. **Explore → datasource menu** — "Editar fuente de datos" / "Intercambiar fuente de
   datos", exercising the lower-case singular mid-sentence.
5. **With the flag off** — the SQL Lab placeholder reads "…buscar bases de datos" and
   the dataset-list import tooltip reads "Importar conjuntos de datos"; both were
   capitalised mid-sentence before.

Catalog checks:

```bash
msgfmt -c --statistics -o /dev/null superset/translations/es/LC_MESSAGES/messages.po
```

Not verified in a running UI, and flagged as such: `Copied!` and `Code Copied!` (both
need a clipboard write or a saved-query/query-history row) and the lower-case
`data connection`, which renders only inside the delete-connection confirmation modal.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SEMANTIC_LAYERS` (for 8 of the 13 entries; the rest
      render in a default install)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
