### PR TITLE
fix(explore): keep certification badges after saving or swapping a dataset

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -278,6 +278,18 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         "database.backend",
         "database.allow_multi_catalog",
         "columns.advanced_data_type",
+        # Certification/warning metadata is stored serialized in the ``extra``
+        # column and surfaced through model properties. Exposing them keeps this
+        # payload consistent with the datasource serialization used by Explore,
+        # so clients hydrating from this endpoint don't lose the badges.
+        "columns.certification_details",
+        "columns.certified_by",
+        "columns.is_certified",
+        "columns.warning_markdown",
+        "metrics.certification_details",
+        "metrics.certified_by",
+        "metrics.is_certified",
+        "metrics.warning_markdown",
         "is_managed_externally",
         "uid",
         "uuid",

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1363,16 +1363,28 @@ class ExtraJSONMixin:
         return value
 
 
+_EXTRA_DICT_CACHE_UNSET = object()
+
+
 class CertificationMixin:
     """Mixin to add extra certification fields"""
 
     extra = sa.Column(sa.Text, default="{}")
 
     def get_extra_dict(self) -> dict[str, Any]:
-        try:
-            return json.loads(self.extra)
-        except (TypeError, json.JSONDecodeError):
-            return {}
+        # Cache the parsed ``extra`` payload on the instance, keyed by the raw
+        # string it was parsed from, so callers reading multiple
+        # certification/warning properties off the same object don't each
+        # trigger their own ``json.loads``. The cache is transient (not a
+        # mapped column) and self-invalidates whenever ``extra`` changes.
+        cache_raw = getattr(self, "_extra_dict_cache_raw", _EXTRA_DICT_CACHE_UNSET)
+        if cache_raw is _EXTRA_DICT_CACHE_UNSET or cache_raw != self.extra:
+            try:
+                self._extra_dict_cache = json.loads(self.extra)
+            except (TypeError, json.JSONDecodeError):
+                self._extra_dict_cache = {}
+            self._extra_dict_cache_raw = self.extra
+        return self._extra_dict_cache
 
     @property
     def is_certified(self) -> bool:

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -20,6 +20,7 @@ import copy
 import unittest
 from datetime import timedelta
 from io import BytesIO
+from typing import Any
 from unittest.mock import ANY, patch
 from zipfile import is_zipfile, ZipFile
 
@@ -71,6 +72,27 @@ from tests.integration_tests.fixtures.importexport import (
     dataset_config,
     dataset_ui_export,
 )
+
+# Fields the dataset ``show`` payload exposes but the ``PUT`` schema doesn't
+# accept: audit timestamps plus attributes derived from the model (type
+# affinity and the certification/warning metadata stored in ``extra``).
+DATASET_READ_ONLY_ITEM_FIELDS = (
+    "changed_on",
+    "created_on",
+    "type_generic",
+    "certification_details",
+    "certified_by",
+    "is_certified",
+    "warning_markdown",
+)
+
+
+def strip_read_only_fields(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop read-only fields so a ``show`` payload can be fed back to ``PUT``."""
+    for item in items:
+        for field in DATASET_READ_ONLY_ITEM_FIELDS:
+            item.pop(field, None)
+    return items
 
 
 class TestDatasetApi(SupersetTestCase):
@@ -1316,17 +1338,10 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.get_assert_metric(uri, "get")
         data = json.loads(rv.data.decode("utf-8"))
 
-        for column in data["result"]["columns"]:
-            column.pop("changed_on", None)
-            column.pop("created_on", None)
-            column.pop("type_generic", None)
+        strip_read_only_fields(data["result"]["columns"])
         data["result"]["columns"].append(new_column_data)
 
-        for metric in data["result"]["metrics"]:
-            metric.pop("changed_on", None)
-            metric.pop("created_on", None)
-            metric.pop("type_generic", None)
-
+        strip_read_only_fields(data["result"]["metrics"])
         data["result"]["metrics"].append(new_metric_data)
 
         with freeze_time() as frozen:
@@ -1404,11 +1419,7 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.get_assert_metric(uri, "get")
         data = json.loads(rv.data.decode("utf-8"))
 
-        for column in data["result"]["columns"]:
-            column.pop("changed_on", None)
-            column.pop("created_on", None)
-            column.pop("type_generic", None)
-
+        strip_read_only_fields(data["result"]["columns"])
         data["result"]["columns"].append(new_column_data)
         rv = self.client.put(uri, json={"columns": data["result"]["columns"]})
 
@@ -1443,10 +1454,7 @@ class TestDatasetApi(SupersetTestCase):
         # Get current cols and alter one
         rv = self.get_assert_metric(uri, "get")
         resp_columns = json.loads(rv.data.decode("utf-8"))["result"]["columns"]
-        for column in resp_columns:
-            column.pop("changed_on", None)
-            column.pop("created_on", None)
-            column.pop("type_generic", None)
+        strip_read_only_fields(resp_columns)
 
         resp_columns[0]["groupby"] = False
         resp_columns[0]["filterable"] = False

--- a/tests/unit_tests/datasets/api_tests.py
+++ b/tests/unit_tests/datasets/api_tests.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 from sqlalchemy.orm.session import Session
 
 from superset import db
+from superset.utils import json
 
 
 def test_put_invalid_dataset(
@@ -214,3 +215,63 @@ def test_handle_filters_args_returns_request_scoped_filters(
     fresh_filters = api.datamodel.get_filters.return_value
     assert fresh_filters.rest_add_filters.call_count == 2
     assert fresh_filters.get_joined_filters.call_count == 2
+
+
+def test_get_dataset_exposes_certification_metadata(
+    session: Session,
+    client: Any,
+    full_api_access: None,
+) -> None:
+    """
+    Dataset API: Test that the show payload exposes the certification and
+    warning metadata for both columns and metrics.
+
+    Regression test for #43279: Explore hydrates its datasource from this
+    endpoint after a dataset save or swap. Without these fields the certified
+    and warning badges disappeared until the page was reloaded, because the
+    Explore bootstrap payload serializes them but this endpoint did not.
+    """
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+    from superset.models.core import Database
+
+    SqlaTable.metadata.create_all(db.session.get_bind())
+
+    extra = json.dumps(
+        {
+            "certification": {
+                "certified_by": "Data Platform",
+                "details": "Reviewed quarterly",
+            },
+            "warning_markdown": "This is a **warning**",
+        }
+    )
+    database = Database(
+        database_name="my_db",
+        sqlalchemy_uri="sqlite://",
+    )
+    dataset = SqlaTable(
+        table_name="test_certification_table",
+        database=database,
+        columns=[
+            TableColumn(column_name="ds", type="TIMESTAMP", extra=extra),
+            TableColumn(
+                column_name="calculated",
+                type="INTEGER",
+                expression="1 + 1",
+                extra=extra,
+            ),
+        ],
+        metrics=[SqlMetric(metric_name="cnt", expression="COUNT(*)", extra=extra)],
+    )
+    db.session.add(dataset)
+    db.session.flush()
+
+    response = client.get(f"/api/v1/dataset/{dataset.id}")
+
+    assert response.status_code == 200
+    result = response.json["result"]
+    for item in [*result["columns"], *result["metrics"]]:
+        assert item["is_certified"] is True
+        assert item["certified_by"] == "Data Platform"
+        assert item["certification_details"] == "Reviewed quarterly"
+        assert item["warning_markdown"] == "This is a **warning**"


### PR DESCRIPTION
### SUMMARY

Saving a dataset from Explore (`...` beside the dataset name → **Edit dataset** → **Save**), or swapping the chart's dataset, temporarily cleared the Certified / Warning icons and the Certified field values for metrics, columns and calculated columns. A full page refresh restored them, so nothing was actually lost on the backend — Explore's client state was simply missing the fields.

Both flows rehydrate the Explore datasource from `GET /api/v1/dataset/:id` (`DatasourceModal` after the `PUT`, and `ChangeDatasourceModal` on swap), and hand the response straight to `changeDatasource()` → `SET_DATASOURCE`.

That payload was missing the certification metadata. `show_select_columns` exposes `columns.extra` and `metrics.extra`, but not the attributes derived from `extra` — `is_certified`, `certified_by`, `certification_details` and `warning_markdown` — which are `@property` values on `CertificationMixin`. The Explore bootstrap serialization (`TableColumn.data` / `SqlMetric.data`) *does* include them, which is why a refresh fixed it.

This adds those four fields, for both columns and metrics, to `show_columns` so the REST endpoint matches the serialization Explore already expects. `show_columns` is the right list (rather than `show_select_columns`) because these are model properties, not database columns — the same place `columns.type_generic` lives.

Metric field values partly survived before because `DatasourceEditor` already re-parses `metric.extra` on mount; columns had no equivalent, so they came back `undefined`. That also meant a second save could write an empty `extra` back for columns, since `buildExtraJsonObject()` rebuilds `extra` from those now-missing fields — this fixes that too.

The change is purely additive to the `show` response. Feeding a `show` payload straight back into `PUT` was already unsupported (`changed_on`, `created_on` and `type_generic` are likewise read-only), so the round-trip tests were updated to strip the new fields alongside the existing ones.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: see the recording in #43279 — icons vanish immediately after Save and return after a page refresh.

After: icons and Certified values stay put after Save and after a dataset swap, with no refresh.

### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/datasets/api_tests.py::test_get_dataset_exposes_certification_metadata
pytest tests/integration_tests/datasets/api_tests.py -k "update_dataset_create_column_and_metric or update_dataset_delete_column or update_dataset_update_column"
```

Manual:

1. Pick a dataset with at least one metric, one physical column and one calculated column that have **Certified by** and/or **Warning** set, so the badges are visible in the chart source.
2. Open a chart on that dataset in Explore.
3. Click `...` beside the dataset name → **Edit dataset** → **Save**, without changing anything.
4. The Certified / Warning icons and the Certified field values remain visible for metrics, columns and calculated columns — no refresh needed.
5. Repeat with a dataset swap instead of a save; the badges should survive that too.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43279
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
