### PR TITLE
fix(explore): legacy boolean filters and limit available operators based on calculated column type

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
@@ -270,6 +270,74 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.comparator).toBe(undefined);
   });
+  // Charts saved before #32701 persisted `==` as the operation for IS_TRUE and
+  // IS_FALSE, alongside a boolean comparator. `translateToSql` and the backend
+  // both key off `operator`, so dropping the comparator would render such a
+  // filter as `col =` and query it as `col IS NULL`.
+  test('keeps the legacy boolean comparator for IS_TRUE', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: '==',
+      operatorId: Operators.IsTrue,
+      comparator: true,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter.operator).toBe('==');
+    expect(adhocFilter.comparator).toBe(true);
+    expect(adhocFilter.translateToSql()).toBe("col = 'TRUE'");
+  });
+  test('keeps the legacy boolean comparator for IS_FALSE', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: '==',
+      operatorId: Operators.IsFalse,
+      comparator: false,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter.operator).toBe('==');
+    expect(adhocFilter.comparator).toBe(false);
+    expect(adhocFilter.translateToSql()).toBe("col = 'FALSE'");
+  });
+  test('restores the boolean even when the stored comparator is missing', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: '==',
+      operatorId: Operators.IsTrue,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter.comparator).toBe(true);
+  });
+  test('keeps a legacy boolean filter intact when the control re-posts it', () => {
+    const stored = {
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: '==',
+      operatorId: Operators.IsTrue,
+      comparator: true,
+      clause: Clauses.Where,
+    };
+    // DndFilterSelect wraps props.value and hands those instances to onChange
+    const posted = JSON.parse(JSON.stringify(new AdhocFilter(stored)));
+    expect(posted.operator).toBe('==');
+    expect(posted.comparator).toBe(true);
+    expect(posted.operatorId).toBe(Operators.IsTrue);
+  });
+  test('leaves a genuine equality filter on a boolean value alone', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'col',
+      operator: '==',
+      operatorId: Operators.Equals,
+      comparator: true,
+      clause: Clauses.Where,
+    });
+    expect(adhocFilter.operator).toBe('==');
+    expect(adhocFilter.comparator).toBe(true);
+    expect(adhocFilter.translateToSql()).toBe("col = 'TRUE'");
+  });
   test('sets the label properly if subject is a string', () => {
     const adhocFilter = new AdhocFilter({
       expressionType: ExpressionTypes.Simple,

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
@@ -30,6 +30,15 @@ const CUSTOM_OPERATIONS = [...CUSTOM_OPERATORS].map(
   op => OPERATOR_ENUM_TO_OPERATOR_TYPE[op].operation,
 );
 
+// Charts saved before #32701 store `==` for IS_TRUE/IS_FALSE with the boolean
+// in the comparator; blanking it makes them query `col IS NULL`. Restoring it
+// leaves the emitted SQL untouched -- reconciling `operator` to `IS TRUE`
+// would not, and Druid rejects that predicate on VARCHAR columns.
+const LEGACY_BOOLEAN_COMPARATORS = new Map<string, boolean>([
+  [Operators.IsTrue, true],
+  [Operators.IsFalse, false],
+]);
+
 interface AdhocFilterInput {
   expressionType?: string;
   subject?: string | { column_name?: string; [key: string]: unknown } | null;
@@ -76,6 +85,16 @@ export default class AdhocFilter {
           0
       ) {
         this.comparator = undefined;
+      }
+      if (
+        this.operator ===
+          OPERATOR_ENUM_TO_OPERATOR_TYPE[Operators.Equals].operation &&
+        adhocFilter.operatorId &&
+        LEGACY_BOOLEAN_COMPARATORS.has(adhocFilter.operatorId)
+      ) {
+        this.comparator = LEGACY_BOOLEAN_COMPARATORS.get(
+          adhocFilter.operatorId,
+        );
       }
       this.clause = adhocFilter.clause || Clauses.Where;
       this.sqlExpression = null;

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -515,6 +515,28 @@ test('will not display boolean operators when column type is string', () => {
   });
 });
 
+test.each(['STRING', 'DATE'])(
+  'will not display boolean operators when an expression column declares type %s',
+  type => {
+    const props = setup({
+      datasource: {
+        type: 'table' as const,
+        datasource_name: 'table1',
+        schema: 'schema',
+        columns: [{ column_name: 'value', type, expression: '"value"' }],
+      },
+      adhocFilter: simpleAdhocFilter,
+    });
+    const { isOperatorRelevant } = useSimpleTabFilterProps(
+      props as unknown as Props,
+    );
+    const booleanOnlyOperators = [Operators.IsTrue, Operators.IsFalse];
+    booleanOnlyOperators.forEach(operator => {
+      expect(isOperatorRelevant(operator, 'value')).toBe(false);
+    });
+  },
+);
+
 test('will display boolean operators when column is an expression', () => {
   const props = setup({
     datasource: {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -160,7 +160,11 @@ export const useSimpleTabFilterProps = (props: Props) => {
       ].includes(operator);
     }
     if (operator === Operators.IsTrue || operator === Operators.IsFalse) {
-      return isColumnBoolean || isColumnNumber || isColumnFunction;
+      // An expression column may evaluate to a boolean, but that is only a
+      // safe assumption while its type is unknown; a declared type wins.
+      return (
+        isColumnBoolean || isColumnNumber || (isColumnFunction && !column?.type)
+      );
     }
     if (isColumnBoolean) {
       return operator === Operators.IsNull || operator === Operators.IsNotNull;


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two defects around `Is true`/`Is false` filters, found investigating charts that silently returned no rows after a 2.1.1 → 6.0 upgrade.

**1. Legacy filters query `IS NULL`.** #32701 changed the operation for `IS_TRUE`/`IS_FALSE` from `==` to `IS TRUE`/`IS FALSE` and made the constructor blank the comparator for those operators, with no migration. Charts saved before it still store `{"operator": "==", "operatorId": "IS_TRUE", "comparator": true}`.

The wipe keys off `operatorId` while `translateToSql` and the backend key off `operator`. Such a filter renders as a bare `col =`, and because `DndFilterSelect` re-posts the wrapped instances whenever any pill is edited, the next query carries `operator: '=='` with no comparator — compiling to `col IS NULL` and silently returning nothing. `isValid()` stays true, so nothing warns the user. Dashboards are unaffected; they render from stored params and never construct an `AdhocFilter`.

Fixed by restoring the boolean comparator while `operator` is still the legacy `==`. Reconciling `operator` to `IS TRUE` would instead change the emitted SQL for every affected chart, onto a predicate that isn't portable (below). Preserving `==` keeps queries byte-identical to pre-#32701 behaviour.

**2. The operator is offered where it cannot work.** A column carrying an `expression` is offered the boolean operators whatever its declared type. That assumption is only safe while the type is unknown — for a column declared `STRING` or `DATE` the predicate cannot match, and Druid and Trino reject it outright. Fixed by letting the declared type take precedence, keeping the exception for untyped columns only.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
