### PR TITLE
fix(sqllab): disable Save dataset until the query runs successfully

### DIFF
--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
 import SaveDatasetActionButton from 'src/SqlLab/components/SaveDatasetActionButton';
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
@@ -40,5 +40,28 @@ describe('SaveDatasetActionButton', () => {
     ).toBeInTheDocument();
     expect(saveBtn).toBeVisible();
     expect(saveDatasetBtn).toBeVisible();
+  });
+
+  test('disables the save dataset button when the query did not run successfully', async () => {
+    render(
+      <SaveDatasetActionButton
+        setShowSave={() => true}
+        onSaveAsExplore={jest.fn()}
+        canSaveDataset={false}
+      />,
+    );
+
+    const saveDatasetBtn = screen.getByRole('button', {
+      name: /save dataset/i,
+    });
+    expect(saveDatasetBtn).toBeDisabled();
+
+    // the disabled button is wrapped in a span so the tooltip still triggers
+    userEvent.hover(saveDatasetBtn.parentElement as HTMLElement);
+    expect(
+      await screen.findByRole('tooltip', {
+        name: 'You must run the query successfully first',
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/SaveDatasetActionButton.test.tsx
@@ -27,6 +27,7 @@ describe('SaveDatasetActionButton', () => {
       <SaveDatasetActionButton
         setShowSave={() => true}
         onSaveAsExplore={onSaveAsExplore}
+        canSaveDataset
       />,
     );
 

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -23,13 +23,13 @@ import { Button } from '@superset-ui/core/components';
 interface SaveDatasetActionButtonProps {
   setShowSave: (arg0: boolean) => void;
   onSaveAsExplore?: () => void;
-  canSaveDataset?: boolean;
+  canSaveDataset: boolean;
 }
 
 const SaveDatasetActionButton = ({
   setShowSave,
   onSaveAsExplore,
-  canSaveDataset = true,
+  canSaveDataset,
 }: SaveDatasetActionButtonProps) => (
   <>
     <Button

--- a/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveDatasetActionButton/index.tsx
@@ -23,11 +23,13 @@ import { Button } from '@superset-ui/core/components';
 interface SaveDatasetActionButtonProps {
   setShowSave: (arg0: boolean) => void;
   onSaveAsExplore?: () => void;
+  canSaveDataset?: boolean;
 }
 
 const SaveDatasetActionButton = ({
   setShowSave,
   onSaveAsExplore,
+  canSaveDataset = true,
 }: SaveDatasetActionButtonProps) => (
   <>
     <Button
@@ -43,8 +45,13 @@ const SaveDatasetActionButton = ({
         color="default"
         variant="text"
         onClick={() => onSaveAsExplore?.()}
+        disabled={!canSaveDataset}
         icon={<Icons.TableOutlined />}
-        tooltip={t('Save or Overwrite Dataset')}
+        tooltip={
+          canSaveDataset
+            ? t('Save or Overwrite Dataset')
+            : t('You must run the query successfully first')
+        }
         aria-label={t('Save dataset')}
       />
     )}

--- a/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/SaveQuery.test.tsx
@@ -35,6 +35,7 @@ const mockedProps = {
   onSave: () => {},
   saveQueryWarning: null,
   columns: [],
+  canSaveDataset: true,
 };
 
 const mockState = {

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -52,6 +52,7 @@ interface SaveQueryProps {
   onUpdate: (arg0: QueryPayload, id: string) => void;
   saveQueryWarning: string | null;
   database: Partial<DatabaseObject> | undefined;
+  canSaveDataset?: boolean;
 }
 
 export type QueryPayload = {
@@ -81,6 +82,7 @@ const SaveQuery = ({
   saveQueryWarning,
   database,
   columns,
+  canSaveDataset = true,
 }: SaveQueryProps) => {
   const queryEditor = useQueryEditor(queryEditorId, [
     'autorun',
@@ -207,6 +209,7 @@ const SaveQuery = ({
         <SaveDatasetActionButton
           setShowSave={setShowSave}
           onSaveAsExplore={canExploreDatabase ? onSaveAsExplore : undefined}
+          canSaveDataset={canSaveDataset}
         />
       )}
       <SaveDatasetModal

--- a/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SaveQuery/index.tsx
@@ -52,7 +52,7 @@ interface SaveQueryProps {
   onUpdate: (arg0: QueryPayload, id: string) => void;
   saveQueryWarning: string | null;
   database: Partial<DatabaseObject> | undefined;
-  canSaveDataset?: boolean;
+  canSaveDataset: boolean;
 }
 
 export type QueryPayload = {
@@ -82,7 +82,7 @@ const SaveQuery = ({
   saveQueryWarning,
   database,
   columns,
-  canSaveDataset = true,
+  canSaveDataset,
 }: SaveQueryProps) => {
   const queryEditor = useQueryEditor(queryEditorId, [
     'autorun',

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -361,16 +361,16 @@ describe('SqlEditor', () => {
   });
 
   test('disables the save dataset button when the latest query failed', async () => {
-    const { findByRole } = setupWithLatestQuery({ state: QueryState.Failed });
-    expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
-  });
-
-  test('disables the save dataset button when the results are not loaded', async () => {
     const { findByRole } = setupWithLatestQuery({
-      state: QueryState.Success,
+      state: QueryState.Failed,
       results: undefined,
     });
     expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
+  });
+
+  test('enables the save dataset button while the query is still running', async () => {
+    const { findByRole } = setupWithLatestQuery({ state: QueryState.Running });
+    expect(await findByRole('button', { name: 'Save dataset' })).toBeEnabled();
   });
 
   test('renders an Extension if provided', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -335,7 +335,7 @@ describe('SqlEditor', () => {
     expect(await findByText('10 000')).toBeInTheDocument();
   });
 
-  const setupWithQueryState = (state: QueryState) =>
+  const setupWithLatestQuery = (overrides: Partial<typeof latestQuery>) =>
     setup(
       mockedProps,
       createStore({
@@ -343,7 +343,7 @@ describe('SqlEditor', () => {
         sqlLab: {
           ...mockInitialState.sqlLab,
           queries: {
-            [latestQuery.id]: { ...latestQuery, state },
+            [latestQuery.id]: { ...latestQuery, ...overrides },
           },
           databases: {
             1991: {
@@ -356,12 +356,20 @@ describe('SqlEditor', () => {
     );
 
   test('enables the save dataset button when the latest query succeeded', async () => {
-    const { findByRole } = setupWithQueryState(QueryState.Success);
+    const { findByRole } = setupWithLatestQuery({ state: QueryState.Success });
     expect(await findByRole('button', { name: 'Save dataset' })).toBeEnabled();
   });
 
   test('disables the save dataset button when the latest query failed', async () => {
-    const { findByRole } = setupWithQueryState(QueryState.Failed);
+    const { findByRole } = setupWithLatestQuery({ state: QueryState.Failed });
+    expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
+  });
+
+  test('disables the save dataset button when the results are not loaded', async () => {
+    const { findByRole } = setupWithLatestQuery({
+      state: QueryState.Success,
+      results: undefined,
+    });
     expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
   });
 

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -21,6 +21,7 @@ import {
   isFeatureEnabled,
   getExtensionsRegistry,
   FeatureFlag,
+  QueryState,
 } from '@superset-ui/core';
 import {
   act,
@@ -332,6 +333,36 @@ describe('SqlEditor', () => {
     const { findByText } = setup(updatedProps, store);
     fireEvent.click(await findByText('Limit'));
     expect(await findByText('10 000')).toBeInTheDocument();
+  });
+
+  const setupWithQueryState = (state: QueryState) =>
+    setup(
+      mockedProps,
+      createStore({
+        ...mockInitialState,
+        sqlLab: {
+          ...mockInitialState.sqlLab,
+          queries: {
+            [latestQuery.id]: { ...latestQuery, state },
+          },
+          databases: {
+            1991: {
+              ...mockInitialState.sqlLab.databases[1991],
+              allows_virtual_table_explore: true,
+            },
+          },
+        },
+      }),
+    );
+
+  test('enables the save dataset button when the latest query succeeded', async () => {
+    const { findByRole } = setupWithQueryState(QueryState.Success);
+    expect(await findByRole('button', { name: 'Save dataset' })).toBeEnabled();
+  });
+
+  test('disables the save dataset button when the latest query failed', async () => {
+    const { findByRole } = setupWithQueryState(QueryState.Failed);
+    expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
   });
 
   test('renders an Extension if provided', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
@@ -368,9 +368,12 @@ describe('SqlEditor', () => {
     expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
   });
 
-  test('enables the save dataset button while the query is still running', async () => {
-    const { findByRole } = setupWithLatestQuery({ state: QueryState.Running });
-    expect(await findByRole('button', { name: 'Save dataset' })).toBeEnabled();
+  test('disables the save dataset button when the results are not loaded', async () => {
+    const { findByRole } = setupWithLatestQuery({
+      state: QueryState.Success,
+      results: undefined,
+    });
+    expect(await findByRole('button', { name: 'Save dataset' })).toBeDisabled();
   });
 
   test('renders an Extension if provided', async () => {

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -866,10 +866,7 @@ const SqlEditor: FC<Props> = ({
           }
           saveQueryWarning={saveQueryWarning}
           database={database}
-          canSaveDataset={
-            latestQuery?.state === QueryState.Success &&
-            !!latestQuery?.results?.columns?.length
-          }
+          canSaveDataset={latestQuery?.state !== QueryState.Failed}
         />
         <ShareSqlLabQuery queryEditorId={queryEditor.id} />
       </>

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -40,6 +40,7 @@ import {
   getExtensionsRegistry,
   QueryResponse,
   Query,
+  QueryState,
 } from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
@@ -712,7 +713,7 @@ const SqlEditor: FC<Props> = ({
 
   const getSecondaryMenuItems = () => {
     const qe = queryEditor;
-    const successful = latestQuery?.state === 'success';
+    const successful = latestQuery?.state === QueryState.Success;
     const scheduleToolTip = successful
       ? t('Schedule the query periodically')
       : t('You must run the query successfully first');
@@ -865,7 +866,7 @@ const SqlEditor: FC<Props> = ({
           }
           saveQueryWarning={saveQueryWarning}
           database={database}
-          canSaveDataset={latestQuery?.state === 'success'}
+          canSaveDataset={latestQuery?.state === QueryState.Success}
         />
         <ShareSqlLabQuery queryEditorId={queryEditor.id} />
       </>

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -866,7 +866,10 @@ const SqlEditor: FC<Props> = ({
           }
           saveQueryWarning={saveQueryWarning}
           database={database}
-          canSaveDataset={latestQuery?.state === QueryState.Success}
+          canSaveDataset={
+            latestQuery?.state === QueryState.Success &&
+            !!latestQuery?.results?.columns?.length
+          }
         />
         <ShareSqlLabQuery queryEditorId={queryEditor.id} />
       </>

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -296,6 +296,9 @@ const SqlEditor: FC<Props> = ({
 
   const SqlFormExtension = extensionsRegistry.get('sqleditor.extension.form');
 
+  const successful = latestQuery?.state === QueryState.Success;
+  const resultColumns = latestQuery?.results?.columns || [];
+
   const startQuery = useCallback(
     (
       ctasArg = false,
@@ -713,7 +716,6 @@ const SqlEditor: FC<Props> = ({
 
   const getSecondaryMenuItems = () => {
     const qe = queryEditor;
-    const successful = latestQuery?.state === QueryState.Success;
     const scheduleToolTip = successful
       ? t('Schedule the query periodically')
       : t('You must run the query successfully first');
@@ -859,14 +861,14 @@ const SqlEditor: FC<Props> = ({
           )}
         <SaveQuery
           queryEditorId={queryEditor.id}
-          columns={latestQuery?.results?.columns || []}
+          columns={resultColumns}
           onSave={onSaveQuery}
           onUpdate={(query, remoteId) =>
             dispatch(updateSavedQuery(query, remoteId))
           }
           saveQueryWarning={saveQueryWarning}
           database={database}
-          canSaveDataset={latestQuery?.state !== QueryState.Failed}
+          canSaveDataset={successful && resultColumns.length > 0}
         />
         <ShareSqlLabQuery queryEditorId={queryEditor.id} />
       </>

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -865,6 +865,7 @@ const SqlEditor: FC<Props> = ({
           }
           saveQueryWarning={saveQueryWarning}
           database={database}
+          canSaveDataset={latestQuery?.state === 'success'}
         />
         <ShareSqlLabQuery queryEditorId={queryEditor.id} />
       </>


### PR DESCRIPTION
### SUMMARY

In SQL Lab the **Save dataset** toolbar button was gated only on `database.allows_virtual_table_explore`, never on the query result. After a failed run it stayed enabled, so you could create a virtual dataset off SQL that produced no result set (columns come from `latestQuery.results.columns`, which is stale from an earlier success or empty).

The button is now gated on `latestQuery?.state === 'success'` and rendered disabled with the tooltip *"You must run the query successfully first"* — the same pattern the Schedule query button already uses. **Save query** is unaffected; only dataset creation requires a successful run.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before:
<img width="1247" height="580" alt="image" src="https://github.com/user-attachments/assets/a2f79533-3085-4d80-b03d-900a86704b16" />

After:
<img width="1244" height="554" alt="image" src="https://github.com/user-attachments/assets/89f3bc59-1453-4f74-b499-15ed6d6f48f7" />



### TESTING INSTRUCTIONS

1. SQL Lab → examples / main → run `SELECT bad FROM definitely_not_a_table_xyz`.
2. Once the query fails, **Save dataset** is disabled and hovering it explains why.
3. Run a valid query — the button becomes enabled again.

Unit tests: `npm run test -- src/SqlLab/components/SaveDatasetActionButton src/SqlLab/components/SqlEditor`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [x] Changes UI — Save dataset button is disabled after a failed/unrun query
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No