### PR TITLE
fix(reports): prevent blank/partial report PDFs from virtualized charts

### DIFF
--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -159,16 +159,49 @@ CHART_ERROR_OR_EMPTY_SELECTOR = (
     f"{ALERT_SELECTOR}, {EMPTY_SELECTOR}, {MISSING_CHART_SELECTOR}"
 )
 
-# Shared body for holder readiness and timeout diagnostics. A holder is ready
-# only after a terminal marker appears and its loading marker disappears.
-UNREADY_CHART_HOLDERS_JS_BODY = f"""
+# Runtime contract with the dashboard frontend. Dispatching this window event
+# forces every DashboardVirtualization row to render regardless of whether it
+# intersects the headless viewport, mirroring the client-side "Download as
+# Image/PDF" path (see FORCE_IN_VIEW_EVENT in
+# superset-frontend/src/dashboard/constants.ts and forceLoadAllCharts in
+# superset-frontend/src/utils/downloadUtils.ts). The non-tiled report capture
+# takes a single full-page screenshot that includes below-the-fold holders, so
+# those holders must be forced to render before the readiness wait -- otherwise
+# a virtualized (or still-loading) off-screen holder is captured blank. A plain
+# Event with no `detail.rowIds` means "force every row", matching the frontend's
+# single-pass branch.
+FORCE_ALL_CHART_HOLDERS_IN_VIEW_EVENT = "superset-force-all-in-view"
+FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS = (
+    f"() => window.dispatchEvent(new Event('{FORCE_ALL_CHART_HOLDERS_IN_VIEW_EVENT}'))"
+)
+
+
+def _unready_chart_holders_js_body(*, viewport_only: bool) -> str:
+    """Return the shared holder-readiness scan body.
+
+    A holder is ready only after a terminal marker appears and its loading
+    marker disappears. When ``viewport_only`` is True the scan skips holders
+    that do not intersect the current viewport: correct for the tiled path,
+    which scrolls every region into view before capturing it, and for
+    thumbnails, which only ever capture the viewport. The non-tiled *report*
+    capture takes a single full-page screenshot that includes below-the-fold
+    holders, so it must scan every mounted holder (``viewport_only=False``) --
+    otherwise an off-screen holder that never rendered is captured blank and
+    silently delivered as a Success.
+    """
+    viewport_skip = (
+        """
+        const r = holder.getBoundingClientRect();
+        if (!(r.top < window.innerHeight && r.bottom > 0)) {
+            continue;
+        }"""
+        if viewport_only
+        else ""
+    )
+    return f"""
     const holders = document.querySelectorAll('{CHART_HOLDER_SELECTOR}');
     const unready = [];
-    for (const holder of holders) {{
-        const r = holder.getBoundingClientRect();
-        if (!(r.top < window.innerHeight && r.bottom > 0)) {{
-            continue;
-        }}
+    for (const holder of holders) {{{viewport_skip}
         const hasSliceContainer = holder.querySelector(
             '{SLICE_CONTAINER_SELECTOR}'
         ) !== null;
@@ -205,6 +238,13 @@ UNREADY_CHART_HOLDERS_JS_BODY = f"""
         }}
     }}
 """
+
+
+# Viewport-scoped scan (tiled path + thumbnails).
+UNREADY_CHART_HOLDERS_JS_BODY = _unready_chart_holders_js_body(viewport_only=True)
+# Full-dashboard scan (non-tiled report capture, which screenshots the whole
+# element in one shot and therefore cannot ignore below-the-fold holders).
+UNREADY_ALL_CHART_HOLDERS_JS_BODY = _unready_chart_holders_js_body(viewport_only=False)
 
 # Diagnostic query for every chart holder, including terminal and virtualized
 # states. It interpolates the same selector constants as the predicates.
@@ -256,11 +296,23 @@ REPORT_CHART_HOLDERS_READY_JS = (
     f"() => {{ {UNREADY_CHART_HOLDERS_JS_BODY} "
     "return holders.length > 0 && unready.length === 0; }"
 )
+# Report readiness for the non-tiled full-page capture: every mounted holder --
+# including below-the-fold ones -- must be terminally rendered. Off-screen
+# holders are forced to render first (FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS); if any
+# still fails to render within budget the wait times out and the report fails
+# loudly rather than shipping a blank/partial screenshot as a Success.
+REPORT_ALL_CHART_HOLDERS_READY_JS = (
+    f"() => {{ {UNREADY_ALL_CHART_HOLDERS_JS_BODY} "
+    "return holders.length > 0 && unready.length === 0; }"
+)
 CHART_HOLDERS_MOUNTED_JS = (
     f"() => document.querySelectorAll('{CHART_HOLDER_SELECTOR}').length > 0"
 )
 FIND_UNREADY_CHART_HOLDERS_JS = (
     f"() => {{ {UNREADY_CHART_HOLDERS_JS_BODY} return unready; }}"
+)
+FIND_ALL_UNREADY_CHART_HOLDERS_JS = (
+    f"() => {{ {UNREADY_ALL_CHART_HOLDERS_JS_BODY} return unready; }}"
 )
 
 # A chart capture has one target rather than dashboard holders, but needs the

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -34,8 +34,10 @@ from superset.utils.screenshot_utils import (
     CHART_CONTAINER_READY_JS,
     CHART_CONTAINER_STATE_JS,
     CHART_HOLDERS_READY_JS,
+    FIND_ALL_UNREADY_CHART_HOLDERS_JS,
     FIND_CHART_HOLDER_STATES_JS,
-    REPORT_CHART_HOLDERS_READY_JS,
+    FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS,
+    REPORT_ALL_CHART_HOLDERS_READY_JS,
     resolve_screenshot_task_budget_seconds,
     ScreenshotTaskBudgetExceededError,
     take_tiled_screenshot,
@@ -382,7 +384,19 @@ class WebDriverPlaywright(WebDriverProxy):
         if element_name == "chart-container":
             readiness_predicate = CHART_CONTAINER_READY_JS
         elif report_execution_context:
-            readiness_predicate = REPORT_CHART_HOLDERS_READY_JS
+            # This non-tiled path captures the whole element in one shot
+            # (`_get_screenshot` uses `full_page=True` / `element.screenshot()`),
+            # so below-the-fold holders end up in the image. Force every
+            # virtualized row to render up front -- mirroring the client-side
+            # "Download as Image/PDF" path -- and then require *all* mounted
+            # holders (not just the viewport-visible ones) to reach a terminal
+            # state. If an off-screen holder never renders, the wait times out
+            # and the report fails loudly instead of silently delivering a
+            # blank/partial screenshot as a Success. The tiled path keeps the
+            # viewport-scoped predicate because it scrolls each region into view
+            # before capturing it.
+            page.evaluate(FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS)
+            readiness_predicate = REPORT_ALL_CHART_HOLDERS_READY_JS
         else:
             # Preserve the thumbnail behavior introduced by #42253. The
             # stricter zero-holder gate is report-specific because an empty
@@ -430,6 +444,16 @@ class WebDriverPlaywright(WebDriverProxy):
             ready_holders = sum(
                 holder.get("state") in ready_states for holder in chart_holder_states
             )
+            # `FIND_CHART_HOLDER_STATES_JS` short-circuits off-screen holders to
+            # "virtualized" (counted as ready above), so on the report path -- a
+            # full-page capture that includes below-the-fold holders -- the real
+            # culprits (off-screen holders that never rendered) would be hidden.
+            # Surface them explicitly using the non-viewport-scoped scan.
+            below_fold_unready = (
+                page.evaluate(FIND_ALL_UNREADY_CHART_HOLDERS_JS)
+                if report_execution_context
+                else unready_chart_holders
+            )
             deadline_elapsed = deadline.elapsed_seconds if deadline else elapsed
             deadline_remaining = (
                 deadline.remaining_seconds if deadline else remaining_budget
@@ -438,7 +462,8 @@ class WebDriverPlaywright(WebDriverProxy):
                 "report_readiness_terminal url=%s expected_holders=%s "
                 "mounted_holders=%s ready_holders=%s elapsed_seconds=%.2f "
                 "remaining_seconds=%s effective_wait_seconds=%.2f%s "
-                "terminal_reason=readiness_timeout unready_holders=%s states=%s; "
+                "terminal_reason=readiness_timeout unready_holders=%s "
+                "all_unready_holders=%s states=%s; "
                 "aborting before capture or delivery",
                 url,
                 expected_holders,
@@ -453,6 +478,7 @@ class WebDriverPlaywright(WebDriverProxy):
                 effective_load_wait,
                 context_suffix,
                 unready_chart_holders,
+                below_fold_unready,
                 chart_holder_states,
             )
             raise
@@ -747,9 +773,21 @@ class WebDriverPlaywright(WebDriverProxy):
                             context_suffix,
                         )
 
-                    # Use tiled screenshots for large dashboards
+                    # Use tiled screenshots for large dashboards. For scheduled
+                    # reports a likely-large dashboard whose measured height is
+                    # at or below a single tile is almost always mid-layout
+                    # (charts still virtualized/collapsed at measurement time),
+                    # not genuinely short -- a 52-chart dashboard is never really
+                    # <one viewport tall. Routing it to the single-shot,
+                    # full-page non-tiled capture risks shipping a windowed
+                    # partial render. Prefer the tiled path, which scrolls every
+                    # region into view and waits per tile; worst case it is a
+                    # single tile. The tiled decision for thumbnails is
+                    # unchanged.
                     use_tiled = likely_large_dashboard and (
-                        height_unknown or dashboard_height > tile_height
+                        height_unknown
+                        or dashboard_height > tile_height
+                        or report_execution_context is not None
                     )
 
                     if use_tiled:

--- a/tests/unit_tests/utils/webdriver_test.py
+++ b/tests/unit_tests/utils/webdriver_test.py
@@ -639,6 +639,91 @@ class TestWebDriverPlaywrightErrorHandling:
 
     @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
     @patch("superset.utils.webdriver._browser_manager")
+    @patch("superset.utils.webdriver.take_tiled_screenshot")
+    def test_large_report_dashboard_tiles_even_when_measured_height_is_short(
+        self, mock_take_tiled, mock_browser_manager
+    ):
+        """Regression: the GOOD (full) report path is the tiled one; BAD
+        (blank/partial) runs mis-route a large dashboard to the single-shot
+        non-tiled capture because ``scrollHeight`` is measured while charts are
+        still virtualized/collapsed (<= one tile). A scheduled report whose
+        dashboard is large by chart count must take the tiled path regardless
+        of that stale height measurement, so every region is scrolled into
+        view and waited on instead of captured as a windowed partial.
+        """
+        mock_user = MagicMock()
+        mock_user.username = "test_user"
+
+        mock_browser = MagicMock()
+        mock_context = MagicMock()
+        mock_page = MagicMock()
+        mock_element = MagicMock()
+        mock_chart_container = MagicMock()
+
+        mock_browser_manager.get_browser.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+
+        def locator_side_effect(selector):
+            if selector == ".chart-container":
+                locator = MagicMock()
+                locator.all.return_value = [mock_chart_container]
+                return locator
+            return mock_element
+
+        mock_page.locator.side_effect = locator_side_effect
+        mock_take_tiled.return_value = b"tiled_screenshot"
+
+        def evaluate_side_effect(script):
+            if script == 'document.querySelectorAll(".chart-container").length':
+                return 52  # mounted containers
+            if "const target = document.querySelector" in script:
+                # Non-zero but <= one tile: the classic mid-layout measurement
+                # that previously vetoed tiling and dropped to the non-tiled
+                # path.
+                return 1500
+            return None
+
+        mock_page.evaluate.side_effect = evaluate_side_effect
+
+        with patch("superset.utils.webdriver.app") as mock_app:
+            mock_app.config = {
+                "WEBDRIVER_OPTION_ARGS": [],
+                "WEBDRIVER_WINDOW": {"pixel_density": 1},
+                "SCREENSHOT_PLAYWRIGHT_DEFAULT_TIMEOUT": 30000,
+                "SCREENSHOT_PLAYWRIGHT_WAIT_EVENT": "networkidle",
+                "SCREENSHOT_SELENIUM_HEADSTART": 1,
+                "SCREENSHOT_SELENIUM_ANIMATION_WAIT": 1,
+                "SCREENSHOT_LOCATE_WAIT": 10,
+                "SCREENSHOT_LOAD_WAIT": 10,
+                "SCREENSHOT_REPLACE_UNEXPECTED_ERRORS": False,
+                "SCREENSHOT_TILED_ENABLED": True,
+                "SCREENSHOT_TILED_CHART_THRESHOLD": 20,
+                "SCREENSHOT_TILED_HEIGHT_THRESHOLD": 5000,
+                # Larger than the measured 1500px height, so only the new
+                # report-mode branch (not `dashboard_height > tile_height`) can
+                # select tiling here.
+                "SCREENSHOT_TILED_VIEWPORT_HEIGHT": 2000,
+            }
+
+            with patch.object(WebDriverPlaywright, "auth") as mock_auth:
+                mock_auth.return_value = mock_context
+
+                driver = WebDriverPlaywright("chrome")
+                result = driver.get_screenshot(
+                    "http://example.com/dashboard/805",
+                    "standalone",
+                    mock_user,
+                    report_execution_context=_report_context(),
+                )
+
+        assert result == b"tiled_screenshot"
+        mock_take_tiled.assert_called_once()
+        # The non-tiled single-shot capture must not run for this large report.
+        mock_page.screenshot.assert_not_called()
+
+    @patch("superset.utils.webdriver.PLAYWRIGHT_AVAILABLE", True)
+    @patch("superset.utils.webdriver._browser_manager")
     @patch("superset.utils.webdriver.logger")
     def test_chart_container_timeout_logs_warning_with_progress_and_raises(
         self, mock_logger, mock_browser_manager
@@ -1167,6 +1252,103 @@ class TestWebDriverPlaywrightChartReadiness:
 
         page.wait_for_function.assert_not_called()
         page.screenshot.assert_not_called()
+
+    def test_report_readiness_forces_below_fold_render_and_waits_for_all_holders(
+        self,
+    ):
+        """Regression for blank/partial report PDFs.
+
+        The non-tiled report capture takes a single full-page screenshot that
+        includes below-the-fold holders, so the readiness gate must (a) force
+        every virtualized row to render up front and (b) require *all* mounted
+        holders -- not just the viewport-visible ones -- to reach a terminal
+        state. Otherwise an off-screen holder that never rendered is captured
+        blank and silently delivered as a Success.
+        """
+        from superset.utils.screenshot_utils import (
+            FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS,
+            REPORT_ALL_CHART_HOLDERS_READY_JS,
+        )
+
+        page = MagicMock()
+        page.evaluate.return_value = [{"chartId": "7", "state": "rendered"}]
+
+        WebDriverPlaywright._wait_for_charts_ready(
+            page,
+            "http://example.com/dashboard/805",
+            5,
+            "standalone",
+            report_execution_context=_report_context(),
+        )
+
+        # (a) Off-screen rows are forced to render before the wait.
+        assert any(
+            call.args and call.args[0] == FORCE_ALL_CHART_HOLDERS_IN_VIEW_JS
+            for call in page.evaluate.call_args_list
+        )
+        # (b) The readiness predicate is the all-holders variant: it must not
+        # skip below-the-fold holders (no viewport-intersection test), so a
+        # virtualized/unrendered off-screen holder cannot satisfy the gate.
+        predicate = page.wait_for_function.call_args.args[0]
+        assert predicate == REPORT_ALL_CHART_HOLDERS_READY_JS
+        assert "getBoundingClientRect" not in predicate
+        assert "window.innerHeight" not in predicate
+
+    @patch("superset.utils.webdriver.logger")
+    def test_report_readiness_below_fold_unrendered_fails_loudly(self, mock_logger):
+        """When an off-screen holder never renders within budget the report
+        must fail loudly (raise) rather than capture/deliver a blank
+        screenshot, and the terminal log must surface the below-the-fold
+        unready holders that the viewport-scoped diagnostic hides as
+        'virtualized'.
+        """
+        from superset.utils.screenshot_utils import (
+            FIND_ALL_UNREADY_CHART_HOLDERS_JS,
+            FIND_CHART_HOLDER_STATES_JS,
+        )
+        from superset.utils.webdriver import PlaywrightTimeout
+
+        page = MagicMock()
+        # 22 on-screen rendered holders + 30 off-screen holders that the
+        # viewport-scoped diagnostic labels 'virtualized' (and would otherwise
+        # count as "ready").
+        holder_states = [
+            {"chartId": str(i), "state": "rendered"} for i in range(22)
+        ] + [{"chartId": str(i), "state": "virtualized"} for i in range(22, 52)]
+        below_fold_unready = [
+            {"chartId": str(i), "state": "nothing_mounted"} for i in range(22, 52)
+        ]
+
+        def _evaluate(script, *args):
+            if script == FIND_ALL_UNREADY_CHART_HOLDERS_JS:
+                return below_fold_unready
+            if script == FIND_CHART_HOLDER_STATES_JS:
+                return holder_states
+            return None
+
+        page.evaluate.side_effect = _evaluate
+        page.wait_for_function.side_effect = PlaywrightTimeout(
+            "below-fold holders never rendered"
+        )
+
+        with pytest.raises(PlaywrightTimeout):
+            WebDriverPlaywright._wait_for_charts_ready(
+                page,
+                "http://example.com/dashboard/805",
+                5,
+                "standalone",
+                report_execution_context=_report_context(),
+            )
+
+        terminal_call = next(
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args and call.args[0].startswith("report_readiness_terminal")
+        )
+        assert "terminal_reason=readiness_timeout" in terminal_call.args[0]
+        # The below-the-fold offenders are surfaced explicitly.
+        assert "all_unready_holders=" in terminal_call.args[0]
+        assert below_fold_unready in terminal_call.args
 
     @patch("superset.utils.webdriver.logger")
     def test_chart_capture_ready_logs_container_state_not_holder_counts(


### PR DESCRIPTION
### SUMMARY
Scheduled dashboard reports render the dashboard headlessly and screenshot it into
a PDF. On tall dashboards with `DashboardVirtualization` active, only a moving
window of charts is mounted, so off-window charts are unrendered placeholders.

- **Tiled path** scrolls each region into view and waits per tile → renders
  correctly even with virtualization active (the good path).
- **Non-tiled path** takes a single full-page screenshot but its readiness gate
  only waits for *viewport-visible* holders, so below-the-fold holders are
  captured blank and delivered as `state=Success`.

A large dashboard mis-routes to the non-tiled path when its `scrollHeight` is
measured while charts are still virtualized/collapsed (`0 < height <= one tile`),
which is why the same dashboard yields good PDFs on some runs and blank on others.

Fix (all server-side — the frontend can't be gated on `standalone=Report` since
the Embedded SDK shares that mode):
- Route large scheduled-report dashboards to the tiled path regardless of a stale
  short height measurement, so they can't fall into the single-shot capture.
- Harden the non-tiled report path: dispatch the client-side
  `superset-force-all-in-view` event to un-window virtualized charts, then require
  **all** mounted holders (not just viewport-visible) to reach a terminal state via
  a new `REPORT_ALL_CHART_HOLDERS_READY_JS` predicate. On timeout it raises, so a
  partial capture fails and retries instead of shipping a blank PDF.
- Surface below-the-fold offenders in the readiness-timeout diagnostics
  (`all_unready_holders`), which the viewport-scoped scan hid as `virtualized`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
_N/A — backend screenshot pipeline change; covered by unit tests._

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/utils/webdriver_test.py tests/unit_tests/utils/test_screenshot_utils.py`.

New regression tests: large report tiles despite a short measured height;
non-tiled report force-renders + waits for all holders; below-fold-unrendered
raises loudly and logs `all_unready_holders`.

Manual: schedule a report for a tall (> 1 viewport) dashboard with
`DASHBOARD_VIRTUALIZATION` enabled and confirm the delivered PDF is complete.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `DASHBOARD_VIRTUALIZATION` (to reproduce)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
