### PR TITLE
fix(table): keep each metric's own aggregate in the summary row by default

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { QueryFormMetric } from '@superset-ui/core';
-import { getTotalsMetrics } from './getTotalsMetrics';
+import { getTotalsMetrics, toTotalsAggregate } from './getTotalsMetrics';
 
 const simpleMetric = (aggregate: string): QueryFormMetric =>
   ({
@@ -76,4 +76,31 @@ describe('getTotalsMetrics', () => {
   test('returns an empty array when given no metrics', () => {
     expect(getTotalsMetrics([], 'AVG')).toEqual([]);
   });
+
+  test("ORIGINAL keeps each metric's own aggregate", () => {
+    const metrics = [
+      simpleMetric('COUNT_DISTINCT'),
+      sqlMetric(),
+      savedMetric(),
+    ];
+    const result = getTotalsMetrics(metrics, 'ORIGINAL');
+
+    expect(result).toBe(metrics);
+    expect(result[0]).toEqual(
+      expect.objectContaining({ aggregate: 'COUNT_DISTINCT' }),
+    );
+  });
+});
+
+describe('toTotalsAggregate', () => {
+  test.each(['SUM', 'AVG'] as const)('passes %s through', value => {
+    expect(toTotalsAggregate(value)).toBe(value);
+  });
+
+  test.each([undefined, null, '', 'MEDIAN', 'sum'])(
+    'falls back to ORIGINAL for %p',
+    value => {
+      expect(toTotalsAggregate(value)).toBe('ORIGINAL');
+    },
+  );
 });

--- a/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.ts
@@ -18,26 +18,46 @@
  */
 import { isAdhocMetricSimple, QueryFormMetric } from '@superset-ui/core';
 
-export type TotalsAggregate = 'SUM' | 'AVG';
+/**
+ * How the "Show summary" totals row aggregates each metric.
+ *
+ * ``ORIGINAL`` keeps every metric's own aggregation. It is the default because
+ * overriding is not universally valid: ``SUM`` over a ``COUNT_DISTINCT`` of a
+ * non-numeric column (a uuid, say) is rejected outright by the database, and
+ * over a numeric id column it silently produces a meaningless number.
+ */
+export type TotalsAggregate = 'ORIGINAL' | 'SUM' | 'AVG';
 
 /**
- * Build the metrics for a chart's "Show summary" totals query, overriding
- * each Simple (adhoc) metric's aggregate function with the user-chosen
- * totals aggregate. The totals query has no GROUP BY, so the database
- * evaluates each metric fresh over all rows -- swapping the aggregate here
- * is a correct, independent computation, not a re-aggregation of
- * already-aggregated per-row values.
+ * Build the metrics for a chart's "Show summary" totals query.
  *
- * Custom-SQL metrics and saved (string) metrics pass through unchanged:
- * there is no safe way to rewrite an arbitrary SQL expression's aggregate
- * function without parsing it, so the totals row keeps their own native
- * aggregate for those.
+ * With SUM or AVG, each Simple (adhoc) metric is cloned with its aggregate
+ * replaced. The totals query has no GROUP BY, so the database evaluates each
+ * metric fresh over all rows -- that swap is an independent computation, not a
+ * re-aggregation of already-aggregated per-row values.
+ *
+ * Custom-SQL and saved (string) metrics always pass through unchanged: there is
+ * no safe way to rewrite an arbitrary SQL expression's aggregate without
+ * parsing it, so the totals row keeps their own native aggregate.
  */
 export function getTotalsMetrics(
   metrics: QueryFormMetric[],
   aggregate: TotalsAggregate,
 ): QueryFormMetric[] {
+  if (aggregate === 'ORIGINAL') {
+    return metrics;
+  }
   return metrics.map(metric =>
     isAdhocMetricSimple(metric) ? { ...metric, aggregate } : metric,
   );
+}
+
+/**
+ * Narrow a raw ``totals_aggregate`` form-data value to a TotalsAggregate.
+ *
+ * Anything other than an explicit SUM/AVG — including charts saved before the
+ * control existed — keeps each metric's own aggregation.
+ */
+export function toTotalsAggregate(value: unknown): TotalsAggregate {
+  return value === 'SUM' || value === 'AVG' ? value : 'ORIGINAL';
 }

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/buildQuery.ts
@@ -38,7 +38,7 @@ import {
   getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
-  TotalsAggregate,
+  toTotalsAggregate,
 } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
@@ -696,13 +696,16 @@ export const buildQueryUncached: BuildQuery<TableChartFormData> = (
       formData.show_totals &&
       queryMode === QueryMode.Aggregate,
     );
-    const totalsAggregate: TotalsAggregate =
-      formData.totals_aggregate === 'AVG' ? 'AVG' : 'SUM';
+    const totalsAggregate = toTotalsAggregate(formData.totals_aggregate);
+    // Raw-mode summary columns have no metric of their own to preserve, so
+    // ORIGINAL has nothing to fall back to; sum them as before.
+    const rawSummaryAggregate =
+      totalsAggregate === 'ORIGINAL' ? 'SUM' : totalsAggregate;
     const totalsMetrics =
       rawSummaryColumns.length > 0
         ? rawSummaryColumns.map(columnName => ({
             expressionType: 'SIMPLE' as const,
-            aggregate: totalsAggregate,
+            aggregate: rawSummaryAggregate,
             column: { column_name: columnName },
             label: columnName,
           }))

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -503,14 +503,18 @@ const config: ControlPanelConfig = {
               label: t('Summary aggregation'),
               renderTrigger: true,
               description: t(
-                'Aggregation used for the summary row, independent of each ' +
-                  "metric's own aggregation. Only applies to simple metrics " +
-                  '(a metric built from custom SQL keeps its own aggregation ' +
-                  'in the summary row).',
+                'Aggregation used for the summary row. By default each metric ' +
+                  'keeps its own aggregation; Sum and Average override it for ' +
+                  'the summary row only. The override applies to simple ' +
+                  'metrics (a metric built from custom SQL always keeps its ' +
+                  'own aggregation). Overriding a count or a distinct count ' +
+                  'sums the counted column instead, which fails outright on a ' +
+                  'non-numeric column.',
               ),
-              default: 'SUM',
+              default: 'ORIGINAL',
               clearable: false,
               choices: [
+                ['ORIGINAL', t("Each metric's own")],
                 ['SUM', t('Sum')],
                 ['AVG', t('Average')],
               ],

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
@@ -1561,7 +1561,7 @@ describe('plugin-chart-ag-grid-table', () => {
       expect(queries[1].metrics).toEqual(['count']);
     });
 
-    test('defaults aggregate-mode totals to SUM for a simple metric', () => {
+    test("defaults aggregate-mode totals to the metric's own aggregate", () => {
       const simpleMetric = {
         expressionType: 'SIMPLE' as const,
         column: { column_name: 'sales' },
@@ -1580,9 +1580,29 @@ describe('plugin-chart-ag-grid-table', () => {
         { ownState: {} },
       );
 
-      expect(queries[1].metrics).toEqual([
-        { ...simpleMetric, aggregate: 'SUM' },
-      ]);
+      expect(queries[1].metrics).toEqual([simpleMetric]);
+    });
+
+    test('keeps COUNT_DISTINCT in aggregate-mode totals by default', () => {
+      const countDistinctMetric = {
+        expressionType: 'SIMPLE' as const,
+        column: { column_name: 'contract_id' },
+        aggregate: 'COUNT_DISTINCT' as const,
+        label: 'contracts',
+      };
+      const { queries } = buildQuery(
+        {
+          viz_type: VizType.Table,
+          datasource: '11__table',
+          query_mode: QueryMode.Aggregate,
+          groupby: ['state'],
+          metrics: [countDistinctMetric],
+          show_totals: true,
+        },
+        { ownState: {} },
+      );
+
+      expect(queries[1].metrics).toEqual([countDistinctMetric]);
     });
 
     test('overrides aggregate-mode totals to AVG for a simple metric when totals_aggregate is set', () => {

--- a/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/buildQuery.ts
@@ -34,7 +34,7 @@ import {
   getTotalsMetrics,
   isTimeComparison,
   timeCompareOperator,
-  TotalsAggregate,
+  toTotalsAggregate,
 } from '@superset-ui/chart-controls';
 import { isEmpty } from 'lodash-es';
 import { TableChartFormData } from './types';
@@ -349,8 +349,7 @@ export const buildQuery: BuildQuery<TableChartFormData> = (
       formData.show_totals &&
       queryMode === QueryMode.Aggregate
     ) {
-      const totalsAggregate: TotalsAggregate =
-        formData.totals_aggregate === 'AVG' ? 'AVG' : 'SUM';
+      const totalsAggregate = toTotalsAggregate(formData.totals_aggregate);
       extraQueries.push({
         ...queryObject,
         columns: [],

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -475,14 +475,18 @@ const config: ControlPanelConfig = {
               type: 'SelectControl',
               label: t('Summary aggregation'),
               description: t(
-                'Aggregation used for the summary row, independent of each ' +
-                  "metric's own aggregation. Only applies to simple metrics " +
-                  '(a metric built from custom SQL keeps its own aggregation ' +
-                  'in the summary row).',
+                'Aggregation used for the summary row. By default each metric ' +
+                  'keeps its own aggregation; Sum and Average override it for ' +
+                  'the summary row only. The override applies to simple ' +
+                  'metrics (a metric built from custom SQL always keeps its ' +
+                  'own aggregation). Overriding a count or a distinct count ' +
+                  'sums the counted column instead, which fails outright on a ' +
+                  'non-numeric column.',
               ),
-              default: 'SUM',
+              default: 'ORIGINAL',
               clearable: false,
               choices: [
+                ['ORIGINAL', t("Each metric's own")],
                 ['SUM', t('Sum')],
                 ['AVG', t('Average')],
               ],

--- a/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/buildQuery.test.ts
@@ -340,7 +340,7 @@ describe('plugin-chart-table', () => {
         label: 'sum_sales',
       };
 
-      test('defaults the totals query metric aggregate to SUM', () => {
+      test("defaults to each metric's own aggregate", () => {
         const { queries } = buildQueryCached({
           ...basicFormData,
           query_mode: QueryMode.Aggregate,
@@ -350,9 +350,28 @@ describe('plugin-chart-table', () => {
         });
 
         expect(queries).toHaveLength(2);
-        expect(queries[1].metrics).toEqual([
-          { ...simpleMetric, aggregate: 'SUM' },
-        ]);
+        expect(queries[1].metrics).toEqual([simpleMetric]);
+      });
+
+      test('keeps COUNT_DISTINCT in the summary row by default', () => {
+        // Overriding this to SUM sums the counted column instead of counting
+        // it, which is meaningless on a numeric id and is rejected outright by
+        // the database on a non-numeric one (e.g. a uuid).
+        const countDistinctMetric = {
+          expressionType: 'SIMPLE' as const,
+          column: { column_name: 'contract_id' },
+          aggregate: 'COUNT_DISTINCT' as const,
+          label: 'contracts',
+        };
+        const { queries } = buildQueryCached({
+          ...basicFormData,
+          query_mode: QueryMode.Aggregate,
+          metrics: [countDistinctMetric],
+          groupby: ['category'],
+          show_totals: true,
+        });
+
+        expect(queries[1].metrics).toEqual([countDistinctMetric]);
       });
 
       test('overrides simple metric aggregate with totals_aggregate for the summary query only', () => {


### PR DESCRIPTION
### SUMMARY

Fixes #43420.

#43027 added a Sum/Average control for the Table and AG Grid Table "Show summary" row, and applied it to every Simple (adhoc) metric unconditionally. The control defaults to `SUM` and is `clearable: false`, so there is no way to keep a metric's own aggregation — and a chart saved before that PR, which has no `totals_aggregate` in its form data, is coerced into `SUM` too.

That silently changes what the summary row means:

- `COUNT_DISTINCT(col)` becomes `SUM(col)`. If `col` is not numeric the database refuses the query outright — on Postgres with a `uuid` column, `function sum(uuid) does not exist`. If it is numeric, the row shows the sum of the ids and nothing signals that anything is wrong.
- The same applies to `COUNT`, `MIN` and `MAX`.

Only the summary query is affected (`queries[1]`, `columns: []`); the main query stays correct, so a partly-broken chart is easy to miss.

#43027's rationale — that swapping the aggregate is safe because the summary query has no `GROUP BY`, so each metric is evaluated fresh over all rows — holds arithmetically. What it does not account for is that the swap assumes the metric's column is summable, and that replacing the aggregate preserves the user's intent. Neither holds for the counting aggregates.

**This PR** adds `ORIGINAL` as a third choice and makes it the default:

- `getTotalsMetrics(metrics, 'ORIGINAL')` returns the metrics untouched.
- A new `toTotalsAggregate()` narrows the raw form-data value in one place, so anything that is not an explicit `SUM`/`AVG` — including charts saved before the control existed — resolves to `ORIGINAL` instead of falling into `SUM`.
- Both control panels gain an "Each metric's own" option, which becomes the default.

Sum and Average remain available exactly as designed in #43027, just as a deliberate choice rather than something applied to every chart on upgrade. Existing charts go back to the behaviour they had before that PR.

AG Grid's raw-mode summary columns are built from column names and have no aggregate of their own to preserve, so they keep summing; `ORIGINAL` maps to `SUM` on that path only.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before, a Table chart with `COUNT_DISTINCT` over a uuid column and "Show summary" enabled:

```
Ошибка базы данных
Error: function sum(uuid) does not exist
LINE 1: SELECT sum(contract_id) AS "Кол-во", SUM(contract_amount/100... ^
HINT: No function matches the given name and argument types.
```

After, the chart renders and the summary row shows the distinct count.

### TESTING INSTRUCTIONS

Manual:

1. Table chart, Aggregate mode, one dimension, one metric `COUNT_DISTINCT(<uuid column>)`.
2. Enable **Show summary**. On `master` the chart fails with `function sum(uuid) does not exist`; with this change it renders, and **Summary aggregation** shows "Each metric's own".
3. Switch **Summary aggregation** to Sum or Average — the override still applies, as added in #43027.
4. Repeat with an AG Grid Table chart, in both Aggregate and Raw mode. Raw mode still sums its summary columns.

Automated:

```
npx jest packages/superset-ui-chart-controls/src/utils/getTotalsMetrics.test.ts \
         plugins/plugin-chart-table/test/buildQuery.test.ts \
         plugins/plugin-chart-ag-grid-table/test/buildQuery.test.ts
```

127 tests pass. New coverage: `ORIGINAL` leaves every metric type untouched; `toTotalsAggregate` maps `SUM`/`AVG` through and everything else (including `undefined`) to `ORIGINAL`; and both plugins keep `COUNT_DISTINCT` in the summary query by default.

Two existing tests asserted the behaviour this PR changes — `defaults the totals query metric aggregate to SUM` and `defaults aggregate-mode totals to SUM for a simple metric` — and are updated to assert the metric's own aggregate is kept.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43420
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Introduced by #43027 (`f7a2f0ec50`). No follow-up commit has touched `getTotalsMetrics.ts` or the totals block in either plugin's `buildQuery.ts`, so `master` at `f2610e9dca` still has it.

#### Charts re-saved between #43027 and this fix are not self-healing

Raised by @kokhlo in review, confirmed by @rusackas. Between #43027 (2026-08-13) and this change
**Summary aggregation** defaulted to `SUM` and was `clearable: false`, so every Table / AG Grid
Table chart saved in that window carries an explicit `totals_aggregate: 'SUM'` in its form data —
whether or not anyone touched the control.

`toTotalsAggregate()` treats an explicit `SUM` as a deliberate choice and passes it through, so
those charts keep overriding their metrics in the summary row and still show the behaviour #43420
describes. Switching **Summary aggregation** to "Each metric's own" once fixes each of them.
Charts saved before #43027 carry no `totals_aggregate` at all, resolve to `ORIGINAL`, and recover
on their own.

A data migration for that cohort was considered and left out of scope here: an explicit `'SUM'` is
indistinguishable from the baked-in default by value alone, so a migration would have to key off
the change window and would also clear the setting for anyone who picked `SUM` on purpose. Happy
to open it as a follow-up if maintainers would prefer that trade-off.

cc @rusackas as the author of #43027 — happy to take this a different way if you would rather the override stay on by default and only be skipped for the counting aggregates; I went with an explicit default because that is also what makes the upgrade non-breaking.

