### PR TITLE
fix: upgrade js-yaml to patched versions (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -17782,9 +17782,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -26718,9 +26718,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27642,9 +27642,9 @@
       }
     },
     "node_modules/lerna/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -34730,9 +34730,9 @@
       }
     },
     "node_modules/react-diff-viewer-continued/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -38419,9 +38419,9 @@
       "license": "ISC"
     },
     "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Summary

`superset-frontend`'s Snyk scan flags `SNYK-JS-JSYAML-18593780` (js-yaml 4.3.0), which corresponds to [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption (`O(n^2)`) in `!!omap` resolution, a DoS reachable via a plain `yaml.load()` call on untrusted input with default options.

- Affected: js-yaml `>=4.0.0 <4.3.1` and `>=3.0.0 <3.15.1`
- Fixed in: **4.3.1** (4.x line) and **3.15.1** (3.x line), both published 2026-07-31
- Verified via npm dist-tags (`v4-legacy: 4.3.1`, `v3-legacy: 3.15.1`) and OSV, which reports 0 known vulnerabilities for js-yaml@4.3.1 vs. 1 for 4.3.0

### Why lockfile-only

Every consumer of js-yaml in this tree already declares a range that admits the patched version, so **no `package.json` change is needed**:

| Consumer | Declared range | Before | After |
|---|---|---|---|
| `overrides.lerna.js-yaml` | `^4.3.0` | 4.3.0 | 4.3.1 |
| `cosmiconfig@8.3.6` (root) | `^4.1.0` | 4.3.0 | 4.3.1 |
| `lerna`'s nested `cosmiconfig@9.0.0` | `^4.1.0` | 4.3.0 (deduped) | 4.3.1 (deduped) |
| `react-diff-viewer-continued@4.4.0` | `^4.2.0` | 4.3.0 | 4.3.1 |
| `stylelint`'s nested `cosmiconfig@9.0.2` | `^4.1.0` | 4.3.0 | 4.3.1 |
| `js-yaml-loader@1.2.2` / `@istanbuljs/load-nyc-config` (root, 3.x) | `^3.13.1` | 3.15.0 | 3.15.1 |

This intentionally avoids adding/broadening a `package.json` `overrides` entry. A prior attempt at a different transitive-dependency CVE fix (#42435) used a broad `overrides` block that crossed a major-version boundary into `lerna`'s pinned `minimatch@3.x` chain and broke `lint-frontend`/`validate-frontend` with `TypeError: expand is not a function` in `Minimatch.braceExpand`. That was fixed by a lockfile-only replacement (#42583). This PR follows the same minimal, lockfile-only pattern — it changes exactly 5 `js-yaml` entries in `package-lock.json` and nothing else.

### Test plan

- [x] `npm ls js-yaml --all` — every resolved instance is now `>= 4.3.1` (4.x line) or `3.15.1` (3.x line); see proof comment.
- [x] `git diff <merge-base> --stat` — only `superset-frontend/package-lock.json`, 15 insertions / 15 deletions.
- [x] `npx eslint --version` still resolves (v10.8.1) and a direct `minimatch`/`braceExpand` smoke check succeeds — confirms this PR does not reproduce the #42435 failure mode.
- [ ] CI (lint-frontend / validate-frontend / unit tests) — pending, will confirm here once CI reports.
