### PR TITLE
fix(examples): replace deprecated timeseries_limit_metric with series_limit_metric

### DIFF
--- a/superset/common/form_data_query_context.py
+++ b/superset/common/form_data_query_context.py
@@ -213,7 +213,9 @@ def orderby_from_form_data(
     # The drag-and-drop "sort by" control persists a list; the frontend unwraps it
     # with ``ensureIsArray(...)[0]`` (``plugin-chart-table/src/buildQuery.ts:67``).
     # Read raw, a list would nest inside ``orderby`` and fail the query.
-    raw_sort_metric = form_data.get("timeseries_limit_metric")
+    raw_sort_metric = form_data.get("series_limit_metric") or form_data.get(
+        "timeseries_limit_metric"
+    )
     sort_metric = (
         next(iter(as_list(raw_sort_metric)), None) if raw_sort_metric else None
     ) or (metrics[0] if form_data.get("sort_by_metric") else None)

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -290,7 +290,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "girl")],
                 row_limit=50,
-                timeseries_limit_metric=metric,
+                series_limit_metric=metric,
                 metrics=[metric],
             ),
             editors=[],
@@ -321,7 +321,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "boy")],
                 row_limit=50,
-                timeseries_limit_metric=metric,
+                series_limit_metric=metric,
                 metrics=[metric],
             ),
             editors=[],
@@ -498,7 +498,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 viz_type="echarts_timeseries_line",
                 granularity_sqla="ds",
                 groupby=["name"],
-                timeseries_limit_metric={
+                series_limit_metric={
                     "expressionType": "SIMPLE",
                     "column": {
                         "column_name": "num_california",
@@ -522,7 +522,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 metrics=metrics,
                 groupby=["name"],
                 row_limit=50,
-                timeseries_limit_metric={
+                series_limit_metric={
                     "expressionType": "SIMPLE",
                     "column": {
                         "column_name": "num_california",

--- a/superset/examples/usa_births_names/charts/Boys.yaml
+++ b/superset/examples/usa_births_names/charts/Boys.yaml
@@ -36,8 +36,8 @@ params:
   metrics:
   - sum__num
   row_limit: 50
+  series_limit_metric: sum__num
   time_range: '100 years ago : now'
-  timeseries_limit_metric: sum__num
   viz_type: table
 query_context: null
 slice_name: Boys

--- a/superset/examples/usa_births_names/charts/Girls.yaml
+++ b/superset/examples/usa_births_names/charts/Girls.yaml
@@ -36,8 +36,8 @@ params:
   metrics:
   - sum__num
   row_limit: 50
+  series_limit_metric: sum__num
   time_range: '100 years ago : now'
-  timeseries_limit_metric: sum__num
   viz_type: table
 query_context: null
 slice_name: Girls

--- a/tests/unit_tests/common/test_form_data_query_context.py
+++ b/tests/unit_tests/common/test_form_data_query_context.py
@@ -218,6 +218,31 @@ def test_orderby_uses_timeseries_limit_metric_and_order_desc() -> None:
     assert query["orderby"] == [["revenue", True]]
 
 
+def test_orderby_uses_series_limit_metric_and_order_desc() -> None:
+    # series_limit_metric is the current field name; timeseries_limit_metric is
+    # the deprecated alias kept above for back-compat with old saved charts.
+    form_data = {
+        "metrics": ["count"],
+        "groupby": ["c"],
+        "series_limit_metric": "revenue",
+        "order_desc": False,
+    }
+    query = build_query_context_from_form_data(form_data, DATASOURCE)["queries"][0]
+    assert query["orderby"] == [["revenue", True]]
+
+
+def test_orderby_prefers_series_limit_metric_over_deprecated_alias() -> None:
+    form_data = {
+        "metrics": ["count"],
+        "groupby": ["c"],
+        "series_limit_metric": "revenue",
+        "timeseries_limit_metric": "profit",
+        "order_desc": False,
+    }
+    query = build_query_context_from_form_data(form_data, DATASOURCE)["queries"][0]
+    assert query["orderby"] == [["revenue", True]]
+
+
 def test_orderby_pie_sort_by_metric() -> None:
     form_data = {"metric": "count", "groupby": ["c"], "sort_by_metric": True}
     query = build_query_context_from_form_data(form_data, DATASOURCE, viz_type="pie")[


### PR DESCRIPTION
**Decisions made that were not in the instructions**
None.

## What the warning was

Production logs showed a recurring `WARNING` on every request that touched the bundled `birth_names` example data:

```
The field `timeseries_limit_metric` is deprecated, please use `series_limit_metric` instead.
```

`QueryObject._rename_deprecated_fields` (`superset/common/query_object.py`) fires this warning whenever it sees the old field name in incoming kwargs, then silently copies the value onto `series_limit_metric`. The example data shipped with Superset itself was still using the old name, so every load of the example dashboard/charts triggered the warning for no reason.

## What changed

1. `superset/examples/birth_names.py` — renamed 4 `timeseries_limit_metric=` call sites to `series_limit_metric=` (the "Girls"/"Boys" table slices, one `echarts_timeseries_line` slice, and the "Names Sorted by Num in California" slice).
2. `superset/examples/usa_births_names/charts/{Boys,Girls}.yaml` — same rename in the newer YAML-fixture version of the same example dashboard, which was hit by the same warning via a separate `load_examples_from_configs` code path.
3. `superset/common/form_data_query_context.py` — `orderby_from_form_data()` only ever read the deprecated `timeseries_limit_metric` key when reconstructing a query straight from a chart's persisted `params` (used by dashboard Excel export and the MCP chart tools). That meant a chart saved with the *current* `series_limit_metric` field — like the examples fixed here — would silently lose its sort-by-metric through that specific path. Added a `series_limit_metric`-first fallback, matching the pattern already used in `query_object.py` and `models/helpers.py`.

## No behavior change

`series_limit_metric` and `timeseries_limit_metric` are treated as fully equivalent everywhere in the normal query/chart-data path (`QueryObject`, `get_sqla_query`, `ChartDataQueryObjectSchema`) — the rename is a no-op there other than dropping the warning. Item 3 above is a genuine bug fix for the one path that previously checked only the old key, but restores intended behavior (existing sort-by-metric) rather than changing it.

## Test plan

- `superset/examples/usa_births_names/charts/{Boys,Girls}.yaml` — validated as parseable YAML.
- `tests/unit_tests/common/test_form_data_query_context.py` — added two tests: `series_limit_metric` alone produces the same `orderby` as the deprecated field, and `series_limit_metric` takes precedence when both are present. Confirmed fail-before/pass-after against the pre-fix code (both new tests fail on `main`, pass after the `form_data_query_context.py` change).
- `ruff check` / `ruff format --check` clean on all changed Python files.
- Full targeted suite: `pytest tests/unit_tests/common/test_form_data_query_context.py` → 40 passed.