### PR TITLE
fix(explore): align viz type gallery thumbnails and Featured tag

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -278,6 +278,24 @@ describe('VizTypeControl', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('Thumbnail labels expose the full chart name via a title tooltip', async () => {
+    // Labels are clamped to a fixed two-line block so every tile is the same
+    // height; the full (possibly truncated) name must stay discoverable through
+    // the title attribute.
+    await waitForRenderWrapper();
+    userEvent.click(screen.getByRole('tab', { name: 'All charts' }));
+
+    const visualizations = screen.getByTestId(getTestId('viz-row'));
+    const labels = await within(visualizations).findAllByTestId(
+      getTestId('viztype-label'),
+    );
+
+    expect(labels.length).toBeGreaterThan(0);
+    labels.forEach(label => {
+      expect(label).toHaveAttribute('title', label.textContent);
+    });
+  });
+
   test('Submit on viz type double-click', async () => {
     await waitForRenderWrapper();
     userEvent.click(screen.getByRole('tab', { name: 'All charts' }));

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -292,7 +292,7 @@ describe('VizTypeControl', () => {
 
     expect(labels.length).toBeGreaterThan(0);
     labels.forEach(label => {
-      expect(label).toHaveAttribute('title', label.textContent);
+      expect(label).toHaveAttribute('title', label.textContent ?? '');
     });
   });
 

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -214,6 +214,9 @@ const IconsPane = styled.div`
   justify-content: space-evenly;
   grid-gap: ${({ theme }) => theme.sizeUnit * 2}px;
   justify-items: center;
+  /* top-align every tile so a longer chart name never pushes the thumbnails
+     of the other tiles in the same row upward */
+  align-items: start;
   /* for some reason this padding doesn't seem to apply at the bottom of the container. Why is a mystery. */
   padding: ${({ theme }) => theme.sizeUnit * 2}px;
 `;
@@ -274,7 +277,6 @@ const thumbnailContainerCss = (theme: SupersetTheme) => css`
   font: inherit;
   cursor: pointer;
   width: ${theme.sizeUnit * THUMBNAIL_GRID_UNITS}px;
-  position: relative;
   outline: none; /* Remove focus outline to show only selected state */
 
   img {
@@ -297,6 +299,16 @@ const thumbnailContainerCss = (theme: SupersetTheme) => css`
   .viztype-label {
     margin-top: ${theme.sizeUnit * 2}px;
     text-align: center;
+    /* reserve a fixed two-line block so every tile is the same height,
+       regardless of how long the chart name is. Longer names are clamped
+       with an ellipsis; the full name stays available via the title tooltip. */
+    line-height: ${theme.sizeUnit * 4}px;
+    height: ${theme.sizeUnit * 8}px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
   }
 `;
 
@@ -320,10 +332,19 @@ const HighlightLabel = styled.div`
   `}
 `;
 
+// Wraps the thumbnail image so the "Featured" badge can be anchored to the
+// image itself rather than to the whole tile (whose height varies with the
+// chart-name length). line-height: 0 removes the inline-image descender gap.
+const ThumbnailImageWrapper = styled.div`
+  position: relative;
+  width: ${({ theme }) => theme.sizeUnit * THUMBNAIL_GRID_UNITS}px;
+  line-height: 0;
+`;
+
 const ThumbnailLabelWrapper = styled.div`
   position: absolute;
   right: ${({ theme }) => theme.sizeUnit}px;
-  top: ${({ theme }) => theme.sizeUnit * 19}px;
+  top: ${({ theme }) => theme.sizeUnit}px;
 `;
 
 const TitleLabelWrapper = styled.div`
@@ -367,27 +388,32 @@ const Thumbnail: FC<ThumbnailProps> = ({
       onFocus={handleFocus}
       data-test="viztype-selector-container"
     >
-      <img
-        alt={type.name}
-        width="100%"
-        className={`viztype-selector ${isSelected ? 'selected' : ''}`}
-        src={
-          isDarkMode && type.thumbnailDark ? type.thumbnailDark : type.thumbnail
-        }
-      />
+      <ThumbnailImageWrapper>
+        <img
+          alt={type.name}
+          width="100%"
+          className={`viztype-selector ${isSelected ? 'selected' : ''}`}
+          src={
+            isDarkMode && type.thumbnailDark
+              ? type.thumbnailDark
+              : type.thumbnail
+          }
+        />
+        {type.label && (
+          <ThumbnailLabelWrapper>
+            <HighlightLabel>
+              <div>{t(type.label)}</div>
+            </HighlightLabel>
+          </ThumbnailLabelWrapper>
+        )}
+      </ThumbnailImageWrapper>
       <div
         className="viztype-label"
         data-test={`${VIZ_TYPE_CONTROL_TEST_ID}__viztype-label`}
+        title={type.name}
       >
         {type.name}
       </div>
-      {type.label && (
-        <ThumbnailLabelWrapper>
-          <HighlightLabel>
-            <div>{t(type.label)}</div>
-          </HighlightLabel>
-        </ThumbnailLabelWrapper>
-      )}
     </button>
   );
 };


### PR DESCRIPTION
### SUMMARY

Two layout problems in the "Select a visualization type" gallery:

- Chart names longer than one line wrapped, changing tile height. Since the grid rows size to their tallest tile, a wrapped name pushed the thumbnails of neighbouring tiles in the same row upward, so thumbnails in a row no longer lined up.
- The "Featured" badge was absolutely positioned against the whole tile at a hardcoded `top: sizeUnit * 19` offset (dating back to when the badge was introduced in #18662), so it drifted as tile height varied.

Fix: clamp the chart-name label to a fixed two-line block with ellipsis overflow so every tile is the same height (full name preserved via a `title` tooltip), top-align the grid items, and anchor the Featured badge to a new `position: relative` wrapper around the thumbnail image so it sits consistently at the image's top-right.

### TESTING INSTRUCTIONS

Create a new chart and open the viz type gallery. Confirm all thumbnails in a row line up regardless of chart-name length, and the Featured badge sits at the thumbnail's top-right on every featured type. Long names truncate with an ellipsis and reveal the full name on hover.

A unit test asserts every label carries a `title` matching its full name.

### BEFORE
<img width="425" height="305" alt="image" src="https://github.com/user-attachments/assets/2aace5d7-0bfc-4abc-b72f-013223054bbf" />

### AFTER 
<img width="308" height="254" alt="image" src="https://github.com/user-attachments/assets/a824f5a6-e01b-4a75-bc9e-0737cd93bbfc" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
