### PR TITLE
fix(explore): honor column Label in filter search and pill

### DIFF
--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndAdhocFilterOption.tsx
@@ -60,7 +60,7 @@ export default function DndAdhocFilterOption({
       <OptionWrapper
         key={index}
         index={index}
-        label={actualTimeRange ?? adhocFilter.getDefaultLabel()}
+        label={actualTimeRange ?? adhocFilter.getDefaultLabel(options)}
         tooltipTitle={title ?? adhocFilter.getTooltipTitle()}
         clickClose={onClickClose}
         onShiftOptions={onShiftOptions}

--- a/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DndColumnSelectControl/DndFilterSelect.test.tsx
@@ -43,7 +43,7 @@ import {
   DndFilterSelectProps,
 } from 'src/explore/components/controls/DndColumnSelectControl/DndFilterSelect';
 import { PLACEHOLDER_DATASOURCE } from 'src/dashboard/constants';
-import { ExpressionTypes } from '../FilterControl/types';
+import { Clauses, ExpressionTypes } from '../FilterControl/types';
 import { DndItemType } from '../../DndItemType';
 import { Datasource } from '../../../types';
 import {
@@ -135,6 +135,35 @@ test('renders with value', async () => {
     store,
   });
   expect(await screen.findByText('COUNT(*)')).toBeInTheDocument();
+});
+
+test('renders the pill using the column verbose_name when one is set', async () => {
+  const value = new AdhocFilter({
+    expressionType: ExpressionTypes.Simple,
+    subject: 'num',
+    operator: '>',
+    comparator: '500',
+    clause: Clauses.Where,
+  });
+  render(
+    setup({
+      value,
+      columns: [
+        {
+          id: 1,
+          type: 'BIGINT',
+          type_generic: GenericDataType.Numeric,
+          column_name: 'num',
+          verbose_name: 'total_count',
+        },
+      ],
+    }),
+    {
+      useDndKit: true,
+      store,
+    },
+  );
+  expect(await screen.findByText('total_count > 500')).toBeInTheDocument();
 });
 
 test('renders options with saved metric', async () => {

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/AdhocFilter.test.ts
@@ -370,4 +370,32 @@ describe('AdhocFilter', () => {
     });
     expect(adhocFilter.getDefaultLabel()).toBe('');
   });
+  test('uses the column verbose_name in the label when one is given', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'num',
+      operator: '>',
+      comparator: '500',
+      clause: Clauses.Where,
+    });
+    expect(
+      adhocFilter.getDefaultLabel([
+        { column_name: 'num', verbose_name: 'total_count' },
+      ]),
+    ).toBe('total_count > 500');
+  });
+  test('falls back to the column_name when no verbose_name is set', () => {
+    const adhocFilter = new AdhocFilter({
+      expressionType: ExpressionTypes.Simple,
+      subject: 'num',
+      operator: '>',
+      comparator: '500',
+      clause: Clauses.Where,
+    });
+    expect(
+      adhocFilter.getDefaultLabel([{ column_name: 'num', verbose_name: '' }]),
+    ).toBe('num > 500');
+    expect(adhocFilter.getDefaultLabel([])).toBe('num > 500');
+    expect(adhocFilter.getDefaultLabel()).toBe('num > 500');
+  });
 });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
@@ -23,7 +23,7 @@ import {
   OPERATOR_ENUM_TO_OPERATOR_TYPE,
   Operators,
 } from 'src/explore/constants';
-import { translateToSql } from '../utils/translateToSQL';
+import { translateToSql, VerboseColumn } from '../utils/translateToSQL';
 import { Clauses, ExpressionTypes } from '../types';
 
 const CUSTOM_OPERATIONS = [...CUSTOM_OPERATORS].map(
@@ -193,8 +193,8 @@ export default class AdhocFilter {
     );
   }
 
-  getDefaultLabel(): string {
-    const label = this.translateToSql();
+  getDefaultLabel(columns?: VerboseColumn[]): string {
+    const label = this.translateToSql({ columns });
     return label.length < 43 ? label : `${label.substring(0, 40)}...`;
   }
 
@@ -202,8 +202,8 @@ export default class AdhocFilter {
     return this.translateToSql();
   }
 
-  translateToSql(): string {
-    return translateToSql(this as unknown as CoreAdhocFilter);
+  translateToSql(params: { columns?: VerboseColumn[] } = {}): string {
+    return translateToSql(this as unknown as CoreAdhocFilter, params);
   }
 }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/AdhocFilterEditPopoverSimpleTabContent.test.tsx
@@ -23,6 +23,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'spec/helpers/testing-library';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -913,4 +914,40 @@ test('dropdown should remain open when clicked after filter is configured', asyn
   });
 
   expect(operatorDropdown).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('filters the subject select by column verbose_name as well as column_name', async () => {
+  setup({
+    options: [
+      {
+        type: 'BIGINT',
+        column_name: 'num',
+        verbose_name: 'total_count',
+        id: 1,
+      },
+      {
+        type: 'VARCHAR(255)',
+        column_name: 'name',
+        verbose_name: 'Full Name',
+        id: 2,
+      },
+    ],
+  });
+
+  const combobox = screen.getByRole('combobox', { name: 'Select subject' });
+  userEvent.click(combobox);
+
+  await userEvent.type(combobox, 'total');
+
+  const dropdown = document.querySelector(
+    '.ant-select-dropdown-list',
+  ) as HTMLElement;
+  expect(within(dropdown).getByText('total_count')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Full Name')).not.toBeInTheDocument();
+
+  await userEvent.clear(combobox);
+  await userEvent.type(combobox, 'num');
+
+  expect(within(dropdown).getByText('total_count')).toBeInTheDocument();
+  expect(within(dropdown).queryByText('Full Name')).not.toBeInTheDocument();
 });

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -639,7 +639,11 @@ const AdhocFilterEditPopoverSimpleTabContent: FC<Props> = props => {
           ('optionName' in column && column.optionName) ||
           undefined,
         label: renderSubjectOptionLabel(column),
+        column_name: 'column_name' in column ? column.column_name : undefined,
+        verbose_name:
+          'verbose_name' in column ? column.verbose_name : undefined,
       }))}
+      optionFilterProps={['column_name', 'verbose_name']}
       {...subjectSelectProps}
     />
   );

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/AdhocFilterOption.test.tsx
@@ -71,6 +71,24 @@ test('should render the control label', async () => {
   expect(await screen.findByText('value > 10')).toBeInTheDocument();
 });
 
+test('should render the control label using the column verbose_name when one is set', async () => {
+  render(
+    setup({
+      ...mockedProps,
+      options: [
+        {
+          type: 'DOUBLE',
+          column_name: 'value',
+          verbose_name: 'total_count',
+          id: 3,
+        },
+      ],
+    }),
+    { useDnd: true, useRedux: true },
+  );
+  expect(await screen.findByText('total_count > 10')).toBeInTheDocument();
+});
+
 test('should render the remove button', async () => {
   render(setup(mockedProps), { useDnd: true, useRedux: true });
   const removeBtn = await screen.findByTestId('remove-control-button');

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterOption/index.tsx
@@ -65,7 +65,7 @@ export default function AdhocFilterOption({
       partitionColumn={partitionColumn ?? undefined}
     >
       <OptionControlLabel
-        label={actualTimeRange ?? adhocFilter.getDefaultLabel()}
+        label={actualTimeRange ?? adhocFilter.getDefaultLabel(options)}
         tooltipTitle={title ?? adhocFilter.getTooltipTitle()}
         onRemove={() =>
           onRemoveFilter({

--- a/superset-frontend/src/explore/components/controls/FilterControl/utils/translateToSQL.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/utils/translateToSQL.ts
@@ -63,9 +63,35 @@ export const OPERATORS_TO_SQL = {
     `= '{{ presto.latest_partition('${datasource.schema}.${datasource.datasource_name}') }}'`,
 };
 
+export interface VerboseColumn {
+  column_name?: string;
+  verbose_name?: string | null;
+}
+
+// Resolves the display label for a filter's subject: the verbose_name of the
+// matching column when one is supplied, falling back to the technical
+// subject used for SQL generation.
+const getDisplaySubject = (
+  subject: string | { column_name?: string } | null | undefined,
+  columns?: VerboseColumn[],
+) => {
+  if (!columns) {
+    return subject ?? undefined;
+  }
+  const columnName =
+    typeof subject === 'object' ? subject?.column_name : subject;
+  const verboseName = columns.find(
+    column => column.column_name === columnName,
+  )?.verbose_name;
+  return verboseName || (subject ?? undefined);
+};
+
 export const translateToSql = (
   adhocFilter: AdhocFilter,
-  { useSimple }: { useSimple: boolean } = { useSimple: false },
+  {
+    useSimple,
+    columns,
+  }: { useSimple?: boolean; columns?: VerboseColumn[] } = {},
 ) => {
   if (isSimpleAdhocFilter(adhocFilter) || useSimple) {
     const { subject, operator } = adhocFilter as SimpleAdhocFilter;
@@ -81,7 +107,11 @@ export const translateToSql = (
           OPERATORS_TO_SQL[operator](adhocFilter)
         : // @ts-expect-error TODO: fix missing operator type `NOT LIKE` and `TEMPORAL RANGE`.
           OPERATORS_TO_SQL[operator];
-    return getSimpleSQLExpression(subject, op, comparator);
+    return getSimpleSQLExpression(
+      getDisplaySubject(subject, columns),
+      op,
+      comparator,
+    );
   }
   if (isFreeFormAdhocFilter(adhocFilter)) {
     return adhocFilter.sqlExpression;


### PR DESCRIPTION
### SUMMARY
When a dataset column has a display Label (`verbose_name`) set, the Explore filter
control had two related display bugs:

- The filter column-picker's search box only matched the technical column name, not
  the Label, so searching for the Label text returned no results.
- After selecting a column by its Label, the saved filter pill showed the technical
  column name instead of the Label — inconsistent with the Metrics control in the
  same panel, which already displays the Label correctly for the same column.

The generated SQL and query results were already correct in both cases; this change
is a display/search-matching fix only. Both fixes mirror the existing, working
implementation already used by the Metrics control for the same column metadata.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Before:** searching a filter column by its Label returns no match; a saved filter pill
for a labeled column shows the technical column name (e.g. `num > 500`).

https://github.com/user-attachments/assets/2c570314-4783-402f-a9df-a9431920db2f

**After:** searching by Label matches the column; the saved filter pill shows the Label
(e.g. `total_count > 500`), matching how the Metrics control already displays it.
Evidence to follow as a comment on this PR.

https://github.com/user-attachments/assets/d5df5e0e-0b3f-4102-a434-9d0d031a7b4c

### TESTING INSTRUCTIONS
1. Edit a dataset column to set a display Label different from its technical name
   (e.g. the `birth_names` dataset's `num` column, Label `total_count`).
2. Open a chart built from that dataset in Explore and add a filter.
3. In the filter column-picker, search using the Label text — the column now appears
   in the results (previously it did not).
4. Select the column, set an operator and value, and save the filter.
5. Confirm the filter pill displays the Label (e.g. `total_count > 500`) rather than
   the technical column name.
6. Open the filter's Custom SQL tab and confirm it still shows the technical column
   name (e.g. `num > 500`) — the underlying query is unaffected by this change.
7. Repeat with a column that has no Label set and confirm search/display continue to
   use the technical column name exactly as before.

Automated coverage: `AdhocFilterEditPopoverSimpleTabContent.test.tsx`,
`AdhocFilter.test.ts`, `AdhocFilterOption.test.tsx`, `DndFilterSelect.test.tsx`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
