### PR TITLE
fix(versioning): suppress automatic chart normalization changes

### DIFF
--- a/superset-frontend/playwright/tests/version-history/activity-log.spec.ts
+++ b/superset-frontend/playwright/tests/version-history/activity-log.spec.ts
@@ -40,9 +40,17 @@ import { testWithAssets, expect } from '../../helpers/fixtures';
 import { apiGet } from '../../helpers/api/requests';
 import { apiPostChart, apiPutChart } from '../../helpers/api/chart';
 import { getDatasetByName } from '../../helpers/api/dataset';
+import { getAccessToken } from '../../helpers/api/embedded';
 import { TIMEOUT } from '../../utils/constants';
 
 const DATASET_NAME = 'birth_names';
+
+async function authorizeApi(page: Page): Promise<void> {
+  const accessToken = await getAccessToken(page);
+  await page.context().setExtraHTTPHeaders({
+    Authorization: `Bearer ${accessToken}`,
+  });
+}
 
 // Visible row text must never expose synthetic identifiers (layout node
 // ids like CHART-xyz / ROW-… or bare UUIDs) — the rendering layer maps
@@ -79,19 +87,35 @@ async function currentUserSubjectId(page: Page): Promise<number> {
  * this reads like its sibling specs, but fall back to whatever the instance
  * has rather than requiring a particular fixture to be loaded.
  */
-async function anyDatasetId(page: Page): Promise<number> {
+async function anyDataset(page: Page): Promise<{
+  id: number;
+  columnName: string;
+}> {
   const named = await getDatasetByName(page, DATASET_NAME);
-  if (named) {
-    return named.id;
+  let datasetId = named?.id;
+  if (!datasetId) {
+    const res = await apiGet(
+      page,
+      `api/v1/dataset/?q=${rison.encode({ columns: ['id'], page_size: 1 })}`,
+    );
+    expect(res.ok(), 'dataset list request').toBeTruthy();
+    const [first] = (await res.json()).result;
+    expect(first, 'the instance has at least one dataset').toBeTruthy();
+    datasetId = first.id;
   }
-  const res = await apiGet(
-    page,
-    `api/v1/dataset/?q=${rison.encode({ columns: ['id'], page_size: 1 })}`,
-  );
-  expect(res.ok(), 'dataset list request').toBeTruthy();
-  const [first] = (await res.json()).result;
-  expect(first, 'the instance has at least one dataset').toBeTruthy();
-  return first.id;
+  if (datasetId === undefined) {
+    throw new Error('Unable to resolve a dataset id');
+  }
+
+  const detailRes = await apiGet(page, `api/v1/dataset/${datasetId}`);
+  expect(detailRes.ok(), 'dataset detail request').toBeTruthy();
+  const { columns } = (await detailRes.json()).result;
+  const [firstColumn] = columns;
+  expect(firstColumn, 'the dataset has at least one column').toBeTruthy();
+  return {
+    id: datasetId,
+    columnName: firstColumn.column_name,
+  };
 }
 
 /** Open the Explore "Additional actions → View version history" panel. */
@@ -109,7 +133,8 @@ testWithAssets(
   async ({ page, testAssets }) => {
     testWithAssets.setTimeout(TIMEOUT.SLOW_TEST);
 
-    const datasetId = await anyDatasetId(page);
+    await authorizeApi(page);
+    const { id: datasetId, columnName } = await anyDataset(page);
 
     const baseName = `version_history_${Date.now()}`;
     const chartResp = await apiPostChart(page, {
@@ -123,7 +148,7 @@ testWithAssets(
         datasource: `${datasetId}__table`,
         viz_type: 'table',
         query_mode: 'raw',
-        all_columns: [],
+        all_columns: [columnName],
         adhoc_filters: [],
         row_limit: 10,
       }),
@@ -169,5 +194,81 @@ testWithAssets(
       OPAQUE_ID.test(panelText),
       `panel leaks a raw id/uuid:\n${panelText}`,
     ).toBeFalsy();
+  },
+);
+
+testWithAssets(
+  'minor edit of a non-canonical chart omits hydration noise',
+  async ({ page, testAssets }) => {
+    testWithAssets.setTimeout(TIMEOUT.SLOW_TEST);
+
+    await authorizeApi(page);
+    const { id: datasetId, columnName } = await anyDataset(page);
+    const baseName = `version_history_normalization_${Date.now()}`;
+    const chartResp = await apiPostChart(page, {
+      slice_name: baseName,
+      viz_type: 'table',
+      datasource_id: datasetId,
+      datasource_type: 'table',
+      // Deliberately omit visualization defaults. Explore hydration supplies
+      // them, reproducing params imported before they were canonical.
+      params: JSON.stringify({
+        datasource: `${datasetId}__table`,
+        viz_type: 'table',
+        query_mode: 'raw',
+        all_columns: [columnName],
+        adhoc_filters: [],
+        extra_form_data: {},
+        dashboards: [],
+        row_limit: 10,
+      }),
+    });
+    expect(chartResp.ok(), 'chart creation').toBeTruthy();
+    const chartBody = await chartResp.json();
+    const chartId: number = chartBody.result?.id ?? chartBody.id;
+    expect(chartId, 'chart creation should return an id').toBeTruthy();
+    testAssets.trackChart(chartId);
+
+    const adminSubjectId = await currentUserSubjectId(page);
+    const editorResp = await apiPutChart(page, chartId, {
+      editors: [adminSubjectId],
+    });
+    expect(editorResp.ok(), 'claim chart editorship').toBeTruthy();
+
+    await page.goto(`explore/?slice_id=${chartId}`);
+    await page.getByRole('combobox', { name: 'Row limit' }).click();
+    await page.getByRole('option', { name: '100', exact: true }).click();
+    await page.locator('[data-test="query-save-button"]').click();
+    await page.locator('[data-test="save-overwrite-radio"]').click();
+
+    const saveResponsePromise = page.waitForResponse(
+      response =>
+        response.request().method() === 'PUT' &&
+        response.url().includes(`/api/v1/chart/${chartId}`),
+    );
+    await page.locator('[data-test="btn-modal-save"]').click();
+    const saveResponse = await saveResponsePromise;
+    expect(saveResponse.ok(), 'chart overwrite').toBeTruthy();
+
+    const requestPayload = saveResponse.request().postDataJSON();
+    const savedParams = JSON.parse(requestPayload.params);
+    expect(
+      savedParams.matrixify_enable,
+      'overwrite contains a default absent from the stored params',
+    ).toBe(false);
+
+    await openVersionHistory(page);
+    const panel = page.locator('[aria-label="Version history"]');
+    const newestGroup = panel
+      .locator('[data-test="version-history-save-group"]')
+      .first();
+    await expect(newestGroup, 'shows the overwrite save group').toBeVisible();
+    await newestGroup.getByRole('button').first().click();
+
+    const rows = newestGroup.locator(
+      '[data-test="version-history-action-row"]',
+    );
+    await expect(rows, 'shows only the intentional edit').toHaveCount(1);
+    await expect(rows.first()).toContainText(/row limit/i);
   },
 );

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -385,7 +385,7 @@ test('seeds only guarded matching-input hydration transitions', () => {
       type: HYDRATE_CHART_NORMALIZATION,
       tracking: expect.objectContaining({
         chartId: 371,
-        exclusions: expect.objectContaining({
+        transitions: expect.objectContaining({
           time_range: {
             control: 'time_range',
             from_present: false,

--- a/superset-frontend/src/explore/actions/hydrateExplore.test.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.test.ts
@@ -17,9 +17,19 @@
  * under the License.
  */
 
-import { VizType } from '@superset-ui/core';
+import { isFeatureEnabled, VizType } from '@superset-ui/core';
+import { HYDRATE_CHART_NORMALIZATION } from 'src/features/versionHistory/reducer';
 import { hydrateExplore, HYDRATE_EXPLORE } from './hydrateExplore';
 import { exploreInitialData } from '../fixtures';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
+
+beforeEach(() => mockedIsFeatureEnabled.mockReturnValue(false));
 
 afterEach(() => {
   window.history.pushState({}, '', '/');
@@ -341,5 +351,69 @@ test('extracts currency formats from metrics in dataset', () => {
         }),
       }),
     }),
+  );
+});
+
+test('seeds only guarded matching-input hydration transitions', () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({
+    user: {},
+    charts: {},
+    datasources: {},
+    common: { conf: { DEFAULT_TIME_FILTER: 'Last year' } },
+    explore: {},
+  }));
+  const persisted = {
+    ...exploreInitialData.form_data,
+  };
+  delete persisted.time_range;
+  const initialData = {
+    ...exploreInitialData,
+    form_data: { ...persisted },
+    slice: {
+      ...exploreInitialData.slice!,
+      form_data: { ...persisted },
+    },
+  };
+
+  // @ts-expect-error focused hydration fixture
+  hydrateExplore(initialData)(dispatch, getState);
+
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: HYDRATE_CHART_NORMALIZATION,
+      tracking: expect.objectContaining({
+        chartId: 371,
+        exclusions: expect.objectContaining({
+          time_range: {
+            control: 'time_range',
+            from_present: false,
+            to_present: true,
+            to_value: 'Last year',
+          },
+        }),
+      }),
+    }),
+  );
+});
+
+test('does not seed normalization metadata for dashboard overrides', () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  window.history.pushState({}, '', '/explore/?dashboard_id=12');
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({
+    user: {},
+    charts: {},
+    datasources: {},
+    common: {},
+    explore: {},
+  }));
+
+  // @ts-expect-error focused hydration fixture
+  hydrateExplore(exploreInitialData)(dispatch, getState);
+
+  expect(dispatch).not.toHaveBeenCalledWith(
+    expect.objectContaining({ type: HYDRATE_CHART_NORMALIZATION }),
   );
 });

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -50,11 +50,14 @@ import { URL_PARAMS } from 'src/constants';
 import { findPermission } from 'src/utils/findPermission';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { nanoid } from 'nanoid';
-import isEqual from 'lodash-es/isEqual';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { hydrateChartNormalization } from 'src/features/versionHistory/reducer';
+import {
+  isJsonValue,
+  jsonValuesEqual,
+} from 'src/features/versionHistory/normalization';
 import type {
-  AutomaticNormalizationExclusions,
+  AutomaticNormalizationTransitions,
   JsonValue,
 } from 'src/features/versionHistory/types';
 
@@ -63,30 +66,12 @@ enum ColorSchemeType {
   SEQUENTIAL = 'SEQUENTIAL',
 }
 
-const isJsonValue = (value: unknown): value is JsonValue => {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
-  }
-  return (
-    typeof value === 'object' &&
-    Object.values(value as Record<string, unknown>).every(isJsonValue)
-  );
-};
-
 const normalizationTransitions = (
   persisted: Record<string, unknown>,
   input: Record<string, unknown>,
   hydrated: Record<string, unknown>,
-): AutomaticNormalizationExclusions => {
-  const transitions: AutomaticNormalizationExclusions = {};
+): AutomaticNormalizationTransitions => {
+  const transitions: AutomaticNormalizationTransitions = {};
   [...new Set([...Object.keys(input), ...Object.keys(hydrated)])].forEach(
     control => {
       const fromPresent = Object.hasOwn(persisted, control);
@@ -97,12 +82,12 @@ const normalizationTransitions = (
       const toValue = hydrated[control];
       if (
         fromPresent === inputPresent &&
-        isEqual(fromValue, inputValue) &&
+        jsonValuesEqual(fromValue, inputValue) &&
         // A missing projected key may only mean that the control is not part
         // of the active visualization. Treating it as normalization could
         // suppress a real removal.
         toPresent &&
-        (fromPresent !== toPresent || !isEqual(fromValue, toValue)) &&
+        (fromPresent !== toPresent || !jsonValuesEqual(fromValue, toValue)) &&
         (!fromPresent || isJsonValue(fromValue)) &&
         (!toPresent || isJsonValue(toValue))
       ) {
@@ -112,7 +97,7 @@ const normalizationTransitions = (
           ...(fromPresent && { from_value: fromValue as JsonValue }),
           to_present: toPresent,
           ...(toPresent && { to_value: toValue as JsonValue }),
-        } as AutomaticNormalizationExclusions[string];
+        } as AutomaticNormalizationTransitions[string];
       }
     },
   );
@@ -334,7 +319,7 @@ export const hydrateExplore =
         hydrateChartNormalization({
           chartId: initialSlice.slice_id,
           hydrationSessionId: nanoid(),
-          exclusions: normalizationTransitions(
+          transitions: normalizationTransitions(
             persistedFormData,
             preHydrationFormData,
             hydratedFormData,

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -52,57 +52,12 @@ import getBootstrapData from 'src/utils/getBootstrapData';
 import { nanoid } from 'nanoid';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { hydrateChartNormalization } from 'src/features/versionHistory/reducer';
-import {
-  isJsonValue,
-  jsonValuesEqual,
-} from 'src/features/versionHistory/normalization';
-import type {
-  AutomaticNormalizationTransitions,
-  JsonValue,
-} from 'src/features/versionHistory/types';
+import { automaticNormalizationTransitions } from 'src/features/versionHistory/normalization';
 
 enum ColorSchemeType {
   CATEGORICAL = 'CATEGORICAL',
   SEQUENTIAL = 'SEQUENTIAL',
 }
-
-const normalizationTransitions = (
-  persisted: Record<string, unknown>,
-  input: Record<string, unknown>,
-  hydrated: Record<string, unknown>,
-): AutomaticNormalizationTransitions => {
-  const transitions: AutomaticNormalizationTransitions = {};
-  [...new Set([...Object.keys(input), ...Object.keys(hydrated)])].forEach(
-    control => {
-      const fromPresent = Object.hasOwn(persisted, control);
-      const inputPresent = Object.hasOwn(input, control);
-      const toPresent = Object.hasOwn(hydrated, control);
-      const fromValue = persisted[control];
-      const inputValue = input[control];
-      const toValue = hydrated[control];
-      if (
-        fromPresent === inputPresent &&
-        jsonValuesEqual(fromValue, inputValue) &&
-        // A missing projected key may only mean that the control is not part
-        // of the active visualization. Treating it as normalization could
-        // suppress a real removal.
-        toPresent &&
-        (fromPresent !== toPresent || !jsonValuesEqual(fromValue, toValue)) &&
-        (!fromPresent || isJsonValue(fromValue)) &&
-        (!toPresent || isJsonValue(toValue))
-      ) {
-        transitions[control] = {
-          control,
-          from_present: fromPresent,
-          ...(fromPresent && { from_value: fromValue as JsonValue }),
-          to_present: toPresent,
-          ...(toPresent && { to_value: toValue as JsonValue }),
-        } as AutomaticNormalizationTransitions[string];
-      }
-    },
-  );
-  return transitions;
-};
 
 export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
@@ -319,7 +274,7 @@ export const hydrateExplore =
         hydrateChartNormalization({
           chartId: initialSlice.slice_id,
           hydrationSessionId: nanoid(),
-          transitions: normalizationTransitions(
+          transitions: automaticNormalizationTransitions(
             persistedFormData,
             preHydrationFormData,
             hydratedFormData,

--- a/superset-frontend/src/explore/actions/hydrateExplore.ts
+++ b/superset-frontend/src/explore/actions/hydrateExplore.ts
@@ -49,11 +49,75 @@ import { getUrlParam } from 'src/utils/urlUtils';
 import { URL_PARAMS } from 'src/constants';
 import { findPermission } from 'src/utils/findPermission';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { nanoid } from 'nanoid';
+import isEqual from 'lodash-es/isEqual';
+import cloneDeep from 'lodash-es/cloneDeep';
+import { hydrateChartNormalization } from 'src/features/versionHistory/reducer';
+import type {
+  AutomaticNormalizationExclusions,
+  JsonValue,
+} from 'src/features/versionHistory/types';
 
 enum ColorSchemeType {
   CATEGORICAL = 'CATEGORICAL',
   SEQUENTIAL = 'SEQUENTIAL',
 }
+
+const isJsonValue = (value: unknown): value is JsonValue => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  return (
+    typeof value === 'object' &&
+    Object.values(value as Record<string, unknown>).every(isJsonValue)
+  );
+};
+
+const normalizationTransitions = (
+  persisted: Record<string, unknown>,
+  input: Record<string, unknown>,
+  hydrated: Record<string, unknown>,
+): AutomaticNormalizationExclusions => {
+  const transitions: AutomaticNormalizationExclusions = {};
+  [...new Set([...Object.keys(input), ...Object.keys(hydrated)])].forEach(
+    control => {
+      const fromPresent = Object.hasOwn(persisted, control);
+      const inputPresent = Object.hasOwn(input, control);
+      const toPresent = Object.hasOwn(hydrated, control);
+      const fromValue = persisted[control];
+      const inputValue = input[control];
+      const toValue = hydrated[control];
+      if (
+        fromPresent === inputPresent &&
+        isEqual(fromValue, inputValue) &&
+        // A missing projected key may only mean that the control is not part
+        // of the active visualization. Treating it as normalization could
+        // suppress a real removal.
+        toPresent &&
+        (fromPresent !== toPresent || !isEqual(fromValue, toValue)) &&
+        (!fromPresent || isJsonValue(fromValue)) &&
+        (!toPresent || isJsonValue(toValue))
+      ) {
+        transitions[control] = {
+          control,
+          from_present: fromPresent,
+          ...(fromPresent && { from_value: fromValue as JsonValue }),
+          to_present: toPresent,
+          ...(toPresent && { to_value: toValue as JsonValue }),
+        } as AutomaticNormalizationExclusions[string];
+      }
+    },
+  );
+  return transitions;
+};
 
 export const HYDRATE_EXPLORE = 'HYDRATE_EXPLORE';
 export const hydrateExplore =
@@ -78,6 +142,8 @@ export const hydrateExplore =
     const fallbackSlice = sliceId ? sliceEntities?.slices?.[sliceId] : null;
     const initialSlice = slice ?? fallbackSlice;
     const initialFormData = form_data ?? initialSlice?.form_data;
+    const persistedFormData = cloneDeep(initialSlice?.form_data ?? {});
+    const preHydrationFormData = cloneDeep(initialFormData ?? {});
     const isCachedFormData = getUrlParam(URL_PARAMS.formDataKey) !== null;
     const [primarySliceNameSource, fallbackSliceNameSource] = isCachedFormData
       ? [initialFormData, initialSlice]
@@ -213,6 +279,10 @@ export const hydrateExplore =
         exploreState,
       );
     });
+    const hydratedFormData = {
+      ...initialFormData,
+      ...getFormDataFromControls(exploreState.controls),
+    };
     const sliceFormData = initialSlice
       ? getFormDataFromControls(initialControls)
       : null;
@@ -233,7 +303,7 @@ export const hydrateExplore =
       lastRendered: 0,
     };
 
-    return dispatch({
+    const result = dispatch({
       type: HYDRATE_EXPLORE,
       data: {
         charts: {
@@ -253,6 +323,28 @@ export const hydrateExplore =
         dataMask,
       },
     });
+    if (
+      isFeatureEnabled(FeatureFlag.VersionHistory) &&
+      initialSlice?.slice_id &&
+      !isCachedFormData &&
+      !dashboardId &&
+      getUrlParam(URL_PARAMS.vizType) === null
+    ) {
+      dispatch(
+        hydrateChartNormalization({
+          chartId: initialSlice.slice_id,
+          hydrationSessionId: nanoid(),
+          exclusions: normalizationTransitions(
+            persistedFormData,
+            preHydrationFormData,
+            hydratedFormData,
+          ),
+          invalidatedControls: {},
+          saveAttemptId: null,
+        }),
+      );
+    }
+    return result;
   };
 
 export type HydrateExplore = {

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -189,6 +189,67 @@ test('existing-chart overwrite sends only still-matching normalization metadata'
   );
 });
 
+test('matches normalization metadata against finalized payload filters', async () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload, {
+    name: updateSliceEndpoint,
+  });
+  const extraTemporalFilter = {
+    expressionType: 'SIMPLE',
+    clause: 'WHERE',
+    subject: 'ds',
+    operator: Operators.TemporalRange,
+    comparator: '',
+    isExtra: true,
+  } as SimpleAdhocFilter;
+  const savedTemporalFilter = {
+    ...extraTemporalFilter,
+    comparator: 'No filter',
+    isExtra: false,
+  };
+  const dispatch = jest.fn();
+  const getState = () => ({
+    explore: {
+      form_data: {
+        datasource: `${datasourceId}__${datasourceType}`,
+        viz_type: vizType,
+        adhoc_filters: [extraTemporalFilter],
+      },
+    },
+    versionHistory: {
+      chartNormalization: {
+        chartId: sliceId,
+        hydrationSessionId: 'hydration-a',
+        saveAttemptId: null,
+        invalidatedControls: {},
+        transitions: {
+          adhoc_filters: {
+            control: 'adhoc_filters',
+            from_present: false as const,
+            to_present: true as const,
+            to_value: [savedTemporalFilter],
+          },
+        },
+      },
+    },
+  });
+
+  await updateSlice(
+    { ...sliceResponsePayload, slice_id: sliceId } as never,
+    sliceName,
+    [],
+  )(dispatch, getState);
+
+  const request = fetchMock.callHistory.lastCall(updateSliceEndpoint);
+  const body = JSON.parse(request?.options.body as string);
+  expect(body.normalization_changes).toEqual([
+    expect.objectContaining({
+      control: 'adhoc_filters',
+      to_value: [savedTemporalFilter],
+    }),
+  ]);
+});
+
 /**
  * Tests updateSlice action
  */

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -21,6 +21,7 @@ import { Dispatch } from 'redux';
 import { ADD_TOAST } from 'src/components/MessageToasts/actions';
 import {
   DatasourceType,
+  isFeatureEnabled,
   QueryFormData,
   SimpleAdhocFilter,
   VizType,
@@ -36,6 +37,13 @@ import {
   PayloadSlice,
 } from './saveModalActions';
 import { Operators } from '../constants';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 // Define test constants and mock data using imported types
 const sliceId = 10;
@@ -92,17 +100,85 @@ const sliceResponsePayload: Partial<PayloadSlice> = {
 };
 
 const sampleError = new Error('sampleError');
+const updateSliceEndpoint = `glob:*/api/v1/chart/${sliceId}`;
 
 jest.mock('../exploreUtils', () => ({
   buildV1ChartDataPayload: jest.fn(() => queryContext),
 }));
 
-beforeEach(() => fetchMock.clearHistory().removeRoutes());
+beforeEach(() => {
+  fetchMock.clearHistory().removeRoutes();
+  mockedIsFeatureEnabled.mockReturnValue(false);
+});
+
+test('existing-chart overwrite sends only still-matching normalization metadata', async () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload, {
+    name: updateSliceEndpoint,
+  });
+  const dispatch = jest.fn();
+  const getState = () => ({
+    explore: {
+      form_data: {
+        datasource: `${datasourceId}__${datasourceType}`,
+        viz_type: vizType,
+        row_limit: 10000,
+        show_legend: true,
+      },
+    },
+    versionHistory: {
+      chartNormalization: {
+        chartId: sliceId,
+        hydrationSessionId: 'hydration-a',
+        saveAttemptId: null,
+        invalidatedControls: { show_legend: true as const },
+        exclusions: {
+          row_limit: {
+            control: 'row_limit',
+            from_present: true as const,
+            from_value: null,
+            to_present: true as const,
+            to_value: 10000,
+          },
+          show_legend: {
+            control: 'show_legend',
+            from_present: false as const,
+            to_present: true as const,
+            to_value: true,
+          },
+        },
+      },
+    },
+  });
+
+  await updateSlice(
+    { ...sliceResponsePayload, slice_id: sliceId } as never,
+    sliceName,
+    [],
+  )(dispatch, getState);
+
+  const request = fetchMock.callHistory.lastCall(updateSliceEndpoint);
+  const body = JSON.parse(request?.options.body as string);
+  expect(body.normalization_changes).toEqual([
+    {
+      control: 'row_limit',
+      from_present: true,
+      from_value: null,
+      to_present: true,
+      to_value: 10000,
+    },
+  ]);
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ type: 'BEGIN_CHART_NORMALIZATION_SAVE' }),
+  );
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({ type: 'COMPLETE_CHART_NORMALIZATION_SAVE' }),
+  );
+});
 
 /**
  * Tests updateSlice action
  */
-const updateSliceEndpoint = `glob:*/api/v1/chart/${sliceId}`;
 test('updateSlice handles success', async () => {
   fetchMock.put(updateSliceEndpoint, sliceResponsePayload, {
     name: updateSliceEndpoint,

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -884,3 +884,97 @@ describe('getSlicePayload', () => {
     });
   });
 });
+
+test('existing-chart overwrite covers stash-removed keys as drop transitions', async () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload, {
+    name: updateSliceEndpoint,
+  });
+  const dispatch = jest.fn();
+  const getState = () => ({
+    explore: {
+      // The stash removed order_desc from active form data...
+      form_data: {
+        datasource: `${datasourceId}__${datasourceType}`,
+        viz_type: vizType,
+        row_limit: 10000,
+      },
+      // ...and holds it with the value it had when hidden.
+      hiddenFormData: { order_desc: true },
+    },
+    versionHistory: {
+      chartNormalization: {
+        chartId: sliceId,
+        hydrationSessionId: 'hydration-drop',
+        saveAttemptId: null,
+        invalidatedControls: {},
+        transitions: {},
+      },
+    },
+  });
+
+  await updateSlice(
+    {
+      ...sliceResponsePayload,
+      slice_id: sliceId,
+      // Persisted params carry the key the stash removed, same value.
+      form_data: { ...formData, order_desc: true },
+    } as never,
+    sliceName,
+    [],
+  )(dispatch, getState);
+
+  const request = fetchMock.callHistory.lastCall(updateSliceEndpoint);
+  const body = JSON.parse(request?.options.body as string);
+  expect(body.normalization_changes).toEqual([
+    {
+      control: 'order_desc',
+      from_present: true,
+      from_value: true,
+      to_present: false,
+    },
+  ]);
+});
+
+test('a stashed value the user changed before hiding is not covered', async () => {
+  mockedIsFeatureEnabled.mockReturnValue(true);
+  fetchMock.put(updateSliceEndpoint, sliceResponsePayload, {
+    name: updateSliceEndpoint,
+  });
+  const dispatch = jest.fn();
+  const getState = () => ({
+    explore: {
+      form_data: {
+        datasource: `${datasourceId}__${datasourceType}`,
+        viz_type: vizType,
+        row_limit: 10000,
+      },
+      // Stash holds a USER-edited value; persisted differs, so the removal
+      // stays recorded.
+      hiddenFormData: { order_desc: false },
+    },
+    versionHistory: {
+      chartNormalization: {
+        chartId: sliceId,
+        hydrationSessionId: 'hydration-drop-2',
+        saveAttemptId: null,
+        invalidatedControls: {},
+        transitions: {},
+      },
+    },
+  });
+
+  await updateSlice(
+    {
+      ...sliceResponsePayload,
+      slice_id: sliceId,
+      form_data: { ...formData, order_desc: true },
+    } as never,
+    sliceName,
+    [],
+  )(dispatch, getState);
+
+  const request = fetchMock.callHistory.lastCall(updateSliceEndpoint);
+  const body = JSON.parse(request?.options.body as string);
+  expect(body.normalization_changes).toBeUndefined();
+});

--- a/superset-frontend/src/explore/actions/saveModalActions.test.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.test.ts
@@ -124,6 +124,7 @@ test('existing-chart overwrite sends only still-matching normalization metadata'
         viz_type: vizType,
         row_limit: 10000,
         show_legend: true,
+        object_control: { a: 1, b: 2 },
       },
     },
     versionHistory: {
@@ -132,7 +133,7 @@ test('existing-chart overwrite sends only still-matching normalization metadata'
         hydrationSessionId: 'hydration-a',
         saveAttemptId: null,
         invalidatedControls: { show_legend: true as const },
-        exclusions: {
+        transitions: {
           row_limit: {
             control: 'row_limit',
             from_present: true as const,
@@ -145,6 +146,12 @@ test('existing-chart overwrite sends only still-matching normalization metadata'
             from_present: false as const,
             to_present: true as const,
             to_value: true,
+          },
+          object_control: {
+            control: 'object_control',
+            from_present: false as const,
+            to_present: true as const,
+            to_value: { b: 2, a: 1 },
           },
         },
       },
@@ -166,6 +173,12 @@ test('existing-chart overwrite sends only still-matching normalization metadata'
       from_value: null,
       to_present: true,
       to_value: 10000,
+    },
+    {
+      control: 'object_control',
+      from_present: false,
+      to_present: true,
+      to_value: { b: 2, a: 1 },
     },
   ]);
   expect(dispatch).toHaveBeenCalledWith(

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -38,15 +38,16 @@ import {
   completeChartNormalizationSave,
 } from 'src/features/versionHistory/reducer';
 import type {
-  AutomaticNormalizationExclusions,
+  AutomaticNormalizationTransitions,
   ChartNormalizationTrackingState,
 } from 'src/features/versionHistory/types';
+import { jsonValuesEqual } from 'src/features/versionHistory/normalization';
 
 export interface PayloadSlice extends Slice {
   params: string;
   dashboards: number[];
   query_context: string;
-  normalization_changes?: AutomaticNormalizationExclusions[string][];
+  normalization_changes?: AutomaticNormalizationTransitions[string][];
 }
 const ADHOC_FILTER_REGEX = /^adhoc_filters/;
 
@@ -260,16 +261,15 @@ export const updateSlice =
     ) as QueryFormData;
     const tracking = initialState.versionHistory?.chartNormalization;
     const saveAttemptId = nanoid();
-    const matchingExclusions = Object.fromEntries(
-      Object.entries(tracking?.exclusions ?? {}).filter(
+    const matchingTransitions = Object.fromEntries(
+      Object.entries(tracking?.transitions ?? {}).filter(
         ([control, transition]) =>
           !tracking?.invalidatedControls[control] &&
           Object.hasOwn(formData, control) === transition.to_present &&
           (!transition.to_present ||
-            JSON.stringify(formData[control]) ===
-              JSON.stringify(transition.to_value)),
+            jsonValuesEqual(formData[control], transition.to_value)),
       ),
-    ) as AutomaticNormalizationExclusions;
+    ) as AutomaticNormalizationTransitions;
     const shouldAttachNormalization =
       isFeatureEnabled(FeatureFlag.VersionHistory) &&
       tracking?.chartId === sliceId;
@@ -290,8 +290,11 @@ export const updateSlice =
         editors as [],
         formDataFromSlice,
       );
-      if (shouldAttachNormalization && Object.keys(matchingExclusions).length) {
-        payload.normalization_changes = Object.values(matchingExclusions);
+      if (
+        shouldAttachNormalization &&
+        Object.keys(matchingTransitions).length
+      ) {
+        payload.normalization_changes = Object.values(matchingTransitions);
       }
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -41,7 +41,10 @@ import type {
   AutomaticNormalizationTransitions,
   ChartNormalizationTrackingState,
 } from 'src/features/versionHistory/types';
-import { matchingAutomaticNormalizationTransitions } from 'src/features/versionHistory/normalization';
+import {
+  matchingAutomaticNormalizationTransitions,
+  stashDropNormalizationTransitions,
+} from 'src/features/versionHistory/normalization';
 
 export interface PayloadSlice extends Slice {
   params: string;
@@ -252,6 +255,10 @@ export const updateSlice =
       versionHistory?: {
         chartNormalization?: ChartNormalizationTrackingState | null;
       };
+      explore?: {
+        form_data?: QueryFormData;
+        hiddenFormData?: Record<string, unknown>;
+      };
     },
   ) => {
     const { slice_id: sliceId, editors, form_data: formDataFromSlice } = slice;
@@ -282,8 +289,22 @@ export const updateSlice =
         formDataFromSlice,
       );
       const savedFormData = JSON.parse(payload.params ?? '{}') as QueryFormData;
+      // Hydration-time transitions that still hold, plus save-time drops of
+      // keys the stash removed (mutually exclusive per control: a surviving
+      // hydration transition implies the key is present in the payload, a
+      // stash drop implies it is absent).
       const matchingTransitions = shouldAttachNormalization
-        ? matchingAutomaticNormalizationTransitions(tracking, savedFormData)
+        ? {
+            ...matchingAutomaticNormalizationTransitions(
+              tracking,
+              savedFormData,
+            ),
+            ...stashDropNormalizationTransitions(
+              (formDataFromSlice ?? {}) as Record<string, unknown>,
+              initialState.explore?.hiddenFormData,
+              savedFormData,
+            ),
+          }
         : {};
       if (
         shouldAttachNormalization &&

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -41,7 +41,7 @@ import type {
   AutomaticNormalizationTransitions,
   ChartNormalizationTrackingState,
 } from 'src/features/versionHistory/types';
-import { jsonValuesEqual } from 'src/features/versionHistory/normalization';
+import { matchingAutomaticNormalizationTransitions } from 'src/features/versionHistory/normalization';
 
 export interface PayloadSlice extends Slice {
   params: string;
@@ -261,18 +261,12 @@ export const updateSlice =
     ) as QueryFormData;
     const tracking = initialState.versionHistory?.chartNormalization;
     const saveAttemptId = nanoid();
-    const matchingTransitions = Object.fromEntries(
-      Object.entries(tracking?.transitions ?? {}).filter(
-        ([control, transition]) =>
-          !tracking?.invalidatedControls[control] &&
-          Object.hasOwn(formData, control) === transition.to_present &&
-          (!transition.to_present ||
-            jsonValuesEqual(formData[control], transition.to_value)),
-      ),
-    ) as AutomaticNormalizationTransitions;
     const shouldAttachNormalization =
       isFeatureEnabled(FeatureFlag.VersionHistory) &&
       tracking?.chartId === sliceId;
+    const matchingTransitions = shouldAttachNormalization
+      ? matchingAutomaticNormalizationTransitions(tracking, formData)
+      : {};
     if (shouldAttachNormalization) {
       dispatch(
         beginChartNormalizationSave(

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -264,9 +264,6 @@ export const updateSlice =
     const shouldAttachNormalization =
       isFeatureEnabled(FeatureFlag.VersionHistory) &&
       tracking?.chartId === sliceId;
-    const matchingTransitions = shouldAttachNormalization
-      ? matchingAutomaticNormalizationTransitions(tracking, formData)
-      : {};
     if (shouldAttachNormalization) {
       dispatch(
         beginChartNormalizationSave(
@@ -284,6 +281,10 @@ export const updateSlice =
         editors as [],
         formDataFromSlice,
       );
+      const savedFormData = JSON.parse(payload.params ?? '{}') as QueryFormData;
+      const matchingTransitions = shouldAttachNormalization
+        ? matchingAutomaticNormalizationTransitions(tracking, savedFormData)
+        : {};
       if (
         shouldAttachNormalization &&
         Object.keys(matchingTransitions).length

--- a/superset-frontend/src/explore/actions/saveModalActions.ts
+++ b/superset-frontend/src/explore/actions/saveModalActions.ts
@@ -21,6 +21,8 @@ import { Dispatch } from 'redux';
 import { t } from '@apache-superset/core/translation';
 import {
   DatasourceType,
+  FeatureFlag,
+  isFeatureEnabled,
   type QueryFormData,
   SimpleAdhocFilter,
   SupersetClient,
@@ -30,11 +32,21 @@ import { isEmpty } from 'lodash-es';
 import { Slice } from 'src/dashboard/types';
 import { Operators } from '../constants';
 import { buildV1ChartDataPayload } from '../exploreUtils';
+import { nanoid } from 'nanoid';
+import {
+  beginChartNormalizationSave,
+  completeChartNormalizationSave,
+} from 'src/features/versionHistory/reducer';
+import type {
+  AutomaticNormalizationExclusions,
+  ChartNormalizationTrackingState,
+} from 'src/features/versionHistory/types';
 
 export interface PayloadSlice extends Slice {
   params: string;
   dashboards: number[];
   query_context: string;
+  normalization_changes?: AutomaticNormalizationExclusions[string][];
 }
 const ADHOC_FILTER_REGEX = /^adhoc_filters/;
 
@@ -233,21 +245,69 @@ export const updateSlice =
       new?: boolean;
     },
   ) =>
-  async (dispatch: Dispatch, getState: () => Partial<QueryFormData>) => {
+  async (
+    dispatch: Dispatch,
+    getState: () => Partial<QueryFormData> & {
+      versionHistory?: {
+        chartNormalization?: ChartNormalizationTrackingState | null;
+      };
+    },
+  ) => {
     const { slice_id: sliceId, editors, form_data: formDataFromSlice } = slice;
-    const formData = getState().explore?.form_data;
+    const initialState = getState();
+    const formData = JSON.parse(
+      JSON.stringify(initialState.explore?.form_data ?? {}),
+    ) as QueryFormData;
+    const tracking = initialState.versionHistory?.chartNormalization;
+    const saveAttemptId = nanoid();
+    const matchingExclusions = Object.fromEntries(
+      Object.entries(tracking?.exclusions ?? {}).filter(
+        ([control, transition]) =>
+          !tracking?.invalidatedControls[control] &&
+          Object.hasOwn(formData, control) === transition.to_present &&
+          (!transition.to_present ||
+            JSON.stringify(formData[control]) ===
+              JSON.stringify(transition.to_value)),
+      ),
+    ) as AutomaticNormalizationExclusions;
+    const shouldAttachNormalization =
+      isFeatureEnabled(FeatureFlag.VersionHistory) &&
+      tracking?.chartId === sliceId;
+    if (shouldAttachNormalization) {
+      dispatch(
+        beginChartNormalizationSave(
+          sliceId,
+          tracking.hydrationSessionId,
+          saveAttemptId,
+        ),
+      );
+    }
     try {
+      const payload = await getSlicePayload(
+        sliceName,
+        formData,
+        dashboards,
+        editors as [],
+        formDataFromSlice,
+      );
+      if (shouldAttachNormalization && Object.keys(matchingExclusions).length) {
+        payload.normalization_changes = Object.values(matchingExclusions);
+      }
       const response = await SupersetClient.put({
         endpoint: `/api/v1/chart/${sliceId}`,
-        jsonPayload: await getSlicePayload(
-          sliceName,
-          formData,
-          dashboards,
-          editors as [],
-          formDataFromSlice,
-        ),
+        jsonPayload: payload,
       });
 
+      if (shouldAttachNormalization) {
+        dispatch(
+          completeChartNormalizationSave(
+            sliceId,
+            tracking.hydrationSessionId,
+            saveAttemptId,
+            {},
+          ),
+        );
+      }
       dispatch(saveSliceSuccess(response.json));
       addToasts(false, sliceName, addedToDashboard).map(dispatch);
       return response.json;

--- a/superset-frontend/src/features/versionHistory/normalization.test.ts
+++ b/superset-frontend/src/features/versionHistory/normalization.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  automaticNormalizationTransitions,
+  isJsonValue,
+  matchingAutomaticNormalizationTransitions,
+} from './normalization';
+
+test('recognizes only values that JSON can represent faithfully', () => {
+  expect(isJsonValue({ nested: [null, true, 3, 'value'] })).toBe(true);
+  expect(isJsonValue(Number.NaN)).toBe(false);
+  expect(isJsonValue(Number.POSITIVE_INFINITY)).toBe(false);
+  expect(isJsonValue(new Date())).toBe(false);
+
+  const cyclic: Record<string, unknown> = {};
+  cyclic.self = cyclic;
+  expect(isJsonValue(cyclic)).toBe(false);
+});
+
+test('records hydration changes only when input matches persisted data', () => {
+  expect(
+    automaticNormalizationTransitions(
+      { row_limit: null },
+      { row_limit: null },
+      { row_limit: 10000, show_legend: true },
+    ),
+  ).toEqual({
+    row_limit: {
+      control: 'row_limit',
+      from_present: true,
+      from_value: null,
+      to_present: true,
+      to_value: 10000,
+    },
+    show_legend: {
+      control: 'show_legend',
+      from_present: false,
+      to_present: true,
+      to_value: true,
+    },
+  });
+
+  expect(
+    automaticNormalizationTransitions(
+      { row_limit: null },
+      { row_limit: 500 },
+      { row_limit: 10000 },
+    ),
+  ).toEqual({});
+});
+
+test('does not interpret a missing hydrated control as normalization', () => {
+  expect(
+    automaticNormalizationTransitions(
+      { obsolete_control: true },
+      { obsolete_control: true },
+      {},
+    ),
+  ).toEqual({});
+});
+
+test('keeps only valid, unchanged transitions for a save', () => {
+  const rowLimit = {
+    control: 'row_limit',
+    from_present: true as const,
+    from_value: null,
+    to_present: true as const,
+    to_value: 10000,
+  };
+  const tracking = {
+    chartId: 7,
+    hydrationSessionId: 'hydration-a',
+    saveAttemptId: null,
+    invalidatedControls: { show_legend: true as const },
+    transitions: {
+      row_limit: rowLimit,
+      show_legend: {
+        control: 'show_legend',
+        from_present: false as const,
+        to_present: true as const,
+        to_value: true,
+      },
+    },
+  };
+
+  expect(
+    matchingAutomaticNormalizationTransitions(tracking, {
+      row_limit: 10000,
+      show_legend: true,
+    }),
+  ).toEqual({ row_limit: rowLimit });
+});

--- a/superset-frontend/src/features/versionHistory/normalization.test.ts
+++ b/superset-frontend/src/features/versionHistory/normalization.test.ts
@@ -20,6 +20,7 @@ import {
   automaticNormalizationTransitions,
   isJsonValue,
   matchingAutomaticNormalizationTransitions,
+  stashDropNormalizationTransitions,
 } from './normalization';
 
 test('recognizes only values that JSON can represent faithfully', () => {
@@ -105,4 +106,53 @@ test('keeps only valid, unchanged transitions for a save', () => {
       show_legend: true,
     }),
   ).toEqual({ row_limit: rowLimit });
+});
+
+test('covers a stash-removed key still equal to its persisted value', () => {
+  expect(
+    stashDropNormalizationTransitions(
+      { order_desc: true, row_limit: 5000 },
+      { order_desc: true },
+      { row_limit: 5000 },
+    ),
+  ).toEqual({
+    order_desc: {
+      control: 'order_desc',
+      from_present: true,
+      from_value: true,
+      to_present: false,
+    },
+  });
+});
+
+test('does not cover a stashed value the user changed before it was hidden', () => {
+  expect(
+    stashDropNormalizationTransitions(
+      { server_page_length: 10 },
+      { server_page_length: 25 },
+      {},
+    ),
+  ).toEqual({});
+});
+
+test('does not cover stashed keys that were never persisted', () => {
+  expect(
+    stashDropNormalizationTransitions({}, { totals_aggregate: 'SUM' }, {}),
+  ).toEqual({});
+});
+
+test('does not cover keys the outgoing payload still carries', () => {
+  expect(
+    stashDropNormalizationTransitions(
+      { order_desc: true },
+      { order_desc: true },
+      { order_desc: true },
+    ),
+  ).toEqual({});
+});
+
+test('drop coverage requires a stash', () => {
+  expect(
+    stashDropNormalizationTransitions({ order_desc: true }, undefined, {}),
+  ).toEqual({});
 });

--- a/superset-frontend/src/features/versionHistory/normalization.ts
+++ b/superset-frontend/src/features/versionHistory/normalization.ts
@@ -17,26 +17,137 @@
  * under the License.
  */
 import isEqual from 'lodash-es/isEqual';
-import type { JsonValue } from './types';
+import type {
+  AutomaticNormalizationTransition,
+  AutomaticNormalizationTransitions,
+  ChartNormalizationTrackingState,
+  JsonValue,
+} from './types';
 
-export const isJsonValue = (value: unknown): value is JsonValue => {
+const isJsonValueInternal = (
+  value: unknown,
+  ancestors: WeakSet<object>,
+): value is JsonValue => {
   if (
     value === null ||
     typeof value === 'string' ||
-    typeof value === 'number' ||
     typeof value === 'boolean'
   ) {
     return true;
   }
-  if (Array.isArray(value)) {
-    return value.every(isJsonValue);
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
   }
-  return (
-    typeof value === 'object' &&
-    Object.values(value as Record<string, unknown>).every(isJsonValue)
-  );
+  if (typeof value !== 'object' || ancestors.has(value)) {
+    return false;
+  }
+
+  ancestors.add(value);
+  let isJsonCompatible: boolean;
+  if (Array.isArray(value)) {
+    isJsonCompatible = value.every(item =>
+      isJsonValueInternal(item, ancestors),
+    );
+  } else {
+    const prototype = Object.getPrototypeOf(value);
+    isJsonCompatible =
+      (prototype === Object.prototype || prototype === null) &&
+      Object.values(value).every(item => isJsonValueInternal(item, ancestors));
+  }
+  ancestors.delete(value);
+  return isJsonCompatible;
 };
+
+export const isJsonValue = (value: unknown): value is JsonValue =>
+  isJsonValueInternal(value, new WeakSet());
 
 /** Structural equality for JSON values, independent of object key order. */
 export const jsonValuesEqual = (left: unknown, right: unknown) =>
   isEqual(left, right);
+
+interface NormalizationSnapshots {
+  control: string;
+  persisted: Record<string, unknown>;
+  input: Record<string, unknown>;
+  hydrated: Record<string, unknown>;
+}
+
+const automaticNormalizationTransition = ({
+  control,
+  persisted,
+  input,
+  hydrated,
+}: NormalizationSnapshots): AutomaticNormalizationTransition | undefined => {
+  const fromPresent = Object.hasOwn(persisted, control);
+  const inputPresent = Object.hasOwn(input, control);
+  const toPresent = Object.hasOwn(hydrated, control);
+  const fromValue = persisted[control];
+  const inputValue = input[control];
+  const toValue = hydrated[control];
+
+  const inputMatchesPersisted =
+    fromPresent === inputPresent && jsonValuesEqual(fromValue, inputValue);
+  const hydrationChangedValue =
+    fromPresent !== toPresent || !jsonValuesEqual(fromValue, toValue);
+
+  if (!inputMatchesPersisted || !toPresent || !hydrationChangedValue) {
+    return undefined;
+  }
+  if (!isJsonValue(toValue)) {
+    return undefined;
+  }
+
+  if (!fromPresent) {
+    return {
+      control,
+      from_present: false,
+      to_present: true,
+      to_value: toValue,
+    };
+  }
+  if (!isJsonValue(fromValue)) {
+    return undefined;
+  }
+  return {
+    control,
+    from_present: true,
+    from_value: fromValue,
+    to_present: true,
+    to_value: toValue,
+  };
+};
+
+export const automaticNormalizationTransitions = (
+  persisted: Record<string, unknown>,
+  input: Record<string, unknown>,
+  hydrated: Record<string, unknown>,
+): AutomaticNormalizationTransitions => {
+  const transitions: AutomaticNormalizationTransitions = {};
+  const controls = new Set([...Object.keys(input), ...Object.keys(hydrated)]);
+  controls.forEach(control => {
+    const transition = automaticNormalizationTransition({
+      control,
+      persisted,
+      input,
+      hydrated,
+    });
+    if (transition) {
+      transitions[control] = transition;
+    }
+  });
+  return transitions;
+};
+
+export const matchingAutomaticNormalizationTransitions = (
+  tracking: ChartNormalizationTrackingState | null | undefined,
+  formData: Record<string, unknown>,
+): AutomaticNormalizationTransitions =>
+  Object.fromEntries(
+    Object.entries(tracking?.transitions ?? {}).filter(
+      ([control, transition]) =>
+        !tracking?.invalidatedControls[control] &&
+        Object.hasOwn(formData, control) === transition.to_present &&
+        (!transition.to_present ||
+          jsonValuesEqual(formData[control], transition.to_value)),
+    ),
+  );

--- a/superset-frontend/src/features/versionHistory/normalization.ts
+++ b/superset-frontend/src/features/versionHistory/normalization.ts
@@ -90,6 +90,12 @@ const automaticNormalizationTransition = ({
   const hydrationChangedValue =
     fromPresent !== toPresent || !jsonValuesEqual(fromValue, toValue);
 
+  // Disappearing keys (!toPresent) are deliberately not covered here:
+  // hydration itself never removes keys from the merged snapshot. Machine
+  // removals happen later, when StashFormDataContainer stashes invisible
+  // controls out of form_data — those are covered at save time by
+  // stashDropNormalizationTransitions, which uses the stash itself
+  // (explore.hiddenFormData) as the proof the removal was not user-made.
   if (!inputMatchesPersisted || !toPresent || !hydrationChangedValue) {
     return undefined;
   }
@@ -134,6 +140,44 @@ export const automaticNormalizationTransitions = (
     if (transition) {
       transitions[control] = transition;
     }
+  });
+  return transitions;
+};
+
+/**
+ * Advisory transitions for keys the stash removed from form_data.
+ *
+ * StashFormDataContainer moves an invisible control's value out of
+ * ``form_data`` into ``explore.hiddenFormData``. That removal is
+ * machine-made by construction, but it happens in render effects after
+ * hydration, so hydration-time tracking cannot see it. This computes the
+ * matching drop transitions at save time: a key counts only when the stash
+ * holds it, the stashed value still equals the persisted value (a user edit
+ * before hiding breaks the equality and stays recorded), and the outgoing
+ * payload no longer carries the key. Keys absent from the stash — e.g.
+ * removed by a viz-type switch — are never covered.
+ */
+export const stashDropNormalizationTransitions = (
+  persisted: Record<string, unknown>,
+  hiddenFormData: Record<string, unknown> | undefined,
+  outgoingFormData: Record<string, unknown>,
+): AutomaticNormalizationTransitions => {
+  const transitions: AutomaticNormalizationTransitions = {};
+  if (!hiddenFormData) {
+    return transitions;
+  }
+  Object.keys(hiddenFormData).forEach(control => {
+    if (!Object.hasOwn(persisted, control)) return;
+    if (Object.hasOwn(outgoingFormData, control)) return;
+    const fromValue = persisted[control];
+    if (!isJsonValue(fromValue)) return;
+    if (!jsonValuesEqual(hiddenFormData[control], fromValue)) return;
+    transitions[control] = {
+      control,
+      from_present: true,
+      from_value: fromValue,
+      to_present: false,
+    };
   });
   return transitions;
 };

--- a/superset-frontend/src/features/versionHistory/normalization.ts
+++ b/superset-frontend/src/features/versionHistory/normalization.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import isEqual from 'lodash-es/isEqual';
+import type { JsonValue } from './types';
+
+export const isJsonValue = (value: unknown): value is JsonValue => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  return (
+    typeof value === 'object' &&
+    Object.values(value as Record<string, unknown>).every(isJsonValue)
+  );
+};
+
+/** Structural equality for JSON values, independent of object key order. */
+export const jsonValuesEqual = (left: unknown, right: unknown) =>
+  isEqual(left, right);

--- a/superset-frontend/src/features/versionHistory/reducer.test.ts
+++ b/superset-frontend/src/features/versionHistory/reducer.test.ts
@@ -18,10 +18,14 @@
  */
 import versionHistoryReducer, {
   appendVersionSessionLog,
+  beginChartNormalizationSave,
   clearVersionPreview,
   clearVersionSessionLog,
+  completeChartNormalizationSave,
   closeVersionHistoryPanel,
   openVersionHistoryPanel,
+  hydrateChartNormalization,
+  invalidateChartNormalizationControls,
   selectIsChartVersionPreviewActive,
   selectIsDashboardVersionPreviewActive,
   selectVersionHistory,
@@ -144,4 +148,56 @@ test('per-entity preview selectors only match their own entity type', () => {
   const state: VersionHistoryRootState = { versionHistory: slice };
   expect(selectIsChartVersionPreviewActive(state)).toBe(true);
   expect(selectIsDashboardVersionPreviewActive(state)).toBe(false);
+});
+
+test('normalization tracking invalidates controls without re-adding exclusions', () => {
+  let state = versionHistoryReducer(
+    initial,
+    hydrateChartNormalization({
+      chartId: 7,
+      hydrationSessionId: 'session-a',
+      exclusions: {
+        row_limit: {
+          control: 'row_limit',
+          from_present: true,
+          from_value: null,
+          to_present: true,
+          to_value: 10000,
+        },
+      },
+      invalidatedControls: {},
+      saveAttemptId: null,
+    }),
+  );
+  state = versionHistoryReducer(
+    state,
+    invalidateChartNormalizationControls(['row_limit']),
+  );
+  expect(state.chartNormalization?.invalidatedControls).toEqual({
+    row_limit: true,
+  });
+  expect(state.chartNormalization?.exclusions.row_limit).toBeDefined();
+});
+
+test('late save completion cannot rebase another hydration session', () => {
+  let state = versionHistoryReducer(
+    initial,
+    hydrateChartNormalization({
+      chartId: 7,
+      hydrationSessionId: 'session-b',
+      exclusions: {},
+      invalidatedControls: {},
+      saveAttemptId: null,
+    }),
+  );
+  state = versionHistoryReducer(
+    state,
+    beginChartNormalizationSave(7, 'session-b', 'attempt-b'),
+  );
+  const unchanged = versionHistoryReducer(
+    state,
+    completeChartNormalizationSave(7, 'session-a', 'attempt-a', {}),
+  );
+  expect(unchanged).toBe(state);
+  expect(unchanged.chartNormalization?.saveAttemptId).toBe('attempt-b');
 });

--- a/superset-frontend/src/features/versionHistory/reducer.test.ts
+++ b/superset-frontend/src/features/versionHistory/reducer.test.ts
@@ -150,13 +150,13 @@ test('per-entity preview selectors only match their own entity type', () => {
   expect(selectIsDashboardVersionPreviewActive(state)).toBe(false);
 });
 
-test('normalization tracking invalidates controls without re-adding exclusions', () => {
+test('normalization tracking invalidates controls without re-adding transitions', () => {
   let state = versionHistoryReducer(
     initial,
     hydrateChartNormalization({
       chartId: 7,
       hydrationSessionId: 'session-a',
-      exclusions: {
+      transitions: {
         row_limit: {
           control: 'row_limit',
           from_present: true,
@@ -176,7 +176,7 @@ test('normalization tracking invalidates controls without re-adding exclusions',
   expect(state.chartNormalization?.invalidatedControls).toEqual({
     row_limit: true,
   });
-  expect(state.chartNormalization?.exclusions.row_limit).toBeDefined();
+  expect(state.chartNormalization?.transitions.row_limit).toBeDefined();
 });
 
 test('late save completion cannot rebase another hydration session', () => {
@@ -185,7 +185,7 @@ test('late save completion cannot rebase another hydration session', () => {
     hydrateChartNormalization({
       chartId: 7,
       hydrationSessionId: 'session-b',
-      exclusions: {},
+      transitions: {},
       invalidatedControls: {},
       saveAttemptId: null,
     }),

--- a/superset-frontend/src/features/versionHistory/reducer.ts
+++ b/superset-frontend/src/features/versionHistory/reducer.ts
@@ -18,6 +18,8 @@
  */
 import type {
   ActivityInclude,
+  AutomaticNormalizationExclusions,
+  ChartNormalizationTrackingState,
   SessionLogEntry,
   VersionedEntityType,
   VersionHistoryState,
@@ -33,6 +35,12 @@ export const VERSION_PREVIEW_APPLIED = 'VERSION_PREVIEW_APPLIED';
 export const VERSION_RESTORED = 'VERSION_RESTORED';
 export const APPEND_VERSION_SESSION_LOG = 'APPEND_VERSION_SESSION_LOG';
 export const CLEAR_VERSION_SESSION_LOG = 'CLEAR_VERSION_SESSION_LOG';
+export const HYDRATE_CHART_NORMALIZATION = 'HYDRATE_CHART_NORMALIZATION';
+export const INVALIDATE_CHART_NORMALIZATION_CONTROLS =
+  'INVALIDATE_CHART_NORMALIZATION_CONTROLS';
+export const BEGIN_CHART_NORMALIZATION_SAVE = 'BEGIN_CHART_NORMALIZATION_SAVE';
+export const COMPLETE_CHART_NORMALIZATION_SAVE =
+  'COMPLETE_CHART_NORMALIZATION_SAVE';
 
 /** Upper bound on retained unsaved-edit entries; older ones drop off. */
 export const MAX_SESSION_LOG_ENTRIES = 50;
@@ -86,6 +94,31 @@ interface ClearSessionLogAction {
   type: typeof CLEAR_VERSION_SESSION_LOG;
 }
 
+interface HydrateChartNormalizationAction {
+  type: typeof HYDRATE_CHART_NORMALIZATION;
+  tracking: ChartNormalizationTrackingState;
+}
+
+interface InvalidateChartNormalizationControlsAction {
+  type: typeof INVALIDATE_CHART_NORMALIZATION_CONTROLS;
+  controls: string[];
+}
+
+interface BeginChartNormalizationSaveAction {
+  type: typeof BEGIN_CHART_NORMALIZATION_SAVE;
+  chartId: number;
+  hydrationSessionId: string;
+  saveAttemptId: string;
+}
+
+interface CompleteChartNormalizationSaveAction {
+  type: typeof COMPLETE_CHART_NORMALIZATION_SAVE;
+  chartId: number;
+  hydrationSessionId: string;
+  saveAttemptId: string;
+  exclusions: AutomaticNormalizationExclusions;
+}
+
 export type VersionHistoryAction =
   | OpenPanelAction
   | ClosePanelAction
@@ -95,7 +128,11 @@ export type VersionHistoryAction =
   | PreviewAppliedAction
   | VersionRestoredAction
   | AppendSessionLogAction
-  | ClearSessionLogAction;
+  | ClearSessionLogAction
+  | HydrateChartNormalizationAction
+  | InvalidateChartNormalizationControlsAction
+  | BeginChartNormalizationSaveAction
+  | CompleteChartNormalizationSaveAction;
 
 export const openVersionHistoryPanel = (
   entityType: VersionedEntityType,
@@ -161,6 +198,44 @@ export const clearVersionSessionLog = (): ClearSessionLogAction => ({
   type: CLEAR_VERSION_SESSION_LOG,
 });
 
+export const hydrateChartNormalization = (
+  tracking: ChartNormalizationTrackingState,
+): HydrateChartNormalizationAction => ({
+  type: HYDRATE_CHART_NORMALIZATION,
+  tracking,
+});
+
+export const invalidateChartNormalizationControls = (
+  controls: string[],
+): InvalidateChartNormalizationControlsAction => ({
+  type: INVALIDATE_CHART_NORMALIZATION_CONTROLS,
+  controls,
+});
+
+export const beginChartNormalizationSave = (
+  chartId: number,
+  hydrationSessionId: string,
+  saveAttemptId: string,
+): BeginChartNormalizationSaveAction => ({
+  type: BEGIN_CHART_NORMALIZATION_SAVE,
+  chartId,
+  hydrationSessionId,
+  saveAttemptId,
+});
+
+export const completeChartNormalizationSave = (
+  chartId: number,
+  hydrationSessionId: string,
+  saveAttemptId: string,
+  exclusions: AutomaticNormalizationExclusions,
+): CompleteChartNormalizationSaveAction => ({
+  type: COMPLETE_CHART_NORMALIZATION_SAVE,
+  chartId,
+  hydrationSessionId,
+  saveAttemptId,
+  exclusions,
+});
+
 const initialState: VersionHistoryState = {
   isPanelOpen: false,
   entityType: null,
@@ -170,6 +245,7 @@ const initialState: VersionHistoryState = {
   sessionLog: [],
   restoreCount: 0,
   lastRestoredEntityUuid: null,
+  chartNormalization: null,
 };
 
 export default function versionHistoryReducer(
@@ -240,6 +316,58 @@ export default function versionHistoryReducer(
     }
     case CLEAR_VERSION_SESSION_LOG:
       return { ...state, sessionLog: [] };
+    case HYDRATE_CHART_NORMALIZATION:
+      return { ...state, chartNormalization: action.tracking };
+    case INVALIDATE_CHART_NORMALIZATION_CONTROLS: {
+      if (!state.chartNormalization || action.controls.length === 0) {
+        return state;
+      }
+      const invalidatedControls = {
+        ...state.chartNormalization.invalidatedControls,
+      };
+      action.controls.forEach(control => {
+        invalidatedControls[control] = true;
+      });
+      return {
+        ...state,
+        chartNormalization: {
+          ...state.chartNormalization,
+          invalidatedControls,
+        },
+      };
+    }
+    case BEGIN_CHART_NORMALIZATION_SAVE:
+      if (
+        state.chartNormalization?.chartId !== action.chartId ||
+        state.chartNormalization.hydrationSessionId !==
+          action.hydrationSessionId
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        chartNormalization: {
+          ...state.chartNormalization,
+          saveAttemptId: action.saveAttemptId,
+        },
+      };
+    case COMPLETE_CHART_NORMALIZATION_SAVE:
+      if (
+        state.chartNormalization?.chartId !== action.chartId ||
+        state.chartNormalization.hydrationSessionId !==
+          action.hydrationSessionId ||
+        state.chartNormalization.saveAttemptId !== action.saveAttemptId
+      ) {
+        return state;
+      }
+      return {
+        ...state,
+        chartNormalization: {
+          ...state.chartNormalization,
+          exclusions: action.exclusions,
+          saveAttemptId: null,
+        },
+      };
     default:
       return state;
   }
@@ -292,3 +420,6 @@ export const selectVersionLastRestoredUuid = (state: VersionHistoryRootState) =>
 
 export const selectVersionSessionLog = (state: VersionHistoryRootState) =>
   selectVersionHistory(state).sessionLog;
+
+export const selectChartNormalization = (state: VersionHistoryRootState) =>
+  selectVersionHistory(state).chartNormalization;

--- a/superset-frontend/src/features/versionHistory/reducer.ts
+++ b/superset-frontend/src/features/versionHistory/reducer.ts
@@ -18,7 +18,7 @@
  */
 import type {
   ActivityInclude,
-  AutomaticNormalizationExclusions,
+  AutomaticNormalizationTransitions,
   ChartNormalizationTrackingState,
   SessionLogEntry,
   VersionedEntityType,
@@ -116,7 +116,7 @@ interface CompleteChartNormalizationSaveAction {
   chartId: number;
   hydrationSessionId: string;
   saveAttemptId: string;
-  exclusions: AutomaticNormalizationExclusions;
+  transitions: AutomaticNormalizationTransitions;
 }
 
 export type VersionHistoryAction =
@@ -227,13 +227,13 @@ export const completeChartNormalizationSave = (
   chartId: number,
   hydrationSessionId: string,
   saveAttemptId: string,
-  exclusions: AutomaticNormalizationExclusions,
+  transitions: AutomaticNormalizationTransitions,
 ): CompleteChartNormalizationSaveAction => ({
   type: COMPLETE_CHART_NORMALIZATION_SAVE,
   chartId,
   hydrationSessionId,
   saveAttemptId,
-  exclusions,
+  transitions,
 });
 
 const initialState: VersionHistoryState = {
@@ -364,7 +364,7 @@ export default function versionHistoryReducer(
         ...state,
         chartNormalization: {
           ...state.chartNormalization,
-          exclusions: action.exclusions,
+          transitions: action.transitions,
           saveAttemptId: null,
         },
       };

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.test.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.test.ts
@@ -21,6 +21,7 @@ import { versionSessionLogMiddleware } from './sessionLogMiddleware';
 import {
   APPEND_VERSION_SESSION_LOG,
   CLEAR_VERSION_SESSION_LOG,
+  INVALIDATE_CHART_NORMALIZATION_CONTROLS,
 } from './reducer';
 
 jest.mock('@superset-ui/core', () => ({
@@ -77,7 +78,7 @@ test('falls back to a humanized control name when no label exists', () => {
   );
 });
 
-test('skips programmatic control writes so untouched charts stay clean', async () => {
+test('programmatic writes invalidate normalization without logging an edit', async () => {
   // Effects rewrite controls with no user gesture (transferred-control
   // cleanup after load, derived margins); logging them would report unsaved
   // edits the user never made. Built with the REAL action creator so the
@@ -89,9 +90,14 @@ test('skips programmatic control writes so untouched charts stay clean', async (
     explore: { controls: { metrics: { label: 'Metrics' } } },
   });
   run(store, setControlValue('metrics', [], undefined, { programmatic: true }));
-  expect(store.dispatch).not.toHaveBeenCalled();
+  expect(store.dispatch).toHaveBeenCalledTimes(1);
+  expect(store.dispatch).toHaveBeenCalledWith({
+    type: INVALIDATE_CHART_NORMALIZATION_CONTROLS,
+    controls: ['metrics'],
+  });
 
   // The same creator without the mark still logs.
+  store.dispatch.mockClear();
   run(store, setControlValue('metrics', []));
   expect(store.dispatch).toHaveBeenCalledWith(
     expect.objectContaining({ type: APPEND_VERSION_SESSION_LOG }),
@@ -188,7 +194,7 @@ test('a history step cannot collapse into an adjacent control entry', async () =
     await import('src/explore/actions/exploreActions');
   const store = buildStore({ explore: { controls: {} } });
   run(store, setExploreControls({} as never));
-  const { entry } = store.dispatch.mock.calls[0][0];
+  const [[{ entry }]] = store.dispatch.mock.calls;
   expect(entry.controlName).not.toMatch(/^[a-z]/);
 });
 

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.test.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.test.ts
@@ -104,6 +104,40 @@ test('programmatic writes invalidate normalization without logging an edit', asy
   );
 });
 
+test('a write matching the hydrated default preserves normalization', async () => {
+  const { setControlValue } =
+    await import('src/explore/actions/exploreActions');
+  const store = buildStore({
+    explore: {
+      controls: { show_totals: { label: 'Show totals' } },
+      form_data: { show_totals: false },
+    },
+    versionHistory: {
+      chartNormalization: {
+        chartId: 7,
+        hydrationSessionId: 'hydration-a',
+        saveAttemptId: null,
+        invalidatedControls: {},
+        transitions: {
+          show_totals: {
+            control: 'show_totals',
+            from_present: false,
+            to_present: true,
+            to_value: false,
+          },
+        },
+      },
+    },
+  });
+
+  run(
+    store,
+    setControlValue('show_totals', false, undefined, { programmatic: true }),
+  );
+
+  expect(store.dispatch).not.toHaveBeenCalled();
+});
+
 test('clears the session log when the explore page hydrates', () => {
   const store = buildStore();
   run(store, { type: 'HYDRATE_EXPLORE', data: {} });

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
@@ -19,7 +19,11 @@
 import type { Middleware } from 'redux';
 import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
-import { appendVersionSessionLog, clearVersionSessionLog } from './reducer';
+import {
+  appendVersionSessionLog,
+  clearVersionSessionLog,
+  invalidateChartNormalizationControls,
+} from './reducer';
 
 // Action types are inlined (rather than imported from the explore
 // module) so this middleware does not pull explore code into every
@@ -47,8 +51,17 @@ interface SessionLogState {
   user?: { firstName?: string; lastName?: string };
   explore?: {
     controls?: Record<string, { label?: unknown } | undefined>;
+    form_data?: Record<string, unknown>;
   };
 }
+
+const changedFormDataKeys = (
+  before: Record<string, unknown> = {},
+  after: Record<string, unknown> = {},
+) =>
+  [...new Set([...Object.keys(before), ...Object.keys(after)])].filter(
+    key => before[key] !== after[key],
+  );
 
 function controlLabel(state: SessionLogState, controlName: string): string {
   const label = state.explore?.controls?.[controlName]?.label;
@@ -71,6 +84,7 @@ function userName(state: SessionLogState): string | null {
  */
 export const versionSessionLogMiddleware: Middleware =
   store => next => action => {
+    const before = (store.getState() as SessionLogState).explore?.form_data;
     const result = next(action);
     if (!isFeatureEnabled(FeatureFlag.VersionHistory)) {
       return result;
@@ -150,6 +164,24 @@ export const versionSessionLogMiddleware: Middleware =
           user: userName(state),
         }),
       );
+    }
+    if (action.type !== HYDRATE_EXPLORE) {
+      const state = store.getState() as SessionLogState;
+      const controls = changedFormDataKeys(before, state.explore?.form_data);
+      if (
+        action.type === SET_FIELD_VALUE &&
+        typeof action.controlName === 'string'
+      ) {
+        controls.push(action.controlName);
+      } else if (action.type === SET_EXPLORE_CONTROLS && action.formData) {
+        controls.push(...Object.keys(action.formData));
+      } else if (action.type === UPDATE_FORM_DATA_BY_DATASOURCE) {
+        controls.push(DATASOURCE_CONTROL_NAME);
+      }
+      const uniqueControls = [...new Set(controls)];
+      if (uniqueControls.length) {
+        store.dispatch(invalidateChartNormalizationControls(uniqueControls));
+      }
     }
     return result;
   };

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
@@ -55,6 +55,12 @@ interface SessionLogState {
   };
 }
 
+interface ExploreBoundaryAction {
+  type: unknown;
+  controlName?: unknown;
+  formData?: Record<string, unknown>;
+}
+
 const changedFormDataKeys = (
   before: Record<string, unknown> = {},
   after: Record<string, unknown> = {},
@@ -62,6 +68,32 @@ const changedFormDataKeys = (
   [...new Set([...Object.keys(before), ...Object.keys(after)])].filter(
     key => before[key] !== after[key],
   );
+
+/**
+ * Anti-corruption adapter from Explore's action vocabulary to the stable
+ * versioning concept of controls whose user-intent evidence is no longer valid.
+ */
+export const normalizationControlsChangedByExplore = (
+  action: ExploreBoundaryAction,
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown> | undefined,
+) => {
+  if (action.type === HYDRATE_EXPLORE) {
+    return [];
+  }
+  const controls = changedFormDataKeys(before, after);
+  if (
+    action.type === SET_FIELD_VALUE &&
+    typeof action.controlName === 'string'
+  ) {
+    controls.push(action.controlName);
+  } else if (action.type === SET_EXPLORE_CONTROLS && action.formData) {
+    controls.push(...Object.keys(action.formData));
+  } else if (action.type === UPDATE_FORM_DATA_BY_DATASOURCE) {
+    controls.push(DATASOURCE_CONTROL_NAME);
+  }
+  return [...new Set(controls)];
+};
 
 function controlLabel(state: SessionLogState, controlName: string): string {
   const label = state.explore?.controls?.[controlName]?.label;
@@ -165,23 +197,14 @@ export const versionSessionLogMiddleware: Middleware =
         }),
       );
     }
-    if (action.type !== HYDRATE_EXPLORE) {
-      const state = store.getState() as SessionLogState;
-      const controls = changedFormDataKeys(before, state.explore?.form_data);
-      if (
-        action.type === SET_FIELD_VALUE &&
-        typeof action.controlName === 'string'
-      ) {
-        controls.push(action.controlName);
-      } else if (action.type === SET_EXPLORE_CONTROLS && action.formData) {
-        controls.push(...Object.keys(action.formData));
-      } else if (action.type === UPDATE_FORM_DATA_BY_DATASOURCE) {
-        controls.push(DATASOURCE_CONTROL_NAME);
-      }
-      const uniqueControls = [...new Set(controls)];
-      if (uniqueControls.length) {
-        store.dispatch(invalidateChartNormalizationControls(uniqueControls));
-      }
+    const state = store.getState() as SessionLogState;
+    const changedControls = normalizationControlsChangedByExplore(
+      action,
+      before,
+      state.explore?.form_data,
+    );
+    if (changedControls.length) {
+      store.dispatch(invalidateChartNormalizationControls(changedControls));
     }
     return result;
   };

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
@@ -55,6 +55,7 @@ interface SessionLogState {
   };
 }
 
+/** Untrusted Explore action shape; fields narrow only at this boundary. */
 interface ExploreBoundaryAction {
   type: unknown;
   controlName?: unknown;

--- a/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
+++ b/superset-frontend/src/features/versionHistory/sessionLogMiddleware.ts
@@ -24,6 +24,8 @@ import {
   clearVersionSessionLog,
   invalidateChartNormalizationControls,
 } from './reducer';
+import { jsonValuesEqual } from './normalization';
+import type { ChartNormalizationTrackingState } from './types';
 
 // Action types are inlined (rather than imported from the explore
 // module) so this middleware does not pull explore code into every
@@ -52,6 +54,9 @@ interface SessionLogState {
   explore?: {
     controls?: Record<string, { label?: unknown } | undefined>;
     form_data?: Record<string, unknown>;
+  };
+  versionHistory?: {
+    chartNormalization?: ChartNormalizationTrackingState | null;
   };
 }
 
@@ -109,6 +114,25 @@ function userName(state: SessionLogState): string | null {
     .join(' ');
   return name || null;
 }
+
+const normalizationControlsNoLongerMatching = (
+  controls: string[],
+  state: SessionLogState,
+) => {
+  const formData = state.explore?.form_data ?? {};
+  const transitions = state.versionHistory?.chartNormalization?.transitions;
+  return controls.filter(control => {
+    const transition = transitions?.[control];
+    if (!transition) {
+      return true;
+    }
+    const present = Object.hasOwn(formData, control);
+    return (
+      present !== transition.to_present ||
+      (present && !jsonValuesEqual(formData[control], transition.to_value))
+    );
+  });
+};
 
 /**
  * Records unsaved explore control changes in the version history
@@ -199,10 +223,13 @@ export const versionSessionLogMiddleware: Middleware =
       );
     }
     const state = store.getState() as SessionLogState;
-    const changedControls = normalizationControlsChangedByExplore(
-      action,
-      before,
-      state.explore?.form_data,
+    const changedControls = normalizationControlsNoLongerMatching(
+      normalizationControlsChangedByExplore(
+        action,
+        before,
+        state.explore?.form_data,
+      ),
+      state,
     );
     if (changedControls.length) {
       store.dispatch(invalidateChartNormalizationControls(changedControls));

--- a/superset-frontend/src/features/versionHistory/types.ts
+++ b/superset-frontend/src/features/versionHistory/types.ts
@@ -209,6 +209,45 @@ export interface SessionLogEntry {
   user: string | null;
 }
 
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type PresentNormalizationValue<Prefix extends 'from' | 'to'> =
+  Prefix extends 'from'
+    ? { from_present: true; from_value: JsonValue }
+    : { to_present: true; to_value: JsonValue };
+
+type MissingNormalizationValue<Prefix extends 'from' | 'to'> =
+  Prefix extends 'from'
+    ? { from_present: false; from_value?: never }
+    : { to_present: false; to_value?: never };
+
+/** One guarded hydration transition sent with an existing-chart overwrite. */
+export type AutomaticNormalizationTransition = { control: string } & (
+  | PresentNormalizationValue<'from'>
+  | MissingNormalizationValue<'from'>
+) &
+  (PresentNormalizationValue<'to'> | MissingNormalizationValue<'to'>);
+
+export type AutomaticNormalizationExclusions = Record<
+  string,
+  AutomaticNormalizationTransition
+>;
+
+/** Identity-bound state for one chart hydration and its in-flight save. */
+export interface ChartNormalizationTrackingState {
+  chartId: number;
+  hydrationSessionId: string;
+  exclusions: AutomaticNormalizationExclusions;
+  invalidatedControls: Record<string, true>;
+  saveAttemptId: string | null;
+}
+
 export interface VersionHistoryState {
   isPanelOpen: boolean;
   entityType: VersionedEntityType | null;
@@ -228,4 +267,6 @@ export interface VersionHistoryState {
    * the one their page shows.
    */
   lastRestoredEntityUuid: string | null;
+  /** Advisory exclusions for the active Explore chart hydration. */
+  chartNormalization?: ChartNormalizationTrackingState | null;
 }

--- a/superset-frontend/src/features/versionHistory/types.ts
+++ b/superset-frontend/src/features/versionHistory/types.ts
@@ -234,7 +234,7 @@ export type AutomaticNormalizationTransition = { control: string } & (
 ) &
   (PresentNormalizationValue<'to'> | MissingNormalizationValue<'to'>);
 
-export type AutomaticNormalizationExclusions = Record<
+export type AutomaticNormalizationTransitions = Record<
   string,
   AutomaticNormalizationTransition
 >;
@@ -243,7 +243,7 @@ export type AutomaticNormalizationExclusions = Record<
 export interface ChartNormalizationTrackingState {
   chartId: number;
   hydrationSessionId: string;
-  exclusions: AutomaticNormalizationExclusions;
+  transitions: AutomaticNormalizationTransitions;
   invalidatedControls: Record<string, true>;
   saveAttemptId: string | null;
 }
@@ -267,6 +267,6 @@ export interface VersionHistoryState {
    * the one their page shows.
    */
   lastRestoredEntityUuid: string | null;
-  /** Advisory exclusions for the active Explore chart hydration. */
+  /** Advisory transitions for the active Explore chart hydration. */
   chartNormalization?: ChartNormalizationTrackingState | null;
 }

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -679,13 +679,17 @@ class ChartRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         except ValidationError as error:
             return self.response_400(message=error.messages)
 
+        normalization_changes: object = item.pop("normalization_changes", None)
+
         # Live version identifiers before the update (empty + query-free when
         # ``ENABLE_VERSIONING_CAPTURE`` is off, so this stays inert under the
         # kill-switch).
         old_info = current_entity_version_info(Slice, pk)
 
         try:
-            changed_model = UpdateChartCommand(pk, item).run()
+            changed_model = UpdateChartCommand(
+                pk, item, normalization_changes=normalization_changes
+            ).run()
             new_info = current_entity_version_info(
                 Slice, changed_model.id, changed_model.uuid
             )

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -415,7 +415,7 @@ class ChartRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: (f"{self.__class__.__name__}.deck_layers"),
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.deck_layers",
         log_to_statsd=False,
     )
     def deck_layers(self, pk: int) -> Response:

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -360,14 +360,28 @@ class ChartPutSchema(Schema):
     external_url = fields.String(allow_none=True, validate=utils.validate_external_url)
     tags = fields.List(fields.Integer(metadata={"description": tags_description}))
     uuid = fields.UUID(allow_none=True)
-    normalization_changes = fields.Raw(
+    normalization_changes: fields.Raw = fields.Raw(
         load_only=True,
+        allow_none=True,
         metadata={
             "description": (
                 "Optional advisory Explore hydration transitions used only to "
                 "remove exact automatic normalization changes from human-readable "
                 "version history. Invalid metadata is ignored."
-            )
+            ),
+            "type": "array",
+            "maxItems": 256,
+            "items": {
+                "type": "object",
+                "required": ["control", "from_present", "to_present"],
+                "properties": {
+                    "control": {"type": "string", "maxLength": 256},
+                    "from_present": {"type": "boolean"},
+                    "from_value": {},
+                    "to_present": {"type": "boolean"},
+                    "to_value": {},
+                },
+            },
         },
     )
 

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -360,6 +360,16 @@ class ChartPutSchema(Schema):
     external_url = fields.String(allow_none=True, validate=utils.validate_external_url)
     tags = fields.List(fields.Integer(metadata={"description": tags_description}))
     uuid = fields.UUID(allow_none=True)
+    normalization_changes = fields.Raw(
+        load_only=True,
+        metadata={
+            "description": (
+                "Optional advisory Explore hydration transitions used only to "
+                "remove exact automatic normalization changes from human-readable "
+                "version history. Invalid metadata is ignored."
+            )
+        },
+    )
 
 
 class ChartGetDatasourceObjectDataResponseSchema(Schema):

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -51,9 +51,7 @@ from superset.tags.models import ObjectType
 from superset.utils import json
 from superset.utils.decorators import on_error, transaction
 from superset.versioning.changes.normalization import (
-    matching_normalization_context,
-    NormalizationContext,
-    store_normalization_context,
+    register_matching_normalization_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,26 +88,14 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
             self._properties["last_saved_at"] = datetime.now()
             self._properties["last_saved_by"] = g.user
 
-        if self._normalization_changes is not None and "params" in self._properties:
-            try:
-                before_params: object = json.loads(self._model.params or "{}")
-                after_params: object = json.loads(self._properties["params"] or "{}")
-                if isinstance(before_params, dict) and isinstance(after_params, dict):
-                    context: NormalizationContext | None = (
-                        matching_normalization_context(
-                            self._model.id,
-                            self._normalization_changes,
-                            before_params,
-                            after_params,
-                        )
-                    )
-                    if context is not None:
-                        store_normalization_context(db.session, context)
-            except Exception:  # pylint: disable=broad-except
-                logger.exception(
-                    "Ignoring chart normalization metadata for chart id=%s",
-                    self._model.id,
-                )
+        if "params" in self._properties:
+            register_matching_normalization_context(
+                db.session,
+                self._model.id,
+                self._normalization_changes,
+                self._model.params,
+                self._properties["params"],
+            )
 
         return ChartDAO.update(self._model, self._properties)
 

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -44,11 +44,17 @@ from superset.commands.utils import (
 from superset.daos.chart import ChartDAO
 from superset.daos.dashboard import DashboardDAO
 from superset.exceptions import SupersetSecurityException
+from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.tags.models import ObjectType
 from superset.utils import json
 from superset.utils.decorators import on_error, transaction
+from superset.versioning.changes.normalization import (
+    matching_normalization_context,
+    NormalizationContext,
+    store_normalization_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,10 +66,16 @@ def is_query_context_update(properties: dict[str, Any]) -> bool:
 
 
 class UpdateChartCommand(UpdateMixin, BaseCommand):
-    def __init__(self, model_id: int, data: dict[str, Any]):
-        self._model_id = model_id
-        self._properties = data.copy()
+    def __init__(
+        self,
+        model_id: int,
+        data: dict[str, Any],
+        normalization_changes: object = None,
+    ) -> None:
+        self._model_id: int = model_id
+        self._properties: dict[str, Any] = data.copy()
         self._model: Optional[Slice] = None
+        self._normalization_changes: object = normalization_changes
 
     @transaction(on_error=partial(on_error, reraise=ChartUpdateFailedError))
     def run(self) -> Model:
@@ -77,6 +89,27 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
         if self._properties.get("query_context_generation") is None:
             self._properties["last_saved_at"] = datetime.now()
             self._properties["last_saved_by"] = g.user
+
+        if self._normalization_changes is not None and "params" in self._properties:
+            try:
+                before_params: object = json.loads(self._model.params or "{}")
+                after_params: object = json.loads(self._properties["params"] or "{}")
+                if isinstance(before_params, dict) and isinstance(after_params, dict):
+                    context: NormalizationContext | None = (
+                        matching_normalization_context(
+                            self._model.id,
+                            self._normalization_changes,
+                            before_params,
+                            after_params,
+                        )
+                    )
+                    if context is not None:
+                        store_normalization_context(db.session, context)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "Ignoring chart normalization metadata for chart id=%s",
+                    self._model.id,
+                )
 
         return ChartDAO.update(self._model, self._properties)
 

--- a/superset/commands/chart/update.py
+++ b/superset/commands/chart/update.py
@@ -88,7 +88,7 @@ class UpdateChartCommand(UpdateMixin, BaseCommand):
             self._properties["last_saved_at"] = datetime.now()
             self._properties["last_saved_by"] = g.user
 
-        if "params" in self._properties:
+        if self._normalization_changes is not None and "params" in self._properties:
             register_matching_normalization_context(
                 db.session,
                 self._model.id,

--- a/superset/versioning/changes/listener.py
+++ b/superset/versioning/changes/listener.py
@@ -50,6 +50,7 @@ from sqlalchemy import event
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session, SessionTransaction
 
+from superset.versioning.changes.normalization import NORMALIZATION_CONTEXT_KEY
 from superset.versioning.changes.shadow_queries import (
     _dashboard_child_records_for_tx_from_shadows,
     _dataset_child_records_for_tx_from_shadows,
@@ -217,6 +218,7 @@ def _reset_transaction_state(session: Session) -> None:
     session.info.pop(ACTION_META_KEY, None)
     session.info.pop(_INITIAL_STATES_KEY, None)
     session.info.pop(_FINALIZING_KEY, None)
+    session.info.pop(NORMALIZATION_CONTEXT_KEY, None)
 
 
 def _reset_after_outer_transaction(

--- a/superset/versioning/changes/normalization.py
+++ b/superset/versioning/changes/normalization.py
@@ -1,0 +1,253 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Types and bounds for chart normalization change summaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, NotRequired, TypeAlias, TypedDict, TypeGuard
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from superset.utils import json
+from superset.versioning.diff import ChangeRecord
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+MAX_NORMALIZATION_TRANSITIONS: Final[int] = 256
+MAX_CONTROL_NAME_BYTES: Final[int] = 256
+MAX_NORMALIZATION_METADATA_BYTES: Final[int] = 256 * 1024
+MAX_NORMALIZATION_VALUE_DEPTH: Final[int] = 20
+
+NORMALIZATION_CONTEXT_KEY: Final[str] = "_versioning_chart_normalization_context"
+
+
+class NormalizationTransitionPayload(TypedDict):
+    """Presence-aware transition received as advisory request metadata."""
+
+    control: str
+    from_present: bool
+    from_value: NotRequired[JsonValue]
+    to_present: bool
+    to_value: NotRequired[JsonValue]
+
+
+@dataclass(frozen=True)
+class NormalizationTransition:
+    """Validated top-level chart params transition."""
+
+    control: str
+    from_present: bool
+    from_value: JsonValue
+    to_present: bool
+    to_value: JsonValue
+
+
+@dataclass(frozen=True)
+class NormalizationContext:
+    """Consume-once evidence scoped to one chart update operation."""
+
+    chart_id: int
+    operation_token: str
+    transitions: tuple[NormalizationTransition, ...]
+
+
+@dataclass
+class NormalizationContextRegistry:
+    """Operation-token registry retained for the active transaction."""
+
+    contexts: dict[tuple[int, str], NormalizationContext]
+    active_tokens: dict[int, str | None]
+
+
+def _json_depth(value: JsonValue) -> int:
+    if isinstance(value, list):
+        return 1 + max((_json_depth(item) for item in value), default=0)
+    if isinstance(value, dict):
+        return 1 + max((_json_depth(item) for item in value.values()), default=0)
+    return 0
+
+
+def _is_json_value(value: object) -> TypeGuard[JsonValue]:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_value(item) for key, item in value.items()
+        )
+    return False
+
+
+def _json_equal(left: JsonValue, right: JsonValue) -> bool:
+    """Compare JSON values without Python's ``True == 1`` coercion."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _json_equal(a, b) for a, b in zip(left, right, strict=False)
+        )
+    if isinstance(left, dict) and isinstance(right, dict):
+        return left.keys() == right.keys() and all(
+            _json_equal(left[key], right[key]) for key in left
+        )
+    return left == right
+
+
+def sanitize_normalization_changes(
+    raw: object,
+) -> tuple[NormalizationTransition, ...]:
+    """Return bounded valid entries, or no exclusions for an invalid envelope."""
+    try:
+        encoded: bytes = json.dumps(
+            raw, ensure_ascii=False, separators=(",", ":")
+        ).encode()
+        if (
+            not isinstance(raw, list)
+            or len(raw) > MAX_NORMALIZATION_TRANSITIONS
+            or len(encoded) > MAX_NORMALIZATION_METADATA_BYTES
+        ):
+            return ()
+        transitions: list[NormalizationTransition] = []
+        controls: set[str] = set()
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            control: object = item.get("control")
+            from_present: object = item.get("from_present")
+            to_present: object = item.get("to_present")
+            if (
+                not isinstance(control, str)
+                or not control
+                or len(control.encode()) > MAX_CONTROL_NAME_BYTES
+                or not isinstance(from_present, bool)
+                or not isinstance(to_present, bool)
+            ):
+                continue
+            if (from_present != ("from_value" in item)) or (
+                to_present != ("to_value" in item)
+            ):
+                continue
+            from_value: object = item.get("from_value")
+            to_value: object = item.get("to_value")
+            if not _is_json_value(from_value) or not _is_json_value(to_value):
+                continue
+            if (
+                _json_depth(from_value) > MAX_NORMALIZATION_VALUE_DEPTH
+                or _json_depth(to_value) > MAX_NORMALIZATION_VALUE_DEPTH
+            ):
+                return ()
+            if control in controls:
+                return ()
+            controls.add(control)
+            transitions.append(
+                NormalizationTransition(
+                    control=control,
+                    from_present=from_present,
+                    from_value=from_value,
+                    to_present=to_present,
+                    to_value=to_value,
+                )
+            )
+        return tuple(transitions)
+    except (TypeError, ValueError, UnicodeError, RecursionError):
+        return ()
+
+
+def matching_normalization_context(
+    chart_id: int,
+    raw: object,
+    before_params: dict[str, JsonValue],
+    after_params: dict[str, JsonValue],
+) -> NormalizationContext | None:
+    """Match sanitized advisory transitions against exact params states."""
+    matching: list[NormalizationTransition] = []
+    for transition in sanitize_normalization_changes(raw):
+        before_present: bool = transition.control in before_params
+        after_present: bool = transition.control in after_params
+        if (
+            before_present != transition.from_present
+            or after_present != transition.to_present
+        ):
+            continue
+        if before_present and not _json_equal(
+            before_params[transition.control], transition.from_value
+        ):
+            continue
+        if after_present and not _json_equal(
+            after_params[transition.control], transition.to_value
+        ):
+            continue
+        matching.append(transition)
+    if not matching:
+        return None
+    return NormalizationContext(chart_id, str(uuid4()), tuple(matching))
+
+
+def store_normalization_context(
+    session: Session, context: NormalizationContext
+) -> None:
+    """Store one operation's evidence, invalidating ambiguous same-chart evidence."""
+    registry: NormalizationContextRegistry = session.info.setdefault(
+        NORMALIZATION_CONTEXT_KEY,
+        NormalizationContextRegistry(contexts={}, active_tokens={}),
+    )
+    existing_token: str | None = registry.active_tokens.get(context.chart_id)
+    if existing_token is not None:
+        registry.contexts.pop((context.chart_id, existing_token), None)
+        registry.active_tokens[context.chart_id] = None
+        return
+    if context.chart_id in registry.active_tokens:
+        return
+    registry.contexts[(context.chart_id, context.operation_token)] = context
+    registry.active_tokens[context.chart_id] = context.operation_token
+
+
+def consume_normalization_context(
+    session: Session, chart_id: int
+) -> NormalizationContext | None:
+    """Consume chart-scoped evidence at most once."""
+    registry: NormalizationContextRegistry | None = session.info.get(
+        NORMALIZATION_CONTEXT_KEY
+    )
+    if registry is None:
+        return None
+    operation_token: str | None = registry.active_tokens.pop(chart_id, None)
+    if operation_token is None:
+        return None
+    return registry.contexts.pop((chart_id, operation_token), None)
+
+
+def filter_normalization_records(
+    records: list[ChangeRecord], context: NormalizationContext | None
+) -> list[ChangeRecord]:
+    """Return a fresh readable diff with exact normalization controls omitted."""
+    if context is None:
+        return list(records)
+    controls: set[str] = {transition.control for transition in context.transitions}
+    return [
+        record
+        for record in records
+        if not (
+            len(record.path) >= 2
+            and record.path[0] == "params"
+            and record.path[1] in controls
+        )
+    ]

--- a/superset/versioning/changes/normalization.py
+++ b/superset/versioning/changes/normalization.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Final, NotRequired, TypeAlias, TypedDict, TypeGuard
 from uuid import uuid4
@@ -36,6 +37,8 @@ MAX_NORMALIZATION_METADATA_BYTES: Final[int] = 256 * 1024
 MAX_NORMALIZATION_VALUE_DEPTH: Final[int] = 20
 
 NORMALIZATION_CONTEXT_KEY: Final[str] = "_versioning_chart_normalization_context"
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class NormalizationTransitionPayload(TypedDict):
@@ -76,6 +79,10 @@ class NormalizationContextRegistry:
     active_tokens: dict[int, str | None]
 
 
+class _InvalidNormalizationEnvelopeError(ValueError):
+    """Advisory metadata whose ambiguity requires rejecting all transitions."""
+
+
 def _json_depth(value: JsonValue) -> int:
     if isinstance(value, list):
         return 1 + max((_json_depth(item) for item in value), default=0)
@@ -111,6 +118,43 @@ def _json_equal(left: JsonValue, right: JsonValue) -> bool:
     return left == right
 
 
+def _parse_normalization_transition(
+    item: object,
+) -> NormalizationTransition | None:
+    """Parse one transition, skipping malformed entries without ambiguity."""
+    if not isinstance(item, dict):
+        return None
+    control: object = item.get("control")
+    from_present: object = item.get("from_present")
+    to_present: object = item.get("to_present")
+    if (
+        not isinstance(control, str)
+        or not control
+        or len(control.encode()) > MAX_CONTROL_NAME_BYTES
+        or not isinstance(from_present, bool)
+        or not isinstance(to_present, bool)
+    ):
+        return None
+    if (from_present != ("from_value" in item)) or (to_present != ("to_value" in item)):
+        return None
+    from_value: object = item.get("from_value")
+    to_value: object = item.get("to_value")
+    if not _is_json_value(from_value) or not _is_json_value(to_value):
+        return None
+    if (
+        _json_depth(from_value) > MAX_NORMALIZATION_VALUE_DEPTH
+        or _json_depth(to_value) > MAX_NORMALIZATION_VALUE_DEPTH
+    ):
+        raise _InvalidNormalizationEnvelopeError
+    return NormalizationTransition(
+        control=control,
+        from_present=from_present,
+        from_value=from_value,
+        to_present=to_present,
+        to_value=to_value,
+    )
+
+
 def sanitize_normalization_changes(
     raw: object,
 ) -> tuple[NormalizationTransition, ...]:
@@ -128,46 +172,23 @@ def sanitize_normalization_changes(
         transitions: list[NormalizationTransition] = []
         controls: set[str] = set()
         for item in raw:
-            if not isinstance(item, dict):
-                continue
-            control: object = item.get("control")
-            from_present: object = item.get("from_present")
-            to_present: object = item.get("to_present")
-            if (
-                not isinstance(control, str)
-                or not control
-                or len(control.encode()) > MAX_CONTROL_NAME_BYTES
-                or not isinstance(from_present, bool)
-                or not isinstance(to_present, bool)
-            ):
-                continue
-            if (from_present != ("from_value" in item)) or (
-                to_present != ("to_value" in item)
-            ):
-                continue
-            from_value: object = item.get("from_value")
-            to_value: object = item.get("to_value")
-            if not _is_json_value(from_value) or not _is_json_value(to_value):
-                continue
-            if (
-                _json_depth(from_value) > MAX_NORMALIZATION_VALUE_DEPTH
-                or _json_depth(to_value) > MAX_NORMALIZATION_VALUE_DEPTH
-            ):
-                return ()
-            if control in controls:
-                return ()
-            controls.add(control)
-            transitions.append(
-                NormalizationTransition(
-                    control=control,
-                    from_present=from_present,
-                    from_value=from_value,
-                    to_present=to_present,
-                    to_value=to_value,
-                )
+            transition: NormalizationTransition | None = (
+                _parse_normalization_transition(item)
             )
+            if transition is None:
+                continue
+            if transition.control in controls:
+                return ()
+            controls.add(transition.control)
+            transitions.append(transition)
         return tuple(transitions)
-    except (TypeError, ValueError, UnicodeError, RecursionError):
+    except (
+        _InvalidNormalizationEnvelopeError,
+        TypeError,
+        ValueError,
+        UnicodeError,
+        RecursionError,
+    ):
         return ()
 
 
@@ -199,6 +220,32 @@ def matching_normalization_context(
     if not matching:
         return None
     return NormalizationContext(chart_id, str(uuid4()), tuple(matching))
+
+
+def register_matching_normalization_context(
+    session: Session,
+    chart_id: int,
+    raw: object,
+    before_params_json: str | bytes | bytearray | None,
+    after_params_json: str | bytes | bytearray | None,
+) -> None:
+    """Validate and register advisory evidence for one chart update."""
+    if raw is None:
+        return
+    try:
+        before_params: object = json.loads(before_params_json or "{}")
+        after_params: object = json.loads(after_params_json or "{}")
+        if not isinstance(before_params, dict) or not isinstance(after_params, dict):
+            return
+        context: NormalizationContext | None = matching_normalization_context(
+            chart_id, raw, before_params, after_params
+        )
+        if context is not None:
+            store_normalization_context(session, context)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Ignoring chart normalization metadata for chart id=%s", chart_id
+        )
 
 
 def store_normalization_context(

--- a/superset/versioning/changes/state.py
+++ b/superset/versioning/changes/state.py
@@ -46,6 +46,10 @@ import sqlalchemy as sa
 from flask_appbuilder import Model
 from sqlalchemy.orm import Session
 
+from superset.versioning.changes.normalization import (
+    consume_normalization_context,
+    filter_normalization_records,
+)
 from superset.versioning.changes.table import version_changes_table
 from superset.versioning.diff import (
     cap_records,
@@ -213,6 +217,16 @@ def bulk_insert_records(
         return
     rows = []
     for (entity_kind, entity_id), records in buffered.items():
+        if entity_kind == "chart":
+            try:
+                records = filter_normalization_records(
+                    records, consume_normalization_context(session, entity_id)
+                )
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "version_changes: normalization filtering failed for chart id=%s",
+                    entity_id,
+                )
         # Bound a single save's output: collapse field-level record explosions
         # and truncate over-large values before they hit version_changes.
         for seq, r in enumerate(cap_records(records)):

--- a/tests/integration_tests/versioning/change_records_tests.py
+++ b/tests/integration_tests/versioning/change_records_tests.py
@@ -51,6 +51,11 @@ from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils import json as _json
+from superset.versioning.changes.normalization import (
+    matching_normalization_context,
+    NormalizationContext,
+    store_normalization_context,
+)
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
     load_birth_names_dashboard_with_slices,
@@ -162,6 +167,77 @@ class TestChartChangeRecords(SupersetTestCase):
         )
         assert path == ["slice_name"]
         assert rows[0]["sequence"] == 0
+
+    def test_matching_hydration_metadata_omits_only_normalization_noise(
+        self,
+    ) -> None:
+        """Readable history omits exact null/default and missing/default changes."""
+        _persist_fixture_state()
+        chart: Slice | None = db.session.query(Slice).first()
+        assert chart is not None
+        before_params: dict[str, Any] = {
+            "viz_type": "table",
+            "granularity_sqla": "ds",
+            "row_limit": None,
+        }
+        after_params: dict[str, Any] = {
+            "viz_type": "table",
+            "granularity_sqla": None,
+            "row_limit": 10000,
+            "show_legend": True,
+        }
+        chart.params = _json.dumps(before_params)
+        db.session.commit()
+
+        metadata: list[dict[str, Any]] = [
+            {
+                "control": "granularity_sqla",
+                "from_present": True,
+                "from_value": "ds",
+                "to_present": True,
+                "to_value": None,
+            },
+            {
+                "control": "row_limit",
+                "from_present": True,
+                "from_value": None,
+                "to_present": True,
+                "to_value": 10000,
+            },
+            {
+                "control": "show_legend",
+                "from_present": False,
+                "to_present": True,
+                "to_value": True,
+            },
+        ]
+        context: NormalizationContext | None = matching_normalization_context(
+            chart.id, metadata, before_params, after_params
+        )
+        assert context is not None
+        store_normalization_context(db.session, context)
+        chart.params = _json.dumps(after_params)
+        chart.slice_name = f"{chart.slice_name[:64]}_intentional"
+        db.session.commit()
+
+        ver_cls: Any = version_class(Slice)
+        update_tx_id: int = (
+            db.session.query(ver_cls.transaction_id)
+            .filter(ver_cls.id == chart.id)
+            .filter(ver_cls.operation_type == 1)
+            .order_by(ver_cls.transaction_id.desc())
+            .first()
+            .transaction_id
+        )
+        rows: list[dict[str, Any]] = _change_rows_for(
+            update_tx_id, entity_kind="chart", entity_id=chart.id
+        )
+        paths: list[list[str]] = [
+            _json.loads(row["path"]) if isinstance(row["path"], str) else row["path"]
+            for row in rows
+        ]
+        assert paths == [["slice_name"]]
+        assert _json.loads(chart.params) == after_params
 
     def test_last_saved_at_is_excluded_as_audit_noise(self) -> None:
         """``last_saved_at`` / ``last_saved_by_fk`` are save-side-effect

--- a/tests/integration_tests/versioning/change_records_tests.py
+++ b/tests/integration_tests/versioning/change_records_tests.py
@@ -51,12 +51,8 @@ from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils import json as _json
-from superset.versioning.changes.normalization import (
-    matching_normalization_context,
-    NormalizationContext,
-    store_normalization_context,
-)
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.constants import ADMIN_USERNAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
     load_birth_names_dashboard_with_slices,
     load_birth_names_data,
@@ -211,14 +207,20 @@ class TestChartChangeRecords(SupersetTestCase):
                 "to_value": True,
             },
         ]
-        context: NormalizationContext | None = matching_normalization_context(
-            chart.id, metadata, before_params, after_params
+        updated_name: str = f"{chart.slice_name[:64]}_intentional"
+        self.login(ADMIN_USERNAME)
+        response: Any = self.client.put(
+            f"/api/v1/chart/{chart.id}",
+            json={
+                "params": _json.dumps(after_params),
+                "slice_name": updated_name,
+                "normalization_changes": metadata,
+            },
         )
-        assert context is not None
-        store_normalization_context(db.session, context)
-        chart.params = _json.dumps(after_params)
-        chart.slice_name = f"{chart.slice_name[:64]}_intentional"
-        db.session.commit()
+        assert response.status_code == 200, response.data
+        response_body: dict[str, Any] = _json.loads(response.data)
+        assert "normalization_changes" not in response_body["result"]
+        db.session.refresh(chart)
 
         ver_cls: Any = version_class(Slice)
         update_tx_id: int = (
@@ -238,6 +240,65 @@ class TestChartChangeRecords(SupersetTestCase):
         ]
         assert paths == [["slice_name"]]
         assert _json.loads(chart.params) == after_params
+
+    def test_null_normalization_metadata_is_ignored_by_chart_put(self) -> None:
+        """Explicit null advisory metadata cannot reject an otherwise valid save."""
+        _persist_fixture_state()
+        chart: Slice | None = db.session.query(Slice).first()
+        assert chart is not None
+        self.login(ADMIN_USERNAME)
+        response: Any = self.client.put(
+            f"/api/v1/chart/{chart.id}",
+            json={
+                "slice_name": f"{chart.slice_name[:64]}_null_metadata",
+                "normalization_changes": None,
+            },
+        )
+        assert response.status_code == 200, response.data
+
+    def test_stale_normalization_metadata_fails_open_through_chart_put(self) -> None:
+        """Mismatched advisory evidence preserves the real params change."""
+        _persist_fixture_state()
+        chart: Slice | None = db.session.query(Slice).first()
+        assert chart is not None
+        before_params: dict[str, Any] = {"viz_type": "table", "row_limit": 100}
+        after_params: dict[str, Any] = {"viz_type": "table", "row_limit": 200}
+        chart.params = _json.dumps(before_params)
+        db.session.commit()
+        self.login(ADMIN_USERNAME)
+        response: Any = self.client.put(
+            f"/api/v1/chart/{chart.id}",
+            json={
+                "params": _json.dumps(after_params),
+                "normalization_changes": [
+                    {
+                        "control": "row_limit",
+                        "from_present": True,
+                        "from_value": 999,
+                        "to_present": True,
+                        "to_value": 200,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.data
+        ver_cls: Any = version_class(Slice)
+        transaction_id: int = (
+            db.session.query(ver_cls.transaction_id)
+            .filter(ver_cls.id == chart.id)
+            .filter(ver_cls.operation_type == 1)
+            .order_by(ver_cls.transaction_id.desc())
+            .first()
+            .transaction_id
+        )
+        rows: list[dict[str, Any]] = _change_rows_for(
+            transaction_id, entity_kind="chart", entity_id=chart.id
+        )
+        paths: list[list[str]] = [
+            _json.loads(row["path"]) if isinstance(row["path"], str) else row["path"]
+            for row in rows
+        ]
+        assert ["params", "row_limit"] in paths
 
     def test_last_saved_at_is_excluded_as_audit_noise(self) -> None:
         """``last_saved_at`` / ``last_saved_by_fk`` are save-side-effect

--- a/tests/unit_tests/versioning/test_listener.py
+++ b/tests/unit_tests/versioning/test_listener.py
@@ -188,6 +188,7 @@ def test_terminal_event_clears_transaction_state(
             listener.ACTION_META_KEY: {"headline": "restored"},
             listener._INITIAL_STATES_KEY: {("chart", 7): object()},
             listener._FINALIZING_KEY: True,
+            listener.NORMALIZATION_CONTEXT_KEY: {"pending": True},
             "unrelated": "preserved",
         }
     )

--- a/tests/unit_tests/versioning/test_normalization_changes.py
+++ b/tests/unit_tests/versioning/test_normalization_changes.py
@@ -141,3 +141,46 @@ def test_context_is_consumed_once_and_same_chart_ambiguity_fails_open() -> None:
     store_normalization_context(session, context)
     store_normalization_context(session, context)
     assert consume_normalization_context(session, 7) is None
+
+
+def test_drop_transition_matches_and_filters_a_remove_record() -> None:
+    """A stash-time drop (present -> absent) suppresses its remove record."""
+    raw: list[dict[str, object]] = [
+        {
+            "control": "order_desc",
+            "from_present": True,
+            "from_value": True,
+            "to_present": False,
+        },
+    ]
+
+    context: NormalizationContext | None = matching_normalization_context(
+        7, raw, {"order_desc": True, "row_limit": 100}, {"row_limit": 100}
+    )
+
+    assert context is not None
+    assert [item.control for item in context.transitions] == ["order_desc"]
+
+    records: list[ChangeRecord] = [
+        ChangeRecord("field", "remove", ["params", "order_desc"], True, None),
+        ChangeRecord("field", "edit", ["params", "row_limit"], 100, 50),
+    ]
+    assert filter_normalization_records(records, context) == [records[1]]
+
+
+def test_drop_transition_requires_the_key_to_be_absent_after() -> None:
+    """A drop advisory does not match when the key survived the save."""
+    raw: list[dict[str, object]] = [
+        {
+            "control": "order_desc",
+            "from_present": True,
+            "from_value": True,
+            "to_present": False,
+        },
+    ]
+    assert (
+        matching_normalization_context(
+            7, raw, {"order_desc": True}, {"order_desc": False}
+        )
+        is None
+    )

--- a/tests/unit_tests/versioning/test_normalization_changes.py
+++ b/tests/unit_tests/versioning/test_normalization_changes.py
@@ -1,0 +1,143 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy.orm import Session
+
+from superset.versioning.changes.normalization import (
+    consume_normalization_context,
+    filter_normalization_records,
+    matching_normalization_context,
+    MAX_NORMALIZATION_TRANSITIONS,
+    NormalizationContext,
+    NormalizationTransition,
+    sanitize_normalization_changes,
+    store_normalization_context,
+)
+from superset.versioning.diff import ChangeRecord
+
+
+def _transition(
+    control: str = "row_limit", from_value: object = None, to_value: object = 10000
+) -> dict[str, object]:
+    return {
+        "control": control,
+        "from_present": True,
+        "from_value": from_value,
+        "to_present": True,
+        "to_value": to_value,
+    }
+
+
+def test_sanitizer_preserves_missing_and_null_as_distinct_states() -> None:
+    missing: dict[str, object] = {
+        "control": "show_legend",
+        "from_present": False,
+        "to_present": True,
+        "to_value": True,
+    }
+    null: dict[str, object] = _transition("row_limit")
+
+    transitions: tuple[NormalizationTransition, ...] = sanitize_normalization_changes(
+        [missing, null]
+    )
+
+    assert len(transitions) == 2
+    assert not transitions[0].from_present
+    assert transitions[1].from_present
+    assert transitions[1].from_value is None
+
+
+def test_sanitizer_ignores_bad_entries_but_rejects_duplicate_envelope() -> None:
+    assert len(sanitize_normalization_changes([{"bad": True}, _transition()])) == 1
+    assert sanitize_normalization_changes([_transition(), _transition()]) == ()
+    assert sanitize_normalization_changes({"not": "a list"}) == ()
+
+
+def test_sanitizer_rejects_bounded_envelope_failures() -> None:
+    too_many: list[dict[str, object]] = [
+        _transition(control=f"control_{index}")
+        for index in range(MAX_NORMALIZATION_TRANSITIONS + 1)
+    ]
+    deep_value: object = None
+    for _index in range(22):
+        deep_value = [deep_value]
+
+    assert sanitize_normalization_changes(too_many) == ()
+    assert sanitize_normalization_changes([_transition(control="x" * 257)]) == ()
+    assert sanitize_normalization_changes([_transition(from_value=deep_value)]) == ()
+    assert sanitize_normalization_changes([object()]) == ()
+
+
+def test_matching_requires_exact_presence_and_json_value_types() -> None:
+    raw: list[dict[str, object]] = [
+        {
+            "control": "show_legend",
+            "from_present": False,
+            "to_present": True,
+            "to_value": True,
+        },
+        _transition(),
+    ]
+
+    context: NormalizationContext | None = matching_normalization_context(
+        7, raw, {"row_limit": None}, {"show_legend": True, "row_limit": 10000}
+    )
+
+    assert context is not None
+    assert {item.control for item in context.transitions} == {
+        "show_legend",
+        "row_limit",
+    }
+    assert (
+        matching_normalization_context(
+            7,
+            [_transition(from_value=True, to_value=2)],
+            {"row_limit": 1},
+            {"row_limit": 2},
+        )
+        is None
+    )
+
+
+def test_filter_returns_fresh_records_without_matching_params_control() -> None:
+    records: list[ChangeRecord] = [
+        ChangeRecord("field", "edit", ["params", "row_limit"], None, 10000),
+        ChangeRecord("field", "edit", ["slice_name"], "Old", "New"),
+    ]
+    context: NormalizationContext | None = matching_normalization_context(
+        7, [_transition()], {"row_limit": None}, {"row_limit": 10000}
+    )
+
+    filtered: list[ChangeRecord] = filter_normalization_records(records, context)
+
+    assert filtered == [records[1]]
+    assert filtered is not records
+
+
+def test_context_is_consumed_once_and_same_chart_ambiguity_fails_open() -> None:
+    session: Session = Session()
+    context: NormalizationContext | None = matching_normalization_context(
+        7, [_transition()], {"row_limit": None}, {"row_limit": 10000}
+    )
+    assert context is not None
+    store_normalization_context(session, context)
+    assert consume_normalization_context(session, 7) == context
+    assert consume_normalization_context(session, 7) is None
+
+    store_normalization_context(session, context)
+    store_normalization_context(session, context)
+    assert consume_normalization_context(session, 7) is None


### PR DESCRIPTION
### SUMMARY

Chart params stored in the metadata database are not guaranteed to be canonicalized against the active Explore control defaults. Non-canonical data can come from chart imports, fixtures, older Superset versions, API or other non-Explore writers, and changes to a visualization plugin's defaults. When Explore hydrates one of these charts, it may populate default control values that were absent or null in the persisted params. Saving immediately afterward made those automatic normalization changes appear as user-authored version history.

The solution collects advisory evidence at the two points where the machine — and provably not the user — changes params, rather than trying to infer intent from the final save payload:

1. **Hydration stamps** (values supplied automatically while hydrating): the frontend records presence-aware before/after transitions, invalidates that evidence if the control is subsequently changed, and sends the surviving transitions atomically with an existing-chart save.
2. **Stash drops** (values removed after hydration): `StashFormDataContainer` moves invisible controls' values out of `form_data` in render effects, which hydration-time tracking cannot see, so a later save would record phantom "Cleared" entries. At save time, a drop transition is attached for a key only when the stash itself holds it, the stashed value still equals the persisted value (a user edit before hiding breaks the equality and stays recorded), and the outgoing payload no longer carries it. Keys removed any other way — a viz-type switch, a genuine clear — are never in the stash and always record.

The backend bounds and validates the metadata against the exact persisted and submitted params (both directions of presence), then omits only matching normalization noise from the human-readable change records. Persisted chart params and complete restorable version snapshots remain unchanged.

The metadata is fail-open: malformed, stale, ambiguous, or mismatched entries do not suppress history.

Known, deliberate residual: keys the save path itself stamps (`dashboards`, `extra_form_data`, and the `granularity_sqla`/`time_range` → `adhoc_filters` temporal migration) still record once on the first modernizing save — the temporal migration is arguably genuine history.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Version-history panel for the same scenario — a chart whose params were authored outside the current Explore serializer (examples fixtures, imports, API-created charts), edited through the UI.

**Before** — a save where the user touched *nothing* records four phantom "Cleared" entries (the stash removing invisible controls' values):

![before: phantom Cleared entries on a no-edit save](https://raw.githubusercontent.com/mikebridge/superset/sc-115766-assets/before-phantom-cleared-entries.png)

**After** — the same cycle records exactly the user's one genuine change:

![after: only the genuine row-limit change recorded](https://raw.githubusercontent.com/mikebridge/superset/sc-115766-assets/after-genuine-change-only.png)

### TESTING INSTRUCTIONS

1. Enable `ENABLE_VERSIONING_CAPTURE`.
2. Open an existing chart whose saved params omit a control that receives a default during Explore hydration.
3. Save the chart without touching that control.
4. Confirm the automatic default transition is absent from the readable version-history changes.
5. Reload the chart (a fresh hydration lets the stash remove hidden controls' values) and save again without touching anything: confirm no phantom "Cleared" entries are recorded for controls whose visibility gates are off (e.g. `order_desc`, `server_page_length`, `totals_aggregate` on a Table chart).
6. Repeat after intentionally changing a control and confirm the intentional change remains visible — including making a hidden control visible (e.g. enable Server pagination), changing its value, and confirming that change records.
7. Confirm the saved chart params and restorable snapshot still contain the complete post-save state.

Automated coverage:

- `pytest -q tests/unit_tests/versioning/test_normalization_changes.py tests/unit_tests/versioning/test_listener.py` — 17 passed (includes drop-transition matching/filtering); integration suites `change_records_tests.py` + `version_restore_tests.py` unchanged by the drop coverage
- Focused Jest suites (versionHistory feature, save actions, hydration) — 215 passed, including the stash-drop guards (covered drop, user-edited-then-hidden not covered, viz-switch removals not covered)
- Feature-scoped MyPy, TypeScript, Ruff, formatter, and frontend lint checks pass

The repository-wide all-files check also exposes pre-existing current-master failures outside this diff: a MyPy error in `superset/semantic_layers/models.py` and unrelated ECharts test type errors.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_VERSIONING_CAPTURE`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


