### PR TITLE
fix(charts): exclude string helpers from post_processing operation allowlist

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1140,29 +1140,6 @@
         "properties": {
           "operation": {
             "description": "Post processing operation type",
-            "enum": [
-              "aggregate",
-              "boxplot",
-              "compare",
-              "contribution",
-              "cum",
-              "diff",
-              "escape_separator",
-              "flatten",
-              "geodetic_parse",
-              "geohash_decode",
-              "geohash_encode",
-              "histogram",
-              "pivot",
-              "prophet",
-              "rank",
-              "rename",
-              "resample",
-              "rolling",
-              "select",
-              "sort",
-              "unescape_separator"
-            ],
             "example": "aggregate",
             "type": "string"
           },

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1012,7 +1012,15 @@ class ChartDataGeodeticParseOptionsSchema(
 
 
 class ChartDataPostProcessingOperationSchema(Schema):
-    _builtin_ops = pandas_postprocessing.__all__
+    # OPERATIONS excludes escape_separator/unescape_separator: those are
+    # internal str -> str helpers used by flatten, not DataFrame
+    # post-processing operations, so dispatching one against a DataFrame
+    # raises a confusing TypeError instead of the intended clean validation
+    # error. No field-level `validate=` here: it would run before, and thus
+    # reject, any EXTRA_PANDAS_POSTPROCESSING_OPS-registered custom
+    # operation, which `validate_operation` below is responsible for
+    # allowing.
+    _builtin_ops = pandas_postprocessing.OPERATIONS
 
     operation = fields.String(
         metadata={

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -17,7 +17,6 @@
 # pylint: disable=too-many-lines
 from __future__ import annotations
 
-import inspect
 from typing import Any, TYPE_CHECKING
 
 from flask import current_app
@@ -978,14 +977,7 @@ class ChartDataPostProcessingOperationSchema(Schema):
             "example": "aggregate",
         },
         required=True,
-        validate=validate.OneOf(
-            choices=[
-                name
-                for name, value in inspect.getmembers(
-                    pandas_postprocessing, inspect.isfunction
-                )
-            ]
-        ),
+        validate=validate.OneOf(choices=pandas_postprocessing.OPERATIONS),
     )
     options = fields.Dict(
         metadata={

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -644,10 +644,10 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                     raise InvalidPostProcessingError(
                         _("`operation` property of post processing object undefined")
                     )
-                # ``__all__`` is the authoritative list of built-in operations.
-                # ``hasattr`` would also match module internals (helpers, imported
-                # submodules, typing aliases), shadowing a like-named custom op.
-                if operation in pandas_postprocessing.__all__:
+                # ``OPERATIONS`` is the authoritative list of built-in operations;
+                # excludes escape_separator/unescape_separator (str -> str helpers
+                # used by flatten, not DataFrame post-processing operations).
+                if operation in pandas_postprocessing.OPERATIONS:
                     func = getattr(pandas_postprocessing, operation)
                 else:
                     extra_ops = pandas_postprocessing.build_extra_ops_map(

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -623,11 +623,11 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                     raise InvalidPostProcessingError(
                         _("`operation` property of post processing object undefined")
                     )
-                if not hasattr(pandas_postprocessing, operation):
+                if operation not in pandas_postprocessing.OPERATIONS:
                     raise InvalidPostProcessingError(
                         _(
                             "Unsupported post processing operation: %(operation)s",
-                            type=operation,
+                            operation=operation,
                         )
                     )
                 options = post_process.get("options", {})

--- a/superset/utils/pandas_postprocessing/__init__.py
+++ b/superset/utils/pandas_postprocessing/__init__.py
@@ -80,3 +80,13 @@ def build_extra_ops_map(
     spec.
     """
     return {name: fn for fn in extra if (name := getattr(fn, "__name__", None))}
+
+
+# Operations that can be requested via a chart's `post_processing` spec.
+# Excludes `escape_separator`/`unescape_separator`: those are internal
+# str -> str helpers used by `flatten`, not DataFrame post-processing
+# operations, so dispatching one against a DataFrame raises a confusing
+# TypeError instead of the intended clean validation error.
+OPERATIONS = [
+    name for name in __all__ if name not in ("escape_separator", "unescape_separator")
+]

--- a/superset/utils/pandas_postprocessing/__init__.py
+++ b/superset/utils/pandas_postprocessing/__init__.py
@@ -63,3 +63,12 @@ __all__ = [
     "escape_separator",
     "unescape_separator",
 ]
+
+# Operations that can be requested via a chart's `post_processing` spec.
+# Excludes `escape_separator`/`unescape_separator`: those are internal
+# str -> str helpers used by `flatten`, not DataFrame post-processing
+# operations, so dispatching one against a DataFrame raises a confusing
+# TypeError instead of the intended clean validation error.
+OPERATIONS = [
+    name for name in __all__ if name not in ("escape_separator", "unescape_separator")
+]

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -559,3 +559,14 @@ def test_chart_data_adhoc_metric_schema_accepts_extended_aggregates(
         }
     )
     assert result["aggregate"] == aggregate
+
+
+@pytest.mark.parametrize("operation", ["escape_separator", "unescape_separator"])
+def test_post_processing_operation_schema_rejects_string_helpers(
+    app_context: None, operation: str
+) -> None:
+    """`escape_separator`/`unescape_separator` are internal str -> str helpers,
+    not DataFrame post-processing operations, and shouldn't validate as one."""
+    schema = ChartDataPostProcessingOperationSchema()
+    with pytest.raises(ValidationError):
+        schema.load({"operation": operation, "options": {}})

--- a/tests/unit_tests/charts/test_schemas.py
+++ b/tests/unit_tests/charts/test_schemas.py
@@ -21,6 +21,7 @@ from marshmallow import ValidationError
 
 from superset.charts.schemas import (
     ChartDataExtrasSchema,
+    ChartDataPostProcessingOperationSchema,
     ChartDataProphetOptionsSchema,
     ChartDataQueryObjectSchema,
     ChartDataResponseResult,
@@ -478,3 +479,22 @@ def test_chart_data_extras_rejects_system_sampling(app_context: None) -> None:
     with pytest.raises(ValidationError) as exc_info:
         ChartDataExtrasSchema().load({"system_sampling": True})
     assert "system_sampling" in exc_info.value.messages
+
+
+@pytest.mark.parametrize("operation", ["escape_separator", "unescape_separator"])
+def test_post_processing_operation_schema_rejects_string_helpers(
+    app_context: None, operation: str
+) -> None:
+    """`escape_separator`/`unescape_separator` are internal str -> str helpers,
+    not DataFrame post-processing operations, and shouldn't validate as one."""
+    schema = ChartDataPostProcessingOperationSchema()
+    with pytest.raises(ValidationError):
+        schema.load({"operation": operation, "options": {}})
+
+
+def test_post_processing_operation_schema_accepts_builtin_op(
+    app_context: None,
+) -> None:
+    schema = ChartDataPostProcessingOperationSchema()
+    result = schema.load({"operation": "aggregate", "options": {}})
+    assert result["operation"] == "aggregate"

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -718,3 +718,20 @@ def test_post_processing_keeps_an_entry_without_an_operation():
     query_object = QueryObject(row_limit=1, post_processing=post_processing)
 
     assert query_object.post_processing == post_processing
+
+
+@pytest.mark.parametrize("operation", ["escape_separator", "unescape_separator"])
+def test_exec_post_processing_rejects_string_helpers(
+    app_context: None, operation: str
+) -> None:
+    """`escape_separator`/`unescape_separator` are str -> str helpers used by
+    `flatten`, not DataFrame post-processing operations, and must not be
+    reachable as a `post_processing` operation name."""
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    query_object = QueryObject(
+        row_limit=10,
+        post_processing=[{"operation": operation, "options": {}}],
+    )
+
+    with pytest.raises(InvalidPostProcessingError):
+        query_object.exec_post_processing(df)

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -16,10 +16,13 @@
 # under the License.
 from unittest.mock import call, patch
 
+import pandas as pd
+import pytest
 from flask_appbuilder.security.sqla.models import User
 
 from superset.common.query_object import QueryObject
 from superset.connectors.sqla.models import SqlaTable
+from superset.exceptions import InvalidPostProcessingError
 from superset.models.core import Database
 from superset.superset_typing import Metric
 from superset.utils import pandas_postprocessing
@@ -579,3 +582,20 @@ def test_post_processing_keeps_an_entry_without_an_operation():
     query_object = QueryObject(row_limit=1, post_processing=post_processing)
 
     assert query_object.post_processing == post_processing
+
+
+@pytest.mark.parametrize("operation", ["escape_separator", "unescape_separator"])
+def test_exec_post_processing_rejects_string_helpers(
+    app_context: None, operation: str
+) -> None:
+    """`escape_separator`/`unescape_separator` are str -> str helpers used by
+    `flatten`, not DataFrame post-processing operations, and must not be
+    reachable as a `post_processing` operation name."""
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    query_object = QueryObject(
+        row_limit=10,
+        post_processing=[{"operation": operation, "options": {}}],
+    )
+
+    with pytest.raises(InvalidPostProcessingError):
+        query_object.exec_post_processing(df)


### PR DESCRIPTION
### SUMMARY

Follow-up from a `codeant-ai-for-open-source` finding on #43337: the `post_processing` operation allowlist (`ChartDataPostProcessingOperationSchema.operation` in `superset/charts/schemas.py`, and the dispatch guard in `QueryObject.exec_post_processing`) accepts `escape_separator`/`unescape_separator` as valid operation names. Those are internal `str -> str` helpers used by `flatten`, not DataFrame post-processing operations — submitting one as an `operation` currently either raises a confusing `TypeError` (the function gets called with a DataFrame instead of a string) rather than a clean validation error.

This is pre-existing on `master`, independent of #43337 (the old `inspect.getmembers(pandas_postprocessing, inspect.isfunction)` allowlist has the same gap).

Adds `pandas_postprocessing.OPERATIONS`, a curated list of the real DataFrame operations (excludes the two string helpers), and uses it in both the schema allowlist and the executor's dispatch guard.

While adding a test for this, found and fixed a second, related bug in the same code path: the `InvalidPostProcessingError` message in `query_object.py` used `type=operation` against a `"...%(operation)s"` format string, so hitting that branch raised a `KeyError` from `flask_babel`'s `gettext` instead of the intended clean error. Fixed to `operation=operation`.

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/charts/test_schemas.py -k post_processing_operation
pytest tests/unit_tests/queries/query_object_test.py -k post_processing
```

Also ran the full `tests/unit_tests/pandas_postprocessing/`, `tests/unit_tests/charts/`, and `tests/unit_tests/queries/` suites locally (349 passed, 2 xfailed, unrelated) and `pre-commit` on the changed files.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API