### PR TITLE
fix: update in the wild link on community page

### DIFF
--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -67,7 +67,7 @@ const communityLinks = [
       'Join our monthly virtual meetups and register for any upcoming events on Meetup',
   },
   {
-    url: 'https://github.com/apache/superset/blob/master/RESOURCES/INTHEWILD.md',
+    url: 'https://superset.apache.org/inTheWild/',
     title: 'Organizations',
     description:
       'A list of some of the organizations using Superset in production.',


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

On the community page, the in the wild link goes to an old github page that has been deleted. This is to point it back to the correct community page

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #43399
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
