### PR TITLE
fix(explore): require a value for adhoc filters before save

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
@@ -207,6 +207,38 @@ describe('AdhocFilter', () => {
     expect(adhocFilter10.isValid()).toBe(true);
   });
 
+  test('is invalid when a comparator-taking operator has no comparator', () => {
+    // A comparator that was never set, or that was cleared through the value
+    // Select's clear affordance, is `undefined` rather than `null` or `[]`.
+    const adhocFilter1 = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'is_intro',
+      operator: 'IN',
+      comparator: undefined,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter1.isValid()).toBe(false);
+
+    const adhocFilter2 = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'is_intro',
+      operator: '==',
+      comparator: undefined,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter2.isValid()).toBe(false);
+
+    // `false` is a legitimate boolean comparator, not a missing value
+    const adhocFilter3 = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'is_intro',
+      operator: '==',
+      comparator: false,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter3.isValid()).toBe(true);
+  });
+
   test('can translate from simple expressions to sql expressions', () => {
     const adhocFilter1 = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
@@ -163,8 +163,10 @@ export default class AdhocFilter {
           // A non-empty array of values ('IN' or 'NOT IN' clauses)
           return this.comparator.length > 0;
         }
-        // A value has been selected or typed
-        return this.comparator !== null;
+        // A value has been selected or typed. An unset comparator is
+        // `undefined` rather than `null`: picking a new subject resets it, and
+        // the value Select's clear affordance emits `undefined` too.
+        return this.comparator != null;
       }
     }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/AdhocFilterEditPopover.test.tsx
@@ -181,6 +181,29 @@ describe('AdhocFilterEditPopover', () => {
     expect(saveButton).toBeDisabled();
   });
 
+  test('disables save button when a boolean column has no value selected', async () => {
+    const booleanColumn = { type: 'BOOL', column_name: 'is_intro' };
+    renderPopover({
+      adhocFilter: new AdhocFilter({
+        expressionType: ExpressionTypes.Simple,
+        clause: Clauses.Where,
+      }),
+      options: [booleanColumn],
+      datasource: { columns: [booleanColumn], filter_select: false },
+    });
+
+    // Picking the subject resets the comparator to `undefined`; the value
+    // control is then left untouched, mirroring the reported repro.
+    await userEvent.click(screen.getByTestId('select-element'));
+    await userEvent.click(
+      await screen.findByRole('option', { name: /is_intro/ }),
+    );
+
+    expect(
+      screen.getByTestId('adhoc-filter-edit-popover-save-button'),
+    ).toBeDisabled();
+  });
+
   test('initiates resize when resize handle is dragged', async () => {
     const onResize = jest.fn();
     renderPopover({ onResize });


### PR DESCRIPTION
### SUMMARY
Adhoc filter validation (`AdhocFilter.isValid()`) only rejected a `null` comparator, so an unset (`undefined`) comparator passed validation and left the Save button enabled. This is most visible on Boolean-column filters: Boolean columns are restricted to unary operators, but the subject-change handler still defaulted a fresh filter's operator to `IN` (never actually selectable for Boolean columns), leaving the comparator `undefined` with no way to set it through the UI. Saving a filter in that state and running the chart surfaced a generic, unhelpful error instead of a clear validation message.

This change tightens the check from `!== null` to `!= null`, which also catches the `undefined` case while still accepting legitimate falsy values like `false` and `0`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**

[before-00.00.09.369-00.00.21.227.webm](https://github.com/user-attachments/assets/d5703dd2-83cc-4e10-bed1-6b99d10d1ccd)

**After:**

[after-00.00.09.000-00.01.02.560.webm](https://github.com/user-attachments/assets/a315ec84-b931-447e-8eed-5e861f4dc165)


### TESTING INSTRUCTIONS
1. In Explore, add a simple adhoc filter on a boolean column.
2. Leave the value unset.
3. Before this change: Save is enabled, and running the chart returns a generic error.
4. After this change: Save is disabled until a value is selected.

Automated coverage: `AdhocFilter.test.ts` and `AdhocFilterEditPopover.test.tsx` (new cases covering an unset comparator).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in SIP-59)
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
