### PR TITLE
fix(mcp): honor use_cache and cache_timeout in get_chart_data

### DIFF
--- a/superset/mcp_service/chart/chart_helpers.py
+++ b/superset/mcp_service/chart/chart_helpers.py
@@ -655,6 +655,7 @@ def build_query_context_from_form_data(
     order_desc: bool | None = None,
     result_type: Any = None,
     force: bool = False,
+    custom_cache_timeout: int | None = None,
 ) -> Any:
     """Build a QueryContext from chart-type-aware Explore form_data."""
     # avoid circular import
@@ -683,6 +684,7 @@ def build_query_context_from_form_data(
         form_data=form_data,
         result_type=result_type,
         force=force,
+        custom_cache_timeout=custom_cache_timeout,
     )
 
 

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -804,7 +804,7 @@ async def get_chart_data(  # noqa: C901
 
             # Cache status information using utility function
             cache_status = get_cache_status_from_result(
-                query_result, force_refresh=effective_force
+                query_result, force_refresh=request.force_refresh
             )
 
             # Generate insights and recommendations
@@ -1126,7 +1126,7 @@ async def _query_from_form_data(
             )
 
         cache_status = get_cache_status_from_result(
-            query_result, force_refresh=effective_force
+            query_result, force_refresh=request.force_refresh
         )
 
         chart_name = form_data.get("slice_name", "Unsaved chart")

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -112,6 +112,11 @@ _VIZ_CATEGORY: dict[str, str] = {
 _MAX_RECOMMENDATIONS = 4
 
 
+def _compute_effective_force(request: GetChartDataRequest) -> bool:
+    """use_cache=False must also bypass the cache, not just force_refresh=True."""
+    return request.force_refresh or not request.use_cache
+
+
 def _coerce_row_limit(value: Any, default: int) -> int:
     """Coerce a row_limit (which may arrive as a str from chart.params) to int,
     falling back to ``default`` when it is missing, non-numeric, or non-positive.
@@ -359,8 +364,7 @@ async def get_chart_data(  # noqa: C901
             request.cache_timeout,
         )
     )
-    # use_cache=False must also bypass the cache, not just force_refresh=True.
-    effective_force = request.force_refresh or not request.use_cache
+    effective_force = _compute_effective_force(request)
 
     try:
         await ctx.report_progress(1, 4, "Looking up chart")
@@ -1060,8 +1064,7 @@ async def _query_from_form_data(
         current_app.config["ROW_LIMIT"],
     )
     viz_type = form_data.get("viz_type", "unknown")
-    # use_cache=False must also bypass the cache, not just force_refresh=True.
-    effective_force = request.force_refresh or not request.use_cache
+    effective_force = _compute_effective_force(request)
 
     try:
         query_context = build_query_context_from_form_data(

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -359,6 +359,8 @@ async def get_chart_data(  # noqa: C901
             request.cache_timeout,
         )
     )
+    # use_cache=False must also bypass the cache, not just force_refresh=True.
+    effective_force = request.force_refresh or not request.use_cache
 
     try:
         await ctx.report_progress(1, 4, "Looking up chart")
@@ -570,7 +572,8 @@ async def get_chart_data(  # noqa: C901
                     extra_form_data=request.extra_form_data,
                     row_limit=row_limit,
                     order_desc=cached_form_data_dict.get("order_desc", True),
-                    force=request.force_refresh,
+                    force=effective_force,
+                    custom_cache_timeout=request.cache_timeout,
                 )
                 await ctx.debug(
                     "Built query_context from cached form_data (unsaved state)"
@@ -666,11 +669,14 @@ async def get_chart_data(  # noqa: C901
                     },
                     queries=fallback_queries,
                     form_data=form_data,
-                    force=request.force_refresh,
+                    force=effective_force,
+                    custom_cache_timeout=request.cache_timeout,
                 )
             elif query_context_json is not None:
                 # Apply request overrides to the saved query_context
-                query_context_json["force"] = request.force_refresh
+                query_context_json["force"] = effective_force
+                if request.cache_timeout is not None:
+                    query_context_json["custom_cache_timeout"] = request.cache_timeout
 
                 # Ignore a non-positive limit so it can't emit LIMIT -1 downstream.
                 if request.limit and request.limit > 0:
@@ -798,7 +804,7 @@ async def get_chart_data(  # noqa: C901
 
             # Cache status information using utility function
             cache_status = get_cache_status_from_result(
-                query_result, force_refresh=request.force_refresh
+                query_result, force_refresh=effective_force
             )
 
             # Generate insights and recommendations
@@ -1054,6 +1060,8 @@ async def _query_from_form_data(
         current_app.config["ROW_LIMIT"],
     )
     viz_type = form_data.get("viz_type", "unknown")
+    # use_cache=False must also bypass the cache, not just force_refresh=True.
+    effective_force = request.force_refresh or not request.use_cache
 
     try:
         query_context = build_query_context_from_form_data(
@@ -1061,7 +1069,8 @@ async def _query_from_form_data(
             extra_form_data=request.extra_form_data,
             row_limit=row_limit,
             order_desc=form_data.get("order_desc", True),
-            force=request.force_refresh,
+            force=effective_force,
+            custom_cache_timeout=request.cache_timeout,
         )
 
         await ctx.report_progress(3, 4, "Executing data query")
@@ -1117,7 +1126,7 @@ async def _query_from_form_data(
             )
 
         cache_status = get_cache_status_from_result(
-            query_result, force_refresh=request.force_refresh
+            query_result, force_refresh=effective_force
         )
 
         chart_name = form_data.get("slice_name", "Unsaved chart")

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -2245,3 +2245,62 @@ async def test_query_from_form_data_use_cache_false_bypasses_cache(
 
     assert captured["force"] is expected_force
     assert captured["custom_cache_timeout"] == 90
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("use_cache", "force_refresh", "expected_refreshed"),
+    [
+        (True, False, False),
+        (False, False, False),
+        (True, True, True),
+        (False, True, True),
+    ],
+)
+async def test_query_from_form_data_refreshed_reflects_force_refresh_only(
+    monkeypatch: pytest.MonkeyPatch,
+    use_cache: bool,
+    force_refresh: bool,
+    expected_refreshed: bool,
+) -> None:
+    """cache_status.refreshed must reflect only the explicit force_refresh
+    request field, not the use_cache-derived effective_force used for query
+    execution; otherwise a use_cache=False, force_refresh=False request would
+    incorrectly report refreshed=True."""
+    module = importlib.import_module("superset.mcp_service.chart.tool.get_chart_data")
+
+    def fake_build(form_data: Any, **kwargs: Any) -> Any:
+        return object()
+
+    class _Command:
+        def __init__(self, query_context: Any) -> None: ...
+        def validate(self) -> None: ...
+        def run(self) -> dict[str, Any]:
+            return {
+                "queries": [{"data": [{"col": 1}], "colnames": ["col"], "rowcount": 1}]
+            }
+
+    monkeypatch.setattr(module, "build_query_context_from_form_data", fake_build)
+    monkeypatch.setattr(
+        module,
+        "event_logger",
+        SimpleNamespace(log_context=lambda **kwargs: nullcontext()),
+    )
+    get_data_command_module = importlib.import_module(
+        "superset.commands.chart.data.get_data_command"
+    )
+    monkeypatch.setattr(get_data_command_module, "ChartDataCommand", _Command)
+
+    result = await _query_from_form_data(
+        {"datasource_id": 1, "datasource_type": "table"},
+        GetChartDataRequest(
+            form_data_key="k",
+            use_cache=use_cache,
+            force_refresh=force_refresh,
+        ),
+        _AsyncContext(),
+    )
+
+    assert isinstance(result, ChartData)
+    assert result.cache_status is not None
+    assert result.cache_status.refreshed is expected_refreshed

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -2186,3 +2186,62 @@ async def test_query_from_form_data_string_row_limit_is_coerced(
 
     assert captured["row_limit"] == 250
     assert isinstance(captured["row_limit"], int)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("use_cache", "force_refresh", "expected_force"),
+    [
+        (True, False, False),
+        (False, False, True),
+        (True, True, True),
+        (False, True, True),
+    ],
+)
+async def test_query_from_form_data_use_cache_false_bypasses_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    use_cache: bool,
+    force_refresh: bool,
+    expected_force: bool,
+) -> None:
+    """use_cache=False must bypass the cache the same way force_refresh=True
+    does; previously only force_refresh was wired to the QueryContext's
+    ``force`` flag and use_cache was silently ignored."""
+    module = importlib.import_module("superset.mcp_service.chart.tool.get_chart_data")
+    captured: dict[str, Any] = {}
+
+    def fake_build(form_data: Any, **kwargs: Any) -> Any:
+        captured["force"] = kwargs.get("force")
+        captured["custom_cache_timeout"] = kwargs.get("custom_cache_timeout")
+        return object()
+
+    class _Command:
+        def __init__(self, query_context: Any) -> None: ...
+        def validate(self) -> None: ...
+        def run(self) -> dict[str, Any]:
+            return {"queries": [{"data": [], "colnames": [], "rowcount": 0}]}
+
+    monkeypatch.setattr(module, "build_query_context_from_form_data", fake_build)
+    monkeypatch.setattr(
+        module,
+        "event_logger",
+        SimpleNamespace(log_context=lambda **kwargs: nullcontext()),
+    )
+    get_data_command_module = importlib.import_module(
+        "superset.commands.chart.data.get_data_command"
+    )
+    monkeypatch.setattr(get_data_command_module, "ChartDataCommand", _Command)
+
+    await _query_from_form_data(
+        {"datasource_id": 1, "datasource_type": "table"},
+        GetChartDataRequest(
+            form_data_key="k",
+            use_cache=use_cache,
+            force_refresh=force_refresh,
+            cache_timeout=90,
+        ),
+        _AsyncContext(),
+    )
+
+    assert captured["force"] is expected_force
+    assert captured["custom_cache_timeout"] == 90


### PR DESCRIPTION
### SUMMARY
`get_chart_data`'s docstring advertises `Cache control: use_cache, force_refresh, cache_timeout`, but only `force_refresh` was actually wired into the `QueryContext`'s `force` flag:

- `use_cache=False` was silently ignored — the tool would still read from cache even when a caller explicitly asked it not to.
- `cache_timeout` was never applied anywhere, despite being a documented, logged request field.

This fixes both by:
- Computing `effective_force = force_refresh or not use_cache` once per call path, and using it everywhere the tool builds or patches a `QueryContext` (the cached-form_data path, the no-saved-query_context fallback path, the saved-`query_context` patch path, and the unsaved-chart-only `_query_from_form_data` path), instead of `force=request.force_refresh`.
- Threading `cache_timeout` through as `QueryContextFactory`'s existing `custom_cache_timeout` parameter (already supported by `QueryContext`/`QueryContextFactory` and by `ChartDataQueryContextSchema` as a top-level field) — added as a new optional param on `build_query_context_from_form_data` in `chart_helpers.py` and passed through at every call site.

No behavior changes for existing callers that don't set `use_cache`/`cache_timeout`: defaults are `use_cache=True`, `cache_timeout=None`, so `effective_force` reduces to `force_refresh` as before.

### TESTING INSTRUCTIONS
- Added `test_query_from_form_data_use_cache_false_bypasses_cache` (parametrized over `use_cache`/`force_refresh` combinations) to `tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py`, asserting the `force` and `custom_cache_timeout` kwargs passed to `build_query_context_from_form_data`.
- `ruff check` / `ruff format --check` / `python -m py_compile` pass on all changed files.
- Could not run the full unit test suite in this environment due to a pre-existing, unrelated local SQLAlchemy/Flask-AppBuilder init issue (`Connection.rollback()` missing) that reproduces identically on `master` before this change.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217660462093341