### PR TITLE
fix(embedded-sdk): grant fullscreen and clipboard-write by default (#39943)

### DIFF
--- a/superset-embedded-sdk/src/index.ts
+++ b/superset-embedded-sdk/src/index.ts
@@ -66,7 +66,7 @@ export type EmbedDashboardParams = {
   iframeTitle?: string;
   /** additional iframe sandbox attributes ex (allow-top-navigation, allow-popups-to-escape-sandbox) **/
   iframeSandboxExtras?: string[];
-  /** iframe allow attribute for Permissions Policy (e.g., ['clipboard-write', 'fullscreen']) **/
+  /** Additional Permissions Policy features for the iframe's `allow` attribute (e.g., ['camera', 'microphone']). `fullscreen` and `clipboard-write` are granted by default. **/
   iframeAllowExtras?: string[];
   /** force a specific refererPolicy to be used in the iframe request **/
   referrerPolicy?: ReferrerPolicy;
@@ -233,9 +233,14 @@ export async function embedDashboard({
       iframe.src = `${supersetDomain}/embedded/${id}${urlParamsString}`;
       iframe.title = iframeTitle;
       iframe.style.background = 'transparent';
-      if (iframeAllowExtras.length > 0) {
-        iframe.setAttribute('allow', iframeAllowExtras.join('; '));
-      }
+      // Permissions Policy features the embedded dashboard relies on. Modern
+      // browsers gate these APIs on the iframe's `allow` attribute regardless
+      // of sandbox flags, so we include them by default. Host apps can extend
+      // the list via `iframeAllowExtras`.
+      const allowFeatures = Array.from(
+        new Set(['fullscreen', 'clipboard-write', ...iframeAllowExtras]),
+      );
+      iframe.setAttribute('allow', allowFeatures.join('; '));
       //@ts-ignore
       mountPoint.replaceChildren(iframe);
       log('placed the iframe');


### PR DESCRIPTION
### SUMMARY

Cherry-pick of #39943 (`d3784879c2`) onto `6.2`. Applies cleanly, no changes from the original.

The embedded SDK builds its iframe without an `allow` attribute unless the host app passes `iframeAllowExtras`, which defaults to `[]`. Browsers gate `requestFullscreen()` and `clipboard-write` on that attribute regardless of `sandbox` flags, so on `6.2` a chart's **Enter fullscreen** control fails with `Error enabling fullscreen: Disallowed by permissions policy`. Not reproducible outside an iframe. This grants both features by default, still merging `iframeAllowExtras`.

### TESTING INSTRUCTIONS

Embed a dashboard via `@superset-ui/embedded-sdk` and open a chart's ⋮ menu → **Enter fullscreen**.

- Before: error toast `Disallowed by permissions policy`; the iframe has no `allow` attribute.
- After: the chart goes fullscreen; the iframe has `allow="fullscreen; clipboard-write"`.

Verified in Chrome against a local embedded dashboard: no error toast, and `document.fullscreenElement` inside the iframe is set to the chart holder.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

(cherry picked from commit d3784879c2994908a405cd9502cfabf25d5b0f4a)
