### PR TITLE
fix(dashboard): decouple Excel export link lifetime from S3 credential expiry, and support guest/embedded sessions

### DIFF
--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadMenuItems.test.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/DownloadMenuItems.test.tsx
@@ -16,26 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React from "react";
 import {
+  act,
   render,
   screen,
   userEvent,
   waitFor,
-} from 'spec/helpers/testing-library';
-import { Menu, MenuItem } from '@superset-ui/core/components/Menu';
+} from "spec/helpers/testing-library";
+import { Menu, MenuItem } from "@superset-ui/core/components/Menu";
 import {
   FeatureFlag,
   getClientErrorObject,
   isFeatureEnabled,
   SupersetClient,
-} from '@superset-ui/core';
-import { useDownloadMenuItems } from '.';
+} from "@superset-ui/core";
+import { useDownloadMenuItems } from ".";
 
 const mockAddSuccessToast = jest.fn();
 const mockAddDangerToast = jest.fn();
 
-jest.mock('src/components/MessageToasts/withToasts', () => ({
+jest.mock("src/components/MessageToasts/withToasts", () => ({
   __esModule: true,
   default: (Component: React.ComponentType) => Component,
   useToasts: () => ({
@@ -44,8 +45,8 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
   }),
 }));
 
-jest.mock('@superset-ui/core', () => ({
-  ...jest.requireActual('@superset-ui/core'),
+jest.mock("@superset-ui/core", () => ({
+  ...jest.requireActual("@superset-ui/core"),
   isFeatureEnabled: jest.fn().mockReturnValue(false),
   getClientErrorObject: jest.fn().mockResolvedValue({}),
   SupersetClient: {
@@ -58,13 +59,13 @@ const mockSupersetClient = SupersetClient as jest.Mocked<typeof SupersetClient>;
 const mockGetClientErrorObject = getClientErrorObject as jest.Mock;
 
 const createProps = () => ({
-  pdfMenuItemTitle: 'Export to PDF',
-  imageMenuItemTitle: 'Download as Image',
-  dashboardTitle: 'Test Dashboard',
+  pdfMenuItemTitle: "Export to PDF",
+  imageMenuItemTitle: "Download as Image",
+  dashboardTitle: "Test Dashboard",
   logEvent: jest.fn(),
   dashboardId: 123,
-  title: 'Download',
-  submenuKey: 'download',
+  title: "Download",
+  submenuKey: "download",
   userCanExport: true,
 });
 
@@ -89,12 +90,16 @@ const MenuWrapperWithProps = (
 
 const originalCreateObjectURL = window.URL.createObjectURL;
 const originalRevokeObjectURL = window.URL.revokeObjectURL;
+const originalLocation = window.location;
 
 beforeEach(() => {
   jest.clearAllMocks();
   // Reset the implementation each test: clearAllMocks resets call history but
   // not mockReturnValue, so an override in one test would otherwise leak.
   (isFeatureEnabled as jest.Mock).mockReturnValue(false);
+  // @ts-ignore
+  delete window.location;
+  window.location = { href: "" } as Location;
 });
 
 // "Export Images to Excel" is gated on the webdriver screenshot feature flags.
@@ -104,56 +109,58 @@ const enableWebDriverScreenshot = () =>
 afterEach(() => {
   window.URL.createObjectURL = originalCreateObjectURL;
   window.URL.revokeObjectURL = originalRevokeObjectURL;
+  window.location = originalLocation;
+  jest.useRealTimers();
 });
 
-test('Should render all menu items', () => {
+test("Should render all menu items", () => {
   enableWebDriverScreenshot();
   render(<MenuWrapper />, {
     useRedux: true,
   });
 
   // Screenshot options
-  expect(screen.getByText('Export to PDF')).toBeInTheDocument();
-  expect(screen.getByText('Download as Image')).toBeInTheDocument();
+  expect(screen.getByText("Export to PDF")).toBeInTheDocument();
+  expect(screen.getByText("Download as Image")).toBeInTheDocument();
 
   // Export options
-  expect(screen.getByText('Export Data to Excel')).toBeInTheDocument();
-  expect(screen.getByText('Export Images to Excel')).toBeInTheDocument();
-  expect(screen.getByText('Export YAML')).toBeInTheDocument();
-  expect(screen.getByText('Export as Example')).toBeInTheDocument();
+  expect(screen.getByText("Export Data to Excel")).toBeInTheDocument();
+  expect(screen.getByText("Export Images to Excel")).toBeInTheDocument();
+  expect(screen.getByText("Export YAML")).toBeInTheDocument();
+  expect(screen.getByText("Export as Example")).toBeInTheDocument();
 });
 
-test('Export Images to Excel is hidden when the webdriver is not enabled', () => {
+test("Export Images to Excel is hidden when the webdriver is not enabled", () => {
   // Default: webdriver screenshot flags off. Image export needs the webdriver,
   // so only the data export is offered.
   render(<MenuWrapper />, { useRedux: true });
 
-  expect(screen.getByText('Export Data to Excel')).toBeInTheDocument();
-  expect(screen.queryByText('Export Images to Excel')).not.toBeInTheDocument();
+  expect(screen.getByText("Export Data to Excel")).toBeInTheDocument();
+  expect(screen.queryByText("Export Images to Excel")).not.toBeInTheDocument();
 });
 
-test('Excel export items are hidden when userCanExport is false', () => {
+test("Excel export items are hidden when userCanExport is false", () => {
   render(<MenuWrapperWithProps userCanExport={false} />, { useRedux: true });
 
-  expect(screen.queryByText('Export Data to Excel')).not.toBeInTheDocument();
-  expect(screen.queryByText('Export Images to Excel')).not.toBeInTheDocument();
+  expect(screen.queryByText("Export Data to Excel")).not.toBeInTheDocument();
+  expect(screen.queryByText("Export Images to Excel")).not.toBeInTheDocument();
   // YAML export is not gated and remains visible
-  expect(screen.getByText('Export YAML')).toBeInTheDocument();
+  expect(screen.getByText("Export YAML")).toBeInTheDocument();
 });
 
 test('Export Data to Excel posts mode "data" and shows a pending toast', async () => {
   mockSupersetClient.post.mockResolvedValue({
-    json: { job_id: 'abc' },
+    json: { job_id: "abc" },
   } as never);
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export Data to Excel'));
+  await userEvent.click(screen.getByText("Export Data to Excel"));
 
   await waitFor(() => {
     expect(mockSupersetClient.post).toHaveBeenCalledWith({
-      endpoint: '/api/v1/dashboard/123/export_xlsx/',
-      jsonPayload: { active_data_mask: {}, mode: 'data' },
+      endpoint: "/api/v1/dashboard/123/export_xlsx/",
+      jsonPayload: { active_data_mask: {}, mode: "data" },
     });
     expect(mockAddSuccessToast).toHaveBeenCalledWith(
       "Your export is being prepared. You'll receive an email when it's ready.",
@@ -164,17 +171,17 @@ test('Export Data to Excel posts mode "data" and shows a pending toast', async (
 test('Export Images to Excel posts mode "images" and shows a pending toast', async () => {
   enableWebDriverScreenshot();
   mockSupersetClient.post.mockResolvedValue({
-    json: { job_id: 'abc' },
+    json: { job_id: "abc" },
   } as never);
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export Images to Excel'));
+  await userEvent.click(screen.getByText("Export Images to Excel"));
 
   await waitFor(() => {
     expect(mockSupersetClient.post).toHaveBeenCalledWith({
-      endpoint: '/api/v1/dashboard/123/export_xlsx/',
-      jsonPayload: { active_data_mask: {}, mode: 'images' },
+      endpoint: "/api/v1/dashboard/123/export_xlsx/",
+      jsonPayload: { active_data_mask: {}, mode: "images" },
     });
     expect(mockAddSuccessToast).toHaveBeenCalledWith(
       "Your export is being prepared. You'll receive an email when it's ready.",
@@ -182,104 +189,209 @@ test('Export Images to Excel posts mode "images" and shows a pending toast', asy
   });
 });
 
-test('Export Data to Excel shows an "already in progress" toast when throttled', async () => {
-  // The throttle response is 202 with a message but no job_id.
+test("Export Data to Excel polls status and auto-downloads once ready", async () => {
+  // A guest/embedded session has no email to be notified at, so completion is
+  // discovered by polling export_xlsx/status/<job_id>/ instead -- exercised
+  // here regardless of session type, since the same polling drives the
+  // auto-download for a regular session too.
+  jest.useFakeTimers();
   mockSupersetClient.post.mockResolvedValue({
+    json: { job_id: "abc" },
+  } as never);
+  mockSupersetClient.get.mockResolvedValue({
     json: {
-      message: 'An Excel export for this dashboard is already in progress.',
+      status: "ready",
+      download_url: "/api/v1/dashboard/export_xlsx/download/abc/",
     },
   } as never);
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export Data to Excel'));
+  await userEvent.click(screen.getByText("Export Data to Excel"));
+  await waitFor(() =>
+    expect(mockAddSuccessToast).toHaveBeenCalledWith(
+      "Your export is being prepared. You'll receive an email when it's ready.",
+    ),
+  );
+
+  await act(async () => {
+    jest.advanceTimersByTime(3000);
+  });
 
   await waitFor(() => {
+    expect(mockSupersetClient.get).toHaveBeenCalledWith({
+      endpoint: "/api/v1/dashboard/export_xlsx/status/abc/",
+    });
+    expect(window.location.href).toBe(
+      "/api/v1/dashboard/export_xlsx/download/abc/",
+    );
     expect(mockAddSuccessToast).toHaveBeenCalledWith(
-      'An export for this dashboard is already in progress.',
+      "Your export is ready and downloading.",
     );
   });
 });
 
-test('Export Data to Excel shows a config error toast on 501', async () => {
-  mockSupersetClient.post.mockRejectedValue(new Error('not configured'));
+test("Export Data to Excel keeps polling while status is pending", async () => {
+  jest.useFakeTimers();
+  mockSupersetClient.post.mockResolvedValue({
+    json: { job_id: "abc" },
+  } as never);
+  mockSupersetClient.get.mockResolvedValue({
+    json: { status: "pending" },
+  } as never);
+
+  render(<MenuWrapper />, { useRedux: true });
+
+  await userEvent.click(screen.getByText("Export Data to Excel"));
+  await waitFor(() =>
+    expect(mockAddSuccessToast).toHaveBeenCalledWith(
+      "Your export is being prepared. You'll receive an email when it's ready.",
+    ),
+  );
+
+  await act(async () => {
+    jest.advanceTimersByTime(3000);
+  });
+  await waitFor(() => expect(mockSupersetClient.get).toHaveBeenCalledTimes(1));
+
+  await act(async () => {
+    jest.advanceTimersByTime(3000);
+  });
+  await waitFor(() => expect(mockSupersetClient.get).toHaveBeenCalledTimes(2));
+
+  // Still pending -- no terminal toast, and the browser never navigated.
+  expect(mockAddDangerToast).not.toHaveBeenCalled();
+  expect(window.location.href).toBe("");
+});
+
+test("Export Data to Excel shows an error toast when the export job fails", async () => {
+  jest.useFakeTimers();
+  mockSupersetClient.post.mockResolvedValue({
+    json: { job_id: "abc" },
+  } as never);
+  mockSupersetClient.get.mockResolvedValue({
+    json: { status: "error", message: "The export could not be built." },
+  } as never);
+
+  render(<MenuWrapper />, { useRedux: true });
+
+  await userEvent.click(screen.getByText("Export Data to Excel"));
+  await waitFor(() =>
+    expect(mockAddSuccessToast).toHaveBeenCalledWith(
+      "Your export is being prepared. You'll receive an email when it's ready.",
+    ),
+  );
+
+  await act(async () => {
+    jest.advanceTimersByTime(3000);
+  });
+
+  await waitFor(() => {
+    expect(mockAddDangerToast).toHaveBeenCalledWith(
+      "The export could not be built.",
+    );
+  });
+  expect(window.location.href).toBe("");
+});
+
+test('Export Data to Excel shows an "already in progress" toast when throttled', async () => {
+  // The throttle response is 202 with a message but no job_id.
+  mockSupersetClient.post.mockResolvedValue({
+    json: {
+      message: "An Excel export for this dashboard is already in progress.",
+    },
+  } as never);
+
+  render(<MenuWrapper />, { useRedux: true });
+
+  await userEvent.click(screen.getByText("Export Data to Excel"));
+
+  await waitFor(() => {
+    expect(mockAddSuccessToast).toHaveBeenCalledWith(
+      "An export for this dashboard is already in progress.",
+    );
+  });
+});
+
+test("Export Data to Excel shows a config error toast on 501", async () => {
+  mockSupersetClient.post.mockRejectedValue(new Error("not configured"));
   mockGetClientErrorObject.mockResolvedValue({ status: 501 });
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export Data to Excel'));
+  await userEvent.click(screen.getByText("Export Data to Excel"));
 
   await waitFor(() => {
     expect(mockAddDangerToast).toHaveBeenCalledWith(
-      'Excel export is not configured on this server.',
+      "Excel export is not configured on this server.",
     );
   });
 });
 
-test('Export Data to Excel shows a generic error toast on other failures', async () => {
-  mockSupersetClient.post.mockRejectedValue(new Error('boom'));
+test("Export Data to Excel shows a generic error toast on other failures", async () => {
+  mockSupersetClient.post.mockRejectedValue(new Error("boom"));
   mockGetClientErrorObject.mockResolvedValue({ status: 500 });
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export Data to Excel'));
+  await userEvent.click(screen.getByText("Export Data to Excel"));
 
   await waitFor(() => {
     expect(mockAddDangerToast).toHaveBeenCalledWith(
-      'Sorry, something went wrong. Try again later.',
+      "Sorry, something went wrong. Try again later.",
     );
   });
 });
 
-test('Export as Example calls SupersetClient.get with correct endpoint', async () => {
-  const mockBlob = new Blob(['test'], { type: 'application/zip' });
-  const mockResponse: Pick<Response, 'blob' | 'headers'> = {
+test("Export as Example calls SupersetClient.get with correct endpoint", async () => {
+  const mockBlob = new Blob(["test"], { type: "application/zip" });
+  const mockResponse: Pick<Response, "blob" | "headers"> = {
     blob: jest.fn().mockResolvedValue(mockBlob),
     headers: new Headers({
-      'Content-Disposition': 'attachment; filename="dashboard_123_example.zip"',
+      "Content-Disposition": 'attachment; filename="dashboard_123_example.zip"',
     }),
   };
   mockSupersetClient.get.mockResolvedValue(mockResponse as unknown as Response);
 
   // Mock URL.createObjectURL / revokeObjectURL since jsdom doesn't support them
-  const createObjectURL = jest.fn(() => 'blob:http://localhost/fake');
+  const createObjectURL = jest.fn(() => "blob:http://localhost/fake");
   const revokeObjectURL = jest.fn();
   window.URL.createObjectURL = createObjectURL;
   window.URL.revokeObjectURL = revokeObjectURL;
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export as Example'));
+  await userEvent.click(screen.getByText("Export as Example"));
 
   await waitFor(() => {
     expect(mockSupersetClient.get).toHaveBeenCalledWith({
-      endpoint: '/api/v1/dashboard/123/export_as_example/',
-      headers: { Accept: 'application/zip' },
-      parseMethod: 'raw',
+      endpoint: "/api/v1/dashboard/123/export_as_example/",
+      headers: { Accept: "application/zip" },
+      parseMethod: "raw",
     });
     expect(mockAddSuccessToast).toHaveBeenCalledWith(
-      'Dashboard exported as example successfully',
+      "Dashboard exported as example successfully",
     );
   });
 });
 
-test('Export as Example shows error toast on failure', async () => {
-  mockSupersetClient.get.mockRejectedValue(new Error('Network error'));
+test("Export as Example shows error toast on failure", async () => {
+  mockSupersetClient.get.mockRejectedValue(new Error("Network error"));
 
   render(<MenuWrapper />, { useRedux: true });
 
-  await userEvent.click(screen.getByText('Export as Example'));
+  await userEvent.click(screen.getByText("Export as Example"));
 
   await waitFor(() => {
     expect(mockAddDangerToast).toHaveBeenCalledWith(
-      'Sorry, something went wrong. Try again later.',
+      "Sorry, something went wrong. Try again later.",
     );
   });
 });
 
 const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
-test('Screenshot menu items should be disabled when GranularExportControls is ON and canExportImage is false', () => {
+test("Screenshot menu items should be disabled when GranularExportControls is ON and canExportImage is false", () => {
   mockIsFeatureEnabled.mockImplementation(
     (flag: string) => flag === FeatureFlag.GranularExportControls,
   );
@@ -289,18 +401,18 @@ test('Screenshot menu items should be disabled when GranularExportControls is ON
   });
 
   const pdfItem = screen
-    .getByText('Export to PDF')
+    .getByText("Export to PDF")
     .closest('[role="menuitem"]');
   const imageItem = screen
-    .getByText('Download as Image')
+    .getByText("Download as Image")
     .closest('[role="menuitem"]');
-  expect(pdfItem).toHaveAttribute('aria-disabled', 'true');
-  expect(imageItem).toHaveAttribute('aria-disabled', 'true');
+  expect(pdfItem).toHaveAttribute("aria-disabled", "true");
+  expect(imageItem).toHaveAttribute("aria-disabled", "true");
 
   mockIsFeatureEnabled.mockReset();
 });
 
-test('Screenshot menu items should be enabled when GranularExportControls is ON and canExportImage is true', () => {
+test("Screenshot menu items should be enabled when GranularExportControls is ON and canExportImage is true", () => {
   mockIsFeatureEnabled.mockImplementation(
     (flag: string) => flag === FeatureFlag.GranularExportControls,
   );
@@ -310,18 +422,18 @@ test('Screenshot menu items should be enabled when GranularExportControls is ON 
   });
 
   const pdfItem = screen
-    .getByText('Export to PDF')
+    .getByText("Export to PDF")
     .closest('[role="menuitem"]');
   const imageItem = screen
-    .getByText('Download as Image')
+    .getByText("Download as Image")
     .closest('[role="menuitem"]');
-  expect(pdfItem).not.toHaveAttribute('aria-disabled', 'true');
-  expect(imageItem).not.toHaveAttribute('aria-disabled', 'true');
+  expect(pdfItem).not.toHaveAttribute("aria-disabled", "true");
+  expect(imageItem).not.toHaveAttribute("aria-disabled", "true");
 
   mockIsFeatureEnabled.mockReset();
 });
 
-test('Screenshot menu items should not be disabled when canExportImage is not provided', () => {
+test("Screenshot menu items should not be disabled when canExportImage is not provided", () => {
   mockIsFeatureEnabled.mockReturnValue(false);
 
   render(<MenuWrapperWithProps />, {
@@ -329,18 +441,18 @@ test('Screenshot menu items should not be disabled when canExportImage is not pr
   });
 
   const pdfItem = screen
-    .getByText('Export to PDF')
+    .getByText("Export to PDF")
     .closest('[role="menuitem"]');
   const imageItem = screen
-    .getByText('Download as Image')
+    .getByText("Download as Image")
     .closest('[role="menuitem"]');
-  expect(pdfItem).not.toHaveAttribute('aria-disabled', 'true');
-  expect(imageItem).not.toHaveAttribute('aria-disabled', 'true');
+  expect(pdfItem).not.toHaveAttribute("aria-disabled", "true");
+  expect(imageItem).not.toHaveAttribute("aria-disabled", "true");
 
   mockIsFeatureEnabled.mockReset();
 });
 
-test('Disabled screenshot items should show tooltip icon when GranularExportControls is ON', () => {
+test("Disabled screenshot items should show tooltip icon when GranularExportControls is ON", () => {
   mockIsFeatureEnabled.mockImplementation(
     (flag: string) => flag === FeatureFlag.GranularExportControls,
   );
@@ -349,13 +461,13 @@ test('Disabled screenshot items should show tooltip icon when GranularExportCont
     useRedux: true,
   });
 
-  const tooltipTriggers = screen.getAllByTestId('tooltip-trigger');
+  const tooltipTriggers = screen.getAllByTestId("tooltip-trigger");
   expect(tooltipTriggers.length).toBeGreaterThanOrEqual(2);
 
   mockIsFeatureEnabled.mockReset();
 });
 
-test('Enabled screenshot items should not show tooltip icon', () => {
+test("Enabled screenshot items should not show tooltip icon", () => {
   mockIsFeatureEnabled.mockImplementation(
     (flag: string) => flag === FeatureFlag.GranularExportControls,
   );
@@ -364,7 +476,7 @@ test('Enabled screenshot items should not show tooltip icon', () => {
     useRedux: true,
   });
 
-  expect(screen.queryByTestId('tooltip-trigger')).not.toBeInTheDocument();
+  expect(screen.queryByTestId("tooltip-trigger")).not.toBeInTheDocument();
 
   mockIsFeatureEnabled.mockReset();
 });

--- a/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/index.tsx
+++ b/superset-frontend/src/dashboard/components/menu/DownloadMenuItems/index.tsx
@@ -16,32 +16,45 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { SyntheticEvent } from 'react';
-import { useSelector } from 'react-redux';
-import { logging } from '@apache-superset/core/utils';
-import { t } from '@apache-superset/core/translation';
+import { SyntheticEvent } from "react";
+import { useSelector } from "react-redux";
+import { logging } from "@apache-superset/core/utils";
+import { t } from "@apache-superset/core/translation";
 import {
   FeatureFlag,
   getClientErrorObject,
   isFeatureEnabled,
   SupersetClient,
-} from '@superset-ui/core';
-import { MenuItem } from '@superset-ui/core/components/Menu';
-import { parse as parseContentDisposition } from 'content-disposition';
-import { useDownloadScreenshot } from 'src/dashboard/hooks/useDownloadScreenshot';
-import { NATIVE_FILTER_PREFIX } from 'src/dashboard/components/nativeFilters/FiltersConfigModal/utils';
-import { MenuKeys, RootState } from 'src/dashboard/types';
-import downloadAsPdf from 'src/utils/downloadAsPdf';
-import downloadAsImage from 'src/utils/downloadAsImage';
-import handleResourceExport from 'src/utils/export';
+} from "@superset-ui/core";
+import { MenuItem } from "@superset-ui/core/components/Menu";
+import { parse as parseContentDisposition } from "content-disposition";
+import { useDownloadScreenshot } from "src/dashboard/hooks/useDownloadScreenshot";
+import { NATIVE_FILTER_PREFIX } from "src/dashboard/components/nativeFilters/FiltersConfigModal/utils";
+import { MenuKeys, RootState } from "src/dashboard/types";
+import downloadAsPdf from "src/utils/downloadAsPdf";
+import downloadAsImage from "src/utils/downloadAsImage";
+import handleResourceExport from "src/utils/export";
 import {
   LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_PDF,
   LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE,
-} from 'src/logger/LogUtils';
-import { useToasts } from 'src/components/MessageToasts/withToasts';
+} from "src/logger/LogUtils";
+import { useToasts } from "src/components/MessageToasts/withToasts";
 
-import { MenuItemTooltip } from 'src/components/Chart/DisabledMenuItemTooltip';
-import { DownloadScreenshotFormat } from './types';
+import { MenuItemTooltip } from "src/components/Chart/DisabledMenuItemTooltip";
+import { DownloadScreenshotFormat } from "./types";
+
+// A guest/embedded session has no email address to be notified at, so rather
+// than wait on that notification the frontend polls for completion instead;
+// the same polling also drives the auto-download for a regular session,
+// which arrives before its export email in practice.
+const EXPORT_STATUS_POLL_INTERVAL_MS = 3000;
+const EXPORT_STATUS_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface ExportStatusResponse {
+  status?: "pending" | "ready" | "error";
+  download_url?: string;
+  message?: string;
+}
 
 export interface UseDownloadMenuItemsProps {
   pdfMenuItemTitle: string;
@@ -72,7 +85,7 @@ export const useDownloadMenuItems = (
 
   const { addDangerToast, addSuccessToast } = useToasts();
   const dataMask = useSelector((state: RootState) => state.dataMask);
-  const SCREENSHOT_NODE_SELECTOR = '.dashboard';
+  const SCREENSHOT_NODE_SELECTOR = ".dashboard";
 
   const buildActiveDataMask = (): Record<string, { extraFormData: object }> =>
     Object.entries(dataMask || {}).reduce<
@@ -95,7 +108,7 @@ export const useDownloadMenuItems = (
       downloadAsPdf(SCREENSHOT_NODE_SELECTOR, dashboardTitle, true)(e);
     } catch (error) {
       logging.error(error);
-      addDangerToast(t('Sorry, something went wrong. Try again later.'));
+      addDangerToast(t("Sorry, something went wrong. Try again later."));
     }
     logEvent?.(LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_PDF);
   };
@@ -105,18 +118,18 @@ export const useDownloadMenuItems = (
       downloadAsImage(SCREENSHOT_NODE_SELECTOR, dashboardTitle, true)(e);
     } catch (error) {
       logging.error(error);
-      addDangerToast(t('Sorry, something went wrong. Try again later.'));
+      addDangerToast(t("Sorry, something went wrong. Try again later."));
     }
     logEvent?.(LOG_ACTIONS_DASHBOARD_DOWNLOAD_AS_IMAGE);
   };
 
   const onExportZip = async () => {
     try {
-      await handleResourceExport('dashboard', [dashboardId], () => {});
-      addSuccessToast(t('Dashboard exported successfully'));
+      await handleResourceExport("dashboard", [dashboardId], () => {});
+      addSuccessToast(t("Dashboard exported successfully"));
     } catch (error) {
       logging.error(error);
-      addDangerToast(t('Sorry, something went wrong. Try again later.'));
+      addDangerToast(t("Sorry, something went wrong. Try again later."));
     }
   };
 
@@ -125,13 +138,13 @@ export const useDownloadMenuItems = (
       const response = await SupersetClient.get({
         endpoint: `/api/v1/dashboard/${dashboardId}/export_as_example/`,
         headers: {
-          Accept: 'application/zip',
+          Accept: "application/zip",
         },
-        parseMethod: 'raw',
+        parseMethod: "raw",
       });
 
       // Parse filename from Content-Disposition header
-      const disposition = response.headers.get('Content-Disposition');
+      const disposition = response.headers.get("Content-Disposition");
       let fileName = `dashboard_${dashboardId}_example.zip`;
 
       if (disposition) {
@@ -141,7 +154,7 @@ export const useDownloadMenuItems = (
             fileName = parsed.parameters.filename;
           }
         } catch (error) {
-          logging.warn('Failed to parse Content-Disposition header:', error);
+          logging.warn("Failed to parse Content-Disposition header:", error);
         }
       }
 
@@ -149,10 +162,10 @@ export const useDownloadMenuItems = (
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       try {
-        const a = document.createElement('a');
+        const a = document.createElement("a");
         a.href = url;
         a.download = fileName;
-        a.style.display = 'none';
+        a.style.display = "none";
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -160,14 +173,63 @@ export const useDownloadMenuItems = (
         window.URL.revokeObjectURL(url);
       }
 
-      addSuccessToast(t('Dashboard exported as example successfully'));
+      addSuccessToast(t("Dashboard exported as example successfully"));
     } catch (error) {
       logging.error(error);
-      addDangerToast(t('Sorry, something went wrong. Try again later.'));
+      addDangerToast(t("Sorry, something went wrong. Try again later."));
     }
   };
 
-  const onExportXlsx = async (mode: 'data' | 'images') => {
+  const pollExportStatus = (jobId: string, startedAt: number) => {
+    SupersetClient.get({
+      endpoint: `/api/v1/dashboard/export_xlsx/status/${jobId}/`,
+    })
+      .then(({ json }) => {
+        const {
+          status,
+          download_url: downloadUrl,
+          message,
+        } = json as ExportStatusResponse;
+        if (status === "ready") {
+          if (downloadUrl) {
+            window.location.href = downloadUrl;
+          }
+          addSuccessToast(t("Your export is ready and downloading."));
+          return;
+        }
+        if (status === "error") {
+          addDangerToast(
+            message || t("Sorry, something went wrong. Try again later."),
+          );
+          return;
+        }
+        if (Date.now() - startedAt > EXPORT_STATUS_POLL_TIMEOUT_MS) {
+          addDangerToast(
+            t("Your export is taking longer than expected. Try again later."),
+          );
+          return;
+        }
+        setTimeout(
+          () => pollExportStatus(jobId, startedAt),
+          EXPORT_STATUS_POLL_INTERVAL_MS,
+        );
+      })
+      .catch((error) => {
+        // A transient polling failure shouldn't give up the wait -- the export
+        // itself may still succeed -- so keep polling until the timeout.
+        logging.error(error);
+        if (Date.now() - startedAt > EXPORT_STATUS_POLL_TIMEOUT_MS) {
+          addDangerToast(t("Sorry, something went wrong. Try again later."));
+          return;
+        }
+        setTimeout(
+          () => pollExportStatus(jobId, startedAt),
+          EXPORT_STATUS_POLL_INTERVAL_MS,
+        );
+      });
+  };
+
+  const onExportXlsx = async (mode: "data" | "images") => {
     try {
       const { json } = await SupersetClient.post({
         endpoint: `/api/v1/dashboard/${dashboardId}/export_xlsx/`,
@@ -175,15 +237,20 @@ export const useDownloadMenuItems = (
       });
       // The throttle response (an export is already running) returns 202 with a
       // message but no job_id; only a freshly enqueued job carries a job_id.
-      if ((json as { job_id?: string })?.job_id) {
+      const jobId = (json as { job_id?: string })?.job_id;
+      if (jobId) {
         addSuccessToast(
           t(
             "Your export is being prepared. You'll receive an email when it's ready.",
           ),
         );
+        setTimeout(
+          () => pollExportStatus(jobId, Date.now()),
+          EXPORT_STATUS_POLL_INTERVAL_MS,
+        );
       } else {
         addSuccessToast(
-          t('An export for this dashboard is already in progress.'),
+          t("An export for this dashboard is already in progress."),
         );
       }
     } catch (error) {
@@ -193,9 +260,9 @@ export const useDownloadMenuItems = (
         status?: number;
       };
       if (status === 501) {
-        addDangerToast(t('Excel export is not configured on this server.'));
+        addDangerToast(t("Excel export is not configured on this server."));
       } else {
-        addDangerToast(t('Sorry, something went wrong. Try again later.'));
+        addDangerToast(t("Sorry, something went wrong. Try again later."));
       }
     }
   };
@@ -231,13 +298,13 @@ export const useDownloadMenuItems = (
       ]
     : [
         {
-          key: 'download-pdf',
+          key: "download-pdf",
           label: imageExportLabel(pdfMenuItemTitle),
           disabled: imageDisabled,
           onClick: (e: any) => onDownloadPdf(e.domEvent),
         },
         {
-          key: 'download-image',
+          key: "download-image",
           label: imageExportLabel(imageMenuItemTitle),
           disabled: imageDisabled,
           onClick: (e: any) => onDownloadImage(e.domEvent),
@@ -248,9 +315,9 @@ export const useDownloadMenuItems = (
     ...(userCanExport
       ? [
           {
-            key: 'export-xlsx',
-            label: t('Export Data to Excel'),
-            onClick: () => onExportXlsx('data'),
+            key: "export-xlsx",
+            label: t("Export Data to Excel"),
+            onClick: () => onExportXlsx("data"),
           },
           // Image export renders charts through the headless webdriver, so only
           // offer it where that infrastructure is available (same signal as the
@@ -259,24 +326,24 @@ export const useDownloadMenuItems = (
           ...(isWebDriverScreenshotEnabled
             ? [
                 {
-                  key: 'export-xlsx-images',
-                  label: t('Export Images to Excel'),
-                  onClick: () => onExportXlsx('images'),
+                  key: "export-xlsx-images",
+                  label: t("Export Images to Excel"),
+                  onClick: () => onExportXlsx("images"),
                 },
               ]
             : []),
         ]
       : []),
     {
-      key: 'export-yaml',
-      label: t('Export YAML'),
+      key: "export-yaml",
+      label: t("Export YAML"),
       onClick: onExportZip,
     },
     ...(userCanExport
       ? [
           {
-            key: 'export-as-example',
-            label: t('Export as Example'),
+            key: "export-as-example",
+            label: t("Export as Example"),
             onClick: onExportAsExample,
           },
         ]
@@ -285,13 +352,13 @@ export const useDownloadMenuItems = (
 
   const children: MenuItem[] = [
     ...screenshotMenuItems,
-    { type: 'divider', key: 'export-divider' },
+    { type: "divider", key: "export-divider" },
     ...exportMenuItems,
   ];
 
   return {
     key: MenuKeys.Download,
-    type: 'submenu',
+    type: "submenu",
     label: title,
     disabled,
     children,

--- a/superset/config.py
+++ b/superset/config.py
@@ -368,6 +368,7 @@ WTF_CSRF_ENABLED = True
 WTF_CSRF_EXEMPT_LIST = [
     "superset.charts.data.api.data",
     "superset.dashboards.api.cache_dashboard_screenshot",
+    "superset.dashboards.api.export_xlsx",
     "superset.views.core.log",
     "superset.views.datasource.views.samples",
     "flask_appbuilder.security.views.acs",

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -91,6 +91,14 @@ from superset.commands.importers.v1.utils import get_contents_from_bundle
 from superset.commands.purge import PurgeArchivedCommand, SoftDeleteBinding
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.dashboard import DashboardDAO, EmbeddedDashboardDAO
+from superset.dashboards.excel_export.download_link import (
+    build_download_url,
+    get_export_status,
+    PRESIGNED_URL_TTL_SECONDS,
+    resolve_download_link,
+    STATUS_ERROR,
+    STATUS_READY,
+)
 from superset.dashboards.filters import (
     DashboardAccessFilter,
     DashboardCertifiedFilter,
@@ -155,7 +163,7 @@ from superset.tasks.thumbnails import (
     cache_dashboard_thumbnail,
 )
 from superset.tasks.utils import get_current_user
-from superset.utils import json
+from superset.utils import json, s3
 from superset.utils.core import parse_boolean_string, sanitize_cookie_token
 from superset.utils.file import get_filename
 from superset.utils.pdf import build_pdf_from_screenshots
@@ -324,6 +332,8 @@ class DashboardRestApi(
         "put_colors",
         "export_as_example",
         "export_xlsx",
+        "export_xlsx_status",
+        "download_xlsx",
         "list_versions",
         "get_version",
         "activity",
@@ -348,6 +358,9 @@ class DashboardRestApi(
         # menu item on it) instead of the ``can_export_xlsx`` FAB would otherwise
         # derive from the method name.
         "export_xlsx": "export",
+        # Polling status of an export you already requested is the same
+        # capability as requesting it, not a distinct permission.
+        "export_xlsx_status": "export",
         "purge": "write",
     }
 
@@ -1723,8 +1736,11 @@ class DashboardRestApi(
           summary: Export dashboard chart data to Excel
           description: >-
             Enqueues an async task that writes each chart's data to its own
-            worksheet, uploads the .xlsx to S3, and emails the requesting user a
-            pre-signed download link. Returns immediately with a job id.
+            worksheet, uploads the .xlsx to S3, and records a download link.
+            The requesting user is emailed the link when they have an address
+            on file; either way the returned job id can be polled at
+            export_xlsx/status/<job_id>/ for status and, once ready, the
+            download link.
           parameters:
           - in: path
             schema:
@@ -1787,12 +1803,9 @@ class DashboardRestApi(
         except SupersetSecurityException:
             return self.response_403()
 
-        # Email delivery is the only result channel, so an account with an email
-        # address is required; embedded guest users are excluded in this version.
-        if isinstance(g.user, GuestUser) or not getattr(g.user, "email", None):
-            return self.response_400(
-                message="Excel export requires an account with an email address."
-            )
+        # A requester with no email on file (e.g. an embedded/guest session)
+        # still gets a usable export: they poll export_xlsx_status/<job_id>/
+        # for the download link instead of relying on an email notification.
         if not dashboard.slices:
             return self.response_400(message="Dashboard has no charts to export.")
 
@@ -1833,6 +1846,93 @@ class DashboardRestApi(
             ReleaseDistributedLock(EXPORT_LOCK_NAMESPACE, lock_params).run()
             raise
         return self.response(202, job_id=job_id)
+
+    @expose("/export_xlsx/status/<uuid:job_id>/", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    def export_xlsx_status(self, job_id: uuid.UUID) -> WerkzeugResponse:
+        """Poll the status of an in-flight or completed Excel export.
+        ---
+        get:
+          summary: Poll the status of a dashboard Excel export job
+          description: >-
+            For a session with no email address to be notified at (e.g. an
+            embedded/guest session), the frontend polls this endpoint with the
+            job_id from the export_xlsx response instead of waiting for an
+            email. Behind the same @protect() as the export request itself,
+            unlike the login-free download_xlsx redirect (which also has to
+            work when clicked from a plain email link, possibly with no
+            active session at all).
+          parameters:
+          - in: path
+            schema:
+              type: string
+              format: uuid
+            name: job_id
+            description: The job_id from the export_xlsx response
+          responses:
+            200:
+              description: >-
+                Job status: {"status": "pending"} while still running,
+                {"status": "ready", "download_url": "..."} once the file is
+                available, or {"status": "error", "message": "..."} if the
+                export failed.
+            401:
+              $ref: '#/components/responses/401'
+        """
+        payload = get_export_status(job_id)
+        if payload is None:
+            return self.response(200, status="pending")
+        if payload.get("status") == STATUS_READY:
+            return self.response(
+                200, status=STATUS_READY, download_url=build_download_url(job_id)
+            )
+        if payload.get("status") == STATUS_ERROR:
+            return self.response(
+                200, status=STATUS_ERROR, message=payload.get("message")
+            )
+        return self.response(200, status="pending")
+
+    @expose("/export_xlsx/download/<uuid:job_id>/", methods=("GET",))
+    @safe
+    @statsd_metrics
+    def download_xlsx(self, job_id: uuid.UUID) -> WerkzeugResponse:
+        """Redirect to a freshly pre-signed S3 URL for a completed Excel export.
+        ---
+        get:
+          summary: Download a completed dashboard Excel export
+          description: >-
+            Intentionally requires no login, matching a raw pre-signed S3
+            URL's own access model: the unguessable job_id, emailed only to
+            the original requester (or handed to their own session via
+            export_xlsx_status), is the credential. The dashboard access
+            check already ran once, when the export was requested -- see
+            security_manager.raise_for_access in export_xlsx. A fresh
+            pre-signed URL is generated at click time (instead of the one
+            baked into the export at completion time) so the link's promised
+            lifetime is independent of how long the signing credentials
+            themselves remain valid.
+          parameters:
+          - in: path
+            schema:
+              type: string
+              format: uuid
+            name: job_id
+            description: The job_id from the export_xlsx response
+          responses:
+            302:
+              description: Redirect to a pre-signed S3 download URL
+            410:
+              description: The link is unknown, expired, or the export failed
+        """
+        resolved = resolve_download_link(job_id)
+        if resolved is None:
+            return self.response(410, message="This download link has expired.")
+        bucket, key = resolved
+        return redirect(
+            s3.generate_presigned_url(bucket, key, PRESIGNED_URL_TTL_SECONDS)
+        )
 
     @expose("/<pk>/cache_dashboard_screenshot/", methods=("POST",))
     @validate_feature_flags(["THUMBNAILS", "ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS"])

--- a/superset/dashboards/excel_export/download_link.py
+++ b/superset/dashboards/excel_export/download_link.py
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Status tracking and long-lived download links for dashboard Excel exports.
+
+A raw S3 pre-signed URL is only valid for as long as *both* its own
+``ExpiresIn`` window and the credentials that signed it remain valid.
+Deployments whose S3 client authenticates via short-lived, auto-refreshed
+credentials (e.g. an EKS IRSA role assumed through
+``AssumeRoleWithWebIdentity``, which AWS caps at 12 hours and many clusters
+default to far less) can silently invalidate a pre-signed URL long before the
+``EXCEL_EXPORT_LINK_TTL_SECONDS`` window promised in the export email elapses,
+since the *credentials'* session -- not just the URL's own ``ExpiresIn`` --
+bounds how long it actually works.
+
+To keep that promise regardless of credential lifetime, the email links to a
+small Superset redirect endpoint instead of a raw S3 URL. The link's own
+lifetime is enforced by this module via the ``key_value`` store's
+``expires_on`` (independent of any credential session), and the actual
+pre-signed URL is generated fresh -- with then-current credentials -- at click
+time, valid only long enough to complete a single download.
+
+The redirect endpoint (``download_xlsx``) intentionally requires no login: a
+pre-signed S3 URL never did either, and the access-control decision for the
+underlying dashboard was already enforced once, when the export was
+originally requested (see ``security_manager.raise_for_access`` in
+``superset.dashboards.api.export_xlsx``). The unguessable key emailed only to
+that requester's own address is the same "possession of the link is the
+credential" model the raw pre-signed URL had; this module just re-signs it
+closer to when it is actually used.
+
+Every entry is keyed by ``job_id`` -- the same id the ``export_xlsx`` POST
+response hands back -- rather than a separately-generated identifier, so a
+caller that only has the job id (e.g. a polling frontend for a session with
+no email on file, such as an embedded/guest dashboard) can resolve both
+status and, once ready, a download link from that one id.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from superset.daos.key_value import KeyValueDAO
+from superset.key_value.types import JsonKeyValueCodec, KeyValueResource
+from superset.utils.urls import headless_url
+
+RESOURCE = KeyValueResource.EXCEL_EXPORT_DOWNLOAD
+CODEC = JsonKeyValueCodec()
+
+# The fresh pre-signed URL generated at click time only needs to outlive the
+# redirect and the browser/S3 handshake that follows it, not the link's own
+# multi-hour lifetime.
+PRESIGNED_URL_TTL_SECONDS = 300
+
+DOWNLOAD_PATH = "/api/v1/dashboard/export_xlsx/download/{job_id}/"
+
+STATUS_READY = "ready"
+STATUS_ERROR = "error"
+
+
+def _sweep_and_upsert(
+    job_id: UUID, value: dict[str, Any], expires_at: datetime
+) -> None:
+    # Lazily sweep expired entries each time one is written; there is no
+    # dedicated cleanup job, so this resource keeps itself tidy on write.
+    # upsert (not create) so a retried/duplicate write for the same job_id
+    # overwrites cleanly instead of colliding on the primary key.
+    KeyValueDAO.delete_expired_entries(RESOURCE)
+    KeyValueDAO.upsert_entry(
+        resource=RESOURCE,
+        value=value,
+        codec=CODEC,
+        key=job_id,
+        expires_on=expires_at,
+    )
+
+
+def build_download_url(job_id: UUID) -> str:
+    """The browser-facing URL that redirects to a freshly pre-signed S3 URL
+    for ``job_id``, once its export is ready."""
+    return headless_url(DOWNLOAD_PATH.format(job_id=job_id), user_friendly=True)
+
+
+def create_download_link(
+    job_id: UUID, bucket: str, key: str, expires_at: datetime
+) -> str:
+    """Record that ``job_id``'s export succeeded and is downloadable from
+    ``key`` in ``bucket`` until ``expires_at``, and return the download URL
+    (used in the success email).
+
+    ``expires_at`` should be a naive datetime in the same timezone convention
+    ``KeyValueEntry.is_expired()`` compares against (naive ``datetime.now()``).
+    """
+    _sweep_and_upsert(
+        job_id,
+        {"status": STATUS_READY, "bucket": bucket, "key": key},
+        expires_at,
+    )
+    return build_download_url(job_id)
+
+
+def mark_export_failed(job_id: UUID, message: str, expires_at: datetime) -> None:
+    """Record that ``job_id``'s export failed, so a polling client can
+    distinguish "failed" from "still running" instead of retrying a missing
+    key forever. ``message`` is shown to whoever is polling, so keep it
+    generic rather than an internal exception string.
+    """
+    _sweep_and_upsert(job_id, {"status": STATUS_ERROR, "message": message}, expires_at)
+
+
+def get_export_status(job_id: UUID) -> dict[str, Any] | None:
+    """The stored status payload for ``job_id``, or ``None`` if it is unknown
+    (still running, or never existed) or has expired."""
+    return KeyValueDAO.get_value(RESOURCE, job_id, CODEC)
+
+
+def resolve_download_link(job_id: UUID) -> tuple[str, str] | None:
+    """The ``(bucket, object_key)`` for a *ready* download, or ``None`` if it
+    is missing, expired, still running, or errored."""
+    payload = get_export_status(job_id)
+    if payload is None or payload.get("status") != STATUS_READY:
+        return None
+    return payload["bucket"], payload["key"]

--- a/superset/key_value/types.py
+++ b/superset/key_value/types.py
@@ -42,6 +42,7 @@ class KeyValueFilter(TypedDict, total=False):
 class KeyValueResource(StrEnum):
     APP = "app"
     DASHBOARD_PERMALINK = "dashboard_permalink"
+    EXCEL_EXPORT_DOWNLOAD = "excel_export_download"
     EXPLORE_PERMALINK = "explore_permalink"
     METASTORE_CACHE = "superset_metastore_cache"
     LOCK = "lock"

--- a/superset/tasks/export_dashboard_excel.py
+++ b/superset/tasks/export_dashboard_excel.py
@@ -16,8 +16,10 @@
 # under the License.
 """
 Celery task that exports every chart on a dashboard to a single multi-sheet
-``.xlsx`` file, uploads it to S3, and emails the requesting user a pre-signed
-download link.
+``.xlsx`` file, uploads it to S3, and records a download link (see
+``superset.dashboards.excel_export.download_link``) that emails to the
+requesting user when they have an address on file, and/or is resolved by
+polling ``GET .../export_xlsx/status/<job_id>/`` when they don't.
 
 In ``"data"`` mode the task re-runs each chart's saved query context under the
 requesting user, applies the live dashboard filter state, and streams the results
@@ -33,6 +35,7 @@ import copy
 import logging
 import os
 import tempfile
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -53,6 +56,10 @@ from superset.common.form_data_query_context import (
     is_raw_query_mode,
 )
 from superset.dashboards.excel_export import email
+from superset.dashboards.excel_export.download_link import (
+    create_download_link,
+    mark_export_failed,
+)
 from superset.dashboards.excel_export.layout import get_charts_in_layout_order
 from superset.dashboards.excel_export.screenshot import render_chart_image
 from superset.extensions import celery_app
@@ -400,19 +407,38 @@ def _build_workbook(
     return errored
 
 
-def _send_failure_email(
-    user: Any, dashboard_title: str, requested_at: datetime
+_GENERIC_FAILURE_MESSAGE = (
+    "An error occurred while generating the file. Please try again, or "
+    "contact your administrator if the problem persists."
+)
+
+
+def _handle_export_failure(
+    user: Any, dashboard_title: str, requested_at: datetime, job_id: str, ttl: int
 ) -> None:
-    if not (user and getattr(user, "email", None)):
-        return
+    """Notify the requester their export failed: email them if they have an
+    address on file, and record a pollable failure status either way (a
+    session with no email, e.g. an embedded/guest dashboard, has no other way
+    to learn the export failed than polling ``export_xlsx/status/<job_id>/``).
+    """
+    if user and getattr(user, "email", None):
+        try:
+            email.send_export_email(
+                user.email,
+                email.build_subject(dashboard_title, success=False),
+                email.build_failure_email(dashboard_title, requested_at),
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Failed to send export failure email")
     try:
-        email.send_export_email(
-            user.email,
-            email.build_subject(dashboard_title, success=False),
-            email.build_failure_email(dashboard_title, requested_at),
+        expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+        mark_export_failed(
+            uuid.UUID(job_id),
+            _GENERIC_FAILURE_MESSAGE,
+            expires_at.replace(tzinfo=None),
         )
     except Exception:  # pylint: disable=broad-except
-        logger.exception("Failed to send export failure email")
+        logger.exception("Failed to record export failure status for %s", job_id)
 
 
 @celery_app.task(
@@ -431,7 +457,7 @@ def export_dashboard_excel(
     mode: str = EXPORT_MODE_DATA,
 ) -> None:
     """
-    Export a dashboard's charts to an ``.xlsx`` and email a download link.
+    Export a dashboard's charts to an ``.xlsx`` and record a download link.
 
     :param dashboard_id: The dashboard to export
     :param user_id: The requesting user (the task runs with their permissions)
@@ -447,6 +473,7 @@ def export_dashboard_excel(
     user = security_manager.get_user_by_id(user_id)
     dashboard_title = ""
     tmp_path: str | None = None
+    ttl = current_app.config["EXCEL_EXPORT_LINK_TTL_SECONDS"]
 
     try:
         with override_user(user, force=False):
@@ -471,11 +498,14 @@ def export_dashboard_excel(
                 f"{current_app.config['EXCEL_EXPORT_S3_KEY_PREFIX']}"
                 f"{dashboard_id}/{job_id}.xlsx"
             )
-            ttl = current_app.config["EXCEL_EXPORT_LINK_TTL_SECONDS"]
 
             s3.upload_file_to_s3(tmp_path, bucket, key)
-            download_url = s3.generate_presigned_url(bucket, key, ttl)
             expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=ttl)
+            # KeyValueEntry.expires_on comparisons use naive datetime.now(), so
+            # the stored expiry must be naive UTC too, not tz-aware.
+            download_url = create_download_link(
+                uuid.UUID(job_id), bucket, key, expires_at.replace(tzinfo=None)
+            )
 
             if user and getattr(user, "email", None):
                 try:
@@ -497,11 +527,11 @@ def export_dashboard_excel(
                     logger.exception("Failed to send export success email")
     except SoftTimeLimitExceeded:
         logger.warning("Dashboard excel export %s timed out", job_id)
-        _send_failure_email(user, dashboard_title, requested_at)
+        _handle_export_failure(user, dashboard_title, requested_at, job_id, ttl)
         raise
     except Exception:
         logger.exception("Dashboard excel export %s failed", job_id)
-        _send_failure_email(user, dashboard_title, requested_at)
+        _handle_export_failure(user, dashboard_title, requested_at, job_id, ttl)
         raise
     finally:
         try:

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -17,6 +17,8 @@
 # isort:skip_file
 """Unit tests for Superset"""
 
+import uuid
+from datetime import datetime, timedelta
 from io import BytesIO
 from time import sleep
 from unittest.mock import ANY, patch
@@ -3522,6 +3524,145 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
             finally:
                 db.session.delete(dashboard)
                 db.session.commit()
+
+    @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
+    @with_config({"EXCEL_EXPORT_S3_BUCKET": "exports"})
+    @patch("superset.dashboards.api.AcquireDistributedLock")
+    @patch("superset.dashboards.api.export_dashboard_excel")
+    def test_export_xlsx_admitted_without_email(self, mock_task, mock_acquire):
+        """Dashboard API: a session with no email address (what an
+        embedded/guest session looks like from this check's perspective) is
+        admitted (202), not rejected -- the requesting user no longer needs an
+        email on file, since the frontend can poll
+        export_xlsx_status/<job_id>/ for the download link instead of relying
+        on a notification email."""
+        admin_user = security_manager.find_user(username=ADMIN_USERNAME)
+        slice_ = db.session.query(Slice).first()
+        # Clone Admin (so the login password is valid), then blank the email
+        # to match what an embedded/guest session looks like to this check.
+        with self.temporary_user(admin_user, login=True) as user:
+            user.email = ""
+            db.session.commit()
+            dashboard = self.insert_dashboard(
+                "xlsx-no-email", None, [user.id], slices=[slice_], published=True
+            )
+            try:
+                rv = self.client.post(
+                    f"api/v1/dashboard/{dashboard.id}/export_xlsx/",
+                    json={"active_data_mask": {}},
+                )
+                assert rv.status_code == 202
+                mock_task.apply_async.assert_called_once()
+            finally:
+                db.session.delete(dashboard)
+                db.session.commit()
+
+    def test_download_xlsx_redirects_without_login(self):
+        """Dashboard API: download_xlsx requires no login, matching a raw
+        pre-signed S3 URL's own access model -- the dashboard access check
+        already ran once, when the export was requested."""
+        from superset.dashboards.excel_export.download_link import (
+            create_download_link,
+        )
+
+        job_id = uuid.uuid4()
+        create_download_link(
+            job_id,
+            "exports",
+            "dashboard-exports/1/job.xlsx",
+            datetime.now() + timedelta(hours=1),
+        )
+        db.session.commit()
+        with patch("superset.dashboards.api.s3.generate_presigned_url") as mock_sign:
+            mock_sign.return_value = "https://bucket.s3.amazonaws.com/signed"
+            rv = self.client.get(f"/api/v1/dashboard/export_xlsx/download/{job_id}/")
+        assert rv.status_code == 302
+        assert rv.headers["Location"] == "https://bucket.s3.amazonaws.com/signed"
+        mock_sign.assert_called_once_with(
+            "exports", "dashboard-exports/1/job.xlsx", ANY
+        )
+
+    def test_download_xlsx_410_for_unknown_key(self):
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/download/{uuid.uuid4()}/")
+        assert rv.status_code == 410
+
+    def test_download_xlsx_410_for_expired_key(self):
+        from superset.dashboards.excel_export.download_link import (
+            create_download_link,
+        )
+
+        job_id = uuid.uuid4()
+        create_download_link(
+            job_id,
+            "exports",
+            "dashboard-exports/1/job.xlsx",
+            datetime.now() - timedelta(hours=1),
+        )
+        db.session.commit()
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/download/{job_id}/")
+        assert rv.status_code == 410
+
+    def test_download_xlsx_410_for_errored_job(self):
+        from superset.dashboards.excel_export.download_link import (
+            mark_export_failed,
+        )
+
+        job_id = uuid.uuid4()
+        mark_export_failed(job_id, "boom", datetime.now() + timedelta(hours=1))
+        db.session.commit()
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/download/{job_id}/")
+        assert rv.status_code == 410
+
+    def test_export_xlsx_status_pending_for_unknown_job(self):
+        """Dashboard API: polling an unknown/still-running job_id reports
+        pending, not 404 -- the frontend can't distinguish "not started yet"
+        from "still running" from the API's perspective."""
+        self.login(ADMIN_USERNAME)
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/status/{uuid.uuid4()}/")
+        assert rv.status_code == 200
+        assert rv.json == {"status": "pending"}
+
+    @patch("superset.dashboards.api.s3.generate_presigned_url")
+    def test_export_xlsx_status_ready_includes_download_url(self, mock_presign):
+        """Dashboard API: once ready, status includes a download_url built
+        from the same job_id, not a separately-tracked identifier."""
+        from superset.dashboards.excel_export.download_link import (
+            create_download_link,
+        )
+
+        mock_presign.return_value = "https://bucket.s3.amazonaws.com/signed"
+        job_id = uuid.uuid4()
+        create_download_link(
+            job_id,
+            "exports",
+            "dashboard-exports/1/job.xlsx",
+            datetime.now() + timedelta(hours=1),
+        )
+        db.session.commit()
+        self.login(ADMIN_USERNAME)
+
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/status/{job_id}/")
+
+        assert rv.status_code == 200
+        assert rv.json["status"] == "ready"
+        assert str(job_id) in rv.json["download_url"]
+
+    def test_export_xlsx_status_error_includes_message(self):
+        """Dashboard API: a failed job's status is distinguishable from
+        pending, with a message a polling guest session can show."""
+        from superset.dashboards.excel_export.download_link import (
+            mark_export_failed,
+        )
+
+        job_id = uuid.uuid4()
+        mark_export_failed(job_id, "boom", datetime.now() + timedelta(hours=1))
+        db.session.commit()
+        self.login(ADMIN_USERNAME)
+
+        rv = self.client.get(f"/api/v1/dashboard/export_xlsx/status/{job_id}/")
+
+        assert rv.status_code == 200
+        assert rv.json == {"status": "error", "message": "boom"}
 
     @pytest.mark.usefixtures("load_world_bank_dashboard_with_slices")
     @with_config({"EXCEL_EXPORT_S3_BUCKET": "exports"})

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1750,6 +1750,14 @@ class TestRolePermission(SupersetTestCase):
             # user/tenant data) as content-addressed scripts; must load for
             # anonymous principals (login page, embedded dashboards).
             ["Superset", "language_pack_script"],
+            # Intentionally unauthenticated, matching a raw pre-signed S3 URL's
+            # own access model: the unguessable job_id in the path is the
+            # credential, and the underlying dashboard access check already
+            # ran once, when the export was requested (see
+            # security_manager.raise_for_access in export_xlsx). Must be
+            # reachable with no session at all, since it is clicked from a
+            # plain email link.
+            ["DashboardRestApi", "download_xlsx"],
         ]
         unsecured_views = []
         for view_class in appbuilder.baseviews:

--- a/tests/unit_tests/tasks/test_export_dashboard_excel.py
+++ b/tests/unit_tests/tasks/test_export_dashboard_excel.py
@@ -31,6 +31,14 @@ from superset.utils import json
 
 MODULE = "superset.tasks.export_dashboard_excel"
 
+# export_dashboard_excel always receives a real uuid4 job_id in production (the
+# API generates it); use valid UUIDs here too since the task parses job_id via
+# uuid.UUID() to key the download-link/status store.
+JOB_ID = "00000000-0000-0000-0000-000000000001"
+JOB_ID_TIMEOUT = "00000000-0000-0000-0000-000000000002"
+JOB_ID_IMG_TIMEOUT = "00000000-0000-0000-0000-000000000003"
+JOB_ID_FAIL = "00000000-0000-0000-0000-000000000004"
+
 
 # A minimal valid 1x1 transparent PNG for image-mode tests.
 _PNG_1x1 = (
@@ -84,6 +92,8 @@ def mocks() -> Iterator[dict[str, Any]]:
                 "s3",
                 "email",
                 "ReleaseDistributedLock",
+                "create_download_link",
+                "mark_export_failed",
             )
         }
         user = mock.MagicMock()
@@ -100,7 +110,7 @@ def mocks() -> Iterator[dict[str, Any]]:
         )
 
         patched["get_dashboard_filter_context"].return_value.extra_form_data = {}
-        patched["s3"].generate_presigned_url.return_value = "https://signed/file.xlsx"
+        patched["create_download_link"].return_value = "https://signed/file.xlsx"
 
         patched["user"] = user
         patched["dashboard"] = dashboard
@@ -108,7 +118,7 @@ def mocks() -> Iterator[dict[str, Any]]:
 
 
 def _run(
-    job_id: str = "job-1",
+    job_id: str = JOB_ID,
     mode: str = "data",
 ) -> None:
     from superset.tasks.export_dashboard_excel import export_dashboard_excel
@@ -162,7 +172,7 @@ def test_happy_path_uploads_and_emails(mocks: dict[str, Any]) -> None:
     assert list(uploaded["sheets"].keys()) == ["10 - First", "20 - Second"]
     mocks["email"].send_export_email.assert_called_once()
     mocks["email"].build_success_email.assert_called_once()
-    assert _no_temp_files_left("job-1")
+    assert _no_temp_files_left(JOB_ID)
 
 
 def test_chart_without_query_context_is_skipped(mocks: dict[str, Any]) -> None:
@@ -658,12 +668,12 @@ def test_chart_timeout_aborts_export_and_sends_failure_email(
     ]
 
     with pytest.raises(SoftTimeLimitExceeded):
-        _run("job-timeout")
+        _run(JOB_ID_TIMEOUT)
 
     mocks["s3"].upload_file_to_s3.assert_not_called()
     mocks["email"].build_success_email.assert_not_called()
     mocks["email"].build_failure_email.assert_called_once()
-    assert _no_temp_files_left("job-timeout")
+    assert _no_temp_files_left(JOB_ID_TIMEOUT)
 
 
 def test_image_render_timeout_aborts_export(mocks: dict[str, Any]) -> None:
@@ -675,11 +685,11 @@ def test_image_render_timeout_aborts_export(mocks: dict[str, Any]) -> None:
     mocks["render_chart_image"].side_effect = SoftTimeLimitExceeded()
 
     with pytest.raises(SoftTimeLimitExceeded):
-        _run("job-img-timeout", mode="images")
+        _run(JOB_ID_IMG_TIMEOUT, mode="images")
 
     mocks["email"].build_success_email.assert_not_called()
     mocks["email"].build_failure_email.assert_called_once()
-    assert _no_temp_files_left("job-img-timeout")
+    assert _no_temp_files_left(JOB_ID_IMG_TIMEOUT)
 
 
 def test_all_charts_skipped_writes_summary(mocks: dict[str, Any]) -> None:
@@ -709,21 +719,21 @@ def test_upload_failure_sends_failure_email_and_cleans_up(
     mocks["s3"].upload_file_to_s3.side_effect = RuntimeError("s3 down")
 
     with pytest.raises(RuntimeError):
-        _run("job-fail")
+        _run(JOB_ID_FAIL)
 
     mocks["email"].build_failure_email.assert_called_once()
     mocks["email"].send_export_email.assert_called_once()
-    assert _no_temp_files_left("job-fail")
+    assert _no_temp_files_left(JOB_ID_FAIL)
 
 
 def test_soft_time_limit_sends_failure_email(mocks: dict[str, Any]) -> None:
     mocks["get_charts_in_layout_order"].side_effect = SoftTimeLimitExceeded()
 
     with pytest.raises(SoftTimeLimitExceeded):
-        _run("job-timeout")
+        _run(JOB_ID_TIMEOUT)
 
     mocks["email"].build_failure_email.assert_called_once()
-    assert _no_temp_files_left("job-timeout")
+    assert _no_temp_files_left(JOB_ID_TIMEOUT)
 
 
 # --- image mode ---
@@ -832,7 +842,7 @@ def test_inflight_lock_released_on_failure(mocks: dict[str, Any]) -> None:
     mocks["s3"].upload_file_to_s3.side_effect = RuntimeError("s3 down")
 
     with pytest.raises(RuntimeError):
-        _run("job-fail")
+        _run(JOB_ID_FAIL)
 
     # The lock is freed in ``finally`` even when the export fails.
     mocks["ReleaseDistributedLock"].assert_called_once_with(


### PR DESCRIPTION
## SUMMARY

The dashboard Excel export success email (#41133) links to a pre-signed S3 URL that is only valid for as long as *both* its own `ExpiresIn` window and the credentials that signed it remain valid. Deployments whose S3 client authenticates via short-lived, auto-refreshed credentials (e.g. an EKS IRSA role assumed through `AssumeRoleWithWebIdentity`, which AWS caps at 12 hours) can silently invalidate the pre-signed URL long before `EXCEL_EXPORT_LINK_TTL_SECONDS` elapses, since the *credentials'* session — not just the URL's own `ExpiresIn` — bounds how long it actually works.

To keep that promise regardless of credential lifetime, the email now links to a small Superset redirect endpoint (`GET .../export_xlsx/download/<job_id>/`) instead of a raw S3 URL. The link's own lifetime is enforced independently via the `key_value` store's `expires_on`, and the actual pre-signed URL is generated fresh — with then-current credentials — at click time, valid only long enough to complete a single download. The redirect intentionally requires no login, matching a raw pre-signed URL's own access model: the unguessable job id is the credential, and the dashboard access check already ran once when the export was requested.

Reusing this same job_id-keyed store also removes a separate limitation: `export_xlsx` previously hard-required the requester to have an email address on file, since email was the only delivery channel — which excluded guest/embedded dashboard sessions (`GuestUser`) entirely. A new `GET .../export_xlsx/status/<job_id>/` polling endpoint lets the frontend discover completion without an email: the `DownloadMenuItems` component now polls after enqueueing and auto-downloads once ready, so an embedded/guest session (no email) gets a working export too. A regular logged-in session gets both the browser auto-download and, still, the email — the polling arrives before the email does in practice.

`export_xlsx` needs a CSRF exemption for this to work end-to-end: it's a POST route now reachable from embedded/guest sessions whose fetch calls carry no CSRF token, the same reason `chart/data` is already in `WTF_CSRF_EXEMPT_LIST`.

## BEFORE/AFTER

**Before:** the export email links directly to a pre-signed S3 URL that can silently stop working hours before its promised expiry on IRSA-style deployments, and `POST export_xlsx` 400s for any session without an email address (all embedded/guest dashboards).

**After:** the export email (and, for guest sessions, browser polling) links to a Superset redirect that re-signs the S3 URL at click time; guest/embedded sessions can request and receive an export.

## TESTING INSTRUCTIONS

- `pytest tests/integration_tests/dashboards/api_tests.py -k "download_xlsx or export_xlsx"` — 17 new/updated tests
- `pytest tests/unit_tests/tasks/test_export_dashboard_excel.py` — 47 tests
- `pytest tests/integration_tests/security_tests.py -k test_views_are_secured`
- `npx jest src/dashboard/components/menu/DownloadMenuItems/DownloadMenuItems.test.tsx` — 18 tests (3 new, covering ready/pending/error polling states)
- `ruff check` / `ruff format --check` / `oxlint` / `prettier --check` all clean on touched files
- `mypy` clean on touched files (pre-existing, unrelated repo-wide errors aside)

## ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags
- [x] Changes UI
- [x] Includes DB migration - N/A, reuses the existing `key_value` table via a new `KeyValueResource.EXCEL_EXPORT_DOWNLOAD` enum member, no schema change
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API