### PR TITLE
feat(plugin-chart-echarts): allow decal patterns in custom ECharts options

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/eChartOptionsSchema.ts
@@ -114,6 +114,23 @@ export const textStyleSchema = z.object({
 // Style Schemas
 // =============================================================================
 
+/** Repeating tile pattern painted over a fill, e.g. hatching */
+export const decalSchema = z.object({
+  symbol: z.union([symbolTypeSchema, z.array(symbolTypeSchema)]).optional(),
+  symbolSize: z.number().optional(),
+  symbolKeepAspect: z.boolean().optional(),
+  color: colorSchema.optional(),
+  backgroundColor: colorSchema.optional(),
+  dashArrayX: z
+    .union([z.number(), z.array(z.union([z.number(), z.array(z.number())]))])
+    .optional(),
+  dashArrayY: z.union([z.number(), z.array(z.number())]).optional(),
+  /** Radians, not degrees. */
+  rotation: z.number().optional(),
+  maxTileWidth: z.number().optional(),
+  maxTileHeight: z.number().optional(),
+});
+
 export const lineStyleSchema = z.object({
   color: colorSchema.optional(),
   width: z.number().optional(),
@@ -150,6 +167,7 @@ export const itemStyleSchema = z.object({
   shadowOffsetX: z.number().optional(),
   shadowOffsetY: z.number().optional(),
   opacity: z.number().min(0).max(1).optional(),
+  decal: decalSchema.optional(),
 });
 
 // =============================================================================
@@ -818,6 +836,7 @@ export type TextStyleOption = z.infer<typeof textStyleSchema>;
 export type LineStyleOption = z.infer<typeof lineStyleSchema>;
 export type AreaStyleOption = z.infer<typeof areaStyleSchema>;
 export type ItemStyleOption = z.infer<typeof itemStyleSchema>;
+export type DecalOption = z.infer<typeof decalSchema>;
 export type LabelOption = z.infer<typeof labelSchema>;
 export type TitleOption = z.infer<typeof titleSchema>;
 export type LegendOption = z.infer<typeof legendSchema>;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser.test.ts
@@ -593,3 +593,94 @@ test('strips tooltip extraCssText instead of passing raw CSS through', () => {
   expect(result.success).toBe(true);
   expect(result.data).toEqual({ tooltip: { show: true } });
 });
+
+test('accepts a decal pattern on itemStyle', () => {
+  const result = parseEChartOptions(
+    `{ series: { itemStyle: { decal: {
+        symbol: 'rect',
+        dashArrayX: [1, 0],
+        dashArrayY: [2, 4],
+        rotation: -0.7853981633974483,
+        color: 'rgba(0, 0, 0, 0.2)',
+      } } } }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({
+    series: {
+      itemStyle: {
+        decal: {
+          symbol: 'rect',
+          dashArrayX: [1, 0],
+          dashArrayY: [2, 4],
+          rotation: -0.7853981633974483,
+          color: 'rgba(0, 0, 0, 0.2)',
+        },
+      },
+    },
+  });
+});
+
+test('accepts the full decal shape, including per-row dash arrays', () => {
+  // `dashArrayX` nests one level to offset rows from each other; `dashArrayY`
+  // has no equivalent.
+  const result = parseEChartOptions(
+    `{ series: { itemStyle: { decal: {
+        symbol: ['rect', 'circle'],
+        symbolSize: 0.8,
+        symbolKeepAspect: false,
+        color: '#383838',
+        backgroundColor: 'transparent',
+        dashArrayX: [[1, 0], [0, 1]],
+        dashArrayY: 5,
+        rotation: 0,
+        maxTileWidth: 512,
+        maxTileHeight: 512,
+      } } } }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(
+    (result.data as { series: { itemStyle: { decal: unknown } } }).series
+      .itemStyle.decal,
+  ).toEqual({
+    symbol: ['rect', 'circle'],
+    symbolSize: 0.8,
+    symbolKeepAspect: false,
+    color: '#383838',
+    backgroundColor: 'transparent',
+    dashArrayX: [
+      [1, 0],
+      [0, 1],
+    ],
+    dashArrayY: 5,
+    rotation: 0,
+    maxTileWidth: 512,
+    maxTileHeight: 512,
+  });
+});
+
+test('strips unknown keys from a decal rather than passing them through', () => {
+  const result = parseEChartOptions(
+    `{ series: { itemStyle: { decal: { symbol: 'rect', onclick: 'alert(1)' } } } }`,
+  );
+
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({
+    series: { itemStyle: { decal: { symbol: 'rect' } } },
+  });
+});
+
+test('rejects a decal whose values are of the wrong type', () => {
+  // Unknown keys are stripped; a known key with a bad type is an error.
+  const input = `{ series: { itemStyle: { decal: { rotation: 'sideways' } } } }`;
+
+  expect(() => parseEChartOptions(input)).toThrow(EChartOptionsParseError);
+  try {
+    parseEChartOptions(input);
+  } catch (error) {
+    expect((error as EChartOptionsParseError).errorType).toBe(
+      'validation_error',
+    );
+  }
+});


### PR DESCRIPTION
### SUMMARY

`itemStyle.decal` is the ECharts property for a patterned fill — hatching,
cross-hatching, dots — rather than a solid colour. It is the only member of
`itemStyle` missing from `itemStyleSchema` in `eChartOptionsSchema.ts`, so it is
stripped during validation while `color`, `borderColor`, `borderWidth`,
`borderType`, `borderRadius`, the shadow properties and `opacity` all pass.

That gap looks accidental. A decal is the same kind of value as its siblings — a
static data structure, which is what the safe parser exists to permit — and it
introduces no new type of input: `symbol` reuses the `symbolTypeSchema` string
already accepted for series symbols and legend icons. The schema mirrors
ECharts' `DecalObject` in full rather than a subset, in the same way
`lineStyleSchema` does, so there is no arbitrary line to defend later.

**What this does not do.** It does not make patterned fills usable. A decal is a
per-series property, and per-series options cannot be reached through this
control at all today: `mergeCustomEChartOptions` replaces arrays rather than
merging them, so supplying `series` discards the computed series, and the
replacement cannot carry its own data because `data` is deliberately not in
`seriesSchema`. Closing the allowlist gap is one half of making a decal
reachable; the merge behaviour is the other, and that is a larger question than
this PR.

So this is a small consistency fix rather than a feature. I am opening it
because it is a one-property gap that costs nothing, and because I am working
toward the other half — per-series visual treatments where the fill pattern
carries meaning independently of colour, which is a common convention in
business reporting. Background and the wider discussion:
https://github.com/apache/superset/discussions/43426

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — this widens what the options schema accepts and adds no
control. Nothing renders differently unless a chart opts in through the
existing *ECharts Options* control, which the testing instructions cover.

### TESTING INSTRUCTIONS

Unit tests: `npm run test -- plugins/plugin-chart-echarts/src/utils/safeEChartOptionsParser`

The unit tests are the verification here, because **a decal cannot currently be
exercised end to end through the control**, for reasons unrelated to this
change:

- a decal is a per-series property, so reaching one means supplying `series`;
- `mergeCustomEChartOptions` replaces arrays rather than merging them, so
  supplying `series` discards the computed series;
- and the replacement cannot carry its own data, because `data` is not in
  `seriesSchema` — by design, since data comes from the query.

So the option is accepted and merged, and nothing in Superset sets one yet.
That is what makes this a prerequisite rather than a feature, and I would rather
say so than dress up a demo.

What is worth checking for regressions:

1. Load an existing chart that already uses *Customize → ECharts Options*, with
   top-level keys such as `xAxis` / `yAxis`, and confirm it renders as before.
   Those merge as objects and are unaffected.
2. Confirm validation still rejects a malformed decal —
   `{ series: { itemStyle: { decal: { rotation: 'sideways' } } } }` raises a
   validation error rather than being silently dropped — and that unknown keys
   inside a decal are still stripped. Both are covered by the new unit tests.

### ADDITIONAL INFORMATION

- [x] Has associated issue: https://github.com/apache/superset/discussions/43426
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
