### PR TITLE
fix(soft-delete): name the recovery location in the archive confirmation

### DIFF
--- a/superset-frontend/src/utils/softDeleteCopy.test.ts
+++ b/superset-frontend/src/utils/softDeleteCopy.test.ts
@@ -96,19 +96,19 @@ test('a malformed window does not leak into the copy', () => {
 test('the confirm copy quotes the window when there is one', () => {
   withConf({ SOFT_DELETE_RETENTION_DAYS: 30 });
   expect(archiveConfirmDescription('chart')).toBe(
-    'This chart will be moved to Recently Archived. You can recover it there within 30 days.',
+    'This chart will be moved to Recently Archived in the Settings menu. You can recover it there within 30 days.',
   );
   expect(archiveConfirmDescription('charts', true)).toBe(
-    'These charts will be moved to Recently Archived. You can recover them there within 30 days.',
+    'These charts will be moved to Recently Archived in the Settings menu. You can recover them there within 30 days.',
   );
 });
 
 test('the confirm copy omits the clause when there is no window', () => {
   withConf({});
   expect(archiveConfirmDescription('dashboard')).toBe(
-    'This dashboard will be moved to Recently Archived. You can recover it there.',
+    'This dashboard will be moved to Recently Archived in the Settings menu. You can recover it there.',
   );
   expect(archiveConfirmDescription('dashboards', true)).toBe(
-    'These dashboards will be moved to Recently Archived. You can recover them there.',
+    'These dashboards will be moved to Recently Archived in the Settings menu. You can recover them there.',
   );
 });

--- a/superset-frontend/src/utils/softDeleteCopy.test.ts
+++ b/superset-frontend/src/utils/softDeleteCopy.test.ts
@@ -103,6 +103,16 @@ test('the confirm copy quotes the window when there is one', () => {
   );
 });
 
+test('a one-day window is quoted in the singular', () => {
+  withConf({ SOFT_DELETE_RETENTION_DAYS: 1 });
+  expect(archiveConfirmDescription('chart')).toBe(
+    'This chart will be moved to Recently Archived in the Settings menu. You can recover it there within 1 day.',
+  );
+  expect(archiveConfirmDescription('charts', true)).toBe(
+    'These charts will be moved to Recently Archived in the Settings menu. You can recover them there within 1 day.',
+  );
+});
+
 test('the confirm copy omits the clause when there is no window', () => {
   withConf({});
   expect(archiveConfirmDescription('dashboard')).toBe(

--- a/superset-frontend/src/utils/softDeleteCopy.ts
+++ b/superset-frontend/src/utils/softDeleteCopy.ts
@@ -66,21 +66,21 @@ export function archiveConfirmDescription(
   if (days) {
     return plural
       ? t(
-          'These %(type)s will be moved to Recently Archived. You can recover them there within %(days)s days.',
+          'These %(type)s will be moved to Recently Archived in the Settings menu. You can recover them there within %(days)s days.',
           { type: typeLabel, days },
         )
       : t(
-          'This %(type)s will be moved to Recently Archived. You can recover it there within %(days)s days.',
+          'This %(type)s will be moved to Recently Archived in the Settings menu. You can recover it there within %(days)s days.',
           { type: typeLabel, days },
         );
   }
   return plural
     ? t(
-        'These %(type)s will be moved to Recently Archived. You can recover them there.',
+        'These %(type)s will be moved to Recently Archived in the Settings menu. You can recover them there.',
         { type: typeLabel },
       )
     : t(
-        'This %(type)s will be moved to Recently Archived. You can recover it there.',
+        'This %(type)s will be moved to Recently Archived in the Settings menu. You can recover it there.',
         { type: typeLabel },
       );
 }

--- a/superset-frontend/src/utils/softDeleteCopy.ts
+++ b/superset-frontend/src/utils/softDeleteCopy.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { escape } from 'lodash-es';
-import { t } from '@apache-superset/core/translation';
+import { t, tn } from '@apache-superset/core/translation';
 import { isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import getBootstrapData from 'src/utils/getBootstrapData';
 
@@ -62,15 +62,22 @@ export function archiveConfirmDescription(
   // Each case is a single, complete translation unit (rather than two joined
   // fragments) so translators control the whole sentence; only the noun and the
   // day count are interpolated, matching Superset's existing `%(...)s` usage.
+  // The timed variants pluralize on the day count (`tn`) because the retention
+  // window accepts 1: "within 1 days" is exactly the copy defect this module
+  // exists to prevent.
   const days = getSoftDeleteRetentionDays();
   if (days) {
     return plural
-      ? t(
+      ? tn(
+          'These %(type)s will be moved to Recently Archived in the Settings menu. You can recover them there within %(days)s day.',
           'These %(type)s will be moved to Recently Archived in the Settings menu. You can recover them there within %(days)s days.',
+          days,
           { type: typeLabel, days },
         )
-      : t(
+      : tn(
+          'This %(type)s will be moved to Recently Archived in the Settings menu. You can recover it there within %(days)s day.',
           'This %(type)s will be moved to Recently Archived in the Settings menu. You can recover it there within %(days)s days.',
+          days,
           { type: typeLabel, days },
         );
   }

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -13831,14 +13831,14 @@ msgstr ""
 
 #, python-format
 msgid ""
-"These %(type)s will be moved to Recently Archived. You can recover them "
-"there within %(days)s days."
+"These %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover them there within %(days)s days."
 msgstr ""
 
 #, python-format
 msgid ""
-"These %(type)s will be moved to Recently Archived. You can recover them "
-"there."
+"These %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover them there."
 msgstr ""
 
 msgid "These are the datasets this filter will be applied to."
@@ -13846,14 +13846,14 @@ msgstr ""
 
 #, python-format
 msgid ""
-"This %(type)s will be moved to Recently Archived. You can recover it "
-"there within %(days)s days."
+"This %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover it there within %(days)s days."
 msgstr ""
 
 #, python-format
 msgid ""
-"This %(type)s will be moved to Recently Archived. You can recover it "
-"there."
+"This %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover it there."
 msgstr ""
 
 msgid ""

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -13832,8 +13832,12 @@ msgstr ""
 #, python-format
 msgid ""
 "These %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover them there within %(days)s day."
+msgid_plural ""
+"These %(type)s will be moved to Recently Archived in the Settings menu. "
 "You can recover them there within %(days)s days."
-msgstr ""
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid ""
@@ -13847,8 +13851,12 @@ msgstr ""
 #, python-format
 msgid ""
 "This %(type)s will be moved to Recently Archived in the Settings menu. "
+"You can recover it there within %(days)s day."
+msgid_plural ""
+"This %(type)s will be moved to Recently Archived in the Settings menu. "
 "You can recover it there within %(days)s days."
-msgstr ""
+msgstr[0] ""
+msgstr[1] ""
 
 #, python-format
 msgid ""


### PR DESCRIPTION
### SUMMARY

With soft delete enabled, the archive confirmation told users their chart, dashboard, or dataset "will be moved to Recently Archived" without saying where that is. QA (SC-117152, TC-099/TC-101) compared the modal against the design of record and found the recovery-location hint missing — the one genuine usability gap among the diffs: a user reading only the modal had no way to know recovery lives under **Settings → Manage → Recently Archived**.

The confirmation body now names the location in all four variants (singular/plural, with and without a configured retention window):

> This chart will be moved to Recently Archived **in the Settings menu**. You can recover it there within 30 days.

Each variant remains a single, complete translation unit; only the noun and day count are interpolated. The four corresponding `messages.pot` msgids are updated in step.

**Terminology decision (recorded on the ticket):** "Archive / Recently Archived" is confirmed as the copy of record — it was chosen deliberately during the soft-delete rollout to keep recoverable deletion distinct from the "Delete permanently" purge action offered on the recovery page. The design node's "Delete / Recently Deleted" wording is the stale side and is being updated separately by design; that work does not block this change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Copy-only change; QA's before screenshots are attached to [SC-117152]. Before/after body text:

| | Body |
|---|---|
| Before | This chart will be moved to Recently Archived. You can recover it there within 30 days. |
| After | This chart will be moved to Recently Archived **in the Settings menu**. You can recover it there within 30 days. |

### TESTING INSTRUCTIONS

1. Enable `SOFT_DELETE`.
2. Trigger delete on a chart, dashboard, or dataset (single and bulk).
3. The confirmation body names the recovery location; title and button still read "Archive".
4. `npm run test -- src/utils/softDeleteCopy.test.ts` — 9 tests, expectations updated to the new copy.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [x] Required feature flags: `SOFT_DELETE` (copy renders only with the flag on; flag-off copy unchanged)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

This PR was developed with AI assistance (Claude Code); a human (@mikebridge) reviews before undrafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
