### PR TITLE
fix(sqllab): re-validate access against rendered SQL and tighten cache/permalink scoping

### DIFF
--- a/superset/commands/sql_lab/execute.py
+++ b/superset/commands/sql_lab/execute.py
@@ -151,6 +151,15 @@ class ExecuteSqlCommand(BaseCommand):
             self._validate_access(query, self._execution_context.template_params)
             self._execution_context.set_query(query)
             rendered_query = self._sql_query_render.render(self._execution_context)
+            # The check above authorizes a render of query.sql + template_params
+            # performed before rendering, so that macros with side effects are
+            # gated before they run. self._sql_query_render.render() above is an
+            # independent second render of the same source; for a
+            # nondeterministic template (e.g. one using Jinja's `random` filter
+            # to pick a table) the two renders can diverge, letting a query
+            # read a table the first check never saw. Re-validate the literal
+            # rendered text that is about to execute.
+            self._validate_rendered_access(query, rendered_query)
             self._set_query_limit_if_required(rendered_query)
             self._query_dao.update(
                 query, {"limit": self._execution_context.query.limit}
@@ -211,6 +220,23 @@ class ExecuteSqlCommand(BaseCommand):
             self._access_validator.validate(query, template_params)
         except Exception as ex:
             raise QueryIsForbiddenToAccessException(self._execution_context, ex) from ex
+
+    def _validate_rendered_access(self, query: Query, rendered_query: str) -> None:
+        """
+        Re-authorize the exact SQL that is about to execute.
+
+        Pins ``query.executed_sql`` to the literal, already-rendered text so
+        ``security_manager.raise_for_access``'s "prefer executed_sql" path
+        authorizes that exact SQL directly, with no further Jinja
+        re-render (see its docstring). ``executed_sql`` is reset
+        afterwards so the execution path can assign its own final
+        (limited / per-block mutated) SQL.
+        """
+        query.executed_sql = rendered_query
+        try:
+            self._validate_access(query, self._execution_context.template_params)
+        finally:
+            query.executed_sql = None
 
     def _set_query_limit_if_required(
         self,

--- a/superset/commands/sql_lab/permalink/get.py
+++ b/superset/commands/sql_lab/permalink/get.py
@@ -17,7 +17,6 @@
 import logging
 from typing import Optional
 
-from superset import db
 from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.commands.sql_lab.permalink.base import BaseSqlLabPermalinkCommand
 from superset.daos.key_value import KeyValueDAO
@@ -27,10 +26,8 @@ from superset.key_value.exceptions import (
     KeyValueParseKeyError,
 )
 from superset.key_value.utils import decode_permalink_id
-from superset.models import core as models
 from superset.sqllab.permalink.exceptions import SqlLabPermalinkGetFailedError
 from superset.sqllab.permalink.types import SqlLabPermalinkValue
-from superset.utils import core as utils, json
 
 logger = logging.getLogger(__name__)
 
@@ -41,18 +38,14 @@ class GetSqlLabPermalinkCommand(BaseSqlLabPermalinkCommand):
 
     def run(self) -> Optional[SqlLabPermalinkValue]:
         self.validate()
-        if self.key.startswith("kv:"):
-            id = int(self.key[3:])
-            try:
-                kv = db.session.query(models.KeyValue).filter_by(id=id).scalar()
-                if not kv:
-                    return None
-                return json.loads(kv.value)
-            except Exception as ex:
-                raise SqlLabPermalinkGetFailedError(
-                    message=utils.error_msg_from_exception(ex)
-                ) from ex
-
+        # Legacy `kv:<int>` keys (from the pre-permalink `keyvalue` table) are
+        # no longer resolved here: that table has sequential integer primary
+        # keys and no owner column, so any authenticated caller could
+        # enumerate other users' saved editor state (SQL text and
+        # connection/schema context) by incrementing the id. Such keys now
+        # fall through to `decode_permalink_id` below, which rejects them
+        # (they don't decode against the salted hashid scheme), leaving the
+        # modern salted-hashid store as the only way to resolve a permalink.
         try:
             key = decode_permalink_id(self.key, salt=self.salt)
             value = KeyValueDAO.get_value(self.resource, key, self.codec)

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -118,6 +118,48 @@ class TimeFilter:
     time_range: str | None
 
 
+class SQLSafeList(list[Any]):  # noqa: FURB189
+    """
+    A list of dialect-escaped values whose *whole-container* string
+    rendering cannot re-introduce raw quote characters.
+
+    Rendering a plain Python list in a Jinja template goes through
+    ``str()``/``repr()``, which wraps every string element in fresh quote
+    delimiters (and switches to double-quote delimiters when the element
+    contains a single quote, emitting that single quote raw). Either way
+    the rendered text can contain quote characters that were never
+    escaped for SQL, so a template interpolating the list inside its own
+    quotes -- e.g. ``LIKE '{{ filter.get('escaped_val') }}'`` -- could be
+    broken out of even though every string leaf was individually escaped.
+    This subclass renders as its (already-escaped) elements joined with
+    ``", "``, with no additional delimiters, so every quote in the output
+    is one the dialect's literal processor already escaped.
+    """
+
+    def __str__(self) -> str:
+        return ", ".join(str(element) for element in self)
+
+    __repr__ = __str__
+
+
+class SQLSafeDict(dict[Any, Any]):  # noqa: FURB189
+    """
+    A dict of dialect-escaped values whose *whole-container* string
+    rendering cannot re-introduce raw quote characters. Mirrors
+    :class:`SQLSafeList` for the mapping case.
+
+    Keys are rendered as-is: they are used for member lookups (for
+    example ``{{ get_guest_user_attribute('tenant').id }}``), not
+    interpolated into SQL, and are never passed through
+    ``ExtraCache._escape_value``.
+    """
+
+    def __str__(self) -> str:
+        return ", ".join(f"{key}: {value}" for key, value in self.items())
+
+    __repr__ = __str__
+
+
 def _normalize_postgresql_backslash_escapes(dialect: Dialect) -> None:
     """Correct a PostgreSQL dialect instance's ``_backslash_escapes`` default
     in place so backslashes round-trip unchanged when the dialect is used to
@@ -467,6 +509,16 @@ class ExtraCache:
         strings nested inside JSON structures are also escaped; dict keys
         are left untouched since they are used for member lookups, not
         interpolation. Non-string leaf values are left as-is.
+
+        Lists and dicts are returned as :class:`SQLSafeList` /
+        :class:`SQLSafeDict` rather than plain ``list``/``dict``: Jinja
+        renders a whole container through ``str()``/``repr()``, which
+        wraps string elements in fresh quote delimiters that were never
+        escaped, so even a fully-escaped container could re-introduce raw
+        quotes when interpolated as a whole. The safe subclasses render
+        without adding such delimiters, while still comparing equal to
+        (and behaving like) their plain built-in counterparts everywhere
+        else.
         """
         if not self.dialect:
             return val
@@ -475,9 +527,9 @@ class ExtraCache:
             _normalize_postgresql_backslash_escapes(compiler.dialect)
             return compiler.render_literal_value(val, String())[1:-1]
         if isinstance(val, list):
-            return [self._escape_value(v) for v in val]
+            return SQLSafeList(self._escape_value(v) for v in val)
         if isinstance(val, dict):
-            return {k: self._escape_value(v) for k, v in val.items()}
+            return SQLSafeDict((k, self._escape_value(v)) for k, v in val.items())
         return val
 
     def get_filters(self, column: str, remove_filter: bool = False) -> list[Filter]:

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -144,14 +144,17 @@ class SQLSafeList(list[Any]):  # noqa: FURB189
 
 class SQLSafeDict(dict[Any, Any]):  # noqa: FURB189
     """
-    A dict of dialect-escaped values whose *whole-container* string
-    rendering cannot re-introduce raw quote characters. Mirrors
+    A dict of dialect-escaped keys and values whose *whole-container*
+    string rendering cannot re-introduce raw quote characters. Mirrors
     :class:`SQLSafeList` for the mapping case.
 
-    Keys are rendered as-is: they are used for member lookups (for
-    example ``{{ get_guest_user_attribute('tenant').id }}``), not
-    interpolated into SQL, and are never passed through
-    ``ExtraCache._escape_value``.
+    Keys are typically used for member lookups (for example
+    ``{{ get_guest_user_attribute('tenant').id }}``) rather than
+    interpolated into SQL directly, but a template can still render the
+    whole dict -- and a key, like a value, may originate from data the
+    caller does not fully control. Keys are therefore escaped the same
+    way values are, through ``ExtraCache._escape_value``, so whole-dict
+    rendering carries the same guarantee as whole-list rendering.
     """
 
     def __str__(self) -> str:
@@ -505,10 +508,9 @@ class ExtraCache:
         to restore parity with PostgreSQL's default configuration, while
         MySQL/MariaDB keep the stricter, backslash-doubling behavior above.
 
-        Lists are processed element-wise and dict values recursively, so
-        strings nested inside JSON structures are also escaped; dict keys
-        are left untouched since they are used for member lookups, not
-        interpolation. Non-string leaf values are left as-is.
+        Lists are processed element-wise and dict keys/values recursively,
+        so strings nested inside JSON structures are also escaped. Non-string
+        leaf values are left as-is.
 
         Lists and dicts are returned as :class:`SQLSafeList` /
         :class:`SQLSafeDict` rather than plain ``list``/``dict``: Jinja
@@ -529,7 +531,9 @@ class ExtraCache:
         if isinstance(val, list):
             return SQLSafeList(self._escape_value(v) for v in val)
         if isinstance(val, dict):
-            return SQLSafeDict((k, self._escape_value(v)) for k, v in val.items())
+            return SQLSafeDict(
+                (self._escape_value(k), self._escape_value(v)) for k, v in val.items()
+            )
         return val
 
     def get_filters(self, column: str, remove_filter: bool = False) -> list[Filter]:

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -943,6 +943,8 @@ class SQLExecutor:
         )
 
         cache_key = self._generate_cache_key(sql, opts)
+        if cache_key is None:
+            return None
 
         if (cached := cache_manager.data_cache.get(cache_key)) is not None:
             # Reconstruct statement results from cached data
@@ -982,6 +984,9 @@ class SQLExecutor:
             return
 
         cache_key = self._generate_cache_key(sql, opts)
+        if cache_key is None:
+            return
+
         timeout = (
             (opts.cache.timeout if opts.cache else None)
             or self.database.cache_timeout
@@ -1018,14 +1023,29 @@ class SQLExecutor:
             timeout=timeout,
         )
 
-    def _generate_cache_key(self, sql: str, opts: QueryOptions) -> str:
+    def _connection_carries_user_identity(self) -> bool:
+        """
+        Whether the raw connection this executor's database hands out is
+        bound to the calling user's identity (user impersonation or
+        per-user OAuth2 tokens), such that two different users running the
+        identical SQL text can see materially different data because the
+        database itself, not just Superset, distinguishes them.
+        """
+        return bool(self.database.impersonate_user) or self.database.is_oauth2_enabled()
+
+    def _generate_cache_key(self, sql: str, opts: QueryOptions) -> str | None:
         """
         Generate cache key for query result.
 
         :param sql: SQL query
         :param opts: Query options
-        :returns: Cache key string
+        :returns: Cache key string, or ``None`` if the query must not be
+            cached because the connection carries per-user identity but
+            the effective user could not be determined -- caching in that
+            case would risk serving one user's results to another.
         """
+        from superset.utils.cache_keys import add_impersonation_cache_key_if_needed
+
         # Include relevant options in the cache key
         key_parts = [
             str(self.database.id),
@@ -1034,6 +1054,24 @@ class SQLExecutor:
             opts.schema or "",
             str(opts.limit) if opts.limit is not None else "",
         ]
+
+        if self._connection_carries_user_identity():
+            user_id = utils.get_user_id()
+            if user_id is None:
+                # Effective identity is unknown (e.g. no request context) --
+                # fail safe by refusing to cache rather than risk sharing
+                # results across users.
+                return None
+            key_parts.append(f"user:{user_id}")
+
+        # Mirror the chart-data cache-key path so CACHE_IMPERSONATION /
+        # CACHE_QUERY_BY_USER / per_user_caching semantics also scope the
+        # SQL executor's result cache.
+        impersonation_cache_dict: dict[str, Any] = {}
+        add_impersonation_cache_key_if_needed(self.database, impersonation_cache_dict)
+        if impersonation_key := impersonation_cache_dict.get("impersonation_key"):
+            key_parts.append(f"impersonation:{impersonation_key}")
+
         key_string = "|".join(key_parts)
         return hashlib.sha256(key_string.encode()).hexdigest()
 

--- a/tests/unit_tests/commands/sql_lab/permalink_get_test.py
+++ b/tests/unit_tests/commands/sql_lab/permalink_get_test.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for GetSqlLabPermalinkCommand's handling of legacy keys."""
+
+from unittest.mock import PropertyMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.commands.sql_lab.permalink.get import GetSqlLabPermalinkCommand
+from superset.key_value.exceptions import KeyValueParseKeyError
+from superset.sqllab.permalink.exceptions import SqlLabPermalinkGetFailedError
+
+
+def test_legacy_kv_keys_are_not_special_cased(mocker: MockerFixture) -> None:
+    """
+    Regression: ``kv:<int>`` keys used to be resolved by a raw sequential
+    primary-key lookup against the legacy ``keyvalue`` table, which has no
+    owner column -- any authenticated caller could enumerate other users'
+    saved SQL Lab editor state (SQL text, connection/schema context) by
+    incrementing the id. Such keys must now be treated like any other
+    permalink key: decoded via the salted hashid scheme (and rejected,
+    since ``kv:<int>`` never was a valid hashid), never looked up by raw
+    integer id.
+    """
+    decode = mocker.patch(
+        "superset.commands.sql_lab.permalink.get.decode_permalink_id",
+        side_effect=KeyValueParseKeyError(),
+    )
+    mocker.patch.object(
+        GetSqlLabPermalinkCommand,
+        "salt",
+        new_callable=PropertyMock,
+        return_value="salt",
+    )
+
+    command = GetSqlLabPermalinkCommand("kv:1")
+    with pytest.raises(SqlLabPermalinkGetFailedError):
+        command.run()
+
+    decode.assert_called_once_with("kv:1", salt="salt")
+
+
+def test_legacy_kv_keys_do_not_touch_the_keyvalue_table(mocker: MockerFixture) -> None:
+    """
+    A ``kv:<int>``-shaped key must never trigger a query against the
+    legacy ``KeyValue`` model, regardless of whether that id exists.
+    """
+    mock_session = mocker.patch("superset.db.session")
+    mocker.patch(
+        "superset.commands.sql_lab.permalink.get.decode_permalink_id",
+        side_effect=KeyValueParseKeyError(),
+    )
+    mocker.patch.object(
+        GetSqlLabPermalinkCommand,
+        "salt",
+        new_callable=PropertyMock,
+        return_value="salt",
+    )
+
+    command = GetSqlLabPermalinkCommand("kv:1")
+    with pytest.raises(SqlLabPermalinkGetFailedError):
+        command.run()
+
+    mock_session.query.assert_not_called()
+
+
+def test_get_command_has_no_legacy_kv_branch() -> None:
+    """The command module no longer imports the legacy KeyValue model."""
+    import superset.commands.sql_lab.permalink.get as get_module
+
+    assert not hasattr(get_module, "db")
+    assert not hasattr(get_module, "models")

--- a/tests/unit_tests/commands/sql_lab/test_execute.py
+++ b/tests/unit_tests/commands/sql_lab/test_execute.py
@@ -1,0 +1,161 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for ExecuteSqlCommand's authorization of the SQL it executes."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from superset.commands.sql_lab.execute import ExecuteSqlCommand
+from superset.sqllab.command_status import SqlJsonExecutionStatus
+from superset.sqllab.exceptions import QueryIsForbiddenToAccessException
+
+
+def _make_command(**overrides: MagicMock) -> ExecuteSqlCommand:
+    kwargs: dict[str, MagicMock] = {
+        "execution_context": MagicMock(),
+        "query_dao": MagicMock(),
+        "database_dao": MagicMock(),
+        "access_validator": MagicMock(),
+        "sql_query_render": MagicMock(),
+        "sql_json_executor": MagicMock(),
+        "execution_context_convertor": MagicMock(),
+    }
+    kwargs.update(overrides)
+    return ExecuteSqlCommand(
+        sqllab_ctas_no_limit_flag=False,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_rendered_access: pin / delegate / reset
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rendered_access_authorizes_the_literal_rendered_sql() -> None:
+    """
+    ``_validate_rendered_access`` must pin ``query.executed_sql`` to the
+    already-rendered text *before* delegating to the access validator, so
+    ``raise_for_access``'s "prefer executed_sql" path authorizes exactly
+    the SQL that is about to execute rather than re-rendering the Jinja
+    source (which could pick a different table for a nondeterministic
+    template). Afterwards ``executed_sql`` must be reset so the execution
+    path can assign its own final (limited / per-block mutated) SQL.
+    """
+    command = _make_command()
+    query = MagicMock()
+    query.executed_sql = None
+    seen_executed_sql = []
+
+    def _capture_validate(q: MagicMock, template_params: object) -> None:
+        seen_executed_sql.append(q.executed_sql)
+
+    command._access_validator.validate.side_effect = _capture_validate  # type: ignore[attr-defined]  # noqa: E501
+
+    command._validate_rendered_access(query, "SELECT * FROM sales")
+
+    assert seen_executed_sql == ["SELECT * FROM sales"]
+    assert query.executed_sql is None
+
+
+def test_validate_rendered_access_resets_executed_sql_on_denial() -> None:
+    """
+    A denial for the rendered SQL must still surface as
+    ``QueryIsForbiddenToAccessException`` and must not leave
+    ``query.executed_sql`` pinned to the rejected text.
+    """
+    command = _make_command()
+    query = MagicMock()
+    query.executed_sql = None
+    command._access_validator.validate.side_effect = Exception("access denied")  # type: ignore[attr-defined]  # noqa: E501
+
+    with pytest.raises(QueryIsForbiddenToAccessException):
+        command._validate_rendered_access(query, "SELECT * FROM secret_payroll")
+
+    assert query.executed_sql is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: nondeterministic templates must not let execution diverge
+# from the authorized render
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.execute.db")
+def test_run_sql_json_exec_from_scratch_revalidates_rendered_sql(
+    mock_db: MagicMock,
+) -> None:
+    """
+    Regression: previously only ``query.sql`` + ``template_params`` was
+    authorized (render #1, inside the access validator) while a second,
+    independent render (``sql_query_render.render()``) produced the SQL
+    that was actually handed to the executor. A nondeterministic Jinja
+    construct (e.g. the ``random`` filter picking a table) could make the
+    two renders diverge, letting a query read a table the authorization
+    check never saw. The literal rendered SQL must now be re-validated
+    before it reaches the executor.
+    """
+    execution_context = MagicMock()
+    execution_context.template_params = {}
+    # Skip the query-limit machinery entirely; it is unrelated to this fix.
+    execution_context.select_as_cta = True
+
+    query = MagicMock()
+    query.id = 1
+    query.executed_sql = None
+    execution_context.create_query.return_value = query
+
+    database_dao = MagicMock()
+    database_dao.find_by_id.return_value = MagicMock()
+
+    access_validator = MagicMock()
+    validate_calls: list[object] = []
+
+    def _capture_validate(q: MagicMock, template_params: object) -> None:
+        validate_calls.append(q.executed_sql)
+
+    access_validator.validate.side_effect = _capture_validate
+
+    sql_query_render = MagicMock()
+    sql_query_render.render.return_value = "SELECT * FROM sales"
+
+    sql_json_executor = MagicMock()
+    sql_json_executor.execute.return_value = SqlJsonExecutionStatus.HAS_RESULTS
+
+    command = _make_command(
+        execution_context=execution_context,
+        database_dao=database_dao,
+        access_validator=access_validator,
+        sql_query_render=sql_query_render,
+        sql_json_executor=sql_json_executor,
+    )
+    command._sqllab_ctas_no_limit = True
+
+    command._run_sql_json_exec_from_scratch()
+
+    # Authorized twice: once before rendering (macros with side effects run
+    # at render time) and again against the literal, already-rendered SQL
+    # that the executor is about to run.
+    assert access_validator.validate.call_count == 2
+    assert validate_calls == [None, "SELECT * FROM sales"]
+    # executed_sql is not left pinned; the execution path assigns its own
+    # final value.
+    assert query.executed_sql is None
+    sql_json_executor.execute.assert_called_once_with(
+        execution_context, "SELECT * FROM sales", None
+    )

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -474,6 +474,73 @@ def test_get_filters_no_escaped_val_without_dialect() -> None:
         assert "escaped_val" not in result[0]
 
 
+def test_escape_value_nested_list_is_escaped() -> None:
+    """
+    Regression: string leaves nested more than one level deep used to pass
+    through ``_escape_value`` untouched, and Jinja's whole-container
+    rendering of the nested list re-emitted the single quote raw --
+    terminating the surrounding SQL string literal.
+    """
+    cache = ExtraCache(
+        dialect=dialect(),
+        query_context_filters=[
+            {
+                "col": "name",
+                "op": "LIKE",
+                "val": [["x' UNION SELECT username FROM users --"]],
+            },
+        ],
+    )
+    [entry] = cache.get_filters("name")
+    rendered = str(entry["escaped_val"])
+    # every single quote in the rendered output must be escaped (doubled)
+    assert "'" not in rendered.replace("''", "")
+    assert "x'' UNION SELECT username FROM users --" in rendered
+
+
+def test_escape_value_flat_list_renders_without_raw_quotes() -> None:
+    """
+    Regression: rendering a whole escaped list used to go through Python's
+    default ``str()``/``repr()``, which wraps elements in fresh quote
+    delimiters -- letting even a payload containing no single quotes break
+    out of the template's own quotes. The escaped list must render as
+    escaped elements only, with no delimiters added.
+    """
+    cache = ExtraCache(
+        dialect=dialect(),
+        query_context_filters=[
+            {"col": "name", "op": "LIKE", "val": ['x") OR 1=1 --', "O'Brien"]},
+        ],
+    )
+    [entry] = cache.get_filters("name")
+    # element-wise access still compares equal to the plain escaped values
+    assert entry["escaped_val"] == ['x") OR 1=1 --', "O''Brien"]
+    # whole-list rendering must not add quote delimiters around elements
+    rendered = str(entry["escaped_val"])
+    assert rendered == "x\") OR 1=1 --, O''Brien"
+    assert "'" not in rendered.replace("''", "")
+
+
+def test_escape_value_dict_renders_without_raw_quotes() -> None:
+    """
+    Regression: a dict value returned by ``get_guest_user_attribute`` is
+    recursively escaped at the leaf level, but rendering the whole dict in
+    a template used to go through Python's default ``repr()``, which
+    re-wraps string values in fresh quote delimiters -- reopening the
+    same whole-container escape hatch as for lists.
+    """
+    cache = ExtraCache(dialect=dialect())
+    escaped = cache._escape_value(  # pylint: disable=protected-access
+        {"id": "foo' OR 1=1 --", "names": ["O'Brien", 42]}
+    )
+    # equality and member access behave exactly like a plain dict
+    assert escaped == {"id": "foo'' OR 1=1 --", "names": ["O''Brien", 42]}
+    assert isinstance(escaped, dict)
+    # whole-container rendering must not add quote delimiters
+    rendered = str(escaped)
+    assert "'" not in rendered.replace("''", "")
+
+
 def test_url_param_query() -> None:
     """
     Test the ``url_param`` macro.

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -541,6 +541,23 @@ def test_escape_value_dict_renders_without_raw_quotes() -> None:
     assert "'" not in rendered.replace("''", "")
 
 
+def test_escape_value_dict_escapes_keys_too() -> None:
+    """
+    Regression: a dict key, like a value, can originate from data the
+    caller does not fully control (for example a guest-token attribute
+    key). Rendering the whole dict must not let a quote in a key
+    re-introduce an unescaped delimiter.
+    """
+    cache = ExtraCache(dialect=dialect())
+    escaped = cache._escape_value(  # pylint: disable=protected-access
+        {"O'Brien' OR 1=1 --": "value"}
+    )
+    [key] = escaped.keys()
+    assert key == "O''Brien'' OR 1=1 --"
+    rendered = str(escaped)
+    assert "'" not in rendered.replace("''", "")
+
+
 def test_url_param_query() -> None:
     """
     Test the ``url_param`` macro.

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -2449,3 +2449,135 @@ def test_build_statement_blocks_skips_validation_for_unparseable_mutated_sql(
 
     assert len(blocks) == 1
     assert blocks[0].count("ENGINE SPECIFIC") == 2
+
+
+# =============================================================================
+# Cache Key Identity Tests
+# =============================================================================
+
+
+def test_generate_cache_key_ignores_user_without_impersonation(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    When the connection does not carry per-user identity, the cache key
+    must not depend on the calling user -- unrelated users legitimately
+    share cache entries for identical queries.
+    """
+    from superset.sql.execution.executor import SQLExecutor
+
+    executor = SQLExecutor(database)
+    options = QueryOptions()
+
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=1)
+    key_user_1 = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=2)
+    key_user_2 = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    assert key_user_1 is not None
+    assert key_user_1 == key_user_2
+
+
+def test_generate_cache_key_scopes_by_user_when_impersonation_enabled(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    Regression: when the database impersonates the connecting user (or
+    uses per-user OAuth2), the effective identity the database sees
+    differs per user even for byte-identical SQL text. The cache key must
+    incorporate that identity so one user's cached rows can never be
+    served to another user the database itself would have denied.
+    """
+    from superset.sql.execution.executor import SQLExecutor
+
+    database.impersonate_user = True
+    executor = SQLExecutor(database)
+    options = QueryOptions()
+
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=1)
+    key_analyst_a = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=2)
+    key_analyst_b = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    assert key_analyst_a is not None
+    assert key_analyst_b is not None
+    assert key_analyst_a != key_analyst_b
+
+
+def test_generate_cache_key_none_when_identity_unknown(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    If the database carries per-user identity but the effective user
+    cannot be determined (e.g. no request context), the query must be
+    treated as uncacheable rather than risk a shared cache entry.
+    """
+    from superset.sql.execution.executor import SQLExecutor
+
+    database.impersonate_user = True
+    executor = SQLExecutor(database)
+    options = QueryOptions()
+
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=None)
+
+    assert executor._generate_cache_key("SELECT * FROM salaries", options) is None
+
+
+def test_get_from_cache_skips_when_identity_unknown(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    ``_get_from_cache`` must not read from the cache backend at all when
+    ``_generate_cache_key`` reports the query as uncacheable.
+    """
+    from superset.extensions import cache_manager
+    from superset.sql.execution.executor import SQLExecutor
+
+    database.impersonate_user = True
+    executor = SQLExecutor(database)
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=None)
+    mock_cache_get = mocker.patch.object(cache_manager.data_cache, "get")
+
+    result = executor._get_from_cache("SELECT * FROM salaries", QueryOptions())
+
+    assert result is None
+    mock_cache_get.assert_not_called()
+
+
+def test_store_in_cache_skips_when_identity_unknown(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    ``_store_in_cache`` must not write to the cache backend at all when
+    ``_generate_cache_key`` reports the query as uncacheable.
+    """
+    from superset_core.queries.types import (
+        QueryResult as QueryResultType,
+        StatementResult,
+    )
+
+    from superset.extensions import cache_manager
+    from superset.sql.execution.executor import SQLExecutor
+
+    database.impersonate_user = True
+    executor = SQLExecutor(database)
+    mocker.patch("superset.sql.execution.executor.utils.get_user_id", return_value=None)
+    mock_cache_set = mocker.patch.object(cache_manager.data_cache, "set")
+
+    result = QueryResultType(
+        status=QueryStatus.SUCCESS,
+        statements=[
+            StatementResult(
+                original_sql="SELECT * FROM salaries",
+                executed_sql="SELECT * FROM salaries",
+                data=pd.DataFrame({"salary": [1]}),
+                row_count=1,
+            )
+        ],
+    )
+
+    executor._store_in_cache(result, "SELECT * FROM salaries", QueryOptions())
+
+    mock_cache_set.assert_not_called()

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -2506,6 +2506,51 @@ def test_generate_cache_key_scopes_by_user_when_impersonation_enabled(
     assert key_analyst_a != key_analyst_b
 
 
+def test_generate_cache_key_includes_impersonation_key_when_present(
+    mocker: MockerFixture, database: Database, app_context: None
+) -> None:
+    """
+    The executor's result cache mirrors the chart-data cache-key path:
+    when CACHE_IMPERSONATION / CACHE_QUERY_BY_USER / per_user_caching
+    resolves an impersonation key for the connection, that key must be
+    folded into the generated cache key so it can't collide with a key
+    generated for a different impersonated identity.
+    """
+    from superset.sql.execution.executor import SQLExecutor
+
+    executor = SQLExecutor(database)
+    options = QueryOptions()
+
+    mocker.patch(
+        "superset.utils.cache_keys.add_impersonation_cache_key_if_needed",
+        side_effect=lambda db, cache_dict: cache_dict.__setitem__(
+            "impersonation_key", "engineer_a"
+        ),
+    )
+    key_engineer_a = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    mocker.patch(
+        "superset.utils.cache_keys.add_impersonation_cache_key_if_needed",
+        side_effect=lambda db, cache_dict: cache_dict.__setitem__(
+            "impersonation_key", "engineer_b"
+        ),
+    )
+    key_engineer_b = executor._generate_cache_key("SELECT * FROM salaries", options)
+
+    mocker.patch(
+        "superset.utils.cache_keys.add_impersonation_cache_key_if_needed",
+        side_effect=lambda db, cache_dict: None,
+    )
+    key_no_impersonation = executor._generate_cache_key(
+        "SELECT * FROM salaries", options
+    )
+
+    assert key_engineer_a is not None
+    assert key_engineer_b is not None
+    assert key_no_impersonation is not None
+    assert len({key_engineer_a, key_engineer_b, key_no_impersonation}) == 3
+
+
 def test_generate_cache_key_none_when_identity_unknown(
     mocker: MockerFixture, database: Database, app_context: None
 ) -> None:


### PR DESCRIPTION
### SUMMARY
- SQL Lab query execution now re-authorizes against the literal rendered SQL immediately before running it, instead of authorizing one render and executing a second, independent render — closing the gap where a nondeterministic Jinja template could authorize against one table and execute against another.
- The SQL executor's result cache is now scoped by effective user identity for connections where that identity varies per user (impersonation/OAuth2), instead of being shared across all callers of the same database connection.
- The legacy `kv:`-prefixed SQL Lab permalink resolution path (a raw sequential-ID lookup with no ownership check) has been removed; only the salted-hashid permalink store remains.
- Jinja's `escaped_val`/`url_param` now render escaped list/dict values through a wrapper that doesn't reintroduce Python's own `repr()`-added quote delimiters around already-escaped elements.

### TESTING INSTRUCTIONS
`pytest tests/unit_tests/jinja_context_test.py tests/unit_tests/sql/execution/test_executor.py tests/unit_tests/commands/sql_lab/` — new/extended tests per change, each verified to fail pre-fix and pass post-fix.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API