### PR TITLE
fix(plugin-chart-echarts): apply contribution before rename with time comparison

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -102,15 +102,18 @@ export default function buildQuery(formData: QueryFormData) {
           1. The resample, rolling, cum, timeCompare operators should be after pivot.
           2. Resample must come before rolling so that imputed values are
              included in the rolling window calculation.
-          3. the flatOperator makes multiIndex Dataframe into flat Dataframe
+          3. Contribution must come before rename because it relies on the
+             `__<time offset>` suffix to compute each time shift separately,
+             and rename strips that suffix.
+          4. the flatOperator makes multiIndex Dataframe into flat Dataframe
         */
         post_processing: [
           pivotOperatorInRuntime,
           resampleOperator(formData, baseQueryObject),
           rollingWindowOperator(formData, baseQueryObject),
           timeCompareOperator(formData, baseQueryObject),
-          renameOperator(formData, baseQueryObject),
           contributionOperator(formData, baseQueryObject, time_offsets),
+          renameOperator(formData, baseQueryObject),
           sortOperator(formData, baseQueryObject),
           flattenOperator(formData, baseQueryObject),
           // todo: move prophet before flatten

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts
@@ -64,6 +64,28 @@ describe('Timeseries buildQuery', () => {
     expect(query.metrics).toEqual(['bar', 'baz']);
   });
 
+  test('should apply contribution before rename with time comparison', () => {
+    // rename strips the `__<offset>` suffix that contribution relies on to
+    // compute each time shift separately
+    const queryContext = buildQuery({
+      ...formData,
+      metrics: ['bar'],
+      x_axis: 'ds',
+      groupby: ['col1'],
+      contributionMode: 'row',
+      comparison_type: 'values',
+      time_compare: ['1 week ago'],
+    });
+    const [query] = queryContext.queries;
+    const operations = (query.post_processing || []).map(
+      operator => operator?.operation,
+    );
+    expect(operations).toContain('contribution');
+    expect(operations.indexOf('contribution')).toBeLessThan(
+      operations.indexOf('rename'),
+    );
+  });
+
   test('should not order by timeseries limit if orderby provided', () => {
     const queryContext = buildQuery({
       ...formData,


### PR DESCRIPTION
### SUMMARY

`renameOperator` rewrites `SUM(sales)__1 week ago` to `1 week ago` and drops the `__` separator. The backend `contribution` operator groups columns by that suffix (`get_column_groups` in `superset/utils/pandas_postprocessing/contribution.py`) so each time shift normalizes on its own. Timeseries `buildQuery` ran rename first, so the current period and the shifted period landed in the same bucket and a row contribution split 100% between them instead of per period.

This swaps the two operators. Timeseries is the only plugin using `contributionOperator`, and post-processing gets rebuilt from form data on every query, so saved charts pick this up without a migration. Note the `time_shifts` grouping added in #28368 never matched for any comparison type, since rename always strips the suffix.

Same pandas input, row contribution with a `1 week ago` shift:

```
before:  current [0.125, 0.375]   shifted [0.25, 0.25]   # the whole row sums to 1
after:   current [0.25,  0.75 ]   shifted [0.5,  0.5 ]   # each period sums to 1
```

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: 
<img width="1647" height="1041" alt="image" src="https://github.com/user-attachments/assets/b7050e84-aab7-43d1-8c1e-d269a090002d" />

After:
<img width="1647" height="1041" alt="image" src="https://github.com/user-attachments/assets/2813bf20-3041-4cea-a6b9-5b28bfdd474e" />




### TESTING INSTRUCTIONS

1. Line chart on `Vehicle Sales`, metric `SUM(sales)`, dimension `product_line`.
2. Contribution Mode `Row`, Stacked Style `Stack`.
3. Filter `order_date` to Jan 2003 through Dec 2003.
4. Time shift `1 week ago`, comparison type `Actual values`.
5. Run the query. The current-period series stack to 100% and the shifted series stack to 100% separately.

Unit test: `npm run test -- plugins/plugin-chart-echarts/test/Timeseries/buildQuery.test.ts`

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [x] Changes UI: Yes, contribution values in stacked ECharts timeseries charts that use a time shift
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No

https://claude.ai/code/session_01UUEazXwEndwJBFkXJrxRwA
