### PR TITLE
fix(plugin-chart-echarts): restore tooltips for metrics labelled like…

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -80,6 +80,7 @@ import {
   getAnnotationData,
 } from '../utils/annotation';
 import {
+  collapseForecastKeys,
   extractForecastSeriesContext,
   extractForecastValuesFromTooltipParams,
   formatForecastTooltipSeries,
@@ -861,12 +862,14 @@ export default function transformProps(
           : params.value[0];
         const forecastValue: any[] = richTooltip ? params : [params];
 
-        const sortedKeys = extractTooltipKeys(
-          forecastValue,
-          // horizontal mode is not supported in mixed series chart
-          1,
-          richTooltip,
-          tooltipSortByMetric,
+        const sortedKeys = collapseForecastKeys(
+          extractTooltipKeys(
+            forecastValue,
+            // horizontal mode is not supported in mixed series chart
+            1,
+            richTooltip,
+            tooltipSortByMetric,
+          ),
         );
 
         const rows: string[][] = [];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -95,6 +95,7 @@ import {
   getAnnotationData,
 } from '../utils/annotation';
 import {
+  collapseForecastKeys,
   extractForecastSeriesContext,
   extractForecastSeriesContexts,
   extractForecastValuesFromTooltipParams,
@@ -1392,11 +1393,13 @@ export default function transformProps(
         const forecastValue: CallbackDataParams[] = richTooltip
           ? params
           : [params];
-        const sortedKeys = extractTooltipKeys(
-          forecastValue,
-          yIndex,
-          richTooltip,
-          tooltipSortByMetric,
+        const sortedKeys = collapseForecastKeys(
+          extractTooltipKeys(
+            forecastValue,
+            yIndex,
+            richTooltip,
+            tooltipSortByMetric,
+          ),
         );
         const filteredForecastValue = forecastValue.filter(
           (item: CallbackDataParams) =>

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/forecast.ts
@@ -60,6 +60,21 @@ export const extractForecastSeriesContexts = (
     {} as { [key: string]: ForecastSeriesEnum[] },
   );
 
+/**
+ * Collapses raw ECharts series ids onto the names used to key tooltip rows.
+ *
+ * Tooltip values are grouped by forecast-stripped name, so any ordering derived
+ * from the raw series ids has to be expressed in the same terms before it can be
+ * matched against them. This matters beyond real Prophet output: a metric simply
+ * labelled `ci__yhat_lower` collapses to `ci` exactly like a forecast bound
+ * does, and a chart whose every series carries such a suffix has no id that
+ * survives the comparison untouched.
+ */
+export const collapseForecastKeys = (seriesIds: string[]): string[] =>
+  Array.from(
+    new Set(seriesIds.map(id => extractForecastSeriesContext(id).name)),
+  );
+
 export const extractForecastValuesFromTooltipParams = (
   params: any[],
   isHorizontal = false,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2529,3 +2529,66 @@ describe('EchartsTimeseries tooltip truncation', () => {
     expect(buildTooltip(undefined, longCategory)).toContain(longCategory);
   });
 });
+
+describe('tooltip for metrics whose labels end in forecast suffixes', () => {
+  const marker = '<span style="background-color:#1f77b4;"></span>';
+  const seriesIds = ['ci__yhat', 'ci__yhat_lower', 'ci__yhat_upper'];
+  const values = [1.5, 0.5, 2.0];
+
+  // Metrics can be labelled `ci__yhat*` with no forecast enabled and no plain
+  // observation series. Every series then collapses onto the same
+  // forecast-stripped tooltip key, so no raw series id matches itself.
+  const buildTooltip = (tooltipSortByMetric = false) => {
+    const chartProps = createTestChartProps({
+      formData: {
+        x_axis: 'dt',
+        metrics: seriesIds,
+        groupby: [],
+        richTooltip: true,
+        tooltipSortByMetric,
+      } as Partial<EchartsTimeseriesFormData>,
+      queriesData: [
+        {
+          data: [
+            {
+              dt: 599616000000,
+              ci__yhat: 1.5,
+              ci__yhat_lower: 0.5,
+              ci__yhat_upper: 2.5,
+            },
+          ],
+        } as ChartDataResponseResult,
+      ],
+    });
+    const tooltipFormatter = (transformProps(chartProps).echartOptions as any)
+      .tooltip.formatter;
+    return tooltipFormatter(
+      seriesIds.map((id, i) => ({
+        seriesId: id,
+        seriesName: id,
+        value: [599616000000, values[i]],
+        data: [599616000000, values[i]],
+        marker,
+      })),
+    );
+  };
+
+  test('renders the collapsed series rather than falling back to "No data"', () => {
+    const html = buildTooltip();
+    expect(html).not.toContain('No data');
+    expect(html).toContain('>ci<');
+    expect(html).toContain('ŷ = 1.5 (0.5, 2.5)');
+  });
+
+  test('renders a single row rather than one per forecast suffix', () => {
+    const html = buildTooltip();
+    expect(html.match(/<tr/g)).toHaveLength(1);
+    expect(html).toContain('>ci<');
+  });
+
+  test('still renders the row when the tooltip is sorted by metric', () => {
+    const html = buildTooltip(true);
+    expect(html).not.toContain('No data');
+    expect(html).toContain('>ci<');
+  });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2548,16 +2548,14 @@ describe('tooltip for metrics whose labels end in forecast suffixes', () => {
         tooltipSortByMetric,
       } as Partial<EchartsTimeseriesFormData>,
       queriesData: [
-        {
-          data: [
-            {
-              dt: 599616000000,
-              ci__yhat: 1.5,
-              ci__yhat_lower: 0.5,
-              ci__yhat_upper: 2.5,
-            },
-          ],
-        } as ChartDataResponseResult,
+        createTestQueryData([
+          {
+            dt: 599616000000,
+            ci__yhat: 1.5,
+            ci__yhat_lower: 0.5,
+            ci__yhat_upper: 2.5,
+          },
+        ]),
       ],
     });
     const tooltipFormatter = (transformProps(chartProps).echartOptions as any)

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/forecast.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@superset-ui/core';
 import { SeriesOption } from 'echarts';
 import {
+  collapseForecastKeys,
   extractForecastSeriesContext,
   extractForecastValuesFromTooltipParams,
   formatForecastTooltipSeries,
@@ -462,5 +463,37 @@ describe('formatForecastTooltipSeries truncation', () => {
       truncation: 'start',
     });
     expect(cell).toBe(`${marker}cpu`);
+  });
+});
+
+describe('collapseForecastKeys', () => {
+  test('leaves plain observation series untouched and in order', () => {
+    expect(collapseForecastKeys(['foo', 'bar'])).toEqual(['foo', 'bar']);
+  });
+
+  test('folds a forecast bundle down to a single key', () => {
+    expect(
+      collapseForecastKeys([
+        'foo',
+        'foo__yhat',
+        'foo__yhat_lower',
+        'foo__yhat_upper',
+      ]),
+    ).toEqual(['foo']);
+  });
+
+  test('keeps a key for metrics whose labels are entirely forecast suffixes', () => {
+    // Charts can carry metrics literally labelled `ci__yhat*` with no plain
+    // observation series. Callers match these against forecast-stripped keys,
+    // so an uncollapsed id here would match nothing and drop every row.
+    expect(
+      collapseForecastKeys(['ci__yhat', 'ci__yhat_lower', 'ci__yhat_upper']),
+    ).toEqual(['ci']);
+  });
+
+  test('preserves the incoming order of distinct series', () => {
+    expect(
+      collapseForecastKeys(['b__yhat_lower', 'a__yhat', 'b__yhat']),
+    ).toEqual(['b', 'a']);
   });
 });


### PR DESCRIPTION
### SUMMARY

Charts whose metric labels all end in a forecast suffix (`__yhat`, `__yhat_lower`, `__yhat_upper`) render a **"No data"** tooltip even though the series plot fine.

[#30819](https://github.com/apache/superset/pull/30819) made the tooltip formatter do `sortedKeys.filter(key => keys.includes(key))`, where `sortedKeys` are raw ECharts series ids but `keys` are `Object.keys(forecastValues)` — keyed by *forecast-stripped* name. A real Prophet bundle also has a plain observation series, so `foo` matches itself and its row renders. When every series carries a suffix, all of them collapse onto one name, nothing matches, every row is dropped, and `tooltipHtml` emits its empty-rows placeholder.

Fix: collapse the ordering keys onto the same forecast-stripped names before the intersection, in both the `Timeseries` and `MixedTimeseries` tooltips (identical defect in both). The `collapseForecastKeys` helper goes in `utils/forecast.ts` rather than `series.ts`, since `forecast.ts` already imports `sanitizeHtml` from `series.ts` and the reverse would be an import cycle.

Genuine forecast charts are unaffected — they already rendered one row per collapsed series.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Tooltip on a line chart with metrics `ci__yhat`, `ci__yhat_lower`, `ci__yhat_upper`:

- **Before:** `No data`

<img width="368" height="507" alt="Screenshot 2026-08-20 at 1 42 53 PM" src="https://github.com/user-attachments/assets/5154cf01-7f36-48a1-b6a5-0ca74b07334e" />

- **After:** `ci    ŷ = 1.5 (0.5, 2.5)`
<img width="572" height="482" alt="Screenshot 2026-08-20 at 1 42 46 PM" src="https://github.com/user-attachments/assets/55fa8738-5b5e-436b-9e17-06cbea488c81" />

### TESTING INSTRUCTIONS

1. Create a timeseries line chart with three metrics labelled `ci__yhat`, `ci__yhat_lower` and `ci__yhat_upper` (custom labels; forecasting stays off).
2. Hover the chart — the tooltip shows a `ci` row instead of "No data".
3. Confirm no regression on a chart with forecasting enabled: one row per series, still formatted `ŷ = … (…, …)`.

Automated: `npx jest plugins/plugin-chart-echarts` — 84 suites / 923 tests pass. The three new `Timeseries` tooltip regression tests and the `collapseForecastKeys` unit tests all fail on unfixed source.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

