### PR TITLE
feat(common): canonical single-query serialization for async chart data

### DIFF
--- a/superset/common/query_serialization.py
+++ b/superset/common/query_serialization.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Canonical, JSON-safe serialization of a single chart-data query.
+
+A chart-data request is a query *context* wrapping N ``QueryObject`` s over one
+datasource. To run a single query on its own (e.g. as an async task), we need a
+self-contained, JSON-safe payload that reconstructs to an identical query — one
+that yields the same ``query_cache_key``, so the reconstructed query reads and
+writes the same DATA-cache entry as the synchronous path.
+
+The payload is the *raw* query dict (the schema-shaped input, as stored in
+``QueryContext.cache_values["queries"]``) plus the context-level inputs needed to
+rebuild it: ``datasource``, ``form_data``, ``result_type``/``result_format``, and
+``force``/``custom_cache_timeout``. Reconstruction feeds these straight back into
+:class:`~superset.common.query_context_factory.QueryContextFactory`, i.e. the same
+path that produced the original key. This avoids serializing the *processed*
+``QueryObject`` (whose ``to_dict()`` emits raw datetimes, renames ``filters`` to
+``filter``, and drops ``time_range``/``datasource``/``result_type``), which would
+not rebuild to the same key.
+
+The raw query and datasource dicts originate from JSON (the HTTP body or
+``Slice.query_context``), so the payload contains only JSON-native types and needs
+no custom encoder.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING, TypedDict
+
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.utils.core import DatasourceDict
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
+
+
+class SerializedQuery(TypedDict):
+    """JSON-safe, self-contained representation of one chart-data query."""
+
+    datasource: DatasourceDict
+    query: dict[str, Any]
+    form_data: dict[str, Any] | None
+    result_type: str
+    result_format: str
+    force: bool
+    custom_cache_timeout: int | None
+
+
+def serialize_query(query_context: "QueryContext", query_index: int) -> SerializedQuery:
+    """Serialize the query at ``query_index`` into a JSON-safe payload.
+
+    Reads the *raw* query dict from ``cache_values`` (not the processed
+    ``QueryObject``) so the payload rebuilds to an identical ``query_cache_key``.
+    ``force`` and ``custom_cache_timeout`` are carried explicitly — they live on
+    the context, not the query, and would otherwise be lost per query.
+
+    :param query_context: the source query context
+    :param query_index: index of the query within ``query_context.queries``
+    :returns: a JSON-safe :class:`SerializedQuery`
+    """
+    cache_values = query_context.cache_values
+    return SerializedQuery(
+        datasource=cache_values["datasource"],
+        query=cache_values["queries"][query_index],
+        form_data=query_context.form_data,
+        result_type=ChartDataResultType(query_context.result_type).value,
+        result_format=ChartDataResultFormat(query_context.result_format).value,
+        force=query_context.force,
+        custom_cache_timeout=query_context.custom_cache_timeout,
+    )
+
+
+def load_serialized_query(payload: SerializedQuery) -> "QueryContext":
+    """Reconstruct a single-query :class:`QueryContext` from a serialized payload.
+
+    Feeds the payload back through :class:`QueryContextFactory`, the same path
+    that produced the original context, so the resulting query's
+    ``query_cache_key`` matches the original. The returned context holds exactly
+    one query; run it via ``QueryContextProcessor.get_df_payload_result``.
+
+    :param payload: a :class:`SerializedQuery` produced by :func:`serialize_query`
+    :returns: a query context containing the single reconstructed query
+    """
+    from superset.common.query_context_factory import QueryContextFactory
+
+    return QueryContextFactory().create(
+        datasource=payload["datasource"],
+        queries=[payload["query"]],
+        form_data=payload["form_data"],
+        result_type=ChartDataResultType(payload["result_type"]),
+        result_format=ChartDataResultFormat(payload["result_format"]),
+        force=payload["force"],
+        custom_cache_timeout=payload["custom_cache_timeout"],
+    )

--- a/tests/integration_tests/query_context_tests.py
+++ b/tests/integration_tests/query_context_tests.py
@@ -35,6 +35,7 @@ from superset.daos.dataset import DatasetDAO
 from superset.daos.datasource import DatasourceDAO
 from superset.extensions import cache_manager
 from superset.superset_typing import AdhocColumn
+from superset.utils import json
 from superset.utils.core import (
     AdhocMetricExpressionType,
     backend,
@@ -275,6 +276,39 @@ class TestQueryContext(SupersetTestCase):
         assert rehydrated_qc.result_type == query_context.result_type
         assert rehydrated_qc.result_format == query_context.result_format
         assert not rehydrated_qc.force
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_serialize_query_round_trip_preserves_cache_key(self):
+        from superset.common.query_serialization import (
+            load_serialized_query,
+            serialize_query,
+        )
+
+        payload = get_query_context(
+            query_name="birth_names",
+            add_postprocessing_operations=True,
+        )
+        payload["force"] = True
+        payload["custom_cache_timeout"] = 321
+
+        query_context = ChartDataQueryContextSchema().load(payload)
+        original_key = query_context.query_cache_key(query_context.queries[0])
+
+        serialized = serialize_query(query_context, 0)
+        # JSON-safe payload — no custom encoder needed.
+        assert json.loads(json.dumps(serialized)) == serialized
+
+        rebuilt = load_serialized_query(serialized)
+
+        # Reconstruction yields a single-query context whose per-query key matches
+        # the original, so it reads/writes the same DATA-cache entry.
+        assert len(rebuilt.queries) == 1
+        assert rebuilt.query_cache_key(rebuilt.queries[0]) == original_key
+        # Context-level params that would otherwise be lost per query survive.
+        assert rebuilt.force is True
+        assert rebuilt.custom_cache_timeout == 321
+        assert rebuilt.result_type == query_context.result_type
+        assert rebuilt.result_format == query_context.result_format
 
     def test_query_cache_key_changes_when_datasource_is_updated(self):
         payload = get_query_context("birth_names")

--- a/tests/unit_tests/common/test_query_serialization.py
+++ b/tests/unit_tests/common/test_query_serialization.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for canonical single-query serialization."""
+
+from pytest_mock import MockerFixture
+
+from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.common.query_serialization import (
+    load_serialized_query,
+    serialize_query,
+    SerializedQuery,
+)
+from superset.utils import json
+
+
+def _payload() -> SerializedQuery:
+    return SerializedQuery(
+        datasource={"id": 1, "type": "table"},
+        query={"metrics": ["count"], "columns": ["name"], "time_range": "No filter"},
+        form_data={"slice_id": 5},
+        result_type="full",
+        result_format="json",
+        force=True,
+        custom_cache_timeout=42,
+    )
+
+
+def test_serialize_query_extracts_raw_query_and_context_params(
+    mocker: MockerFixture,
+) -> None:
+    ctx = mocker.MagicMock()
+    ctx.cache_values = {
+        "datasource": {"id": 1, "type": "table"},
+        "queries": [{"a": 1}, {"b": 2}],
+    }
+    ctx.form_data = {"slice_id": 5}
+    ctx.result_type = ChartDataResultType.FULL
+    ctx.result_format = ChartDataResultFormat.JSON
+    ctx.force = True
+    ctx.custom_cache_timeout = 42
+
+    # Serializes the *raw* query dict (not the processed QueryObject) plus the
+    # context-level params (force/custom_cache_timeout live on the context).
+    assert serialize_query(ctx, 1) == {
+        "datasource": {"id": 1, "type": "table"},
+        "query": {"b": 2},
+        "form_data": {"slice_id": 5},
+        "result_type": "full",
+        "result_format": "json",
+        "force": True,
+        "custom_cache_timeout": 42,
+    }
+
+
+def test_serialized_query_is_json_safe() -> None:
+    payload = _payload()
+    # The payload uses only JSON-native types, so no custom encoder is needed.
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_load_serialized_query_rebuilds_via_factory(mocker: MockerFixture) -> None:
+    factory_cls = mocker.patch(
+        "superset.common.query_context_factory.QueryContextFactory"
+    )
+    factory = factory_cls.return_value
+    payload = _payload()
+
+    result = load_serialized_query(payload)
+
+    # Reconstruction goes through the same factory path that produced the
+    # original context, with result_type/result_format back as enum members.
+    assert result is factory.create.return_value
+    factory.create.assert_called_once_with(
+        datasource={"id": 1, "type": "table"},
+        queries=[payload["query"]],
+        form_data={"slice_id": 5},
+        result_type=ChartDataResultType.FULL,
+        result_format=ChartDataResultFormat.JSON,
+        force=True,
+        custom_cache_timeout=42,
+    )


### PR DESCRIPTION
> **Part of the [GAQ→GTF epic](https://github.com/apache/superset/pull/43407)** — this is **PR 2 (Canonical `QueryObject` serialization)**, targeting the `gaq-to-gtf` feature branch.

### SUMMARY

Adds a canonical, JSON-safe, self-contained serialization for a **single chart-data query** — the atomic unit a later PR (PR 3) will run as its own async GTF task. Today the async path serializes the *entire* query context (the request dict misleadingly named `form_data`); PR 3 will instead fan out one task per `QueryObject`, and each task needs to reconstruct exactly its query so it caches under the same `query_cache_key` as the synchronous path. This PR provides that primitive (with tests); PR 3 consumes it.

**API** (`superset/common/query_serialization.py`):
- `serialize_query(query_context, query_index) -> SerializedQuery` — a JSON-safe dict of the **raw** query (from `QueryContext.cache_values["queries"]`) plus the context-level inputs needed to rebuild it: `datasource`, `form_data`, `result_type`, `result_format`, `force`, `custom_cache_timeout`.
- `load_serialized_query(payload) -> QueryContext` — rebuilds a **single-query** `QueryContext` via `QueryContextFactory` (the same path that produced the original), so `query_cache_key` matches.

**Why the raw query, not `QueryObject.to_dict()`.** Reconstructing from `to_dict()` would change the cache key: `to_dict()` emits `from_dttm`/`to_dttm` as raw datetimes, uses the key `filter` where the factory expects `filters`, and omits `time_range`/`datasource`/`result_type`. Serializing the raw schema-shaped query and rebuilding through the factory reuses the exact key-producing path (the same pattern `Slice.query_context` already relies on), giving a provably identical `query_cache_key`.

**`force`/`custom_cache_timeout` survival.** These live on `QueryContext`, not `QueryObject`, so a per-query payload must carry them explicitly — they're serialized and restored, and the integration test asserts it.

### BEFORE / AFTER

No behavior change to the live async flow in this PR — it adds a foundation primitive. The misleading `form_data` rename and the duplicate `_create_query_context_from_form` dedup are intentionally deferred to **PR 3**, which rewrites `tasks/async_queries.py` and replaces `create_async_job_command.py` (doing the rename here would be throwaway).

### TESTING INSTRUCTIONS

- Unit (`tests/unit_tests/common/test_query_serialization.py`, green locally): payload extraction reads the raw query + context params; payload is JSON round-trippable; `load_serialized_query` reconstructs via `QueryContextFactory` with `result_type`/`result_format` back as enums.
- Integration (`tests/integration_tests/query_context_tests.py::test_serialize_query_round_trip_preserves_cache_key`): builds a real `birth_names` query context, serializes + reloads query 0, and asserts the reconstructed `query_cache_key` equals the original and that `force`/`custom_cache_timeout`/`result_type`/`result_format` survive.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API (`serialize_query` / `load_serialized_query`)
- [ ] Removes existing feature or API

_Note: the whole-project frontend type-check has pre-existing failures unrelated to this change._
