### PR TITLE
fix(charts): escape untrusted strings before rendering into chart tooltips and popups

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -51,6 +51,23 @@ export interface MetricOptionProps {
   shouldShowTooltip?: boolean;
 }
 
+/**
+ * SECURITY: `url` is an arbitrary caller-supplied string that is rendered
+ * as an href to whoever views the metric label (e.g. the Time-series Table
+ * chart forwards a chart-creator-authored template here). Only http(s) and
+ * relative URLs may become links; `javascript:` and other script-bearing
+ * schemes degrade to plain text. React only dev-warns on javascript: hrefs
+ * and rel/target do not mitigate them, so the check must happen here.
+ */
+function isSafeHref(url: string): boolean {
+  try {
+    const { protocol } = new URL(url, window.location.origin);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function MetricOption({
   metric,
   labelRef,
@@ -70,7 +87,7 @@ export function MetricOption({
       `}
       ref={labelRef}
     >
-      {url ? (
+      {url && isSafeHref(url) ? (
         <Typography.Link
           href={url}
           target={openInNewWindow ? '_blank' : ''}

--- a/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/components/MetricOption.tsx
@@ -52,12 +52,9 @@ export interface MetricOptionProps {
 }
 
 /**
- * SECURITY: `url` is an arbitrary caller-supplied string that is rendered
- * as an href to whoever views the metric label (e.g. the Time-series Table
- * chart forwards a chart-creator-authored template here). Only http(s) and
- * relative URLs may become links; `javascript:` and other script-bearing
- * schemes degrade to plain text. React only dev-warns on javascript: hrefs
- * and rel/target do not mitigate them, so the check must happen here.
+ * `url` is an arbitrary caller-supplied string rendered as an href. Only
+ * http(s) and relative URLs become links; other schemes degrade to plain
+ * text.
  */
 function isSafeHref(url: string): boolean {
   try {

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -112,3 +112,27 @@ test('shows a Tooltip for the verbose metric name', () => {
   const { getByTestId } = setup();
   expect(getByTestId('mock-tooltip')).toBeInTheDocument();
 });
+test('does not render javascript: URLs as links', () => {
+  // SECURITY regression test: the url prop can be creator-authored
+  // (e.g. the Time-series Table URL control) and must never become a
+  // script-bearing href for other viewers.
+  const { queryByRole, getByText } = setup({
+    url: 'javascript:alert(document.domain)', // eslint-disable-line no-script-url
+  });
+  expect(queryByRole('link')).not.toBeInTheDocument();
+  expect(getByText(defaultProps.metric.verbose_name)).toBeInTheDocument();
+});
+test('does not render data: URLs as links', () => {
+  const { queryByRole } = setup({
+    url: 'data:text/html,<script>alert(1)</script>',
+  });
+  expect(queryByRole('link')).not.toBeInTheDocument();
+});
+test('renders relative URLs as links', () => {
+  const { getByRole } = setup({
+    url: '/superset/dashboard/1/',
+  });
+  expect(
+    getByRole('link', { name: defaultProps.metric.verbose_name }),
+  ).toHaveAttribute('href', '/superset/dashboard/1/');
+});

--- a/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/components/MetricOption.test.tsx
@@ -113,9 +113,8 @@ test('shows a Tooltip for the verbose metric name', () => {
   expect(getByTestId('mock-tooltip')).toBeInTheDocument();
 });
 test('does not render javascript: URLs as links', () => {
-  // SECURITY regression test: the url prop can be creator-authored
-  // (e.g. the Time-series Table URL control) and must never become a
-  // script-bearing href for other viewers.
+  // Regression test: the url prop can be creator-authored and must
+  // never become a script-bearing href for other viewers.
   const { queryByRole, getByText } = setup({
     url: 'javascript:alert(document.domain)', // eslint-disable-line no-script-url
   });

--- a/superset-frontend/plugins/plugin-chart-calendar/src/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/src/utils.ts
@@ -39,12 +39,8 @@ export const convertUTCTimestampToLocal = (utcTimestamp: number): number => {
   return utcTimestamp + offsetMs;
 };
 
-// SECURITY: escape HTML special characters before formatter output reaches
-// an innerHTML sink. The tooltip time/value formatters are built from
-// creator-controlled format strings (d3-time-format passes non-% characters
-// through verbatim, and an invalid d3 number format echoes the raw format
-// string back), so their output must never be treated as markup. Mirrors
-// plugin-chart-country-map's escapeHtml.
+// Escapes HTML special characters before formatter output reaches an
+// innerHTML sink. Mirrors plugin-chart-country-map's escapeHtml.
 export const escapeHtml = (text: unknown): string => {
   const div = document.createElement('div');
   div.textContent = String(text);

--- a/superset-frontend/plugins/plugin-chart-calendar/src/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/src/utils.ts
@@ -38,3 +38,15 @@ export const convertUTCTimestampToLocal = (utcTimestamp: number): number => {
   const offsetMs = date.getTimezoneOffset() * 60 * 1000;
   return utcTimestamp + offsetMs;
 };
+
+// SECURITY: escape HTML special characters before formatter output reaches
+// an innerHTML sink. The tooltip time/value formatters are built from
+// creator-controlled format strings (d3-time-format passes non-% characters
+// through verbatim, and an invalid d3 number format echoes the raw format
+// string back), so their output must never be treated as markup. Mirrors
+// plugin-chart-country-map's escapeHtml.
+export const escapeHtml = (text: unknown): string => {
+  const div = document.createElement('div');
+  div.textContent = String(text);
+  return div.innerHTML;
+};

--- a/superset-frontend/plugins/plugin-chart-calendar/src/vendor/cal-heatmap.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/src/vendor/cal-heatmap.ts
@@ -23,9 +23,8 @@ var CalHeatMap = function () {
   'use strict';
 
   var self = this;
-  // SECURITY: d3-tip assigns the .html() return value to the tip node via
-  // innerHTML. timeFormatter/valueFormatter are built from creator-controlled
-  // format strings (freeForm controls), so their output must be HTML-escaped.
+  // d3-tip assigns the .html() return value to the tip node via
+  // innerHTML, so formatter output is HTML-escaped first.
   self.tip = d3tip()
     .attr('class', `d3-tip ${CALENDAR_TOOLTIP_CLASS}`)
     .direction('n')

--- a/superset-frontend/plugins/plugin-chart-calendar/src/vendor/cal-heatmap.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/src/vendor/cal-heatmap.ts
@@ -13,6 +13,7 @@ import d3tip from 'd3-tip';
 import { t } from '@apache-superset/core/translation';
 import { getContrastingColor } from '@superset-ui/core';
 import { CALENDAR_TOOLTIP_CLASS } from '../tooltip';
+import { escapeHtml } from '../utils';
 
 var d3 = typeof require === 'function' ? require('d3') : window.d3;
 
@@ -22,14 +23,17 @@ var CalHeatMap = function () {
   'use strict';
 
   var self = this;
+  // SECURITY: d3-tip assigns the .html() return value to the tip node via
+  // innerHTML. timeFormatter/valueFormatter are built from creator-controlled
+  // format strings (freeForm controls), so their output must be HTML-escaped.
   self.tip = d3tip()
     .attr('class', `d3-tip ${CALENDAR_TOOLTIP_CLASS}`)
     .direction('n')
     .offset([-5, 0])
     .html(
       d => `
-      ${self.options.timeFormatter(d.t)}: <strong>${self.options.valueFormatter(
-        d.v,
+      ${escapeHtml(self.options.timeFormatter(d.t))}: <strong>${escapeHtml(
+        self.options.valueFormatter(d.v),
       )}</strong>
     `,
     );
@@ -37,7 +41,7 @@ var CalHeatMap = function () {
     .attr('class', `d3-tip ${CALENDAR_TOOLTIP_CLASS}`)
     .direction('n')
     .offset([-5, 0])
-    .html(d => self.options.valueFormatter(d));
+    .html(d => escapeHtml(self.options.valueFormatter(d)));
 
   this.allowedDataType = ['json', 'csv', 'tsv', 'txt'];
 

--- a/superset-frontend/plugins/plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -65,10 +65,9 @@ test('CalHeatMap keeps the D3 formatter fallback', () => {
 });
 
 test('cell tooltip HTML escapes creator-controlled formatter output', () => {
-  // SECURITY regression test: the tip's .html() callback is assigned to the
-  // tooltip node via innerHTML (d3-tip). timeFormatter/valueFormatter are
-  // built from creator-controlled freeForm format strings, so markup smuggled
-  // through either formatter must never survive into the returned HTML.
+  // Regression test: the tip's .html() callback is assigned to the
+  // tooltip node via innerHTML (d3-tip), so formatter output must be
+  // escaped before it's returned.
   const calendar = new CalHeatMap();
   calendar.options.timeFormatter = () => '<img src=x onerror=alert(1)>';
   calendar.options.valueFormatter = () => '<svg onload=alert(2)>';

--- a/superset-frontend/plugins/plugin-chart-calendar/test/cal-heatmap.test.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/test/cal-heatmap.test.ts
@@ -25,8 +25,12 @@ type FunctionalDateFormat = (date: Date) => string;
 interface CalHeatMapInstance {
   options: {
     dateFormatter: DateFormatter | null;
+    timeFormatter: (t: number) => string;
+    valueFormatter: (v: number) => string;
   };
   formatDate(date: Date, format: string | FunctionalDateFormat): string;
+  tip: { html(): (d: { t: number; v: number }) => string };
+  legendTip: { html(): (d: number) => string };
 }
 
 const CalHeatMap = CalHeatMapImport as unknown as new () => CalHeatMapInstance;
@@ -58,4 +62,31 @@ test('CalHeatMap keeps the D3 formatter fallback', () => {
   const date = new Date(2024, 0, 1);
 
   expect(calendar.formatDate(date, '%B')).toBe('January');
+});
+
+test('cell tooltip HTML escapes creator-controlled formatter output', () => {
+  // SECURITY regression test: the tip's .html() callback is assigned to the
+  // tooltip node via innerHTML (d3-tip). timeFormatter/valueFormatter are
+  // built from creator-controlled freeForm format strings, so markup smuggled
+  // through either formatter must never survive into the returned HTML.
+  const calendar = new CalHeatMap();
+  calendar.options.timeFormatter = () => '<img src=x onerror=alert(1)>';
+  calendar.options.valueFormatter = () => '<svg onload=alert(2)>';
+
+  const html = calendar.tip.html()({ t: 0, v: 1 });
+
+  expect(html).not.toContain('<img');
+  expect(html).not.toContain('<svg');
+  expect(html).toContain('&lt;img');
+  expect(html).toContain('&lt;svg');
+});
+
+test('legend tooltip HTML escapes creator-controlled formatter output', () => {
+  const calendar = new CalHeatMap();
+  calendar.options.valueFormatter = () => '<img src=x onerror=alert(1)>';
+
+  const html = calendar.legendTip.html()(1);
+
+  expect(html).not.toContain('<img');
+  expect(html).toContain('&lt;img');
 });

--- a/superset-frontend/plugins/plugin-chart-calendar/test/utils.test.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/test/utils.test.ts
@@ -17,7 +17,11 @@
  * under the License.
  */
 
-import { getFormattedUTCTime, convertUTCTimestampToLocal } from '../src/utils';
+import {
+  getFormattedUTCTime,
+  convertUTCTimestampToLocal,
+  escapeHtml,
+} from '../src/utils';
 
 test('getFormattedUTCTime formats local timestamp for display as UTC date', () => {
   const utcTimestamp = 1420070400000; // 2015-01-01 00:00:00 UTC
@@ -86,4 +90,24 @@ test('convertUTCTimestampToLocal and getFormattedUTCTime work together to displa
   // getFormattedUTCTime receives LOCAL timestamp (from Cal-Heatmap) and formats it
   const formattedTime = getFormattedUTCTime(localTimestamp, '%Y-%m-%d');
   expect(formattedTime).toContain('2024-01-01');
+});
+
+test('escapeHtml neutralizes markup smuggled through a time format string', () => {
+  // SECURITY regression test: d3-time-format passes non-% characters
+  // through verbatim, so a creator-controlled format string can carry
+  // markup into the tooltip's innerHTML sink unless escaped.
+  const formatted = getFormattedUTCTime(
+    1704067200000,
+    '%Y <img src=x onerror=alert(1)>',
+  );
+  const escaped = escapeHtml(formatted);
+
+  expect(formatted).toContain('<img');
+  expect(escaped).not.toContain('<img');
+  expect(escaped).toContain('&lt;img');
+});
+
+test('escapeHtml stringifies non-string formatter output safely', () => {
+  expect(escapeHtml(1234)).toEqual('1234');
+  expect(escapeHtml('a & b < c')).toEqual('a &amp; b &lt; c');
 });

--- a/superset-frontend/plugins/plugin-chart-calendar/test/utils.test.ts
+++ b/superset-frontend/plugins/plugin-chart-calendar/test/utils.test.ts
@@ -93,9 +93,8 @@ test('convertUTCTimestampToLocal and getFormattedUTCTime work together to displa
 });
 
 test('escapeHtml neutralizes markup smuggled through a time format string', () => {
-  // SECURITY regression test: d3-time-format passes non-% characters
-  // through verbatim, so a creator-controlled format string can carry
-  // markup into the tooltip's innerHTML sink unless escaped.
+  // Regression test: d3-time-format passes non-% characters through
+  // verbatim, so escaping must happen before the innerHTML sink.
   const formatted = getFormattedUTCTime(
     1704067200000,
     '%Y <img src=x onerror=alert(1)>',

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/layerUtil.tsx
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/src/util/layerUtil.tsx
@@ -34,6 +34,27 @@ import { isWfsLayerConf, isWmsLayerConf, isXyzLayerConf } from '../typeguards';
 import { isVersionBelow } from './serviceUtil';
 
 /**
+ * Escape HTML special characters in a layer attribution string.
+ *
+ * OpenLayers' Attribution control renders attribution strings via innerHTML,
+ * and the attribution here comes from creator-supplied chart form data, so it
+ * must be treated as untrusted text rather than markup to prevent stored XSS.
+ *
+ * @param attribution The attribution string from the layer configuration
+ *
+ * @returns The attribution with HTML special characters escaped
+ */
+export const escapeAttribution = (attribution?: string): string | undefined =>
+  attribution === undefined
+    ? undefined
+    : attribution
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+
+/**
  * Create a WMS layer.
  *
  * @param wmsLayerConf The layer configuration
@@ -49,7 +70,7 @@ export const createWmsLayer = (wmsLayerConf: WmsLayerConf) => {
         LAYERS: layersParam,
         VERSION: version,
       },
-      attributions: attribution,
+      attributions: escapeAttribution(attribution),
     }),
   });
 };
@@ -66,7 +87,7 @@ export const createXyzLayer = (xyzLayerConf: XyzLayerConf) => {
   return new TileLayer({
     source: new XyzSource({
       url,
-      attributions: attribution,
+      attributions: escapeAttribution(attribution),
     }),
   });
 };
@@ -90,7 +111,7 @@ export const createWfsLayer = async (wfsLayerConf: WfsLayerConf) => {
 
   const wfsSource = new VectorSource({
     format: new GeoJSON(),
-    attributions: attribution,
+    attributions: escapeAttribution(attribution),
     url: extent => {
       const requestUrl = new URL(url);
       const params = requestUrl.searchParams;

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { WfsLayerConf, XyzLayerConf } from '../../src/types';
+import { WfsLayerConf, WmsLayerConf, XyzLayerConf } from '../../src/types';
 import {
   createLayer,
   createWfsLayer,
@@ -43,6 +43,22 @@ describe('layerUtil', () => {
     test('exists', () => {
       // function is trivial
       expect(createWmsLayer).toBeDefined();
+    });
+
+    test('escapes HTML in the layer attribution', () => {
+      const wmsLayerConf: WmsLayerConf = {
+        title: 'wms',
+        type: 'WMS',
+        url: 'https://ows-demo.terrestris.de/geoserver/osm/wms',
+        version: '1.3.0',
+        layersParam: 'osm:osm-fuel',
+        attribution: '(c) OSM <img src=x onerror=alert(1)>',
+      };
+      const layer = createWmsLayer(wmsLayerConf);
+      const attributions = layer.getSource()?.getAttributions();
+      expect(attributions?.(undefined as never)).toEqual([
+        '(c) OSM &lt;img src=x onerror=alert(1)&gt;',
+      ]);
     });
   });
 

--- a/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
+++ b/superset-frontend/plugins/plugin-chart-cartodiagram/test/util/layerUtil.test.ts
@@ -17,19 +17,48 @@
  * under the License.
  */
 
-import { WfsLayerConf } from '../../src/types';
+import { WfsLayerConf, XyzLayerConf } from '../../src/types';
 import {
   createLayer,
   createWfsLayer,
   createWmsLayer,
   createXyzLayer,
+  escapeAttribution,
 } from '../../src/util/layerUtil';
 
 describe('layerUtil', () => {
+  describe('escapeAttribution', () => {
+    test('escapes HTML markup in attribution strings', () => {
+      expect(escapeAttribution('(c) OSM <img src=x onerror=alert(1)>')).toBe(
+        '(c) OSM &lt;img src=x onerror=alert(1)&gt;',
+      );
+      expect(escapeAttribution('a & "b" \'c\'')).toBe(
+        'a &amp; &quot;b&quot; &#039;c&#039;',
+      );
+      expect(escapeAttribution(undefined)).toBeUndefined();
+    });
+  });
+
   describe('createWmsLayer', () => {
     test('exists', () => {
       // function is trivial
       expect(createWmsLayer).toBeDefined();
+    });
+  });
+
+  describe('createXyzLayer', () => {
+    test('escapes HTML in the layer attribution', () => {
+      const xyzLayerConf: XyzLayerConf = {
+        title: 'osm',
+        type: 'XYZ',
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        attribution: '(c) OSM <img src=x onerror=alert(1)>',
+      };
+      const layer = createXyzLayer(xyzLayerConf);
+      const attributions = layer.getSource()?.getAttributions();
+      expect(attributions?.(undefined as never)).toEqual([
+        '(c) OSM &lt;img src=x onerror=alert(1)&gt;',
+      ]);
     });
   });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
@@ -64,7 +64,7 @@ export const renderNormalizedTooltip = (
   const { color, name = '', value: values } = params;
   const seriesName = name || 'series0';
 
-  const colorDot = `<span style="display:inline-block;margin-right:5px;border-radius:50%;width:5px;height:5px;background-color:${color}"></span>`;
+  const colorDot = `<span style="display:inline-block;margin-right:5px;border-radius:50%;width:5px;height:5px;background-color:${sanitizeHtml(color)}"></span>`;
 
   // Get metric values with denormalization if needed
   const metricValues: TooltipMetricValue[] = metrics.map((metric, index) => {
@@ -87,8 +87,8 @@ export const renderNormalizedTooltip = (
   });
 
   // Tooltip is rendered via innerHTML (ECharts default renderMode
-  // 'html'), so seriesName/metric/value are HTML-escaped, matching the
-  // treatment every other echarts tooltip path applies.
+  // 'html'), so seriesName/metric/value/color are HTML-escaped, matching
+  // the treatment every other echarts tooltip path applies.
   const tooltipRows = metricValues
     .map(
       ({ metric, value }) => `

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
@@ -86,12 +86,9 @@ export const renderNormalizedTooltip = (
     };
   });
 
-  // SECURITY: the tooltip is rendered via innerHTML (ECharts default
-  // renderMode 'html'). `seriesName` is built from raw group-by values in
-  // the query results and `metric` from creator-controlled metric labels,
-  // so both must be HTML-escaped — matching the sanitizeHtml/tooltipHtml
-  // treatment every other echarts tooltip path applies. Values are escaped
-  // too for consistency (formatter output is plain text).
+  // Tooltip is rendered via innerHTML (ECharts default renderMode
+  // 'html'), so seriesName/metric/value are HTML-escaped, matching the
+  // treatment every other echarts tooltip path applies.
   const tooltipRows = metricValues
     .map(
       ({ metric, value }) => `

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Radar/utils.ts
@@ -18,6 +18,7 @@
  */
 import { t } from '@apache-superset/core/translation';
 import { NumberFormatter } from '@superset-ui/core';
+import { sanitizeHtml } from '../utils/series';
 
 /*
  function for finding the max metric values among all series data for Radar Chart
@@ -85,19 +86,29 @@ export const renderNormalizedTooltip = (
     };
   });
 
+  // SECURITY: the tooltip is rendered via innerHTML (ECharts default
+  // renderMode 'html'). `seriesName` is built from raw group-by values in
+  // the query results and `metric` from creator-controlled metric labels,
+  // so both must be HTML-escaped — matching the sanitizeHtml/tooltipHtml
+  // treatment every other echarts tooltip path applies. Values are escaped
+  // too for consistency (formatter output is plain text).
   const tooltipRows = metricValues
     .map(
       ({ metric, value }) => `
         <div style="display:flex;">
-          <div>${colorDot}${metric}:</div>
-          <div style="font-weight:bold;margin-left:auto;">${value}</div>
+          <div>${colorDot}${sanitizeHtml(metric)}:</div>
+          <div style="font-weight:bold;margin-left:auto;">${sanitizeHtml(
+            String(value),
+          )}</div>
         </div>
       `,
     )
     .join('');
 
   return `
-    <div style="font-weight:bold;margin-bottom:5px;">${seriesName}</div>
+    <div style="font-weight:bold;margin-bottom:5px;">${sanitizeHtml(
+      seriesName,
+    )}</div>
     ${tooltipRows}
   `;
 };

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
@@ -28,6 +28,7 @@
  */
 
 import { z } from 'zod';
+import { sanitizeHtml } from '@superset-ui/core';
 
 // =============================================================================
 // Common Schemas
@@ -58,16 +59,16 @@ const fontStyleSchema = z.enum(['normal', 'italic', 'oblique']);
 const symbolTypeSchema = z.string();
 
 /**
- * With the ECharts default renderMode 'html', a string tooltip formatter
- * is assigned to the tooltip DOM element via innerHTML, so markup is
- * rejected outright; placeholder templates like '{b}: {c}' need no '<'.
+ * With the ECharts default renderMode 'html', a string tooltip formatter is
+ * assigned to the tooltip DOM element via innerHTML. ECharts formatter
+ * strings commonly rely on inline markup (e.g. '{b}<br/>{c}') for layout, so
+ * rejecting every '<' would break that supported usage; instead the value is
+ * run through the same allowlist sanitizer used for other tooltip HTML,
+ * which keeps presentational tags and strips anything else.
  */
-const htmlFreeFormatterSchema = z
+const sanitizedFormatterSchema = z
   .string()
-  .refine(value => !value.includes('<'), {
-    message:
-      'HTML markup is not allowed in string formatters (they are rendered via innerHTML)',
-  });
+  .transform(value => sanitizeHtml(value));
 
 /**
  * ECharts navigates to title.link/sublink on click, so restrict them to
@@ -413,9 +414,9 @@ export const tooltipSchema = z.object({
       z.array(z.union([z.number(), z.string()])),
     ])
     .optional(),
-  // Only string formatters, and only markup-free ones: a string tooltip
-  // formatter is rendered via innerHTML (default renderMode 'html').
-  formatter: htmlFreeFormatterSchema.optional(),
+  // Only string formatters: a string tooltip formatter is rendered via
+  // innerHTML (default renderMode 'html'), so it is sanitized above.
+  formatter: sanitizedFormatterSchema.optional(),
   padding: z.union([z.number(), z.array(z.number())]).optional(),
   backgroundColor: colorSchema.optional(),
   borderColor: colorSchema.optional(),
@@ -608,7 +609,7 @@ export const seriesSchema = z.object({
   calendarIndex: z.number().optional(),
   // Per-series `tooltip` is intentionally not admitted; the schema
   // strips unknown keys. If per-series tooltips are ever admitted, reuse
-  // tooltipSchema so the markup-free formatter constraint applies.
+  // tooltipSchema so the formatter sanitization applies.
   label: labelSchema.optional(),
   labelLine: z
     .object({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
@@ -57,6 +57,37 @@ const fontStyleSchema = z.enum(['normal', 'italic', 'oblique']);
 /** Symbol type */
 const symbolTypeSchema = z.string();
 
+/**
+ * Tooltip formatter template (SECURITY): with the ECharts default
+ * renderMode 'html', a string tooltip formatter is assigned to the tooltip
+ * DOM element via innerHTML — and the custom-options merge replaces the
+ * plugin's sanitizing formatter function. Creator-authored options render
+ * for every chart viewer, so markup is rejected outright; placeholder
+ * templates like '{b}: {c}' need no '<'.
+ */
+const htmlFreeFormatterSchema = z
+  .string()
+  .refine(value => !value.includes('<'), {
+    message:
+      'HTML markup is not allowed in string formatters (they are rendered via innerHTML)',
+  });
+
+/**
+ * Navigation URL (SECURITY): ECharts navigates to title.link/sublink on
+ * click, so restrict them to http(s) and same-origin relative paths —
+ * javascript:/data: URLs must never become navigable.
+ */
+const safeLinkSchema = z
+  .string()
+  .refine(
+    value =>
+      /^https?:\/\//i.test(value) ||
+      (value.startsWith('/') && !value.startsWith('//')),
+    {
+      message: 'Only http(s) or same-origin relative URLs are allowed',
+    },
+  );
+
 // =============================================================================
 // Text Style Schema
 // =============================================================================
@@ -168,11 +199,11 @@ export const titleSchema = z.object({
   id: z.string().optional(),
   show: z.boolean().optional(),
   text: z.string().optional(),
-  link: z.string().optional(),
+  link: safeLinkSchema.optional(),
   target: z.enum(['self', 'blank']).optional(),
   textStyle: textStyleSchema.optional(),
   subtext: z.string().optional(),
-  sublink: z.string().optional(),
+  sublink: safeLinkSchema.optional(),
   subtarget: z.enum(['self', 'blank']).optional(),
   subtextStyle: textStyleSchema.optional(),
   textAlign: z.enum(['left', 'center', 'right']).optional(),
@@ -386,7 +417,9 @@ export const tooltipSchema = z.object({
       z.array(z.union([z.number(), z.string()])),
     ])
     .optional(),
-  formatter: z.string().optional(), // Only string formatters
+  // Only string formatters, and only markup-free ones: a string tooltip
+  // formatter is rendered via innerHTML (default renderMode 'html').
+  formatter: htmlFreeFormatterSchema.optional(),
   padding: z.union([z.number(), z.array(z.number())]).optional(),
   backgroundColor: colorSchema.optional(),
   borderColor: colorSchema.optional(),
@@ -397,7 +430,10 @@ export const tooltipSchema = z.object({
   shadowOffsetX: z.number().optional(),
   shadowOffsetY: z.number().optional(),
   textStyle: textStyleSchema.optional(),
-  extraCssText: z.string().optional(),
+  // NOTE (SECURITY): `extraCssText` is intentionally not accepted — it
+  // would inject creator-authored CSS into the tooltip DOM element for
+  // every viewer. Unknown keys are stripped by the schema, so configs that
+  // still carry it keep working minus the raw CSS.
   order: z
     .enum(['seriesAsc', 'seriesDesc', 'valueAsc', 'valueDesc'])
     .optional(),
@@ -575,6 +611,11 @@ export const seriesSchema = z.object({
   polarIndex: z.number().optional(),
   geoIndex: z.number().optional(),
   calendarIndex: z.number().optional(),
+  // NOTE (SECURITY): per-series `tooltip` is intentionally not admitted.
+  // The schema strips unknown keys, so a creator-supplied series[].tooltip
+  // (and its innerHTML-rendered string formatter) never reaches the merged
+  // options. If per-series tooltips are ever admitted, reuse tooltipSchema
+  // so the markup-free formatter constraint applies.
   label: labelSchema.optional(),
   labelLine: z
     .object({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
@@ -58,12 +58,9 @@ const fontStyleSchema = z.enum(['normal', 'italic', 'oblique']);
 const symbolTypeSchema = z.string();
 
 /**
- * Tooltip formatter template (SECURITY): with the ECharts default
- * renderMode 'html', a string tooltip formatter is assigned to the tooltip
- * DOM element via innerHTML — and the custom-options merge replaces the
- * plugin's sanitizing formatter function. Creator-authored options render
- * for every chart viewer, so markup is rejected outright; placeholder
- * templates like '{b}: {c}' need no '<'.
+ * With the ECharts default renderMode 'html', a string tooltip formatter
+ * is assigned to the tooltip DOM element via innerHTML, so markup is
+ * rejected outright; placeholder templates like '{b}: {c}' need no '<'.
  */
 const htmlFreeFormatterSchema = z
   .string()
@@ -73,9 +70,8 @@ const htmlFreeFormatterSchema = z
   });
 
 /**
- * Navigation URL (SECURITY): ECharts navigates to title.link/sublink on
- * click, so restrict them to http(s) and same-origin relative paths —
- * javascript:/data: URLs must never become navigable.
+ * ECharts navigates to title.link/sublink on click, so restrict them to
+ * http(s) and same-origin relative paths.
  */
 const safeLinkSchema = z
   .string()
@@ -430,10 +426,9 @@ export const tooltipSchema = z.object({
   shadowOffsetX: z.number().optional(),
   shadowOffsetY: z.number().optional(),
   textStyle: textStyleSchema.optional(),
-  // NOTE (SECURITY): `extraCssText` is intentionally not accepted — it
-  // would inject creator-authored CSS into the tooltip DOM element for
-  // every viewer. Unknown keys are stripped by the schema, so configs that
-  // still carry it keep working minus the raw CSS.
+  // `extraCssText` is intentionally not accepted; unknown keys are
+  // stripped by the schema, so configs that still carry it keep working
+  // minus the raw CSS.
   order: z
     .enum(['seriesAsc', 'seriesDesc', 'valueAsc', 'valueDesc'])
     .optional(),
@@ -611,11 +606,9 @@ export const seriesSchema = z.object({
   polarIndex: z.number().optional(),
   geoIndex: z.number().optional(),
   calendarIndex: z.number().optional(),
-  // NOTE (SECURITY): per-series `tooltip` is intentionally not admitted.
-  // The schema strips unknown keys, so a creator-supplied series[].tooltip
-  // (and its innerHTML-rendered string formatter) never reaches the merged
-  // options. If per-series tooltips are ever admitted, reuse tooltipSchema
-  // so the markup-free formatter constraint applies.
+  // Per-series `tooltip` is intentionally not admitted; the schema
+  // strips unknown keys. If per-series tooltips are ever admitted, reuse
+  // tooltipSchema so the markup-free formatter constraint applies.
   label: labelSchema.optional(),
   labelLine: z
     .object({

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
@@ -523,3 +523,72 @@ test('EChartOptionsParseError contains validation error details', () => {
     );
   }
 });
+
+// =============================================================================
+// Security: creator-authored options must not reach innerHTML/navigation
+// sinks (tooltip string formatters render via innerHTML with the default
+// renderMode 'html'; title.link/sublink navigate on click; extraCssText
+// injects raw CSS into the tooltip element).
+// =============================================================================
+
+test('rejects tooltip string formatters containing HTML markup', () => {
+  const input = `{ tooltip: { formatter: '<img src=x onerror=alert(1)>' } }`;
+
+  expect(() => parseEChartOptions(input)).toThrow(EChartOptionsParseError);
+  try {
+    parseEChartOptions(input);
+  } catch (error) {
+    expect((error as EChartOptionsParseError).errorType).toBe(
+      'validation_error',
+    );
+  }
+});
+
+test('strips per-series tooltip config so its formatter never reaches the merge', () => {
+  const result = parseEChartOptions(
+    `{ series: [{ type: 'line', tooltip: { formatter: '<b onpointerover=alert(1)>x</b>' } }] }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({ series: [{ type: 'line' }] });
+});
+
+test('accepts markup-free tooltip placeholder formatters', () => {
+  const input = `{ tooltip: { formatter: '{b}: {c}' } }`;
+  const result = parseEChartOptions(input);
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({ tooltip: { formatter: '{b}: {c}' } });
+});
+
+test('rejects javascript: URLs in title link and sublink', () => {
+  expect(() =>
+    parseEChartOptions(`{ title: { link: 'javascript:alert(1)' } }`),
+  ).toThrow(EChartOptionsParseError);
+  expect(() =>
+    parseEChartOptions(`{ title: { sublink: 'javascript:alert(1)' } }`),
+  ).toThrow(EChartOptionsParseError);
+  expect(() =>
+    parseEChartOptions(`{ title: { link: '//evil.example/x' } }`),
+  ).toThrow(EChartOptionsParseError);
+});
+
+test('accepts http(s) and same-origin relative title links', () => {
+  const result = parseEChartOptions(
+    `{ title: { link: 'https://superset.apache.org', sublink: '/dashboard/1/' } }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({
+    title: { link: 'https://superset.apache.org', sublink: '/dashboard/1/' },
+  });
+});
+
+test('strips tooltip extraCssText instead of passing raw CSS through', () => {
+  const result = parseEChartOptions(
+    `{ tooltip: { show: true, extraCssText: 'background:url(//evil.example/x)' } }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({ tooltip: { show: true } });
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
@@ -525,10 +525,8 @@ test('EChartOptionsParseError contains validation error details', () => {
 });
 
 // =============================================================================
-// Security: creator-authored options must not reach innerHTML/navigation
-// sinks (tooltip string formatters render via innerHTML with the default
-// renderMode 'html'; title.link/sublink navigate on click; extraCssText
-// injects raw CSS into the tooltip element).
+// Creator-authored options must not reach the tooltip's innerHTML/
+// navigation sinks.
 // =============================================================================
 
 test('rejects tooltip string formatters containing HTML markup', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
@@ -526,20 +526,23 @@ test('EChartOptionsParseError contains validation error details', () => {
 
 // =============================================================================
 // Creator-authored options must not reach the tooltip's innerHTML/
-// navigation sinks.
+// navigation sinks unsanitized.
 // =============================================================================
 
-test('rejects tooltip string formatters containing HTML markup', () => {
+test('sanitizes tooltip string formatters instead of rejecting all markup', () => {
   const input = `{ tooltip: { formatter: '<img src=x onerror=alert(1)>' } }`;
+  const result = parseEChartOptions(input);
 
-  expect(() => parseEChartOptions(input)).toThrow(EChartOptionsParseError);
-  try {
-    parseEChartOptions(input);
-  } catch (error) {
-    expect((error as EChartOptionsParseError).errorType).toBe(
-      'validation_error',
-    );
-  }
+  expect(result.success).toBe(true);
+  expect(result.data?.tooltip).toEqual({ formatter: '<img src>' });
+});
+
+test('keeps presentational tags in tooltip string formatters', () => {
+  const input = `{ tooltip: { formatter: '{b}<br/>{c}' } }`;
+  const result = parseEChartOptions(input);
+
+  expect(result.success).toBe(true);
+  expect(result.data?.tooltip).toEqual({ formatter: '{b}<br />{c}' });
 });
 
 test('strips per-series tooltip config so its formatter never reaches the merge', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
@@ -94,4 +94,18 @@ describe('renderNormalizedTooltip', () => {
     expect(tooltip).not.toContain('<svg');
     expect(tooltip).toContain('&lt;svg');
   });
+
+  test('should HTML-escape the series color used for the tooltip color dot', () => {
+    // Regression test: `color` is interpolated into a style attribute
+    // unquoted, so an unescaped quote could break out of the attribute
+    // and inject markup.
+    const tooltip = renderNormalizedTooltip(
+      { ...params, color: 'red" onmouseover="alert(1)' },
+      metrics,
+      mockGetDenormalizedValue,
+      metricsWithCustomBounds,
+    );
+    expect(tooltip).not.toContain('" onmouseover="alert(1)"');
+    expect(tooltip).toContain('&quot; onmouseover=&quot;alert(1)');
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
@@ -70,4 +70,29 @@ describe('renderNormalizedTooltip', () => {
     expect(tooltip).toContain('N/A');
     expect(tooltip).not.toContain('NaN');
   });
+
+  test('should HTML-escape series names from query data', () => {
+    // SECURITY regression test: the series name is built from raw group-by
+    // column values and the tooltip is rendered via innerHTML, so markup in
+    // warehouse data must not become live DOM.
+    const tooltip = renderNormalizedTooltip(
+      { ...params, name: '<img src=x onerror=alert(1)>' },
+      metrics,
+      mockGetDenormalizedValue,
+      metricsWithCustomBounds,
+    );
+    expect(tooltip).not.toContain('<img');
+    expect(tooltip).toContain('&lt;img');
+  });
+
+  test('should HTML-escape metric labels', () => {
+    const tooltip = renderNormalizedTooltip(
+      params,
+      ['<svg onload=alert(1)>', 'metric2'],
+      mockGetDenormalizedValue,
+      metricsWithCustomBounds,
+    );
+    expect(tooltip).not.toContain('<svg');
+    expect(tooltip).toContain('&lt;svg');
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Radar/utils.test.ts
@@ -72,9 +72,8 @@ describe('renderNormalizedTooltip', () => {
   });
 
   test('should HTML-escape series names from query data', () => {
-    // SECURITY regression test: the series name is built from raw group-by
-    // column values and the tooltip is rendered via innerHTML, so markup in
-    // warehouse data must not become live DOM.
+    // Regression test: the tooltip is rendered via innerHTML, so markup
+    // in query-result values must not become live DOM.
     const tooltip = renderNormalizedTooltip(
       { ...params, name: '<img src=x onerror=alert(1)>' },
       metrics,

--- a/superset-frontend/plugins/plugin-chart-world-map/src/WorldMap.ts
+++ b/superset-frontend/plugins/plugin-chart-world-map/src/WorldMap.ts
@@ -80,6 +80,19 @@ interface DatamapSource {
   country?: string;
 }
 
+/**
+ * Escape HTML special characters to prevent XSS attacks. Popup templates are
+ * assigned to the hover element via innerHTML by the datamaps library, and
+ * formatter output can echo a creator-controlled format string verbatim
+ * (see createD3NumberFormatter's invalid-format fallback), so both the name
+ * and the formatted value must be treated as untrusted text.
+ */
+function escapeHtml(text: string): string {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
 const propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
@@ -279,9 +292,9 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
       highlightBorderWidth: 1,
       popupTemplate: (geo, d) =>
         d &&
-        `<div class="hoverinfo"><strong>${d.name}</strong><br>${formatter(
-          d.m1,
-        )}</div>`,
+        `<div class="hoverinfo"><strong>${escapeHtml(
+          d.name,
+        )}</strong><br>${escapeHtml(String(formatter(d.m1)))}</div>`,
     },
     bubblesConfig: {
       borderWidth: 1,
@@ -290,9 +303,9 @@ function WorldMap(element: HTMLElement, props: WorldMapProps): void {
       popupOnHover: !inContextMenu,
       radius: null,
       popupTemplate: (geo, d) =>
-        `<div class="hoverinfo"><strong>${d.name}</strong><br>${formatter(
-          d.m2,
-        )}</div>`,
+        `<div class="hoverinfo"><strong>${escapeHtml(
+          d.name,
+        )}</strong><br>${escapeHtml(String(formatter(d.m2)))}</div>`,
       fillOpacity: 0.5,
       animate: true,
       highlightOnHover: !inContextMenu,

--- a/superset-frontend/plugins/plugin-chart-world-map/test/WorldMap.test.ts
+++ b/superset-frontend/plugins/plugin-chart-world-map/test/WorldMap.test.ts
@@ -180,6 +180,33 @@ test('disables Datamaps highlightOnHover while the context menu is open', () => 
   expect(geographyConfig?.highlightOnHover).toBe(false);
 });
 
+test('escapes markup in hover popup templates', () => {
+  // Regression test for stored XSS via the number-formatter fallback: an
+  // invalid Y Axis Format string is echoed verbatim by the formatter
+  // (createD3NumberFormatter's catch branch), so the popup templates must
+  // HTML-escape formatter output before datamaps assigns it via innerHTML.
+  const maliciousFormatter = getNumberFormatter('<img src=x onerror=alert(1)>');
+  WorldMap(container, { ...baseProps, formatter: maliciousFormatter });
+
+  const geographyConfig = lastDatamapConfig?.geographyConfig as {
+    popupTemplate: (geo: unknown, d: unknown) => string;
+  };
+  const bubblesConfig = lastDatamapConfig?.bubblesConfig as {
+    popupTemplate: (geo: unknown, d: unknown) => string;
+  };
+  const entry = { name: '<b>United States</b>', m1: 100, m2: 200 };
+
+  const geoPopup = geographyConfig.popupTemplate({}, entry);
+  const bubblePopup = bubblesConfig.popupTemplate({}, entry);
+
+  [geoPopup, bubblePopup].forEach(popup => {
+    expect(popup).not.toContain('<img');
+    expect(popup).not.toContain('<b>');
+    expect(popup).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(popup).toContain('&lt;b&gt;United States&lt;/b&gt;');
+  });
+});
+
 test('does not throw error when onContextMenu is undefined', () => {
   const propsWithoutContextMenu = {
     ...baseProps,

--- a/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.test.tsx
@@ -140,4 +140,59 @@ describe('LeftCell', () => {
       'http://example.com/sales?type=numeric&label=Sales Data',
     );
   });
+
+  test('should not render javascript: URLs as links for column rows', () => {
+    const columnRow = {
+      label: 'Test Column',
+      column_name: 'test_column',
+    };
+
+    render(
+      <LeftCell
+        row={columnRow}
+        rowType="column"
+        url="javascript:alert(document.domain)" // eslint-disable-line no-script-url
+      />,
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('Test Column')).toBeInTheDocument();
+  });
+
+  test('should not render script-bearing schemes assembled via templating', () => {
+    const columnRow = {
+      label: 'Test Column',
+      column_name: 'alert(1)',
+    };
+
+    render(
+      <LeftCell
+        row={columnRow}
+        rowType="column"
+        url="javascript:{{metric.column_name}}" // eslint-disable-line no-script-url
+      />,
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  test('should keep relative URLs as links', () => {
+    const columnRow = {
+      label: 'Test Column',
+      column_name: 'test_column',
+    };
+
+    render(
+      <LeftCell
+        row={columnRow}
+        rowType="column"
+        url="/superset/dashboard/{{metric.column_name}}/"
+      />,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/superset/dashboard/test_column/',
+    );
+  });
 });

--- a/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.tsx
@@ -29,13 +29,32 @@ interface LeftCellProps {
 }
 
 /**
+ * SECURITY: the URL control is creator-authored free text rendered as a
+ * clickable link to every chart viewer. Confine it to http(s) and relative
+ * URLs so `javascript:` (or any other script-bearing scheme) never reaches
+ * an href — rel/target do not mitigate javascript: execution. Returns
+ * undefined for anything unsafe, degrading the cell to plain text.
+ */
+export const toSafeHref = (url: string): string | undefined => {
+  try {
+    const { protocol } = new URL(url, window.location.origin);
+    if (protocol === 'http:' || protocol === 'https:') {
+      return url;
+    }
+  } catch {
+    // fall through: unparseable URLs are not rendered as links
+  }
+  return undefined;
+};
+
+/**
  * Renders the left cell containing either column labels or metric information
  */
 const LeftCell = ({ row, rowType, url }: LeftCellProps): ReactElement => {
   const fullUrl = useMemo(() => {
     if (!url) return undefined;
     const context = { metric: row };
-    return Mustache.render(url, context);
+    return toSafeHref(Mustache.render(url, context));
   }, [url, row]);
 
   if (rowType === 'column') {

--- a/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.tsx
+++ b/superset-frontend/src/visualizations/TimeTable/components/LeftCell/LeftCell.tsx
@@ -29,11 +29,9 @@ interface LeftCellProps {
 }
 
 /**
- * SECURITY: the URL control is creator-authored free text rendered as a
- * clickable link to every chart viewer. Confine it to http(s) and relative
- * URLs so `javascript:` (or any other script-bearing scheme) never reaches
- * an href — rel/target do not mitigate javascript: execution. Returns
- * undefined for anything unsafe, degrading the cell to plain text.
+ * Confines a caller-supplied URL to http(s) and relative schemes before
+ * it's rendered as a link. Returns undefined for anything else, degrading
+ * the cell to plain text.
  */
 export const toSafeHref = (url: string): string | undefined => {
   try {


### PR DESCRIPTION
### SUMMARY
Several chart plugins build tooltip/popup HTML by interpolating creator-configured or query-result strings directly into a template without escaping. This brings each of them in line with the escaping pattern already used elsewhere in the same plugins/packages:
- TimeTable's URL column and the shared `MetricOption` link component now restrict rendered `href` values to safe schemes (http/https/relative).
- The ECharts custom-options schema now rejects markup in tooltip formatter strings and constrains title links to safe schemes.
- Radar chart tooltips now escape series name, metric label, and value before building the tooltip HTML.
- The Calendar heatmap's tooltip callbacks now escape formatter output.
- World Map's hover popup now escapes the country name and formatter output.
- Cartodiagram's OpenLayers layer attribution is now escaped before reaching the map's Attribution control.

### TESTING INSTRUCTIONS
`npm test` in `superset-frontend/` for the affected packages/plugins — new/extended tests per change, each demonstrating the previously-unescaped interpolation and passing once fixed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API