### PR TITLE
fix(explore): exclude permalink_key from chart URL params

### DIFF
--- a/superset-frontend/src/constants.test.ts
+++ b/superset-frontend/src/constants.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  URL_PARAMS,
+  RESERVED_CHART_URL_PARAMS,
+  RESERVED_DASHBOARD_URL_PARAMS,
+} from 'src/constants';
+
+test('permalinkKey is reserved on both the chart and dashboard URL param lists', () => {
+  // Dashboard and explore permalinks resolve against different backend
+  // KV resources/salts, so a key from one must never leak into the other's
+  // URL via the reserved-params passthrough logic.
+  expect(RESERVED_DASHBOARD_URL_PARAMS).toContain(URL_PARAMS.permalinkKey.name);
+  expect(RESERVED_CHART_URL_PARAMS).toContain(URL_PARAMS.permalinkKey.name);
+});

--- a/superset-frontend/src/constants.ts
+++ b/superset-frontend/src/constants.ts
@@ -123,6 +123,7 @@ export const RESERVED_CHART_URL_PARAMS: string[] = [
   URL_PARAMS.datasourceId.name,
   URL_PARAMS.datasourceType.name,
   URL_PARAMS.datasetId.name,
+  URL_PARAMS.permalinkKey.name,
   URL_PARAMS.versionHistory.name,
 ];
 export const RESERVED_DASHBOARD_URL_PARAMS: string[] = [


### PR DESCRIPTION
### SUMMARY
Opening a dashboard permalink and editing a chart into Explore, then refreshing the Explore page, can render Explore's "missing datasource" error. `RESERVED_CHART_URL_PARAMS` was missing `permalink_key`, so a dashboard-scoped permalink key could be copied into a chart-scoped Explore URL by the URL-rewrite logic in `ExploreViewContainer`. On refresh, that key is sent to the backend and resolved against the wrong key-value namespace (dashboard vs. explore permalinks use different backend resources/salts), which fails and surfaces as a missing-datasource error.

This adds `permalink_key` to `RESERVED_CHART_URL_PARAMS`, mirroring its existing presence in `RESERVED_DASHBOARD_URL_PARAMS` and the same exclusion pattern already used in the dashboard's native filter bar.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — this is a fix to URL-parameter handling, not a visual change.

### TESTING INSTRUCTIONS
1. Open a dashboard.
2. Open the vertical ellipsis menu on any chart and choose Share > Copy permalink to clipboard.
3. Open the dashboard using that permalink URL.
4. Edit the chart from the dashboard (opens Explore).
5. Refresh the Explore page.
6. Before this change: the page can show a "missing datasource" error. After this change: the chart loads normally.

Also covered by the added unit test: `superset-frontend/src/constants.test.ts`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
