### PR TITLE
fix(mcp): reject unsafe dashboard layout replacements

### DIFF
--- a/superset/mcp_service/dashboard/layout_validation.py
+++ b/superset/mcp_service/dashboard/layout_validation.py
@@ -25,39 +25,162 @@ from typing import Any
 _ROOT_ID = "ROOT_ID"
 _GRID_ID = "GRID_ID"
 _HEADER_ID = "HEADER_ID"
+_VERSION_KEY = "DASHBOARD_VERSION_KEY"
 _CHART_TYPE = "CHART"
-_CONTAINER_TYPES = {"GRID", "TABS"}
-_ALLOWED_CHILD_TYPES = {
-    "ROOT": {"GRID", "TABS"},
-    "GRID": {
-        "CHART",
-        "COLUMN",
-        "DIVIDER",
-        "DYNAMIC",
-        "HEADER",
-        "MARKDOWN",
-        "ROW",
-        "TABS",
-    },
-    "ROW": {"CHART", "COLUMN", "DYNAMIC", "MARKDOWN"},
-    "TABS": {"TAB"},
-    "TAB": {
-        "CHART",
-        "COLUMN",
-        "DIVIDER",
-        "DYNAMIC",
-        "HEADER",
-        "MARKDOWN",
-        "ROW",
-        "TABS",
-    },
-    "COLUMN": {"CHART", "DIVIDER", "HEADER", "MARKDOWN", "ROW", "TABS"},
-    "CHART": set(),
-    "DIVIDER": set(),
-    "DYNAMIC": set(),
-    "HEADER": set(),
-    "MARKDOWN": set(),
+
+# Keep in sync with the frontend's parent/child contract in
+# superset-frontend/src/dashboard/util/isValidChild.ts. The frontend also uses
+# depth limits for drag-and-drop; validation is iterative so deeply nested input
+# cannot overflow Python's call stack.
+_ALLOWED_CHILD_TYPES: dict[str, frozenset[str]] = {
+    "ROOT": frozenset({"GRID", "TABS"}),
+    "GRID": frozenset(
+        {
+            "CHART",
+            "COLUMN",
+            "DIVIDER",
+            "DYNAMIC",
+            "HEADER",
+            "MARKDOWN",
+            "ROW",
+            "TABS",
+        }
+    ),
+    "ROW": frozenset({"CHART", "COLUMN", "DYNAMIC", "MARKDOWN"}),
+    "TABS": frozenset({"TAB"}),
+    "TAB": frozenset(
+        {
+            "CHART",
+            "COLUMN",
+            "DIVIDER",
+            "DYNAMIC",
+            "HEADER",
+            "MARKDOWN",
+            "ROW",
+            "TABS",
+        }
+    ),
+    "COLUMN": frozenset({"CHART", "DIVIDER", "HEADER", "MARKDOWN", "ROW", "TABS"}),
+    "CHART": frozenset(),
+    "DIVIDER": frozenset(),
+    "DYNAMIC": frozenset(),
+    "HEADER": frozenset(),
+    "MARKDOWN": frozenset(),
 }
+_CONTAINER_TYPES = frozenset(
+    component_type
+    for component_type, child_types in _ALLOWED_CHILD_TYPES.items()
+    if child_types
+)
+_META_REQUIRED_TYPES = frozenset(_ALLOWED_CHILD_TYPES) - {"ROOT", "GRID"}
+
+
+def normalize_chart_id(value: Any) -> int | None:
+    """Normalize an integer or canonical decimal-string chart ID."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str) and value.isascii() and value.isdecimal():
+        normalized = int(value)
+        return normalized if normalized > 0 else None
+    return None
+
+
+def _validate_component_shapes(  # noqa: C901
+    layout: dict[str, Any],
+) -> tuple[dict[str, dict[str, Any]], str | None]:
+    """Validate and return every component object in a raw layout mapping."""
+    if layout.get(_VERSION_KEY) != "v2":
+        return {}, f"{_VERSION_KEY} must be the string 'v2'."
+
+    components: dict[str, dict[str, Any]] = {}
+    for component_id, component in layout.items():
+        if component_id == _VERSION_KEY:
+            continue
+        if not isinstance(component, dict):
+            return {}, f"Layout value {component_id} must be a component object."
+        if component.get("id") != component_id:
+            return {}, f"Layout component {component_id} must have the same id value."
+
+        component_type = component.get("type")
+        if not isinstance(component_type, str) or component_type not in (
+            _ALLOWED_CHILD_TYPES
+        ):
+            return {}, f"Layout component {component_id} has unsupported type."
+        if component_type == "DYNAMIC":
+            return {}, (
+                f"Layout component {component_id} uses DYNAMIC, which cannot be "
+                "safely validated by the server."
+            )
+
+        children = component.get("children")
+        if component_type in _CONTAINER_TYPES and children is None:
+            return {}, f"Layout component {component_id} must define children."
+        if children is not None and (
+            not isinstance(children, list)
+            or not all(isinstance(child_id, str) for child_id in children)
+        ):
+            return {}, f"Layout component {component_id}.children must be a list."
+        if component_type not in _CONTAINER_TYPES and children not in (None, []):
+            return {}, f"Layout component {component_id} cannot have children."
+        if component_type == "TABS" and not children:
+            return {}, f"Tabs component {component_id} must contain at least one tab."
+        if component_type in _META_REQUIRED_TYPES and not isinstance(
+            component.get("meta"), dict
+        ):
+            return {}, f"Layout component {component_id}.meta must be an object."
+
+        components[component_id] = component
+
+    return components, None
+
+
+def _validate_edges(
+    components: dict[str, dict[str, Any]],
+) -> tuple[dict[str, str], str | None]:
+    """Validate graph edges and return each component's actual parent."""
+    parent_by_child: dict[str, str] = {}
+    for parent_id, parent in components.items():
+        parent_type = parent["type"]
+        for child_id in parent.get("children") or []:
+            child = components.get(child_id)
+            if child is None:
+                return {}, f"Layout references missing component {child_id}."
+            if child["type"] not in _ALLOWED_CHILD_TYPES[parent_type]:
+                return {}, (
+                    f"Layout component {child_id} cannot be a child of {parent_id}."
+                )
+            if child_id in parent_by_child:
+                return {}, f"Layout component {child_id} has more than one parent."
+            parent_by_child[child_id] = parent_id
+
+    if _ROOT_ID in parent_by_child:
+        return {}, "ROOT_ID must not have a parent."
+    return parent_by_child, None
+
+
+def _find_cycle(components: dict[str, dict[str, Any]]) -> str | None:
+    """Return a component ID in a cycle using an iterative depth-first walk."""
+    state: dict[str, int] = {}
+    for start_id in components:
+        if state.get(start_id) == 2:
+            continue
+        stack: list[tuple[str, bool]] = [(start_id, False)]
+        while stack:
+            component_id, exiting = stack.pop()
+            if exiting:
+                state[component_id] = 2
+                continue
+            if state.get(component_id) == 1:
+                return component_id
+            if state.get(component_id) == 2:
+                continue
+            state[component_id] = 1
+            stack.append((component_id, True))
+            for child_id in reversed(components[component_id].get("children") or []):
+                stack.append((child_id, False))
+    return None
 
 
 def validate_dashboard_layout(  # noqa: C901
@@ -65,126 +188,66 @@ def validate_dashboard_layout(  # noqa: C901
 ) -> str | None:
     """Return an error when an MCP layout replacement is unsafe to persist.
 
-    Superset renders only components reachable from ``ROOT_ID``. It separately
-    indexes every chart component in ``position_json``, including unreachable
-    ones, so an orphaned chart can suppress hydration's missing-chart fallback
-    while remaining invisible. Validate graph reachability and parent paths,
-    then require the layout to contain exactly the dashboard's associated
-    charts before allowing a full replacement.
+    Superset renders only components reachable from ``ROOT_ID`` but indexes all
+    chart nodes during hydration. This validates renderer-required component
+    shape and graph topology, then requires the reachable charts to match the
+    dashboard's associated charts before allowing a full replacement.
 
     ``HEADER_ID`` is dashboard metadata rather than a rendered tree child.
     Superset also retains an empty, detached ``GRID_ID`` when top-level tabs are
     used; both are allowed as explicit reserved-node exceptions.
     """
-    root = layout.get(_ROOT_ID)
-    if not isinstance(root, dict) or root.get("type") != "ROOT":
-        return "Layout must contain a ROOT_ID component with type ROOT."
-
-    root_children = root.get("children", [])
-    if not isinstance(root_children, list) or not all(
-        isinstance(child_id, str) for child_id in root_children
-    ):
-        return "ROOT_ID.children must be a list of component IDs."
-    if len(root_children) > 1:
-        return "ROOT_ID may contain at most one GRID or TABS component."
-    if root_children:
-        root_child = layout.get(root_children[0])
-        root_child_type = (
-            root_child.get("type") if isinstance(root_child, dict) else None
-        )
-        if not isinstance(root_child_type, str) or root_child_type not in (
-            _CONTAINER_TYPES
-        ):
-            return "ROOT_ID's child must be a GRID or TABS component."
-
-    visited: set[str] = set()
-    visiting: set[str] = set()
-    reachable_chart_ids: set[int] = set()
-
-    def visit(  # noqa: C901
-        component_id: str, ancestors: list[str]
-    ) -> str | None:
-        if component_id in visiting:
-            return f"Layout contains a cycle at {component_id}."
-        if component_id in visited:
-            return f"Layout component {component_id} has more than one parent."
-
-        component = layout.get(component_id)
-        if not isinstance(component, dict):
-            return f"Layout references missing component {component_id}."
-        if component.get("id") != component_id:
-            return f"Layout component {component_id} must have the same id value."
-        if component_id == _ROOT_ID:
-            if component.get("parents", []) not in ([], None):
-                return "ROOT_ID must not have parents."
-        elif component.get("parents") != ancestors:
-            return f"Layout component {component_id} has inconsistent parents."
-
-        children = component.get("children", [])
-        if not isinstance(children, list) or not all(
-            isinstance(child_id, str) for child_id in children
-        ):
-            return f"Layout component {component_id}.children must be a list."
-
-        component_type = component.get("type")
-        if not isinstance(component_type, str):
-            return f"Layout component {component_id} has unsupported type."
-        allowed_child_types = _ALLOWED_CHILD_TYPES.get(component_type)
-        if allowed_child_types is None:
-            return f"Layout component {component_id} has unsupported type."
-
-        for child_id in children:
-            child = layout.get(child_id)
-            if not isinstance(child, dict):
-                return f"Layout references missing component {child_id}."
-            if child.get("type") not in allowed_child_types:
-                return (
-                    f"Layout component {child_id} cannot be a child of {component_id}."
-                )
-
-        if component_type == _CHART_TYPE:
-            meta = component.get("meta")
-            chart_id = meta.get("chartId") if isinstance(meta, dict) else None
-            if not isinstance(chart_id, int) or isinstance(chart_id, bool):
-                return f"Chart component {component_id} must have an integer chartId."
-            if children:
-                return f"Chart component {component_id} cannot have children."
-            reachable_chart_ids.add(chart_id)
-
-        visiting.add(component_id)
-        for child_id in children:
-            if error := visit(child_id, [*ancestors, component_id]):
-                return error
-        visiting.remove(component_id)
-        visited.add(component_id)
-        return None
-
-    if error := visit(_ROOT_ID, []):
+    components, error = _validate_component_shapes(layout)
+    if error:
         return error
 
-    detached_grid_allowed = bool(
-        root_children
-        and isinstance(layout.get(root_children[0]), dict)
-        and layout[root_children[0]].get("type") == "TABS"
-    )
-    for component_id, component in layout.items():
-        if not isinstance(component, dict) or "type" not in component:
-            continue
+    root = components.get(_ROOT_ID)
+    if root is None or root.get("type") != "ROOT":
+        return "Layout must contain a ROOT_ID component with type ROOT."
+    root_children = root.get("children") or []
+    if len(root_children) != 1:
+        return "ROOT_ID must contain exactly one GRID or TABS component."
+
+    parent_by_child, error = _validate_edges(components)
+    if error:
+        return error
+    if cycle_id := _find_cycle(components):
+        return f"Layout contains a cycle at {cycle_id}."
+
+    visited: set[str] = set()
+    reachable_chart_ids: set[int] = set()
+    stack: list[tuple[str, list[str]]] = [(_ROOT_ID, [])]
+    while stack:
+        component_id, ancestors = stack.pop()
+        component = components[component_id]
+        expected_parents = [] if component_id == _ROOT_ID else ancestors
+        if component.get("parents", []) != expected_parents:
+            return f"Layout component {component_id} has inconsistent parents."
+        visited.add(component_id)
+
+        if component["type"] == _CHART_TYPE:
+            chart_id = normalize_chart_id(component["meta"].get("chartId"))
+            if chart_id is None:
+                return (
+                    f"Chart component {component_id} must have a positive integer "
+                    "or decimal-string chartId."
+                )
+            reachable_chart_ids.add(chart_id)
+
+        for child_id in reversed(component.get("children") or []):
+            stack.append((child_id, [*ancestors, component_id]))
+
+    top_level_type = components[root_children[0]]["type"]
+    for component_id, component in components.items():
         if component_id in visited:
             continue
-        if (
-            component_id == _HEADER_ID
-            and component.get("id") == _HEADER_ID
-            and component.get("type") == "HEADER"
-            and component.get("children", []) == []
-        ):
+        if component_id == _HEADER_ID and component["type"] == "HEADER":
             continue
         if (
             component_id == _GRID_ID
-            and detached_grid_allowed
-            and component.get("id") == _GRID_ID
-            and component.get("type") == "GRID"
-            and component.get("children", []) == []
+            and top_level_type == "TABS"
+            and component["type"] == "GRID"
+            and component.get("children") == []
             and component.get("parents") == [_ROOT_ID]
         ):
             continue

--- a/superset/mcp_service/dashboard/layout_validation.py
+++ b/superset/mcp_service/dashboard/layout_validation.py
@@ -1,0 +1,199 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Validation for dashboard layouts supplied through MCP tools."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import Any
+
+_ROOT_ID = "ROOT_ID"
+_GRID_ID = "GRID_ID"
+_HEADER_ID = "HEADER_ID"
+_CHART_TYPE = "CHART"
+_CONTAINER_TYPES = {"GRID", "TABS"}
+_ALLOWED_CHILD_TYPES = {
+    "ROOT": {"GRID", "TABS"},
+    "GRID": {
+        "CHART",
+        "COLUMN",
+        "DIVIDER",
+        "DYNAMIC",
+        "HEADER",
+        "MARKDOWN",
+        "ROW",
+        "TABS",
+    },
+    "ROW": {"CHART", "COLUMN", "DYNAMIC", "MARKDOWN"},
+    "TABS": {"TAB"},
+    "TAB": {
+        "CHART",
+        "COLUMN",
+        "DIVIDER",
+        "DYNAMIC",
+        "HEADER",
+        "MARKDOWN",
+        "ROW",
+        "TABS",
+    },
+    "COLUMN": {"CHART", "DIVIDER", "HEADER", "MARKDOWN", "ROW", "TABS"},
+    "CHART": set(),
+    "DIVIDER": set(),
+    "DYNAMIC": set(),
+    "HEADER": set(),
+    "MARKDOWN": set(),
+}
+
+
+def validate_dashboard_layout(  # noqa: C901
+    layout: dict[str, Any], expected_chart_ids: Collection[int]
+) -> str | None:
+    """Return an error when an MCP layout replacement is unsafe to persist.
+
+    Superset renders only components reachable from ``ROOT_ID``. It separately
+    indexes every chart component in ``position_json``, including unreachable
+    ones, so an orphaned chart can suppress hydration's missing-chart fallback
+    while remaining invisible. Validate graph reachability and parent paths,
+    then require the layout to contain exactly the dashboard's associated
+    charts before allowing a full replacement.
+
+    ``HEADER_ID`` is dashboard metadata rather than a rendered tree child.
+    Superset also retains an empty, detached ``GRID_ID`` when top-level tabs are
+    used; both are allowed as explicit reserved-node exceptions.
+    """
+    root = layout.get(_ROOT_ID)
+    if not isinstance(root, dict) or root.get("type") != "ROOT":
+        return "Layout must contain a ROOT_ID component with type ROOT."
+
+    root_children = root.get("children", [])
+    if not isinstance(root_children, list) or not all(
+        isinstance(child_id, str) for child_id in root_children
+    ):
+        return "ROOT_ID.children must be a list of component IDs."
+    if len(root_children) > 1:
+        return "ROOT_ID may contain at most one GRID or TABS component."
+    if root_children:
+        root_child = layout.get(root_children[0])
+        root_child_type = (
+            root_child.get("type") if isinstance(root_child, dict) else None
+        )
+        if not isinstance(root_child_type, str) or root_child_type not in (
+            _CONTAINER_TYPES
+        ):
+            return "ROOT_ID's child must be a GRID or TABS component."
+
+    visited: set[str] = set()
+    visiting: set[str] = set()
+    reachable_chart_ids: set[int] = set()
+
+    def visit(  # noqa: C901
+        component_id: str, ancestors: list[str]
+    ) -> str | None:
+        if component_id in visiting:
+            return f"Layout contains a cycle at {component_id}."
+        if component_id in visited:
+            return f"Layout component {component_id} has more than one parent."
+
+        component = layout.get(component_id)
+        if not isinstance(component, dict):
+            return f"Layout references missing component {component_id}."
+        if component.get("id") != component_id:
+            return f"Layout component {component_id} must have the same id value."
+        if component_id == _ROOT_ID:
+            if component.get("parents", []) not in ([], None):
+                return "ROOT_ID must not have parents."
+        elif component.get("parents") != ancestors:
+            return f"Layout component {component_id} has inconsistent parents."
+
+        children = component.get("children", [])
+        if not isinstance(children, list) or not all(
+            isinstance(child_id, str) for child_id in children
+        ):
+            return f"Layout component {component_id}.children must be a list."
+
+        component_type = component.get("type")
+        if not isinstance(component_type, str):
+            return f"Layout component {component_id} has unsupported type."
+        allowed_child_types = _ALLOWED_CHILD_TYPES.get(component_type)
+        if allowed_child_types is None:
+            return f"Layout component {component_id} has unsupported type."
+
+        for child_id in children:
+            child = layout.get(child_id)
+            if not isinstance(child, dict):
+                return f"Layout references missing component {child_id}."
+            if child.get("type") not in allowed_child_types:
+                return (
+                    f"Layout component {child_id} cannot be a child of {component_id}."
+                )
+
+        if component_type == _CHART_TYPE:
+            meta = component.get("meta")
+            chart_id = meta.get("chartId") if isinstance(meta, dict) else None
+            if not isinstance(chart_id, int) or isinstance(chart_id, bool):
+                return f"Chart component {component_id} must have an integer chartId."
+            if children:
+                return f"Chart component {component_id} cannot have children."
+            reachable_chart_ids.add(chart_id)
+
+        visiting.add(component_id)
+        for child_id in children:
+            if error := visit(child_id, [*ancestors, component_id]):
+                return error
+        visiting.remove(component_id)
+        visited.add(component_id)
+        return None
+
+    if error := visit(_ROOT_ID, []):
+        return error
+
+    detached_grid_allowed = bool(
+        root_children
+        and isinstance(layout.get(root_children[0]), dict)
+        and layout[root_children[0]].get("type") == "TABS"
+    )
+    for component_id, component in layout.items():
+        if not isinstance(component, dict) or "type" not in component:
+            continue
+        if component_id in visited:
+            continue
+        if (
+            component_id == _HEADER_ID
+            and component.get("id") == _HEADER_ID
+            and component.get("type") == "HEADER"
+            and component.get("children", []) == []
+        ):
+            continue
+        if (
+            component_id == _GRID_ID
+            and detached_grid_allowed
+            and component.get("id") == _GRID_ID
+            and component.get("type") == "GRID"
+            and component.get("children", []) == []
+            and component.get("parents") == [_ROOT_ID]
+        ):
+            continue
+        return f"Layout component {component_id} is unreachable from ROOT_ID."
+
+    expected = set(expected_chart_ids)
+    if missing := sorted(expected - reachable_chart_ids):
+        return f"Layout would hide dashboard charts: {missing}."
+    if unknown := sorted(reachable_chart_ids - expected):
+        return f"Layout references charts not associated with the dashboard: {unknown}."
+
+    return None

--- a/superset/mcp_service/dashboard/layout_validation.py
+++ b/superset/mcp_service/dashboard/layout_validation.py
@@ -216,13 +216,13 @@ def validate_dashboard_layout(  # noqa: C901
 
     visited: set[str] = set()
     reachable_chart_ids: set[int] = set()
-    stack: list[tuple[str, list[str]]] = [(_ROOT_ID, [])]
+    # The frontend treats ``parents`` as derived metadata and recomputes it
+    # during hydration. Saved layouts can therefore omit it or retain stale
+    # values after drag-and-drop; the validated child edges are authoritative.
+    stack = [_ROOT_ID]
     while stack:
-        component_id, ancestors = stack.pop()
+        component_id = stack.pop()
         component = components[component_id]
-        expected_parents = [] if component_id == _ROOT_ID else ancestors
-        if component.get("parents", []) != expected_parents:
-            return f"Layout component {component_id} has inconsistent parents."
         visited.add(component_id)
 
         if component["type"] == _CHART_TYPE:
@@ -235,7 +235,7 @@ def validate_dashboard_layout(  # noqa: C901
             reachable_chart_ids.add(chart_id)
 
         for child_id in reversed(component.get("children") or []):
-            stack.append((child_id, [*ancestors, component_id]))
+            stack.append(child_id)
 
     top_level_type = components[root_children[0]]["type"]
     for component_id, component in components.items():
@@ -248,7 +248,6 @@ def validate_dashboard_layout(  # noqa: C901
             and top_level_type == "TABS"
             and component["type"] == "GRID"
             and component.get("children") == []
-            and component.get("parents") == [_ROOT_ID]
         ):
             continue
         return f"Layout component {component_id} is unreachable from ROOT_ID."

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -762,9 +762,10 @@ class UpdateDashboardRequest(BaseModel):
         None,
         description=(
             "Optional replacement layout (Superset's position_json dict). "
-            "When set, fully replaces the existing layout. Get the current "
-            "layout via ``get_dashboard_info`` first if you want to make "
-            "incremental changes."
+            "When set, fully replaces the existing layout and must keep every "
+            "dashboard chart reachable from ROOT_ID, with consistent children "
+            "and parents. Get the current layout via ``get_dashboard_layout`` "
+            "first if you want to make incremental changes."
         ),
     )
     json_metadata_overrides: Dict[str, Any] | None = Field(

--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -764,8 +764,9 @@ class UpdateDashboardRequest(BaseModel):
             "Optional replacement layout (Superset's position_json dict). "
             "When set, fully replaces the existing layout and must keep every "
             "dashboard chart reachable from ROOT_ID, with consistent children "
-            "and parents. Get the current layout via ``get_dashboard_layout`` "
-            "first if you want to make incremental changes."
+            "and parents. Do not use this field for incremental edits: MCP does "
+            "not currently expose the complete raw layout tree needed to safely "
+            "round-trip a replacement. Prefer purpose-built dashboard tools."
         ),
     )
     json_metadata_overrides: Dict[str, Any] | None = Field(

--- a/superset/mcp_service/dashboard/tool/remove_chart_from_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/remove_chart_from_dashboard.py
@@ -35,6 +35,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException, ForbiddenError
 from superset.extensions import event_logger
+from superset.mcp_service.dashboard.layout_validation import normalize_chart_id
 from superset.mcp_service.dashboard.schemas import (
     DashboardInfo,
     RemoveChartFromDashboardRequest,
@@ -59,14 +60,12 @@ def _find_chart_keys(layout: Dict[str, Any], chart_id: int) -> list[str]:
     A chart can legitimately appear more than once in a layout (e.g. under
     multiple tabs), so all occurrences are returned.
     """
-    # Accept both int and string chartId — position_json is user/frontend-authored
-    # and imported or hand-edited layouts may store chartId as a string.
     return [
         key
         for key, node in layout.items()
         if isinstance(node, dict)
         and node.get("type") == "CHART"
-        and (node.get("meta") or {}).get("chartId") in (chart_id, str(chart_id))
+        and normalize_chart_id((node.get("meta") or {}).get("chartId")) == chart_id
     ]
 
 

--- a/superset/mcp_service/dashboard/tool/update_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/update_dashboard.py
@@ -298,9 +298,10 @@ async def update_dashboard(
 ) -> UpdateDashboardResponse | DashboardError:
     """Patch an existing dashboard's layout, theme, styling, or metadata.
 
-    Companion to ``generate_dashboard`` for incremental edits. An LLM can:
+    Companion to ``generate_dashboard`` for incremental metadata and styling
+    edits. An LLM can:
 
-      - Set or replace ``position_json`` after auto-generation
+      - Replace ``position_json`` only when it already has the complete raw tree
       - Apply brand ``label_colors`` and ``color_scheme`` via
         ``json_metadata_overrides``
       - Inject ``css`` to hide chrome on print-ready dashboards

--- a/superset/mcp_service/dashboard/tool/update_dashboard.py
+++ b/superset/mcp_service/dashboard/tool/update_dashboard.py
@@ -33,6 +33,7 @@ from superset_core.mcp.decorators import tool, ToolAnnotations
 from superset.commands.dashboard.exceptions import DashboardNotFoundError
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, event_logger
+from superset.mcp_service.dashboard.layout_validation import validate_dashboard_layout
 from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
     DashboardError,
@@ -236,6 +237,14 @@ def _validate_update_request(
     from superset.commands.utils import validate_tags
     from superset.dashboards.schemas import validate_css
     from superset.tags.models import ObjectType
+
+    if request.position_json is not None:
+        chart_ids = [chart.id for chart in dashboard.slices]
+        if error := validate_dashboard_layout(request.position_json, chart_ids):
+            return DashboardError(
+                error=f"Dashboard layout is invalid: {error}",
+                error_type="InvalidDashboardLayout",
+            )
 
     # Empty string clears CSS (no validation needed); only validate real content.
     if request.css:

--- a/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
@@ -18,13 +18,14 @@
 """Tests for MCP dashboard layout validation."""
 
 from copy import deepcopy
+from typing import Any
 
 from superset.mcp_service.dashboard.layout_validation import (
     validate_dashboard_layout,
 )
 
 
-def _grid_layout() -> dict:
+def _grid_layout() -> dict[str, Any]:
     return {
         "DASHBOARD_VERSION_KEY": "v2",
         "ROOT_ID": {
@@ -41,6 +42,7 @@ def _grid_layout() -> dict:
         "ROW-1": {
             "children": ["CHART-1"],
             "id": "ROW-1",
+            "meta": {},
             "parents": ["ROOT_ID", "GRID_ID"],
             "type": "ROW",
         },
@@ -56,6 +58,22 @@ def _grid_layout() -> dict:
 
 def test_valid_layout() -> None:
     assert validate_dashboard_layout(_grid_layout(), {1}) is None
+
+
+def test_valid_empty_grid() -> None:
+    layout = _grid_layout()
+    layout["GRID_ID"]["children"] = []
+    del layout["ROW-1"]
+    del layout["CHART-1"]
+
+    assert validate_dashboard_layout(layout, set()) is None
+
+
+def test_accepts_decimal_string_chart_id() -> None:
+    layout = _grid_layout()
+    layout["CHART-1"]["meta"]["chartId"] = "1"
+
+    assert validate_dashboard_layout(layout, {1}) is None
 
 
 def test_valid_top_level_tabs_with_reserved_nodes() -> None:
@@ -80,12 +98,14 @@ def test_valid_top_level_tabs_with_reserved_nodes() -> None:
         "TABS-1": {
             "children": ["TAB-1"],
             "id": "TABS-1",
+            "meta": {},
             "parents": ["ROOT_ID"],
             "type": "TABS",
         },
         "TAB-1": {
             "children": ["CHART-1"],
             "id": "TAB-1",
+            "meta": {"text": "Overview"},
             "parents": ["ROOT_ID", "TABS-1"],
             "type": "TAB",
         },
@@ -120,9 +140,16 @@ def test_rejects_missing_child_reference() -> None:
 
 def test_rejects_cycle() -> None:
     layout = _grid_layout()
-    layout["CHART-1"]["type"] = "COLUMN"
-    layout["CHART-1"].pop("meta")
-    layout["CHART-1"]["children"] = ["ROW-1"]
+    layout["GRID_ID"]["children"] = []
+    layout["ROW-1"]["children"] = ["COLUMN-1"]
+    layout["ROW-1"]["parents"] = ["COLUMN-1"]
+    layout["COLUMN-1"] = {
+        "children": ["ROW-1"],
+        "id": "COLUMN-1",
+        "meta": {},
+        "parents": ["ROW-1"],
+        "type": "COLUMN",
+    }
 
     error = validate_dashboard_layout(layout, {1})
 
@@ -153,7 +180,7 @@ def test_rejects_unsupported_component_type() -> None:
 
     error = validate_dashboard_layout(layout, {1})
 
-    assert error == "Layout component ROW-1 cannot be a child of GRID_ID."
+    assert error == "Layout component ROW-1 has unsupported type."
 
 
 def test_rejects_layout_that_hides_associated_chart() -> None:
@@ -169,3 +196,76 @@ def test_rejects_chart_not_associated_with_dashboard() -> None:
     error = validate_dashboard_layout(_grid_layout(), set())
 
     assert error == "Layout references charts not associated with the dashboard: [1]."
+
+
+def test_rejects_empty_root() -> None:
+    layout = _grid_layout()
+    layout["ROOT_ID"]["children"] = []
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "ROOT_ID must contain exactly one GRID or TABS component."
+    )
+
+
+def test_rejects_empty_tabs() -> None:
+    layout = _grid_layout()
+    layout["ROOT_ID"]["children"] = ["TABS-1"]
+    layout["TABS-1"] = {
+        "children": [],
+        "id": "TABS-1",
+        "meta": {},
+        "parents": ["ROOT_ID"],
+        "type": "TABS",
+    }
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "Tabs component TABS-1 must contain at least one tab."
+    )
+
+
+def test_rejects_non_component_top_level_value() -> None:
+    layout = _grid_layout()
+    layout["BROKEN"] = None
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "Layout value BROKEN must be a component object."
+    )
+
+
+def test_rejects_invalid_version() -> None:
+    layout = _grid_layout()
+    layout["DASHBOARD_VERSION_KEY"] = None
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "DASHBOARD_VERSION_KEY must be the string 'v2'."
+    )
+
+
+def test_rejects_missing_renderer_metadata() -> None:
+    layout = _grid_layout()
+    del layout["ROW-1"]["meta"]
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "Layout component ROW-1.meta must be an object."
+    )
+
+
+def test_rejects_dynamic_component() -> None:
+    layout = _grid_layout()
+    layout["CHART-1"]["type"] = "DYNAMIC"
+    layout["CHART-1"]["meta"] = {"componentKey": "unknown"}
+
+    assert validate_dashboard_layout(layout, set()) == (
+        "Layout component CHART-1 uses DYNAMIC, which cannot be safely "
+        "validated by the server."
+    )
+
+
+def test_rejects_malformed_string_chart_id() -> None:
+    layout = _grid_layout()
+    layout["CHART-1"]["meta"]["chartId"] = "1.0"
+
+    assert validate_dashboard_layout(layout, {1}) == (
+        "Chart component CHART-1 must have a positive integer or "
+        "decimal-string chartId."
+    )

--- a/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
@@ -18,7 +18,10 @@
 """Tests for MCP dashboard layout validation."""
 
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from superset.mcp_service.dashboard.layout_validation import (
     validate_dashboard_layout,
@@ -156,13 +159,38 @@ def test_rejects_cycle() -> None:
     assert error == "Layout contains a cycle at ROW-1."
 
 
-def test_rejects_inconsistent_parents() -> None:
+def test_accepts_stale_parents_metadata() -> None:
     layout = _grid_layout()
     layout["CHART-1"]["parents"] = ["ROOT_ID", "GRID_ID"]
 
-    error = validate_dashboard_layout(layout, {1})
+    assert validate_dashboard_layout(layout, {1}) is None
 
-    assert error == "Layout component CHART-1 has inconsistent parents."
+
+def test_accepts_missing_parents_metadata() -> None:
+    layout = _grid_layout()
+    del layout["GRID_ID"]["parents"]
+    del layout["CHART-1"]["parents"]
+
+    assert validate_dashboard_layout(layout, {1}) is None
+
+
+def test_accepts_saved_example_layout_with_stale_parents() -> None:
+    fixture_path = (
+        Path(__file__).parents[4]
+        / "superset"
+        / "examples"
+        / "video_game_sales"
+        / "dashboard.yaml"
+    )
+    with fixture_path.open(encoding="utf-8") as fixture:
+        layout = yaml.safe_load(fixture)["position"]
+    chart_ids = {
+        component["meta"]["chartId"]
+        for component in layout.values()
+        if isinstance(component, dict) and component.get("type") == "CHART"
+    }
+
+    assert validate_dashboard_layout(layout, chart_ids) is None
 
 
 def test_rejects_component_in_invalid_parent() -> None:

--- a/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_layout_validation.py
@@ -1,0 +1,171 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for MCP dashboard layout validation."""
+
+from copy import deepcopy
+
+from superset.mcp_service.dashboard.layout_validation import (
+    validate_dashboard_layout,
+)
+
+
+def _grid_layout() -> dict:
+    return {
+        "DASHBOARD_VERSION_KEY": "v2",
+        "ROOT_ID": {
+            "children": ["GRID_ID"],
+            "id": "ROOT_ID",
+            "type": "ROOT",
+        },
+        "GRID_ID": {
+            "children": ["ROW-1"],
+            "id": "GRID_ID",
+            "parents": ["ROOT_ID"],
+            "type": "GRID",
+        },
+        "ROW-1": {
+            "children": ["CHART-1"],
+            "id": "ROW-1",
+            "parents": ["ROOT_ID", "GRID_ID"],
+            "type": "ROW",
+        },
+        "CHART-1": {
+            "children": [],
+            "id": "CHART-1",
+            "meta": {"chartId": 1},
+            "parents": ["ROOT_ID", "GRID_ID", "ROW-1"],
+            "type": "CHART",
+        },
+    }
+
+
+def test_valid_layout() -> None:
+    assert validate_dashboard_layout(_grid_layout(), {1}) is None
+
+
+def test_valid_top_level_tabs_with_reserved_nodes() -> None:
+    layout = {
+        "DASHBOARD_VERSION_KEY": "v2",
+        "ROOT_ID": {
+            "children": ["TABS-1"],
+            "id": "ROOT_ID",
+            "type": "ROOT",
+        },
+        "GRID_ID": {
+            "children": [],
+            "id": "GRID_ID",
+            "parents": ["ROOT_ID"],
+            "type": "GRID",
+        },
+        "HEADER_ID": {
+            "id": "HEADER_ID",
+            "meta": {"text": "Tabbed dashboard"},
+            "type": "HEADER",
+        },
+        "TABS-1": {
+            "children": ["TAB-1"],
+            "id": "TABS-1",
+            "parents": ["ROOT_ID"],
+            "type": "TABS",
+        },
+        "TAB-1": {
+            "children": ["CHART-1"],
+            "id": "TAB-1",
+            "parents": ["ROOT_ID", "TABS-1"],
+            "type": "TAB",
+        },
+        "CHART-1": {
+            "id": "CHART-1",
+            "meta": {"chartId": 1},
+            "parents": ["ROOT_ID", "TABS-1", "TAB-1"],
+            "type": "CHART",
+        },
+    }
+
+    assert validate_dashboard_layout(layout, {1}) is None
+
+
+def test_rejects_unreachable_chart() -> None:
+    layout = _grid_layout()
+    layout["GRID_ID"]["children"] = []
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout component ROW-1 is unreachable from ROOT_ID."
+
+
+def test_rejects_missing_child_reference() -> None:
+    layout = _grid_layout()
+    del layout["ROW-1"]
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout references missing component ROW-1."
+
+
+def test_rejects_cycle() -> None:
+    layout = _grid_layout()
+    layout["CHART-1"]["type"] = "COLUMN"
+    layout["CHART-1"].pop("meta")
+    layout["CHART-1"]["children"] = ["ROW-1"]
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout contains a cycle at ROW-1."
+
+
+def test_rejects_inconsistent_parents() -> None:
+    layout = _grid_layout()
+    layout["CHART-1"]["parents"] = ["ROOT_ID", "GRID_ID"]
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout component CHART-1 has inconsistent parents."
+
+
+def test_rejects_component_in_invalid_parent() -> None:
+    layout = _grid_layout()
+    layout["ROW-1"]["type"] = "TABS"
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout component CHART-1 cannot be a child of ROW-1."
+
+
+def test_rejects_unsupported_component_type() -> None:
+    layout = _grid_layout()
+    layout["ROW-1"]["type"] = "UNKNOWN"
+
+    error = validate_dashboard_layout(layout, {1})
+
+    assert error == "Layout component ROW-1 cannot be a child of GRID_ID."
+
+
+def test_rejects_layout_that_hides_associated_chart() -> None:
+    layout = deepcopy(_grid_layout())
+    layout["CHART-1"]["meta"]["chartId"] = 2
+
+    error = validate_dashboard_layout(layout, {1, 2})
+
+    assert error == "Layout would hide dashboard charts: [1]."
+
+
+def test_rejects_chart_not_associated_with_dashboard() -> None:
+    error = validate_dashboard_layout(_grid_layout(), set())
+
+    assert error == "Layout references charts not associated with the dashboard: [1]."

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -24,6 +24,7 @@ import pytest
 from fastmcp import Client, Context
 
 from superset.mcp_service.app import mcp
+from superset.mcp_service.dashboard.schemas import serialize_dashboard_object
 from superset.utils import json
 
 
@@ -67,6 +68,7 @@ def _mock_dashboard(
     dashboard.position_json = position_json
     dashboard.certified_by = None
     dashboard.certification_details = None
+    dashboard.deleted_at = None
     dashboard.is_managed_externally = False
     dashboard.external_url = None
     dashboard.created_on = datetime(2024, 1, 1)
@@ -149,6 +151,43 @@ class TestUpdateDashboard:
         payload = json.loads(result.content[0].text)
         changed = set(payload.get("changed_fields") or [])
         assert {"position_json", "json_metadata", "css"} <= changed
+
+    @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_read_modify_write_persists_clean_dashboard_values(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        stored_title = "Quarterly [ESCAPED-UNTRUSTED-CONTENT-CLOSE] dashboard"
+        stored_description = "Line one\n[UNTRUSTED-CONTENT] literal"
+        dash = _mock_dashboard(id=42, title=stored_title)
+        dash.description = stored_description
+        mock_get.return_value = dash
+
+        read_result = serialize_dashboard_object(dash)
+        assert read_result.dashboard_title == stored_title
+        assert read_result.description == stored_description
+        modified_title = f"{read_result.dashboard_title} updated"
+        modified_description = f"{read_result.description}\nupdated"
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "update_dashboard",
+                {
+                    "request": {
+                        "identifier": 42,
+                        "dashboard_title": modified_title,
+                        "description": modified_description,
+                    }
+                },
+            )
+
+        assert dash.dashboard_title == modified_title
+        assert dash.description == modified_description
+        mock_session.commit.assert_called()
+        payload = json.loads(result.content[0].text)
+        assert payload["dashboard"]["dashboard_title"] == modified_title
+        assert payload["dashboard"]["description"] == modified_description
 
     @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
     @patch("superset.extensions.db.session")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -103,6 +103,7 @@ class TestUpdateDashboard:
         mock_get.return_value = dash
 
         position = {
+            "DASHBOARD_VERSION_KEY": "v2",
             "ROOT_ID": {
                 "id": "ROOT_ID",
                 "type": "ROOT",
@@ -157,6 +158,7 @@ class TestUpdateDashboard:
     ) -> None:
         original_position = json.dumps(
             {
+                "DASHBOARD_VERSION_KEY": "v2",
                 "ROOT_ID": {
                     "id": "ROOT_ID",
                     "type": "ROOT",
@@ -180,6 +182,7 @@ class TestUpdateDashboard:
         dash.slices = [Mock(id=10)]
         mock_get.return_value = dash
         unreachable_layout = {
+            "DASHBOARD_VERSION_KEY": "v2",
             "ROOT_ID": {
                 "id": "ROOT_ID",
                 "type": "ROOT",
@@ -188,12 +191,14 @@ class TestUpdateDashboard:
             "TABS-1": {
                 "id": "TABS-1",
                 "type": "TABS",
+                "meta": {},
                 "parents": ["ROOT_ID"],
                 "children": ["TAB-1"],
             },
             "TAB-1": {
                 "id": "TAB-1",
                 "type": "TAB",
+                "meta": {"text": "Overview"},
                 "parents": ["ROOT_ID", "TABS-1"],
                 "children": [],
             },
@@ -211,6 +216,8 @@ class TestUpdateDashboard:
                 {
                     "request": {
                         "identifier": 42,
+                        "dashboard_title": "Must not be applied",
+                        "css": ".must-not-be-applied { color: red; }",
                         "position_json": unreachable_layout,
                     }
                 },
@@ -220,6 +227,8 @@ class TestUpdateDashboard:
         assert payload["error_type"] == "InvalidDashboardLayout"
         assert "unreachable" in payload["error"]
         assert dash.position_json == original_position
+        assert dash.dashboard_title == "Test Dashboard"
+        assert dash.css is None
         mock_session.commit.assert_not_called()
 
     @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py
@@ -24,7 +24,6 @@ import pytest
 from fastmcp import Client, Context
 
 from superset.mcp_service.app import mcp
-from superset.mcp_service.dashboard.schemas import serialize_dashboard_object
 from superset.utils import json
 
 
@@ -68,7 +67,6 @@ def _mock_dashboard(
     dashboard.position_json = position_json
     dashboard.certified_by = None
     dashboard.certification_details = None
-    dashboard.deleted_at = None
     dashboard.is_managed_externally = False
     dashboard.external_url = None
     dashboard.created_on = datetime(2024, 1, 1)
@@ -104,7 +102,19 @@ class TestUpdateDashboard:
         )
         mock_get.return_value = dash
 
-        position = {"ROOT_ID": {"type": "ROOT", "children": ["GRID_ID"]}}
+        position = {
+            "ROOT_ID": {
+                "id": "ROOT_ID",
+                "type": "ROOT",
+                "children": ["GRID_ID"],
+            },
+            "GRID_ID": {
+                "id": "GRID_ID",
+                "type": "GRID",
+                "parents": ["ROOT_ID"],
+                "children": [],
+            },
+        }
         overrides = {
             "label_colors": {"Electronics": "#4C78A8"},
             "cross_filters_enabled": False,
@@ -142,20 +152,58 @@ class TestUpdateDashboard:
     @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
-    async def test_read_modify_write_persists_clean_dashboard_values(
+    async def test_invalid_layout_does_not_replace_existing_content(
         self, mock_session: Mock, mock_get: Mock, mcp_server: object
     ) -> None:
-        stored_title = "Quarterly [ESCAPED-UNTRUSTED-CONTENT-CLOSE] dashboard"
-        stored_description = "Line one\n[UNTRUSTED-CONTENT] literal"
-        dash = _mock_dashboard(id=42, title=stored_title)
-        dash.description = stored_description
+        original_position = json.dumps(
+            {
+                "ROOT_ID": {
+                    "id": "ROOT_ID",
+                    "type": "ROOT",
+                    "children": ["GRID_ID"],
+                },
+                "GRID_ID": {
+                    "id": "GRID_ID",
+                    "type": "GRID",
+                    "parents": ["ROOT_ID"],
+                    "children": ["CHART-old"],
+                },
+                "CHART-old": {
+                    "id": "CHART-old",
+                    "type": "CHART",
+                    "parents": ["ROOT_ID", "GRID_ID"],
+                    "meta": {"chartId": 10},
+                },
+            }
+        )
+        dash = _mock_dashboard(id=42, position_json=original_position)
+        dash.slices = [Mock(id=10)]
         mock_get.return_value = dash
-
-        read_result = serialize_dashboard_object(dash)
-        assert read_result.dashboard_title == stored_title
-        assert read_result.description == stored_description
-        modified_title = f"{read_result.dashboard_title} updated"
-        modified_description = f"{read_result.description}\nupdated"
+        unreachable_layout = {
+            "ROOT_ID": {
+                "id": "ROOT_ID",
+                "type": "ROOT",
+                "children": ["TABS-1"],
+            },
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "parents": ["ROOT_ID"],
+                "children": ["TAB-1"],
+            },
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "parents": ["ROOT_ID", "TABS-1"],
+                "children": [],
+            },
+            "CHART-10": {
+                "id": "CHART-10",
+                "type": "CHART",
+                "parents": ["ROOT_ID", "TABS-1", "TAB-1"],
+                "meta": {"chartId": 10},
+            },
+        }
 
         async with Client(mcp_server) as client:
             result = await client.call_tool(
@@ -163,18 +211,16 @@ class TestUpdateDashboard:
                 {
                     "request": {
                         "identifier": 42,
-                        "dashboard_title": modified_title,
-                        "description": modified_description,
+                        "position_json": unreachable_layout,
                     }
                 },
             )
 
-        assert dash.dashboard_title == modified_title
-        assert dash.description == modified_description
-        mock_session.commit.assert_called()
         payload = json.loads(result.content[0].text)
-        assert payload["dashboard"]["dashboard_title"] == modified_title
-        assert payload["dashboard"]["description"] == modified_description
+        assert payload["error_type"] == "InvalidDashboardLayout"
+        assert "unreachable" in payload["error"]
+        assert dash.position_json == original_position
+        mock_session.commit.assert_not_called()
 
     @patch("superset.daos.dashboard.DashboardDAO.get_by_id_or_slug")
     @patch("superset.extensions.db.session")


### PR DESCRIPTION
### SUMMARY

Reject unsafe full `position_json` replacements in the MCP `update_dashboard` tool before they overwrite a valid saved layout.

Superset renders only layout nodes reachable from `ROOT_ID`, but dashboard hydration indexes every `CHART` node in `position_json`. An unreachable chart therefore prevents the normal missing-chart fallback while remaining invisible, which can leave a dashboard blank even though the chart nodes and slice associations still exist.

This change validates renderer-required component shape, the v2 marker, graph references, parent/child compatibility, cycles, component IDs, parent paths, reachability, and root/top-level-tab shape. Traversal is iterative, imported decimal-string chart IDs are normalized through a helper shared with chart removal, and `DYNAMIC` nodes are rejected because the backend cannot validate the frontend registry. Reachable chart IDs must exactly match the charts associated with the dashboard.

Invalid updates return `InvalidDashboardLayout` before any field mutation or commit, preserving the previous layout. The validator handles Superset's two reserved exceptions: detached `HEADER_ID`, and the empty detached `GRID_ID` retained by top-level tab layouts.

The MCP schema now explicitly states that `get_dashboard_layout` is a summary rather than a round-trippable raw tree, so callers are not directed into unsafe incremental full replacements.

Tracking: [SC-117987](https://app.shortcut.com/preset/story/117987) `[sc-117987]`

Related: #43133 contains generate-only fallback validation as part of native AI authoring. This PR provides the stronger shared validator for that path to reuse after rebase while keeping update rejection separate from generate fallback behavior.

### TESTING INSTRUCTIONS

- `pre-commit run --files superset/mcp_service/dashboard/layout_validation.py superset/mcp_service/dashboard/schemas.py superset/mcp_service/dashboard/tool/update_dashboard.py superset/mcp_service/dashboard/tool/remove_chart_from_dashboard.py tests/unit_tests/mcp_service/dashboard/test_layout_validation.py tests/unit_tests/mcp_service/dashboard/tool/test_update_dashboard.py`
- `ruff check` and `ruff format --check` pass for all changed Python files.
- `git diff --check`
- 19 standalone structural validator regression cases pass locally.
- GitHub's Python unit-test matrix passes; the full workflow reruns for the latest commit.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-117987](https://app.shortcut.com/preset/story/117987)
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
