### PR TITLE
refactor(coordination): reliable Redis Streams await/notify (replace at-most-once pub/sub)

### DIFF
--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -295,13 +295,25 @@ high-performance distributed operations. This configuration enables:
 
 - **Distributed locking**: Moves lock operations from the metadata database to Redis, improving
   performance and reducing metastore load
-- **Real-time event notifications**: Enables instant pub/sub messaging for task abort signals and
-  completion notifications instead of polling-based approaches
+- **Reliable, event-driven notifications**: Task completion and abort signals are delivered over
+  Redis **Streams**, so waiters (sync join-and-wait, task-dependency DAGs, abort listeners) wake the
+  instant a signal lands instead of polling the metadata database. Streams provide guaranteed
+  delivery — a waiter that reads slightly late, reconnects, or survives a failover still receives the
+  signal — so it is reliable, not merely faster. Without this backend, these operations fall back to
+  reliable database polling.
 
 :::note
-This requires Redis or Valkey specifically—it uses Redis-specific features (pub/sub, `SET NX EX`)
-that are not available in general Flask-Caching backends.
+This requires Redis or Valkey specifically—it uses Redis-specific features (Streams, pub/sub,
+`SET NX EX`) that are not available in general Flask-Caching backends.
 :::
+
+Signal streams are capped to their latest entry and expire automatically so they cannot accumulate
+in Redis/Valkey. Tune the retention window with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (seconds,
+default 24 hours):
+
+```python
+DISTRIBUTED_COORDINATION_SIGNAL_TTL = 24 * 60 * 60
+```
 
 ### Configuration
 

--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -295,21 +295,20 @@ high-performance distributed operations. This configuration enables:
 
 - **Distributed locking**: Moves lock operations from the metadata database to Redis, improving
   performance and reducing metastore load
-- **Reliable, event-driven notifications**: Task completion and abort signals are delivered over
-  Redis **Streams**, so waiters (sync join-and-wait, task-dependency DAGs, abort listeners) wake the
-  instant a signal lands instead of polling the metadata database. Streams provide guaranteed
-  delivery — a waiter that reads slightly late, reconnects, or survives a failover still receives the
-  signal — so it is reliable, not merely faster. Without this backend, these operations fall back to
-  reliable database polling.
+- **Event-driven notifications**: Task completion and abort signals are delivered over Redis
+  **Streams**, so waiters (sync join-and-wait, task-dependency DAGs, abort listeners) wake when a
+  signal lands instead of polling the metadata database. Because stream entries are persisted, a
+  waiter that reads slightly late, reconnects, or fails over still receives the signal. Without this
+  backend, these operations poll the metadata database instead.
 
 :::note
 This requires Redis or Valkey specifically—it uses Redis-specific features (Streams, pub/sub,
 `SET NX EX`) that are not available in general Flask-Caching backends.
 :::
 
-Signal streams are capped to their latest entry and expire automatically so they cannot accumulate
-in Redis/Valkey. Tune the retention window with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (seconds,
-default 24 hours):
+Each signal stream keeps only its latest entry and is given a TTL, so signal streams for tasks that
+are never awaited do not accumulate in Redis/Valkey. Set the retention window with
+`DISTRIBUTED_COORDINATION_SIGNAL_TTL` (seconds, default 24 hours):
 
 ```python
 DISTRIBUTED_COORDINATION_SIGNAL_TTL = 24 * 60 * 60

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -403,7 +403,7 @@ The prune job only removes tasks in terminal states (`SUCCESS`, `FAILURE`, `ABOR
 See `superset/config.py` for a complete example configuration.
 
 :::tip Distributed Coordination for Faster Notifications
-By default, abort detection and sync join-and-wait poll the task row in the metadata database. Configure `DISTRIBUTED_COORDINATION_CONFIG` (Redis/Valkey) and these become event-driven: completion and abort are signalled over Redis **Streams**, so a waiter wakes the instant the signal lands and no longer polls the database. Streams give guaranteed delivery — a waiter that reads slightly late, reconnects, or survives a failover still receives the signal — so this is reliable, not just faster. The signal streams are short-lived and self-clean; tune retention with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (default 24h). See [Distributed Coordination Backend](/admin-docs/configuration/cache#signal-cache-backend) for configuration details.
+By default, abort detection and sync join-and-wait poll the task row in the metadata database. Configure `DISTRIBUTED_COORDINATION_CONFIG` (Redis/Valkey) and these become event-driven: completion and abort are signalled over Redis **Streams**, so a waiter wakes when the signal lands instead of polling the database. Because stream entries are persisted, a waiter that reads slightly late, reconnects, or fails over still receives the signal. Each signal stream keeps only its latest entry and is given a TTL, so streams for tasks that are never awaited do not accumulate; set the retention window with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (default 24h). See [Distributed Coordination Backend](/admin-docs/configuration/cache#signal-cache-backend) for configuration details.
 :::
 
 ## API Reference

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -403,7 +403,7 @@ The prune job only removes tasks in terminal states (`SUCCESS`, `FAILURE`, `ABOR
 See `superset/config.py` for a complete example configuration.
 
 :::tip Distributed Coordination for Faster Notifications
-By default, abort detection and sync join-and-wait use database polling. Configure `DISTRIBUTED_COORDINATION_CONFIG` to enable Redis pub/sub for real-time notifications. See [Distributed Coordination Backend](/admin-docs/configuration/cache#signal-cache-backend) for configuration details.
+By default, abort detection and sync join-and-wait poll the task row in the metadata database. Configure `DISTRIBUTED_COORDINATION_CONFIG` (Redis/Valkey) and these become event-driven: completion and abort are signalled over Redis **Streams**, so a waiter wakes the instant the signal lands and no longer polls the database. Streams give guaranteed delivery — a waiter that reads slightly late, reconnects, or survives a failover still receives the signal — so this is reliable, not just faster. The signal streams are short-lived and self-clean; tune retention with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (default 24h). See [Distributed Coordination Backend](/admin-docs/configuration/cache#signal-cache-backend) for configuration details.
 :::
 
 ## API Reference

--- a/superset/async_events/cache_backend.py
+++ b/superset/async_events/cache_backend.py
@@ -154,6 +154,47 @@ class RedisCacheBackend(RedisCache):
         count = count or self.MAX_EVENT_COUNT
         return self._cache.xrange(stream_name, start, end, count)
 
+    def xread(
+        self,
+        streams: dict[str, str],
+        count: int | None = None,
+        block_ms: int | None = None,
+    ) -> list[Any]:
+        """
+        Read new entries from one or more streams, optionally blocking.
+
+        Reliable, event-driven delivery: pass the last id already seen per stream
+        and this returns only entries added *after* it — so a signal is never
+        missed, even across reconnects (unlike pub/sub). ``block_ms`` blocks up to
+        that many milliseconds waiting for a new entry (``None``/``0`` returns
+        immediately).
+
+        :param streams: mapping of ``{stream_name: last_id_seen}``
+        :param count: max entries to return
+        :param block_ms: milliseconds to block for a new entry (``None`` = no block)
+        :returns: redis-py XREAD reply — ``[[stream, [(id, {field: value}), ...]]]``
+            — or an empty list when nothing arrived before the block elapsed
+        """
+        return self._cache.xread(streams, count=count, block=block_ms) or []
+
+    def stream_last_id(self, stream_name: str) -> str:
+        """
+        Return the id of the last entry in a stream, or ``"0-0"`` if it is empty.
+
+        Used to capture a baseline before waiting so a subsequent blocking
+        :meth:`xread` from that id catches every entry added afterwards — closing
+        the publish-before-subscribe race that pub/sub cannot.
+        """
+        entries = self._cache.xrevrange(stream_name, count=1)
+        if not entries:
+            return "0-0"
+        last_id = entries[0][0]
+        return last_id.decode() if isinstance(last_id, bytes) else last_id
+
+    def expire(self, name: str, seconds: int) -> bool:
+        """Set a TTL (seconds) on a key; used to bound signal-stream growth."""
+        return bool(self._cache.expire(name, seconds))
+
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> RedisCacheBackend:
         kwargs = {
@@ -346,6 +387,29 @@ class RedisSentinelCacheBackend(RedisSentinelCache):
     ) -> list[Any]:
         count = count or self.MAX_EVENT_COUNT
         return self._cache.xrange(stream_name, start, end, count)
+
+    def xread(
+        self,
+        streams: dict[str, str],
+        count: int | None = None,
+        block_ms: int | None = None,
+    ) -> list[Any]:
+        """Reliable, optionally-blocking stream read (see
+        :meth:`RedisCacheBackend.xread`)."""
+        return self._cache.xread(streams, count=count, block=block_ms) or []
+
+    def stream_last_id(self, stream_name: str) -> str:
+        """Return the last entry id, or ``"0-0"`` if empty (see
+        :meth:`RedisCacheBackend.stream_last_id`)."""
+        entries = self._cache.xrevrange(stream_name, count=1)
+        if not entries:
+            return "0-0"
+        last_id = entries[0][0]
+        return last_id.decode() if isinstance(last_id, bytes) else last_id
+
+    def expire(self, name: str, seconds: int) -> bool:
+        """Set a TTL (seconds) on a key; used to bound signal-stream growth."""
+        return bool(self._cache.expire(name, seconds))
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> RedisSentinelCacheBackend:

--- a/superset/config.py
+++ b/superset/config.py
@@ -3289,6 +3289,13 @@ TASK_PROGRESS_UPDATE_THROTTLE_INTERVAL = 2  # seconds
 # }
 DISTRIBUTED_COORDINATION_CONFIG: CacheConfig | None = None
 
+# Retention (seconds) for the Redis Streams the coordination service uses to deliver
+# signals (e.g. task completion/abort). Each signal is one short-lived stream entry
+# that a waiter consumes almost immediately; the TTL is a safety net so signal
+# streams for tasks that never get awaited cannot accumulate in Redis/Valkey
+# indefinitely. Defaults to 24 hours.
+DISTRIBUTED_COORDINATION_SIGNAL_TTL = int(timedelta(hours=24).total_seconds())
+
 # Default lock TTL (time-to-live) in seconds for distributed locks.
 # Can be overridden per-call via the `ttl_seconds` parameter.
 # After TTL expires, the lock is automatically released to prevent deadlocks.

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -26,9 +26,11 @@ import threading
 import time
 from typing import Any, Callable, TYPE_CHECKING, TypeVar
 
+from flask import current_app
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
 from superset.coordination.exceptions import CoordinationBackendUnavailableError
 from superset.coordination.types import SignalListener
-from superset.coordination.utils import close_pubsub
 
 if TYPE_CHECKING:
     from superset.coordination.types import CoordinationBackend
@@ -37,10 +39,21 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-# Poll cadence for the pub/sub wait loop: how long each ``get_message`` blocks
-# before the loop re-checks the predicate, the timeout, and the stop flag. Keeps
-# stop latency and missed-message recovery bounded to ~1s.
-_PUBSUB_TICK_SECONDS = 1.0
+# Reliable signalling uses Redis Streams: entries are persisted and replayable, so a
+# waiter still receives a signal if it subscribes slightly late, reconnects, or
+# survives a failover. A signal is a single stream entry; the caller-supplied
+# predicate stays the source of truth, so the stream only needs to retain its latest
+# entry briefly.
+_SIGNAL_STREAM_MAXLEN = 1
+# Fallback signal-stream retention (seconds) when the app config is unavailable;
+# operators tune it via ``DISTRIBUTED_COORDINATION_SIGNAL_TTL`` (default 24h).
+_DEFAULT_SIGNAL_STREAM_TTL_SECONDS = 86400
+# Blocking-XREAD chunk. The wait is event-driven — it returns the instant an entry
+# lands — so this only bounds how long each read parks before the loop re-checks the
+# deadline. Generous on purpose.
+_STREAM_BLOCK_MS = 5000
+# Shorter chunk for background listeners so stop() and signal detection stay prompt.
+_LISTEN_BLOCK_MS = 1000
 
 
 class CoordinationService:
@@ -48,19 +61,21 @@ class CoordinationService:
 
     Two layers of API:
 
-    - **Raw primitives** — ``publish``, ``get`` / ``set`` / ``delete``,
-      ``stream_add`` / ``stream_range``. These are backend-only and have no fallback:
-      they raise :class:`CoordinationBackendUnavailableError` when no backend is
-      available, rather than silently doing nothing. Each accepts an optional
-      ``backend`` so a caller with its own connection (Global Async Queries, during
-      the deprecation window) can run against it instead of the shared coordinator.
-    - **Higher-level await/notify** — ``wait_for_signal`` (blocking) and
-      ``listen_for_signal`` (background). These combine a pub/sub channel with a
-      caller-supplied predicate:
-      when a backend is defined they wake promptly on a published message and
-      re-check the predicate each tick; without a backend they poll the predicate.
-      This keeps the pub/sub-vs-poll boilerplate in one place; callers just supply a
-      channel and a check.
+    - **Raw primitives** — ``publish`` (best-effort, at-most-once pub/sub),
+      ``get`` / ``set`` / ``delete``, ``stream_add`` / ``stream_range``. These are
+      backend-only and have no fallback: they raise
+      :class:`CoordinationBackendUnavailableError` when no backend is available,
+      rather than silently doing nothing. Each accepts an optional ``backend`` so a
+      caller with its own connection (Global Async Queries, during the deprecation
+      window) can run against it instead of the shared coordinator.
+    - **Reliable await/notify** — ``notify`` (signal) plus ``wait_for_signal``
+      (blocking) and ``listen_for_signal`` (background), combining a channel with a
+      caller-supplied predicate. Signals ride Redis Streams, so a waiter that reads
+      slightly late, reconnects, or survives a failover still receives them (unlike
+      pub/sub). With a backend the waiter blocks on the stream and wakes the instant a
+      signal lands (event-driven, no polling); without a backend it polls the
+      predicate. The predicate is always the source of truth, so a duplicate or
+      already-seen signal is harmless. Callers just supply a channel and a check.
 
     All methods are class-level: the service is app-global. Calls resolve the shared
     coordination backend from ``DISTRIBUTED_COORDINATION_CONFIG`` on each call, except
@@ -132,11 +147,15 @@ class CoordinationService:
         message: str,
         backend: "CoordinationBackend | None" = None,
     ) -> int:
-        """Publish a message to a channel; returns the subscriber count.
+        """Best-effort pub/sub publish (**at-most-once** — may be lost).
 
-        Only publishing is offered here — subscribing needs the native connection
-        (a long-lived subscription with its own receive loop), so consumers that
-        subscribe should obtain it via :meth:`get_backend`.
+        Redis pub/sub does not persist messages: if no subscriber is connected at
+        publish time, or one disconnects/reconnects/fails over, the message is
+        *forever lost*. Use this **only** for loss-tolerant nudges. For any signal a
+        receiver must not miss (task completion, abort), use :meth:`notify`
+        (Redis Streams, guaranteed delivery) instead.
+
+        Only publishing is offered here — subscribing needs the native connection.
 
         :param backend: optional explicit backend (see :meth:`_require_backend`).
         :raises CoordinationBackendUnavailableError: if no backend is available.
@@ -226,6 +245,39 @@ class CoordinationService:
     # -- Await / notify ------------------------------------------------------
 
     @classmethod
+    def notify(
+        cls,
+        channel: str,
+        message: str = "1",
+        *,
+        ttl: int | None = None,
+        backend: "CoordinationBackend | None" = None,
+    ) -> None:
+        """Reliably signal ``channel`` so waiters wake and re-check.
+
+        Appends an entry to the channel's Redis Stream — guaranteed delivery: a
+        waiter that reads slightly late, reconnects, or survives a failover still
+        receives it — and gives the stream a TTL so signal streams for tasks that
+        are never awaited cannot accumulate in Redis/Valkey. Pair with
+        :meth:`wait_for_signal` / :meth:`listen_for_signal`.
+
+        :param message: small marker stored on the entry; the caller's predicate is
+            the source of truth, so this is only a wake-up nudge.
+        :param ttl: seconds to retain the signal stream; defaults to
+            ``DISTRIBUTED_COORDINATION_SIGNAL_TTL``.
+        :param backend: optional explicit backend (see :meth:`_require_backend`).
+        :raises CoordinationBackendUnavailableError: if no backend is available.
+        """
+        backend = cls._require_backend(backend)
+        if ttl is None:
+            ttl = current_app.config.get(
+                "DISTRIBUTED_COORDINATION_SIGNAL_TTL",
+                _DEFAULT_SIGNAL_STREAM_TTL_SECONDS,
+            )
+        backend.xadd(channel, {"m": message}, "*", _SIGNAL_STREAM_MAXLEN)
+        backend.expire(channel, ttl)
+
+    @classmethod
     def wait_for_signal(
         cls,
         channel: str,
@@ -236,62 +288,100 @@ class CoordinationService:
     ) -> T:
         """Block until ``check()`` returns a non-``None`` value; return that value.
 
-        ``check`` is the source of truth (typically a metastore read). When a
-        coordination backend is defined, this subscribes to ``channel`` and re-runs
-        ``check`` promptly whenever a message is published; otherwise it polls
-        ``check`` every ``poll_interval`` seconds. ``check`` is also re-evaluated on
-        every tick even in pub/sub mode, so a signal published before the subscription
-        (or a dropped message) is still caught.
+        ``check`` is the source of truth (typically a metastore read). With a
+        coordination backend, this waits on ``channel``'s Redis Stream and re-runs
+        ``check`` the instant a signal (:meth:`notify`) lands — event-driven, no
+        polling. Without a backend it polls ``check`` every ``poll_interval``
+        seconds.
 
-        :param channel: pub/sub channel that peers publish to when the awaited state
-            is reached (used only as a low-latency wake-up; correctness relies on
-            ``check``).
-        :param check: returns a truthy result once the wait is satisfied, else
-            ``None``.
+        :param channel: stream that peers :meth:`notify` when the awaited state is
+            reached.
+        :param check: returns a truthy result once satisfied, else ``None``.
         :param timeout: max seconds to wait; ``None`` waits indefinitely.
-        :param poll_interval: poll cadence when no backend is defined.
+        :param poll_interval: poll cadence for the no-backend fallback.
         :raises TimeoutError: if ``timeout`` elapses before ``check`` is satisfied.
         """
         deadline = None if timeout is None else time.monotonic() + timeout
-        # Check first, before touching the backend: if the awaited state is already
-        # reached (e.g. the task is already terminal), return straight from the
-        # source of truth so the fast path never requires the backend to be reachable.
+        # Fast path: already satisfied → return without touching the backend.
         if (result := check()) is not None:
             return result
         backend = cls.get_backend()
-        pubsub = backend.pubsub() if backend is not None else None
-        try:
-            if pubsub is not None:
-                pubsub.subscribe(channel)
-            while True:
-                # Re-check every tick even in pub/sub mode, so a signal published
-                # before the subscription (or a dropped message) is still caught.
-                if (result := check()) is not None:
-                    return result
-                remaining = (
-                    None if deadline is None else max(0.0, deadline - time.monotonic())
-                )
-                if remaining is not None and remaining <= 0:
-                    raise TimeoutError(f"Timed out waiting on channel {channel}")
-                cls._wait_tick(pubsub, poll_interval, remaining)
-        finally:
-            if pubsub is not None:
-                close_pubsub(pubsub)
+        if backend is None:
+            return cls._poll_until(channel, check, deadline, poll_interval)
+        # Capture the stream position, then re-check: a signal that lands between the
+        # fast-path check and now is caught here (peers write the authoritative state
+        # before they notify); anything after is delivered by the blocking read.
+        last_id = backend.stream_last_id(channel)
+        if (result := check()) is not None:
+            return result
+        while True:
+            remaining = cls._remaining(deadline, channel)
+            last_id = cls._read_stream(
+                backend,
+                channel,
+                last_id,
+                cls._bounded_block_ms(_STREAM_BLOCK_MS, remaining),
+            )
+            if (result := check()) is not None:
+                return result
 
     @staticmethod
-    def _wait_tick(pubsub: Any, poll_interval: float, remaining: float | None) -> None:
-        """Block for one wait tick: a pub/sub message (nudge) or a poll sleep."""
-        if pubsub is not None:
-            wait = (
-                _PUBSUB_TICK_SECONDS
-                if remaining is None
-                else min(_PUBSUB_TICK_SECONDS, remaining)
-            )
-            pubsub.get_message(ignore_subscribe_messages=True, timeout=wait)
-        else:
+    def _remaining(deadline: float | None, channel: str) -> float | None:
+        """Seconds left before ``deadline``; raise ``TimeoutError`` if already past."""
+        if deadline is None:
+            return None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"Timed out waiting on {channel}")
+        return remaining
+
+    @classmethod
+    def _poll_until(
+        cls,
+        channel: str,
+        check: Callable[[], T | None],
+        deadline: float | None,
+        poll_interval: float,
+    ) -> T:
+        """No-backend fallback: poll ``check`` every ``poll_interval`` seconds."""
+        while True:
+            remaining = cls._remaining(deadline, channel)
             time.sleep(
                 poll_interval if remaining is None else min(poll_interval, remaining)
             )
+            if (result := check()) is not None:
+                return result
+
+    @staticmethod
+    def _bounded_block_ms(block_ms: int, remaining: float | None) -> int:
+        """Clamp a blocking-read duration (ms) to the time left before the deadline."""
+        if remaining is None:
+            return block_ms
+        return max(1, min(block_ms, int(remaining * 1000)))
+
+    @classmethod
+    def _read_stream(
+        cls,
+        backend: "CoordinationBackend",
+        channel: str,
+        last_id: str,
+        block_ms: int,
+    ) -> str:
+        """Block for the next entry on ``channel``; return the new last-seen id.
+
+        A socket timeout mid-block means "nothing arrived yet": the caller re-checks
+        the predicate and reads again, so a short ``socket_timeout`` only affects
+        cadence, never correctness.
+        """
+        try:
+            entries = backend.xread({channel: last_id}, block_ms=block_ms)
+        except (RedisTimeoutError, OSError):
+            return last_id
+        for _stream, items in entries:
+            if items:
+                new_id = items[-1][0]
+                last_id = new_id.decode() if isinstance(new_id, bytes) else new_id
+        return last_id
 
     @classmethod
     def listen_for_signal(
@@ -305,36 +395,26 @@ class CoordinationService:
     ) -> SignalListener:
         """Run a background daemon that invokes ``on_signal`` once ``check`` is true.
 
-        Same wake-vs-poll model as :meth:`wait_for_signal`: a published message on
-        ``channel`` wakes the loop when a backend is defined, otherwise it polls
-        ``check`` every ``poll_interval`` seconds. The thread stops after firing
-        ``on_signal`` once, or when :meth:`SignalListener.stop` is called.
+        Same model as :meth:`wait_for_signal`: with a backend it waits on
+        ``channel``'s Redis Stream (event-driven); without one it polls ``check``
+        every ``poll_interval`` seconds. The thread stops after firing ``on_signal``
+        once, or when :meth:`SignalListener.stop` is called.
 
-        :param channel: pub/sub channel peers publish to when the condition is met.
+        :param channel: stream peers :meth:`notify` when the condition is met.
         :param check: returns ``True`` once ``on_signal`` should fire.
         :param on_signal: invoked (once) when ``check`` becomes true.
-        :param poll_interval: poll cadence when no backend is defined.
+        :param poll_interval: poll cadence for the no-backend fallback.
         :param name: optional thread name suffix for logging.
         """
         stop_event = threading.Event()
-        backend = cls.get_backend()
-        pubsub = backend.pubsub() if backend is not None else None
-        if pubsub is not None:
-            # Subscribe in the caller's thread so a connection failure surfaces here
-            # (fail-fast) rather than dying silently in the daemon thread.
-            try:
-                pubsub.subscribe(channel)
-            except Exception:
-                close_pubsub(pubsub)
-                raise
         thread = threading.Thread(
             target=cls._run_listen_loop,
-            args=(channel, check, on_signal, stop_event, poll_interval, pubsub),
+            args=(channel, check, on_signal, stop_event, poll_interval),
             daemon=True,
             name=f"coord-listen-{name or channel}",
         )
         thread.start()
-        return SignalListener(thread, stop_event, pubsub)
+        return SignalListener(thread, stop_event)
 
     @classmethod
     def _run_listen_loop(
@@ -344,37 +424,23 @@ class CoordinationService:
         on_signal: Callable[[], None],
         stop_event: threading.Event,
         poll_interval: float,
-        pubsub: Any,
     ) -> None:
         """Body of the background listener thread (see :meth:`listen_for_signal`)."""
+        backend = cls.get_backend()
+        # Baseline before the first check (see wait_for_signal), so a signal that
+        # lands between capturing it and the first check is not missed.
+        last_id = backend.stream_last_id(channel) if backend is not None else "0-0"
         try:
             while not stop_event.is_set():
-                try:
-                    if check():
-                        on_signal()
-                        return
-                    if pubsub is not None:
-                        # Blocks up to a tick; the message is just a wake-up nudge.
-                        pubsub.get_message(
-                            ignore_subscribe_messages=True,
-                            timeout=_PUBSUB_TICK_SECONDS,
-                        )
-                    else:
-                        stop_event.wait(timeout=poll_interval)
-                except (ValueError, OSError) as ex:
-                    # Connection torn down (e.g. stop() closing the subscription, or
-                    # shutdown). Expected when stopping; otherwise surface it and bail.
-                    if not stop_event.is_set():
-                        logger.error(
-                            "Signal listener on %s failed: %s",
-                            channel,
-                            ex,
-                            exc_info=True,
-                        )
+                if check():
+                    on_signal()
                     return
+                if backend is not None:
+                    last_id = cls._read_stream(
+                        backend, channel, last_id, _LISTEN_BLOCK_MS
+                    )
+                else:
+                    stop_event.wait(timeout=poll_interval)
         except Exception:  # pylint: disable=broad-except
             if not stop_event.is_set():
                 logger.exception("Signal listener on %s crashed", channel)
-        finally:
-            if pubsub is not None:
-                close_pubsub(pubsub)

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -48,9 +48,9 @@ _SIGNAL_STREAM_MAXLEN = 1
 # Fallback signal-stream retention (seconds) when the app config is unavailable;
 # operators tune it via ``DISTRIBUTED_COORDINATION_SIGNAL_TTL`` (default 24h).
 _DEFAULT_SIGNAL_STREAM_TTL_SECONDS = 86400
-# Blocking-XREAD chunk. The wait is event-driven — it returns the instant an entry
-# lands — so this only bounds how long each read parks before the loop re-checks the
-# deadline. Generous on purpose.
+# Blocking-XREAD chunk: how long each read parks before the loop re-checks the
+# deadline. The read returns as soon as an entry lands, so this only bounds the
+# no-signal wakeup cadence and can be generous.
 _STREAM_BLOCK_MS = 5000
 # Shorter chunk for background listeners so stop() and signal detection stay prompt.
 _LISTEN_BLOCK_MS = 1000
@@ -68,14 +68,14 @@ class CoordinationService:
       rather than silently doing nothing. Each accepts an optional ``backend`` so a
       caller with its own connection (Global Async Queries, during the deprecation
       window) can run against it instead of the shared coordinator.
-    - **Reliable await/notify** — ``notify`` (signal) plus ``wait_for_signal``
+    - **Await / notify** — ``notify`` (signal) plus ``wait_for_signal``
       (blocking) and ``listen_for_signal`` (background), combining a channel with a
-      caller-supplied predicate. Signals ride Redis Streams, so a waiter that reads
-      slightly late, reconnects, or survives a failover still receives them (unlike
-      pub/sub). With a backend the waiter blocks on the stream and wakes the instant a
-      signal lands (event-driven, no polling); without a backend it polls the
-      predicate. The predicate is always the source of truth, so a duplicate or
-      already-seen signal is harmless. Callers just supply a channel and a check.
+      caller-supplied predicate. Signals ride Redis Streams; because stream entries
+      are persisted, a waiter that reads slightly late, reconnects, or fails over
+      still receives them. With a backend the waiter blocks on the stream and wakes
+      when a signal lands (event-driven, no polling); without a backend it polls the
+      predicate. The predicate is the source of truth, so a duplicate or already-seen
+      signal is harmless.
 
     All methods are class-level: the service is app-global. Calls resolve the shared
     coordination backend from ``DISTRIBUTED_COORDINATION_CONFIG`` on each call, except
@@ -152,8 +152,8 @@ class CoordinationService:
         Redis pub/sub does not persist messages: if no subscriber is connected at
         publish time, or one disconnects/reconnects/fails over, the message is
         *forever lost*. Use this **only** for loss-tolerant nudges. For any signal a
-        receiver must not miss (task completion, abort), use :meth:`notify`
-        (Redis Streams, guaranteed delivery) instead.
+        receiver must not miss (task completion, abort), use :meth:`notify` (backed by
+        Redis Streams) instead.
 
         Only publishing is offered here — subscribing needs the native connection.
 
@@ -253,13 +253,13 @@ class CoordinationService:
         ttl: int | None = None,
         backend: "CoordinationBackend | None" = None,
     ) -> None:
-        """Reliably signal ``channel`` so waiters wake and re-check.
+        """Signal ``channel`` so waiters wake and re-check.
 
-        Appends an entry to the channel's Redis Stream — guaranteed delivery: a
-        waiter that reads slightly late, reconnects, or survives a failover still
-        receives it — and gives the stream a TTL so signal streams for tasks that
-        are never awaited cannot accumulate in Redis/Valkey. Pair with
-        :meth:`wait_for_signal` / :meth:`listen_for_signal`.
+        Appends an entry to the channel's Redis Stream. Because stream entries are
+        persisted, a waiter that reads slightly late, reconnects, or fails over still
+        receives it. The stream is capped to its latest entry and given a TTL, so
+        signal streams for tasks that are never awaited do not accumulate in
+        Redis/Valkey. Pair with :meth:`wait_for_signal` / :meth:`listen_for_signal`.
 
         :param message: small marker stored on the entry; the caller's predicate is
             the source of truth, so this is only a wake-up nudge.
@@ -290,7 +290,7 @@ class CoordinationService:
 
         ``check`` is the source of truth (typically a metastore read). With a
         coordination backend, this waits on ``channel``'s Redis Stream and re-runs
-        ``check`` the instant a signal (:meth:`notify`) lands — event-driven, no
+        ``check`` when a signal (:meth:`notify`) lands — event-driven, no
         polling. Without a backend it polls ``check`` every ``poll_interval``
         seconds.
 

--- a/superset/coordination/types.py
+++ b/superset/coordination/types.py
@@ -20,9 +20,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, TYPE_CHECKING
-
-from superset.coordination.utils import close_pubsub
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from superset.async_events.cache_backend import (
@@ -40,28 +38,22 @@ class SignalListener:
     """Handle for a background listener started by
     :meth:`~superset.coordination.base.CoordinationService.listen_for_signal`.
 
-    Wraps the daemon thread, its stop flag, and (in pub/sub mode) the subscription.
-    :meth:`stop` sets the flag and closes the subscription so a thread blocked in
-    ``get_message`` wakes immediately, then joins.
+    Wraps the daemon thread and its stop flag. :meth:`stop` sets the flag and joins;
+    the listener's bounded blocking read means it notices the flag within one short
+    tick.
     """
 
     def __init__(
         self,
         thread: threading.Thread,
         stop_event: threading.Event,
-        pubsub: Any = None,
     ) -> None:
         self._thread = thread
         self._stop_event = stop_event
-        self._pubsub = pubsub
 
     def stop(self) -> None:
         """Signal the listener to stop and wait briefly for the thread to finish."""
         self._stop_event.set()
-        # Closing the subscription unblocks a thread parked in get_message so
-        # teardown is near-immediate rather than waiting a full poll tick.
-        if self._pubsub is not None:
-            close_pubsub(self._pubsub)
         if self._thread.is_alive():
             self._thread.join(timeout=2.0)
             if self._thread.is_alive():

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -89,10 +89,15 @@ class TaskManager:
     @classmethod
     def publish_abort(cls, task_uuid: UUID) -> bool:
         """
-        Publish an abort message to the task's channel.
+        Signal that the task should abort so any abort listener wakes and re-checks.
+
+        Uses the coordination service's reliable stream-backed signal, so a listener
+        that reads slightly late still sees it. Best-effort: no-op (returns False)
+        when no coordination backend is configured, in which case listeners poll the
+        task row instead.
 
         :param task_uuid: UUID of the task to abort
-        :returns: True if message was published, False if Redis unavailable
+        :returns: True if the signal was emitted, False if no backend / Redis error
         """
         from superset.coordination.base import CoordinationService
 
@@ -101,15 +106,11 @@ class TaskManager:
 
         try:
             channel = cls.get_abort_channel(task_uuid)
-            subscriber_count = CoordinationService.publish(channel, "abort")
-            logger.debug(
-                "Published abort to channel %s (%d subscribers)",
-                channel,
-                subscriber_count,
-            )
+            CoordinationService.notify(channel, "abort")
+            logger.debug("Signalled abort on %s", channel)
             return True
         except redis.RedisError as ex:
-            logger.error("Failed to publish abort for task %s: %s", task_uuid, ex)
+            logger.error("Failed to signal abort for task %s: %s", task_uuid, ex)
             return False
 
     @classmethod
@@ -125,14 +126,18 @@ class TaskManager:
     @classmethod
     def publish_completion(cls, task_uuid: UUID, status: str) -> bool:
         """
-        Publish a completion message to the task's channel.
+        Signal task completion so any waiter wakes and re-checks.
 
-        Called when task reaches terminal state (SUCCESS, FAILURE, ABORTED, TIMED_OUT).
-        This notifies any waiters (e.g., sync callers waiting for an existing task).
+        Called when the task reaches a terminal state (SUCCESS, FAILURE, ABORTED,
+        TIMED_OUT); notifies waiters (e.g. sync join-and-wait, DAG dependents). Uses
+        the coordination service's reliable stream-backed signal so a waiter that
+        reads slightly late, reconnects, or survives a failover still sees it.
+        Best-effort: no-op (returns False) when no coordination backend is
+        configured, in which case waiters poll the task row instead.
 
         :param task_uuid: UUID of the completed task
         :param status: Final status of the task
-        :returns: True if message was published, False if Redis unavailable
+        :returns: True if the signal was emitted, False if no backend / Redis error
         """
         from superset.coordination.base import CoordinationService
 
@@ -141,16 +146,11 @@ class TaskManager:
 
         try:
             channel = cls.get_completion_channel(task_uuid)
-            subscriber_count = CoordinationService.publish(channel, status)
-            logger.debug(
-                "Published completion to channel %s (status=%s, %d subscribers)",
-                channel,
-                status,
-                subscriber_count,
-            )
+            CoordinationService.notify(channel, status)
+            logger.debug("Signalled completion on %s (status=%s)", channel, status)
             return True
         except redis.RedisError as ex:
-            logger.error("Failed to publish completion for task %s: %s", task_uuid, ex)
+            logger.error("Failed to signal completion for task %s: %s", task_uuid, ex)
             return False
 
     @classmethod

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -48,8 +48,9 @@ class TaskManager:
     3. Handling deduplication (returning existing active task if duplicate)
     4. Managing real-time abort notifications (optional)
 
-    Redis pub/sub is opt-in via DISTRIBUTED_COORDINATION_CONFIG configuration. When not
-    configured, tasks use database polling for abort detection.
+    Signal delivery is opt-in via DISTRIBUTED_COORDINATION_CONFIG. When configured,
+    completion/abort are delivered over Redis Streams; when not, tasks use database
+    polling for abort detection and completion waits.
     """
 
     # Class-level state (initialized once via init_app)
@@ -91,10 +92,10 @@ class TaskManager:
         """
         Signal that the task should abort so any abort listener wakes and re-checks.
 
-        Uses the coordination service's reliable stream-backed signal, so a listener
-        that reads slightly late still sees it. Best-effort: no-op (returns False)
-        when no coordination backend is configured, in which case listeners poll the
-        task row instead.
+        Emits the abort signal through the coordination service (Redis Streams when
+        a backend is configured), so an abort listener wakes and re-checks. Best-effort:
+        no-op (returns False) when no coordination backend is configured, in which case
+        listeners poll the task row instead.
 
         :param task_uuid: UUID of the task to abort
         :returns: True if the signal was emitted, False if no backend / Redis error
@@ -129,11 +130,10 @@ class TaskManager:
         Signal task completion so any waiter wakes and re-checks.
 
         Called when the task reaches a terminal state (SUCCESS, FAILURE, ABORTED,
-        TIMED_OUT); notifies waiters (e.g. sync join-and-wait, DAG dependents). Uses
-        the coordination service's reliable stream-backed signal so a waiter that
-        reads slightly late, reconnects, or survives a failover still sees it.
-        Best-effort: no-op (returns False) when no coordination backend is
-        configured, in which case waiters poll the task row instead.
+        TIMED_OUT); wakes waiters (e.g. sync join-and-wait, DAG dependents) through
+        the coordination service (Redis Streams when a backend is configured).
+        Best-effort: no-op (returns False) when no coordination backend is configured,
+        in which case waiters poll the task row instead.
 
         :param task_uuid: UUID of the completed task
         :param status: Final status of the task
@@ -164,7 +164,7 @@ class TaskManager:
         """
         Block until task reaches terminal state.
 
-        Delegates the pub/sub-wake-else-poll orchestration to
+        Delegates the wake-else-poll orchestration to
         :meth:`CoordinationService.wait_for_signal`; here we only supply the
         completion channel and a metastore predicate that returns the task once it is
         terminal.

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -111,7 +111,9 @@ class TaskManager:
             logger.debug("Signalled abort on %s", channel)
             return True
         except redis.RedisError as ex:
-            logger.error("Failed to signal abort for task %s: %s", task_uuid, ex)
+            # Best-effort: listeners fall back to polling, so a transient Redis
+            # error here is not a correctness problem.
+            logger.warning("Failed to signal abort for task %s: %s", task_uuid, ex)
             return False
 
     @classmethod
@@ -150,7 +152,9 @@ class TaskManager:
             logger.debug("Signalled completion on %s (status=%s)", channel, status)
             return True
         except redis.RedisError as ex:
-            logger.error("Failed to signal completion for task %s: %s", task_uuid, ex)
+            # Best-effort: waiters fall back to polling, so a transient Redis
+            # error here is not a correctness problem.
+            logger.warning("Failed to signal completion for task %s: %s", task_uuid, ex)
             return False
 
     @classmethod

--- a/tests/unit_tests/async_events/test_cache_backend.py
+++ b/tests/unit_tests/async_events/test_cache_backend.py
@@ -173,3 +173,30 @@ def test_redis_cache_backend_stream_helpers(mocker: MockerFixture) -> None:
     client.expire.return_value = 1
     assert backend.expire("s", 60) is True
     client.expire.assert_called_once_with("s", 60)
+
+
+def test_redis_sentinel_cache_backend_stream_helpers(mocker: MockerFixture) -> None:
+    """Sentinel backend routes the new stream helpers through its master client."""
+    from superset.async_events.cache_backend import RedisSentinelCacheBackend
+
+    sentinel_mock = mocker.patch("superset.async_events.cache_backend.Sentinel")
+    master = mock.Mock()
+    sentinel_mock.return_value.master_for.return_value = master
+    backend = RedisSentinelCacheBackend(
+        sentinels=[("sentinel1", 26379)], master="mymaster"
+    )
+
+    master.xread.return_value = [["s", [(b"1-0", {})]]]
+    assert backend.xread({"s": "0-0"}, count=5, block_ms=100) == [["s", [(b"1-0", {})]]]
+    master.xread.assert_called_once_with({"s": "0-0"}, count=5, block=100)
+    master.xread.return_value = None
+    assert backend.xread({"s": "0-0"}) == []
+
+    master.xrevrange.return_value = [(b"5-0", {b"m": b"x"})]
+    assert backend.stream_last_id("s") == "5-0"
+    master.xrevrange.return_value = []
+    assert backend.stream_last_id("s") == "0-0"
+
+    master.expire.return_value = 1
+    assert backend.expire("s", 60) is True
+    master.expire.assert_called_once_with("s", 60)

--- a/tests/unit_tests/async_events/test_cache_backend.py
+++ b/tests/unit_tests/async_events/test_cache_backend.py
@@ -146,3 +146,30 @@ def test_redis_sentinel_cache_backend_from_config_reads_timeout_keys(
     assert master_kwargs["protocol"] == 2
     assert master_kwargs["socket_timeout"] == 20
     assert master_kwargs["socket_connect_timeout"] == 4
+
+
+def test_redis_cache_backend_stream_helpers(mocker: MockerFixture) -> None:
+    """xread / stream_last_id / expire delegate to the redis client correctly."""
+    from superset.async_events.cache_backend import RedisCacheBackend
+
+    redis_mock = mocker.patch("superset.async_events.cache_backend.redis")
+    client = redis_mock.Redis.return_value
+    backend = RedisCacheBackend(host="localhost", port=6379)
+
+    # xread passes block/count through and coalesces a None reply to []
+    client.xread.return_value = [["s", [(b"1-0", {})]]]
+    assert backend.xread({"s": "0-0"}, count=5, block_ms=100) == [["s", [(b"1-0", {})]]]
+    client.xread.assert_called_once_with({"s": "0-0"}, count=5, block=100)
+    client.xread.return_value = None
+    assert backend.xread({"s": "0-0"}) == []
+
+    # stream_last_id decodes the bytes id, and returns "0-0" for an empty stream
+    client.xrevrange.return_value = [(b"5-0", {b"m": b"x"})]
+    assert backend.stream_last_id("s") == "5-0"
+    client.xrevrange.return_value = []
+    assert backend.stream_last_id("s") == "0-0"
+
+    # expire delegates and coerces the reply to bool
+    client.expire.return_value = 1
+    assert backend.expire("s", 60) is True
+    client.expire.assert_called_once_with("s", 60)

--- a/tests/unit_tests/coordination/test_service.py
+++ b/tests/unit_tests/coordination/test_service.py
@@ -80,6 +80,7 @@ def test_backend_only_ops_raise_when_backend_unavailable(
 
     for op in (
         lambda: CoordinationService.publish("channel", "msg"),
+        lambda: CoordinationService.notify("channel", "msg"),
         lambda: CoordinationService.get_value("key"),
         lambda: CoordinationService.set_value("key", "value"),
         lambda: CoordinationService.delete_value("key"),
@@ -165,26 +166,69 @@ def test_wait_for_signal_times_out(app_context: None, mocker: MockerFixture) -> 
         )
 
 
-def test_wait_for_signal_wakes_via_pubsub_and_cleans_up(
+def test_notify_appends_to_stream_with_ttl(
     app_context: None, mocker: MockerFixture
 ) -> None:
     backend = mocker.MagicMock(name="backend")
-    pubsub = mocker.MagicMock(name="pubsub")
-    backend.pubsub.return_value = pubsub
+    _patch_distributed_coordination(mocker, backend)
+
+    CoordinationService.notify("ch", "done", ttl=60)
+
+    backend.xadd.assert_called_once_with("ch", {"m": "done"}, "*", 1)
+    backend.expire.assert_called_once_with("ch", 60)
+
+
+def test_notify_uses_config_ttl_by_default(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    backend = mocker.MagicMock(name="backend")
+    _patch_distributed_coordination(mocker, backend)
+    mocker.patch.dict(
+        "flask.current_app.config", {"DISTRIBUTED_COORDINATION_SIGNAL_TTL": 123}
+    )
+
+    CoordinationService.notify("ch")
+
+    backend.expire.assert_called_once_with("ch", 123)
+
+
+def test_wait_for_signal_wakes_via_stream(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    backend = mocker.MagicMock(name="backend")
+    backend.stream_last_id.return_value = "0-0"
+    # A blocking xread returns a new entry, waking the predicate re-check.
+    backend.xread.return_value = [["ch", [("1-0", {"m": "done"})]]]
     mocker.patch.object(CoordinationService, "get_backend", return_value=backend)
-    # First check (pre-subscribe fast path) is None, so we subscribe; the next None
-    # forces one pub/sub nudge, then "done" satisfies the wait.
+    # fast-path None, post-baseline re-check None, then "done" after the stream read.
     results = iter([None, None, "done"])
 
     result = CoordinationService.wait_for_signal(
         "ch", lambda: next(results), timeout=5.0
     )
     assert result == "done"
-    pubsub.subscribe.assert_called_once_with("ch")
-    # One wake-up nudge between the post-subscribe (None) and final (done) check.
-    pubsub.get_message.assert_called_once()
-    pubsub.unsubscribe.assert_called_once()
-    pubsub.close.assert_called_once()
+    backend.stream_last_id.assert_called_once_with("ch")
+    backend.xread.assert_called_once()
+
+
+def test_wait_for_signal_stream_socket_timeout_is_retried(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    from redis.exceptions import TimeoutError as RedisTimeoutError
+
+    backend = mocker.MagicMock(name="backend")
+    backend.stream_last_id.return_value = "0-0"
+    # A socket timeout mid-block is treated as "nothing yet": the loop re-checks and
+    # reads again rather than erroring.
+    backend.xread.side_effect = [RedisTimeoutError("blocked"), [["ch", [("1-0", {})]]]]
+    mocker.patch.object(CoordinationService, "get_backend", return_value=backend)
+    results = iter([None, None, None, "done"])
+
+    result = CoordinationService.wait_for_signal(
+        "ch", lambda: next(results), timeout=5.0
+    )
+    assert result == "done"
+    assert backend.xread.call_count == 2
 
 
 def test_wait_for_signal_already_satisfied_skips_backend(

--- a/tests/unit_tests/coordination/test_service.py
+++ b/tests/unit_tests/coordination/test_service.py
@@ -21,7 +21,7 @@ import threading
 import pytest
 from pytest_mock import MockerFixture
 
-from superset.coordination.base import CoordinationService
+from superset.coordination.base import _SIGNAL_STREAM_MAXLEN, CoordinationService
 from superset.coordination.exceptions import CoordinationBackendUnavailableError
 from superset.coordination.types import SignalListener
 
@@ -174,7 +174,9 @@ def test_notify_appends_to_stream_with_ttl(
 
     CoordinationService.notify("ch", "done", ttl=60)
 
-    backend.xadd.assert_called_once_with("ch", {"m": "done"}, "*", 1)
+    backend.xadd.assert_called_once_with(
+        "ch", {"m": "done"}, "*", _SIGNAL_STREAM_MAXLEN
+    )
     backend.expire.assert_called_once_with("ch", 60)
 
 
@@ -271,6 +273,24 @@ def test_listen_does_not_fire_when_condition_never_met(
     )
     listener.stop()
     on_signal.assert_not_called()
+
+
+def test_listen_fires_via_stream(app_context: None, mocker: MockerFixture) -> None:
+    backend = mocker.MagicMock(name="backend")
+    backend.stream_last_id.return_value = "0-0"
+    backend.xread.return_value = [["ch", [("1-0", {"m": "abort"})]]]
+    mocker.patch.object(CoordinationService, "get_backend", return_value=backend)
+    fired = threading.Event()
+    # First check is False (so the loop reads the stream), then True after the signal.
+    checks = iter([False, True])
+
+    listener = CoordinationService.listen_for_signal(
+        "ch", check=lambda: next(checks), on_signal=fired.set, poll_interval=0.01
+    )
+    assert fired.wait(timeout=2.0) is True
+    listener.stop()
+    backend.stream_last_id.assert_called_once_with("ch")
+    backend.xread.assert_called()
 
 
 def test_signal_listener_stop_signals_and_joins(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -114,16 +114,19 @@ class TestTaskManagerPublish:
     @patch(GET_BACKEND)
     def test_publish_abort_success(self, mock_get_backend):
         backend = MagicMock()
-        backend.publish.return_value = 1
+        backend.xadd.return_value = "1-0"
         mock_get_backend.return_value = backend
 
         assert TaskManager.publish_abort("test-uuid") is True
-        backend.publish.assert_called_once_with("gtf:abort:test-uuid", "abort")
+        backend.xadd.assert_called_once_with(
+            "gtf:abort:test-uuid", {"m": "abort"}, "*", 1
+        )
+        backend.expire.assert_called_once()
 
     @patch(GET_BACKEND)
     def test_publish_abort_redis_error(self, mock_get_backend):
         backend = MagicMock()
-        backend.publish.side_effect = redis.RedisError("Connection lost")
+        backend.xadd.side_effect = redis.RedisError("Connection lost")
         mock_get_backend.return_value = backend
 
         assert TaskManager.publish_abort("test-uuid") is False
@@ -135,16 +138,19 @@ class TestTaskManagerPublish:
     @patch(GET_BACKEND)
     def test_publish_completion_success(self, mock_get_backend):
         backend = MagicMock()
-        backend.publish.return_value = 1
+        backend.xadd.return_value = "1-0"
         mock_get_backend.return_value = backend
 
         assert TaskManager.publish_completion("test-uuid", "success") is True
-        backend.publish.assert_called_once_with("gtf:complete:test-uuid", "success")
+        backend.xadd.assert_called_once_with(
+            "gtf:complete:test-uuid", {"m": "success"}, "*", 1
+        )
+        backend.expire.assert_called_once()
 
     @patch(GET_BACKEND)
     def test_publish_completion_redis_error(self, mock_get_backend):
         backend = MagicMock()
-        backend.publish.side_effect = redis.RedisError("Connection lost")
+        backend.xadd.side_effect = redis.RedisError("Connection lost")
         mock_get_backend.return_value = backend
 
         assert TaskManager.publish_completion("test-uuid", "success") is False
@@ -242,23 +248,29 @@ class TestTaskManagerWaitForCompletion:
 
     @patch(GET_BACKEND)
     @patch("superset.daos.tasks.TaskDAO")
-    def test_pubsub_success_subscribes_and_cleans_up(self, mock_dao, mock_get_backend):
+    def test_stream_success_reads_and_returns(self, mock_dao, mock_get_backend):
         pending = MagicMock()
         pending.status = "pending"
         complete = MagicMock()
         complete.status = "success"
-        # find_one_or_none is called for: the existence check, the pre-subscribe fast
-        # path (still pending → we subscribe), then the post-subscribe check (success).
-        mock_dao.find_one_or_none.side_effect = [pending, pending, complete]
+        # find_one_or_none: existence check, fast-path (pending), post-baseline
+        # re-check (pending), then after the stream read (success).
+        mock_dao.find_one_or_none.side_effect = [
+            pending,
+            pending,
+            pending,
+            complete,
+        ]
 
         backend = MagicMock()
-        pubsub = MagicMock()
-        backend.pubsub.return_value = pubsub
+        backend.stream_last_id.return_value = "0-0"
+        backend.xread.return_value = [
+            ["gtf:complete:test-uuid", [("1-0", {"m": "success"})]]
+        ]
         mock_get_backend.return_value = backend
 
         result = TaskManager.wait_for_completion("test-uuid", timeout=5.0)
 
         assert result.status == "success"
-        pubsub.subscribe.assert_called_once_with("gtf:complete:test-uuid")
-        pubsub.unsubscribe.assert_called_once()
-        pubsub.close.assert_called_once()
+        backend.stream_last_id.assert_called_once_with("gtf:complete:test-uuid")
+        backend.xread.assert_called_once()


### PR DESCRIPTION
> **Part of the [GAQ→GTF epic](https://github.com/apache/superset/pull/43407)** — the **coordination cleanup ("C")** step, targeting the `gaq-to-gtf` feature branch.

### SUMMARY

Moves the coordination service's await/notify off **at-most-once pub/sub** onto **Redis Streams** (guaranteed delivery), and migrates GTF task completion/abort onto it.

**Why.** Redis Pub/Sub is documented *at-most-once / fire-and-forget* — "if the subscriber is unable to handle the message (for example, due to an error or a network disconnect) the message is forever lost." To stay correct on top of that, the old `wait_for_signal` treated a published message as a mere nudge and **re-read the task row every ~1s** as a backstop — i.e. it degraded to polling even when Redis was available (and each poll loaded the full `Task` ORM). Redis's own recommendation for guaranteed delivery is **Streams** (persisted, replayable), which lets the wait be genuinely event-driven with no busy-poll.

**What changed.**
- **`CoordinationService.notify(channel)`** appends a signal to the channel's Redis Stream (`MAXLEN 1` + TTL). Guaranteed delivery: a waiter that reads slightly late, reconnects, or survives a failover still sees it.
- **`wait_for_signal` / `listen_for_signal`** block on the stream (event-driven, **no polling**) when `DISTRIBUTED_COORDINATION_CONFIG` is set — capturing a baseline id first so no signal is missed (race-free). Without a backend they poll the caller's predicate exactly as before. The predicate stays the source of truth, so a duplicate/late signal is harmless.
- **`TaskManager.publish_completion` / `publish_abort`** emit via `notify` (streams).
- **Pub/Sub (`publish`) is retained only as an explicit best-effort, at-most-once nudge** — documented as such — and is no longer used for awaiting. `SignalListener` no longer wraps a subscription.
- New backend primitives `xread` (blocking), `stream_last_id` (baseline), `expire`; and config **`DISTRIBUTED_COORDINATION_SIGNAL_TTL`** (default 24h) bounds signal-stream retention so streams for never-awaited tasks cannot accumulate.

**Delivery model (documented).** Streams for anything that must be delivered (task completion/abort — the typical case); pub/sub only for loss-tolerant nudges; DB polling as the no-backend fallback. Docs updated in the GTF developer guide and the cache admin guide.

### BEFORE / AFTER

- **Before:** backend present → wake on a lossy pub/sub message + re-read the full Task ORM every ~1s as a delivery backstop.
- **After:** backend present → block on the stream, wake the instant the signal lands, zero polling; delivery guaranteed. No backend → reliable predicate polling (unchanged).

### TESTING INSTRUCTIONS

- Unit (green locally, 396 across the affected suites): `tests/unit_tests/coordination/test_service.py` (notify + stream wait + socket-timeout retry), `tests/unit_tests/tasks/test_manager.py` (completion/abort via streams, stream wait), `tests/unit_tests/async_events/test_cache_backend.py` (xread/stream_last_id/expire).
- Manual (live Redis/Valkey): with `DISTRIBUTED_COORDINATION_CONFIG` set, run a sync join-and-wait / a task DAG and confirm dependents wake promptly with no per-second DB reads; confirm signal stream keys (`gtf:complete:*`, `gtf:abort:*`) carry a TTL and self-expire.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Required feature flags: `GLOBAL_TASK_FRAMEWORK`
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API (`CoordinationService.notify`; `DISTRIBUTED_COORDINATION_SIGNAL_TTL` config)
- [ ] Removes existing feature or API

_Note: the whole-project frontend type-check has pre-existing failures unrelated to this change._
