### PR TITLE
feat(listview): realtime list updates baked into useListViewResource

### DIFF
--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -227,4 +227,16 @@ describe('realtime WebSocket acceleration', () => {
     asyncEvent.handleRealtimeMessage(realtime('task-1', 'success'));
     await promise;
   });
+
+  test('a tier-2 message is a no-op when async queries are disabled', () => {
+    // The shared socket connects whenever WEBSOCKET_ENABLED, independent of the
+    // GLOBAL_ASYNC_QUERIES flag, so a realtime message can arrive with no active
+    // async flow — it must not throw (waiter registry stays an empty map).
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    asyncEvent.init(config);
+
+    expect(() =>
+      asyncEvent.handleRealtimeMessage(realtime('task-1', 'success')),
+    ).not.toThrow();
+  });
 });

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -159,11 +159,10 @@ test('settles every request awaiting a deduplicated shared task', async () => {
 });
 
 describe('realtime WebSocket acceleration', () => {
-  const realtime = (taskId: string, status: string) =>
-    JSON.stringify({
-      channel: `realtime:user:1`,
-      payload: { task_id: taskId, status },
-    });
+  const realtime = (taskId: string, status: string) => ({
+    channel: `realtime:user:1`,
+    payload: { task_id: taskId, status },
+  });
 
   // waitForAsyncData registers its waiter only after the baseline cursor fetch
   // resolves; wait a tick so a one-shot socket message isn't delivered before
@@ -206,7 +205,7 @@ describe('realtime WebSocket acceleration', () => {
     expect(refetch).not.toHaveBeenCalled();
   });
 
-  test('ignores non-realtime channels and malformed data', async () => {
+  test('ignores non-realtime channels', async () => {
     queueStatuses();
     asyncEvent.init(config);
 
@@ -218,14 +217,10 @@ describe('realtime WebSocket acceleration', () => {
 
     await afterRegistered();
     // A public entity-change nudge carries no status and must not settle a chart.
-    asyncEvent.handleRealtimeMessage(
-      JSON.stringify({
-        channel: 'entity-changes:task',
-        payload: { entity_type: 'task', id: 'task-1' },
-      }),
-    );
-    // Malformed data must be swallowed, not thrown.
-    expect(() => asyncEvent.handleRealtimeMessage('not json')).not.toThrow();
+    asyncEvent.handleRealtimeMessage({
+      channel: 'entity-changes:task',
+      payload: { entity_type: 'task', id: 'task-1' },
+    });
     expect(refetch).not.toHaveBeenCalled();
 
     // The task is still pending; complete it so the test doesn't leak a waiter.

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -75,7 +75,11 @@ let pollingTimeoutId: number;
 // shared poll loop fans status changes out to whichever requests are awaiting them.
 // A SHARED task can be deduplicated across concurrent chart requests, so each task
 // id maps to a *set* of waiters (never overwrite an earlier subscriber).
-let waitersByTaskId: Map<string, Set<Waiter>>;
+// Initialized eagerly (not just in init()): the shared realtime socket connects
+// whenever WEBSOCKET_ENABLED — independent of GLOBAL_ASYNC_QUERIES — so the
+// subscribed handler may run applyStatus even when async queries are off, and
+// must find a map rather than undefined.
+let waitersByTaskId: Map<string, Set<Waiter>> = new Map();
 // Server-issued watermark: fetched as a baseline at init (before any chart query
 // is triggered) so no task created afterwards is missed, then advanced by each
 // poll. Always the server's own clock, never the browser's.

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -24,6 +24,11 @@ import {
 } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import {
+  connectRealtime,
+  subscribeRealtime,
+  type RealtimeMessage,
+} from 'src/middleware/realtime';
 
 // The GTF task type chart-data queries run under (see
 // superset/tasks/async_queries.py CHART_QUERY_TASK). Polling is filtered to this
@@ -80,17 +85,12 @@ let baselineReady: Promise<void> | null;
 // stop instead of scheduling a second loop or mutating fresh state.
 let pollingGeneration = 0;
 
-// Optional realtime WebSocket transport (superset-websocket). It merely
-// accelerates completion: a per-principal tier-2 message carries a task's
-// terminal status so a waiting chart settles immediately instead of at the next
-// poll tick. The interval poll below is the correctness backstop, so the socket
-// is strictly best-effort — if it is down or a message is lost, nothing breaks.
-let ws: WebSocket | undefined;
-let wsReconnectTimeoutId: number;
-let wsReconnectDelayMs: number;
 // Per-principal channel prefix (mirrors superset-websocket routing and
 // TaskManager.REALTIME_CHANNEL_PREFIX). The browser socket is JWT-bound to its
 // own principal channel, so it only ever receives its own realtime messages.
+// The shared realtime client (src/middleware/realtime.ts) owns the socket; here
+// we only consume the tier-2 messages relevant to chart-data completion. The
+// socket is best-effort — the interval poll below is the correctness backstop.
 const REALTIME_CHANNEL_PREFIX = 'realtime:';
 
 const fetchStatusChanges = makeApi<
@@ -175,81 +175,28 @@ const loadStatusChanges = async (generation: number) => {
 };
 
 /**
- * Apply a realtime message received over the WebSocket.
+ * Handle a realtime message from the shared client (src/middleware/realtime.ts).
  *
- * The server forwards a generic ``{channel, payload}`` envelope. For a
- * per-principal (tier-2) chart-data message the payload is ``{task_id, status}``;
- * because delivery is scoped to this principal's own JWT-bound channel, the
- * status is authoritative enough to settle the waiter immediately (the ensuing
- * ``refetch`` reads the authorized per-query cache anyway). Any other channel
- * (e.g. the public ``entity-changes:*`` nudges) is ignored here — chart-data
- * only cares about its own tasks. Strictly best-effort: malformed data is
- * dropped, never thrown.
+ * For a per-principal (tier-2) chart-data message the payload is
+ * ``{task_id, status}``; because delivery is scoped to this principal's own
+ * JWT-bound channel, the status is authoritative enough to settle the waiter
+ * immediately (the ensuing ``refetch`` reads the authorized per-query cache
+ * anyway). Any other channel (e.g. the public ``entity-changes:*`` list-view
+ * nudges) is ignored here — chart-data only cares about its own tasks.
  */
-export const handleRealtimeMessage = (rawData: string) => {
-  try {
-    const { channel, payload } = JSON.parse(rawData) ?? {};
-    if (typeof channel !== 'string') return;
-    if (!channel.startsWith(REALTIME_CHANNEL_PREFIX)) return;
-    const taskId = payload?.task_id;
-    const status = payload?.status;
-    if (typeof taskId === 'string' && typeof status === 'string') {
-      applyStatus(taskId, status);
-    }
-  } catch (err) {
-    logging.warn('Failed to handle realtime message', err);
+export const handleRealtimeMessage = (message: RealtimeMessage) => {
+  const { channel, payload } = message;
+  if (!channel.startsWith(REALTIME_CHANNEL_PREFIX)) return;
+  const taskId = payload?.task_id;
+  const status = payload?.status;
+  if (typeof taskId === 'string' && typeof status === 'string') {
+    applyStatus(taskId, status);
   }
 };
 
-const teardownWebSocket = () => {
-  if (wsReconnectTimeoutId) clearTimeout(wsReconnectTimeoutId);
-  if (ws) {
-    // Detach handlers first so the in-flight socket's close doesn't schedule a
-    // reconnect against the superseded generation.
-    ws.onmessage = null;
-    ws.onclose = null;
-    ws.onerror = null;
-    try {
-      ws.close();
-    } catch {
-      // ignore: closing an already-closed/broken socket is harmless
-    }
-    ws = undefined;
-  }
-};
-
-// Open the realtime WebSocket (if enabled) and route its messages. The JWT
-// channel cookie (set by the Flask app) rides the handshake automatically since
-// the server runs on the same host. On close we reconnect after a delay; the
-// interval poll keeps completions flowing meanwhile, so a socket outage only
-// costs latency, not correctness.
-const connectWebSocket = (generation: number) => {
-  if (generation !== pollingGeneration) return;
-  const url = config?.WEBSOCKET_URL;
-  if (!config?.WEBSOCKET_ENABLED || !url || typeof WebSocket === 'undefined') {
-    return;
-  }
-  try {
-    ws = new WebSocket(url);
-  } catch (err) {
-    logging.warn('Failed to open realtime WebSocket', err);
-    return;
-  }
-  ws.onmessage = (event: MessageEvent) => {
-    if (generation !== pollingGeneration) return;
-    handleRealtimeMessage(String(event.data));
-  };
-  ws.onclose = () => {
-    if (generation !== pollingGeneration) return;
-    wsReconnectTimeoutId = window.setTimeout(
-      () => connectWebSocket(generation),
-      wsReconnectDelayMs,
-    );
-  };
-  // Errors surface as a subsequent close; let onclose own the reconnect and
-  // avoid logging the (payload-free) error event on every transient blip.
-  ws.onerror = () => {};
-};
+// Consume the shared realtime socket once at module load. The handler reads the
+// live waiter registry, so it stays correct across init() generations.
+subscribeRealtime(handleRealtimeMessage);
 
 /**
  * Await completion of an async chart-data job's query tasks, then re-issue the
@@ -310,21 +257,22 @@ export const waitForAsyncData = async <T = unknown[]>(
 export const init = (appConfig?: AppConfig) => {
   pollingGeneration += 1;
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
-  teardownWebSocket();
+
+  config = appConfig || getBootstrapData().common.conf;
+
+  // (Re)connect the shared realtime socket whenever the websocket transport is
+  // enabled — independent of GLOBAL_ASYNC_QUERIES, since realtime list views
+  // (tier-1 entity-change nudges) ride the same socket. Idempotent: a no-op when
+  // WEBSOCKET_ENABLED is false, and supersedes any prior socket otherwise.
+  connectRealtime(config);
+
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
 
   const generation = pollingGeneration;
   waitersByTaskId = new Map();
   cursor = null;
 
-  config = appConfig || getBootstrapData().common.conf;
   pollingDelayMs = config.GLOBAL_ASYNC_QUERIES_POLLING_DELAY || 500;
-  wsReconnectDelayMs =
-    config.GLOBAL_ASYNC_QUERIES_WEBSOCKET_RECONNECT_DELAY || 5000;
-
-  // Open the realtime socket (no-op unless WEBSOCKET_ENABLED); it only
-  // accelerates the poll loop below.
-  connectWebSocket(generation);
 
   // Establish a baseline cursor before any chart query is triggered, so tasks
   // created afterwards are all caught by the changed-since poll, then start the

--- a/superset-frontend/src/middleware/realtime.test.ts
+++ b/superset-frontend/src/middleware/realtime.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  connectRealtime,
+  dispatchRealtimeMessage,
+  resetRealtimeForTests,
+  subscribeRealtime,
+  type RealtimeMessage,
+} from 'src/middleware/realtime';
+
+// A minimal fake WebSocket so connectRealtime can "open" a socket without a
+// real network connection. Instances register themselves so a test can drive
+// onmessage/onclose.
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  onclose: (() => void) | null = null;
+
+  onerror: (() => void) | null = null;
+
+  close = jest.fn();
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+}
+
+const originalWebSocket = global.WebSocket;
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  (global as any).WebSocket = FakeWebSocket;
+});
+
+afterEach(() => {
+  resetRealtimeForTests();
+  (global as any).WebSocket = originalWebSocket;
+});
+
+const ENABLED = {
+  WEBSOCKET_ENABLED: true,
+  WEBSOCKET_URL: 'ws://localhost:8080/',
+};
+
+test('dispatches a parsed envelope to every subscribed handler', () => {
+  const a = jest.fn();
+  const b = jest.fn();
+  subscribeRealtime(a);
+  subscribeRealtime(b);
+
+  dispatchRealtimeMessage(
+    JSON.stringify({ channel: 'entity-changes:task', payload: { id: '7' } }),
+  );
+
+  const expected: RealtimeMessage = {
+    channel: 'entity-changes:task',
+    payload: { id: '7' },
+  };
+  expect(a).toHaveBeenCalledWith(expected);
+  expect(b).toHaveBeenCalledWith(expected);
+});
+
+test('unsubscribe stops a handler from receiving further messages', () => {
+  const handler = jest.fn();
+  const unsubscribe = subscribeRealtime(handler);
+
+  unsubscribe();
+  dispatchRealtimeMessage(
+    JSON.stringify({ channel: 'entity-changes:task', payload: {} }),
+  );
+
+  expect(handler).not.toHaveBeenCalled();
+});
+
+test('ignores malformed data and messages without a channel', () => {
+  const handler = jest.fn();
+  subscribeRealtime(handler);
+
+  expect(() => dispatchRealtimeMessage('not json')).not.toThrow();
+  dispatchRealtimeMessage(JSON.stringify({ payload: { id: '7' } })); // no channel
+
+  expect(handler).not.toHaveBeenCalled();
+});
+
+test('a throwing handler does not break other handlers', () => {
+  const bad = jest.fn(() => {
+    throw new Error('boom');
+  });
+  const good = jest.fn();
+  subscribeRealtime(bad);
+  subscribeRealtime(good);
+
+  expect(() =>
+    dispatchRealtimeMessage(
+      JSON.stringify({ channel: 'entity-changes:task', payload: {} }),
+    ),
+  ).not.toThrow();
+  expect(good).toHaveBeenCalledTimes(1);
+});
+
+test('does not open a socket when disabled', () => {
+  connectRealtime({ WEBSOCKET_ENABLED: false, WEBSOCKET_URL: 'ws://x/' });
+  expect(FakeWebSocket.instances).toHaveLength(0);
+});
+
+test('opens a socket when enabled and routes its messages to handlers', () => {
+  const handler = jest.fn();
+  subscribeRealtime(handler);
+  connectRealtime(ENABLED);
+
+  expect(FakeWebSocket.instances).toHaveLength(1);
+  const ws = FakeWebSocket.instances[0];
+  expect(ws.url).toBe(ENABLED.WEBSOCKET_URL);
+
+  ws.onmessage?.({
+    data: JSON.stringify({ channel: 'realtime:user:1', payload: { ok: true } }),
+  });
+
+  expect(handler).toHaveBeenCalledWith({
+    channel: 'realtime:user:1',
+    payload: { ok: true },
+  });
+});
+
+test('reconnects after the socket closes', () => {
+  jest.useFakeTimers();
+  connectRealtime(ENABLED);
+  expect(FakeWebSocket.instances).toHaveLength(1);
+
+  FakeWebSocket.instances[0].onclose?.();
+  jest.advanceTimersByTime(5000);
+
+  expect(FakeWebSocket.instances).toHaveLength(2);
+  jest.useRealTimers();
+});
+
+test('disconnect closes the socket and stops reconnecting', () => {
+  jest.useFakeTimers();
+  connectRealtime(ENABLED);
+  const ws = FakeWebSocket.instances[0];
+
+  // disconnect via a superseding reset; the prior socket must not reconnect.
+  resetRealtimeForTests();
+  expect(ws.close).toHaveBeenCalled();
+
+  ws.onclose?.(); // a late close from the torn-down socket
+  jest.advanceTimersByTime(5000);
+  expect(FakeWebSocket.instances).toHaveLength(1); // no new socket
+  jest.useRealTimers();
+});

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Shared client for the realtime WebSocket transport (`superset-websocket`).
+ *
+ * Owns the single browser socket and fans every message out to registered
+ * handlers, so multiple features share one connection: async chart-data
+ * completion (per-principal `realtime:*` messages, see `asyncEvent.ts`) and
+ * realtime list views (public `entity-changes:*` nudges, see
+ * `useListViewResource`). The server forwards a generic `{channel, payload}`
+ * envelope and this client is deliberately payload-agnostic — each handler
+ * routes on `channel` and interprets `payload` for its own feature.
+ *
+ * The transport is strictly best-effort: it is only an acceleration layer over
+ * each feature's own authorized fetch/poll, so a socket outage costs latency,
+ * not correctness. Connection auth is the `superset-ws-token` JWT cookie, which
+ * rides the handshake automatically (same-host requirement).
+ */
+import { logging } from '@apache-superset/core/utils';
+import getBootstrapData from 'src/utils/getBootstrapData';
+
+/** The generic envelope the server forwards to the browser. */
+export interface RealtimeMessage {
+  channel: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: any;
+}
+
+type RealtimeHandler = (message: RealtimeMessage) => void;
+
+type RealtimeConfig = {
+  WEBSOCKET_ENABLED?: boolean;
+  WEBSOCKET_URL?: string;
+};
+
+// Backoff before reconnecting after the socket closes (mirrors the Node
+// server's own subscribe retry). The socket is best-effort, so a generous
+// delay is fine — each feature's poll/fetch covers the gap.
+const RECONNECT_DELAY_MS = 5000;
+
+let socket: WebSocket | undefined;
+let reconnectTimeoutId: number;
+let enabled = false;
+let url: string | undefined;
+let started = false;
+// Bumped on every (re)configuration so an in-flight reconnect scheduled against
+// a superseded socket detects it is stale and stops.
+let generation = 0;
+const handlers = new Set<RealtimeHandler>();
+
+/**
+ * Parse a raw socket message and dispatch the `{channel, payload}` envelope to
+ * every handler. Exported for tests. Strictly best-effort: malformed data and a
+ * throwing handler are logged and swallowed, never propagated.
+ */
+export const dispatchRealtimeMessage = (rawData: string): void => {
+  let message: RealtimeMessage;
+  try {
+    const parsed = JSON.parse(rawData) ?? {};
+    if (typeof parsed.channel !== 'string') return;
+    message = { channel: parsed.channel, payload: parsed.payload };
+  } catch (err) {
+    logging.warn('Failed to parse realtime message', err);
+    return;
+  }
+  handlers.forEach(handler => {
+    try {
+      handler(message);
+    } catch (err) {
+      logging.warn('Realtime handler error', err);
+    }
+  });
+};
+
+const openSocket = (thisGeneration: number): void => {
+  if (thisGeneration !== generation) return;
+  if (!enabled || !url || typeof WebSocket === 'undefined') return;
+  let ws: WebSocket;
+  try {
+    ws = new WebSocket(url);
+  } catch (err) {
+    logging.warn('Failed to open realtime WebSocket', err);
+    return;
+  }
+  socket = ws;
+  ws.onmessage = (event: MessageEvent) => {
+    if (thisGeneration === generation)
+      dispatchRealtimeMessage(String(event.data));
+  };
+  ws.onclose = () => {
+    if (thisGeneration !== generation) return;
+    reconnectTimeoutId = window.setTimeout(
+      () => openSocket(thisGeneration),
+      RECONNECT_DELAY_MS,
+    );
+  };
+  // Errors surface as a subsequent close; let onclose own the reconnect and
+  // avoid logging the (payload-free) error event on every transient blip.
+  ws.onerror = () => {};
+};
+
+const teardownSocket = (): void => {
+  if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
+  if (socket) {
+    // Detach handlers first so the closing socket can't schedule a reconnect
+    // against the superseded generation.
+    socket.onmessage = null;
+    socket.onclose = null;
+    socket.onerror = null;
+    try {
+      socket.close();
+    } catch {
+      // ignore: closing an already-closed/broken socket is harmless
+    }
+    socket = undefined;
+  }
+};
+
+/**
+ * (Re)configure and (re)connect the shared socket. Idempotent and safe to call
+ * repeatedly (e.g. from app bootstrap): it supersedes any prior socket. Reads
+ * `WEBSOCKET_ENABLED` / `WEBSOCKET_URL` from bootstrap config when none is
+ * passed. A no-op (and tears down any existing socket) when disabled.
+ */
+export const connectRealtime = (config?: RealtimeConfig): void => {
+  const conf = config ?? getBootstrapData().common.conf;
+  teardownSocket();
+  generation += 1;
+  started = true;
+  enabled = Boolean(conf?.WEBSOCKET_ENABLED);
+  url = conf?.WEBSOCKET_URL;
+  openSocket(generation);
+};
+
+/** Tear down the socket and stop reconnecting. */
+export const disconnectRealtime = (): void => {
+  generation += 1;
+  teardownSocket();
+};
+
+/**
+ * Register a handler for every realtime message; returns an unsubscribe
+ * function. On the first subscription this lazily connects the socket from
+ * bootstrap config (unless `connectRealtime` was already called), so a feature
+ * can opt into realtime purely by subscribing.
+ */
+export const subscribeRealtime = (handler: RealtimeHandler): (() => void) => {
+  handlers.add(handler);
+  if (!started) connectRealtime();
+  return () => {
+    handlers.delete(handler);
+  };
+};
+
+// Test-only: reset module state between cases.
+export const resetRealtimeForTests = (): void => {
+  disconnectRealtime();
+  handlers.clear();
+  started = false;
+  enabled = false;
+  url = undefined;
+};

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -118,7 +118,18 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
     state: { loading, resourceCount: tasksCount, resourceCollection: tasks },
     fetchData,
     refreshData,
-  } = useListViewResource<Task>('task', t('task'), addDangerToast);
+  } = useListViewResource<Task>(
+    'task',
+    t('task'),
+    addDangerToast,
+    true, // infoEnable
+    [], // defaultCollectionValue
+    undefined, // baseFilters
+    true, // initialLoadingState
+    undefined, // selectColumns
+    true, // enableRealtime
+    'uuid', // realtimeIdField (tasks are keyed by uuid)
+  );
 
   // Get full user with roles to check admin status
   const bootstrapData = getBootstrapData();

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -128,7 +128,6 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
     true, // initialLoadingState
     undefined, // selectColumns
     true, // enableRealtime
-    'uuid', // realtimeIdField (tasks are keyed by uuid)
   );
 
   // Get full user with roles to check admin status

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -27,6 +27,10 @@ import {
   useChartEditModal,
 } from './hooks';
 import type Chart from 'src/types/Chart';
+import {
+  dispatchRealtimeMessage,
+  resetRealtimeForTests,
+} from 'src/middleware/realtime';
 
 /** Find the endpoint string from a spy's mock calls that matches a substring. */
 function findEndpoint(spy: jest.SpyInstance, substring: string): string {
@@ -45,6 +49,12 @@ function findEndpoint(spy: jest.SpyInstance, substring: string): string {
 
 beforeEach(() => {
   jest.restoreAllMocks();
+});
+
+afterEach(() => {
+  // Clear the shared realtime client's module-level handlers/socket so a
+  // realtime-enabled hook from one test can't leak into the next.
+  resetRealtimeForTests();
 });
 
 // useListViewResource
@@ -393,6 +403,106 @@ test('useListViewResource: uses desc sort direction when desc is true', async ()
 
   const endpoint = findEndpoint(getSpy, '/api/v1/chart/?q=');
   expect(endpoint).toContain('order_direction:desc');
+});
+
+test('useListViewResource: realtime nudge live-patches a displayed row in place', async () => {
+  const initial = [
+    { id: 1, name: 'A' },
+    { id: 2, name: 'B' },
+  ];
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockResolvedValueOnce({
+      json: { permissions: [] },
+    } as unknown as JsonResponse) // _info
+    .mockResolvedValueOnce({
+      json: { result: initial, count: 2 },
+    } as unknown as JsonResponse) // fetchData
+    .mockResolvedValueOnce({
+      json: { result: [{ id: 1, name: 'A-updated' }] },
+    } as unknown as JsonResponse); // batched realtime refetch
+
+  const { result } = renderHook(() =>
+    useListViewResource(
+      'chart',
+      'Charts',
+      jest.fn(),
+      true,
+      [],
+      undefined,
+      true,
+      undefined,
+      true, // enableRealtime
+    ),
+  );
+
+  await act(async () => {
+    await result.current.fetchData({
+      pageIndex: 0,
+      pageSize: 25,
+      sortBy: [{ id: 'id', desc: false }],
+      filters: [],
+    });
+  });
+  expect(result.current.state.resourceCollection).toEqual(initial);
+
+  // A nudge for a displayed row triggers one batched refetch (col:id op:in),
+  // and the fetched row is merged in place; the untouched row is unchanged.
+  act(() => {
+    dispatchRealtimeMessage(
+      JSON.stringify({ channel: 'entity-changes:chart', payload: { id: 1 } }),
+    );
+  });
+
+  await waitFor(() => {
+    expect(result.current.state.resourceCollection).toEqual([
+      { id: 1, name: 'A-updated' },
+      { id: 2, name: 'B' },
+    ]);
+  });
+  const endpoint = findEndpoint(getSpy, 'col:id');
+  expect(endpoint).toContain('opr:in');
+});
+
+test('useListViewResource: realtime ignores nudges for rows not on screen', async () => {
+  const initial = [{ id: 1, name: 'A' }];
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: { result: initial, count: 1 },
+  } as unknown as JsonResponse);
+
+  const { result } = renderHook(() =>
+    useListViewResource(
+      'chart',
+      'Charts',
+      jest.fn(),
+      true,
+      [],
+      undefined,
+      true,
+      undefined,
+      true,
+    ),
+  );
+
+  await act(async () => {
+    await result.current.fetchData({
+      pageIndex: 0,
+      pageSize: 25,
+      sortBy: [{ id: 'id', desc: false }],
+      filters: [],
+    });
+  });
+
+  const callsBefore = getSpy.mock.calls.length;
+  act(() => {
+    dispatchRealtimeMessage(
+      JSON.stringify({ channel: 'entity-changes:chart', payload: { id: 999 } }),
+    );
+  });
+
+  // No id=999 row is displayed, so no batched refetch is scheduled.
+  await new Promise(resolve => setTimeout(resolve, 600));
+  expect(getSpy.mock.calls.length).toBe(callsBefore);
 });
 
 // useSingleViewResource

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -454,12 +454,15 @@ test('useListViewResource: realtime nudge live-patches a displayed row in place'
     );
   });
 
-  await waitFor(() => {
-    expect(result.current.state.resourceCollection).toEqual([
-      { id: 1, name: 'A-updated' },
-      { id: 2, name: 'B' },
-    ]);
-  });
+  await waitFor(
+    () => {
+      expect(result.current.state.resourceCollection).toEqual([
+        { id: 1, name: 'A-updated' },
+        { id: 2, name: 'B' },
+      ]);
+    },
+    { timeout: 3000 },
+  );
   const endpoint = findEndpoint(getSpy, 'col:id');
   expect(endpoint).toContain('opr:in');
 });

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -57,7 +57,7 @@ import {
 
 // Realtime list views coalesce a burst of entity-change nudges into at most one
 // batched row fetch per this window, bounding backend load under heavy churn.
-const REALTIME_REFETCH_DEBOUNCE_MS = 500;
+const REALTIME_REFETCH_DEBOUNCE_MS = 1000;
 
 interface ListViewResourceState<D extends object = any> {
   loading: boolean;

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -46,10 +46,18 @@ import { getShareableUrl } from 'src/utils/navigationUtils';
 import SupersetText from 'src/utils/textUtils';
 import { DatabaseObject } from 'src/features/databases/types';
 import {
+  subscribeRealtime,
+  type RealtimeMessage,
+} from 'src/middleware/realtime';
+import {
   FavoriteStatus,
   FileEncryptedExtraFields,
   ImportResourceName,
 } from './types';
+
+// Realtime list views coalesce a burst of entity-change nudges into at most one
+// batched row fetch per this window, bounding backend load under heavy churn.
+const REALTIME_REFETCH_DEBOUNCE_MS = 500;
 
 interface ListViewResourceState<D extends object = any> {
   loading: boolean;
@@ -86,6 +94,13 @@ export function useListViewResource<D extends object = any>(
   baseFilters?: FilterValue[], // must be memoized
   initialLoadingState = true,
   selectColumns?: string[],
+  // Realtime: when enabled, the list subscribes to the entity-change nudge
+  // channel and live-patches only its currently-displayed rows (see the
+  // realtime effect below). `realtimeIdField` is the row identity used both to
+  // match nudges against the collection and to filter the batched refetch
+  // (default the integer `id`; UUID-facing resources like tasks pass `uuid`).
+  enableRealtime = false,
+  realtimeIdField = 'id',
 ) {
   const [state, setState] = useState<ListViewResourceState<D>>({
     count: 0,
@@ -238,6 +253,77 @@ export function useListViewResource<D extends object = any>(
     },
     [fetchData],
   );
+
+  // Realtime list updates: on an entity-change nudge for a row currently on
+  // screen, debounce-collect the ids and batch-refetch just those rows through
+  // the normal authorized list endpoint (authz/RLS still apply), merging them in
+  // place. Update-only — no new-row insertion — and best-effort, so a downed
+  // socket just defers the update to the next normal fetch.
+  const collectionRef = useRef(state.collection);
+  collectionRef.current = state.collection;
+
+  useEffect(() => {
+    if (!enableRealtime) return undefined;
+
+    const channel = `entity-changes:${resource}`;
+    const pendingIds = new Set<string>();
+    let debounceId: ReturnType<typeof setTimeout> | undefined;
+
+    const rowId = (row: D): string =>
+      String((row as Record<string, unknown>)[realtimeIdField]);
+    const isDisplayed = (id: string): boolean =>
+      collectionRef.current.some(row => rowId(row) === id);
+
+    const flush = () => {
+      debounceId = undefined;
+      // Re-check membership: the collection may have changed (paged/filtered)
+      // since the nudges arrived, so only fetch rows still on screen.
+      const ids = [...pendingIds].filter(isDisplayed);
+      pendingIds.clear();
+      if (!ids.length) return;
+
+      const query = rison.encode_uri({
+        filters: [{ col: realtimeIdField, opr: 'in', value: ids }],
+        page: 0,
+        page_size: ids.length,
+      });
+      SupersetClient.get({ endpoint: `/api/v1/${resource}/?q=${query}` })
+        .then(({ json = {} }) => {
+          const fetched: D[] = json.result ?? [];
+          if (!fetched.length) return;
+          const byId = new Map(fetched.map(row => [rowId(row), row]));
+          // Replace matched rows in place; keep order, count, and every
+          // untouched row reference (so React only re-renders changed rows).
+          setState(current => ({
+            ...current,
+            collection: current.collection.map(
+              row => byId.get(rowId(row)) ?? row,
+            ),
+          }));
+        })
+        .catch(() => {
+          // Best-effort: a failed patch just leaves the stale rows until the
+          // next normal fetch; never surface a toast for a background refresh.
+        });
+    };
+
+    const unsubscribe = subscribeRealtime((message: RealtimeMessage) => {
+      if (message.channel !== channel) return;
+      const id = message.payload?.id;
+      if (id == null) return;
+      const idStr = String(id);
+      if (!isDisplayed(idStr)) return;
+      pendingIds.add(idStr);
+      if (debounceId === undefined) {
+        debounceId = setTimeout(flush, REALTIME_REFETCH_DEBOUNCE_MS);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      if (debounceId !== undefined) clearTimeout(debounceId);
+    };
+  }, [enableRealtime, resource, realtimeIdField]);
 
   return {
     state: {

--- a/superset/commands/tasks/cancel.py
+++ b/superset/commands/tasks/cancel.py
@@ -110,12 +110,17 @@ class CancelTaskCommand(BaseCommand):
         with task_lock(dedup_key):
             result = self._execute_with_transaction()
 
+        from superset.tasks.manager import TaskManager
+
         # Publish abort notification AFTER transaction commits
         # This prevents race conditions where listeners check DB before commit
         if self._should_publish_abort:
-            from superset.tasks.manager import TaskManager
-
             TaskManager.publish_abort(self._task_uuid)
+
+        # Nudge realtime list views of the abort/cancel state change (post-commit).
+        # Abort transitions (→ABORTING/ABORTED) don't go through
+        # InternalStatusTransitionCommand, so they are emitted here instead.
+        TaskManager.publish_entity_change(self._task_uuid)
 
         return result
 

--- a/superset/commands/tasks/internal_update.py
+++ b/superset/commands/tasks/internal_update.py
@@ -43,6 +43,19 @@ from superset.utils.decorators import on_error, transaction
 logger = logging.getLogger(__name__)
 
 
+def _publish_entity_change(task_uuid: UUID) -> None:
+    """Best-effort realtime nudge for a committed task change.
+
+    Emitted after the transaction commits (so a client that re-fetches sees the
+    new state), on every status transition and throttled progress/payload write
+    — not just terminal completion — so realtime list views reflect intermediate
+    states (e.g. IN_PROGRESS, progress) live.
+    """
+    from superset.tasks.manager import TaskManager
+
+    TaskManager.publish_entity_change(task_uuid)
+
+
 class InternalUpdateTaskCommand(BaseCommand):
     """
     Zero-read task update command for properties/payload.
@@ -82,8 +95,15 @@ class InternalUpdateTaskCommand(BaseCommand):
         """No validation needed for internal command."""
         pass
 
-    @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))
     def run(self) -> bool:
+        """Write, then nudge realtime consumers of the change (post-commit)."""
+        updated = self._run_in_transaction()
+        if updated:
+            _publish_entity_change(self._task_uuid)
+        return updated
+
+    @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))
+    def _run_in_transaction(self) -> bool:
         """
         Execute zero-read update.
 
@@ -167,8 +187,15 @@ class InternalStatusTransitionCommand(BaseCommand):
         """No validation needed for internal command."""
         pass
 
-    @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))
     def run(self) -> bool:
+        """Transition, then nudge realtime consumers of the change (post-commit)."""
+        updated = self._run_in_transaction()
+        if updated:
+            _publish_entity_change(self._task_uuid)
+        return updated
+
+    @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))
+    def _run_in_transaction(self) -> bool:
         """
         Execute atomic conditional status update.
 

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -69,6 +69,17 @@ class TaskDAO(BaseDAO[Task]):
         return result[0] if result else None
 
     @classmethod
+    def get_id(cls, task_uuid: UUID) -> int | None:
+        """Return a task's integer primary key by UUID, or None if not found.
+
+        Lightweight scalar lookup (no entity load, no base filter): used to carry
+        the primary id in the realtime entity-change nudge, which the list view
+        matches and refetches by. Internal plumbing on a task the caller already
+        owns, not a user-facing lookup.
+        """
+        return db.session.query(Task.id).filter(Task.uuid == task_uuid).scalar()
+
+    @classmethod
     def get_statuses_changed_since(
         cls, cursor: datetime | None, task_type: str | None = None
     ) -> tuple[dict[str, dict[str, Any]], datetime]:

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -131,7 +131,7 @@ class TaskRestApi(BaseSupersetModelRestApi):
         "status",
         "created_by",
         "created_on",
-        "uuid",
+        "id",
     ]
 
     base_order = ("created_on", "desc")

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -131,6 +131,7 @@ class TaskRestApi(BaseSupersetModelRestApi):
         "status",
         "created_by",
         "created_on",
+        "uuid",
     ]
 
     base_order = ("created_on", "desc")

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -81,37 +81,43 @@ class TaskManager:
     # channel per entity type (``entity-changes:task``, later ``:dashboard``,
     # ``:chart``, ``:dataset`` etc.) so consumers subscribe only to the types they
     # care about. The contract is general across all entity types: a nudge carries
-    # ONLY ``{entity_type, id}`` — no status or payload (status is task-specific and
-    # would not generalize). It's published once to the type's channel (not fanned
-    # out per subscriber). Id existence is intentionally public; anything sensitive
-    # (including a task's status/result) is delivered on the per-principal channel
-    # or fetched through the authorized REST API (``TaskFilter``/RLS), so this
-    # channel never carries authz-sensitive data.
+    # ONLY ``{entity_type, id}`` (the integer primary key) — no status or payload
+    # (status is task-specific and would not generalize). It's published once to
+    # the type's channel (not fanned out per subscriber). Id existence is
+    # intentionally public; anything sensitive (including a task's status/result)
+    # is delivered on the per-principal channel or fetched through the authorized
+    # REST API (``TaskFilter``/RLS), so this channel never carries authz-sensitive
+    # data.
     ENTITY_CHANGES_CHANNEL_PREFIX = "entity-changes:"
 
     @classmethod
     def publish_entity_change(cls, task_uuid: UUID) -> bool:
         """Publish a lossy, opaque, public "entity changed" nudge for realtime UIs.
 
-        Best-effort pub/sub (may be dropped) carrying only ``{entity_type, id}`` —
-        no status or payload — published once to the per-type channel
+        Best-effort pub/sub (may be dropped) carrying only ``{entity_type, id}``
+        (the integer primary key, which a realtime list view matches and refetches
+        by) — no status or payload — published once to the per-type channel
         (``entity-changes:task``). A browser transport (superset-websocket) forwards
         it to subscribed clients, which then re-fetch the actual (authz-scoped)
-        state through the authorized REST API (``/api/v1/task/status_changes``,
-        etc.). No-op when no coordination backend is configured.
+        state through the authorized REST API. No-op when no coordination backend
+        is configured or the task no longer exists.
 
         :param task_uuid: UUID of the changed task
         :returns: True if the nudge was published, False otherwise
         """
         from superset.coordination.base import CoordinationService
+        from superset.daos.tasks import TaskDAO
         from superset.utils import json
 
         if not CoordinationService.is_backend_defined():
             return False
         try:
+            task_id = TaskDAO.get_id(task_uuid)
+            if task_id is None:
+                return False
             CoordinationService.publish(
                 f"{cls.ENTITY_CHANGES_CHANNEL_PREFIX}task",
-                json.dumps({"entity_type": "task", "id": str(task_uuid)}),
+                json.dumps({"entity_type": "task", "id": task_id}),
             )
             return True
         except Exception as ex:  # noqa: BLE001 pylint: disable=broad-except
@@ -252,12 +258,11 @@ class TaskManager:
             channel = cls.get_completion_channel(task_uuid)
             CoordinationService.notify(channel, status)
             logger.debug("Signalled completion on %s (status=%s)", channel, status)
-            # Also emit a lossy opaque nudge for realtime UI transports (separate
-            # from the guaranteed completion signal above).
-            cls.publish_entity_change(task_uuid)
-            # And push the terminal status to each subscriber's per-principal
-            # channel (tier-2), so a chart-data client learns completion detail
-            # over the socket instead of re-polling the REST API.
+            # The tier-1 entity-change nudge for the terminal transition is emitted
+            # by InternalStatusTransitionCommand (post-commit), so it is not
+            # repeated here. Push the terminal status to each subscriber's
+            # per-principal channel (tier-2) so a chart-data client learns
+            # completion detail over the socket instead of re-polling the REST API.
             cls.publish_task_status(task_uuid, status)
             return True
         except redis.RedisError as ex:

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -169,30 +169,39 @@ class TestTaskManagerEntityChange:
 
     IS_DEFINED = "superset.coordination.base.CoordinationService.is_backend_defined"
     PUBLISH = "superset.coordination.base.CoordinationService.publish"
+    GET_ID = "superset.daos.tasks.TaskDAO.get_id"
 
     @patch(IS_DEFINED, return_value=False)
     def test_no_backend(self, mock_defined):
         assert TaskManager.publish_entity_change(uuid.uuid4()) is False
 
+    @patch(GET_ID, return_value=42)
     @patch(PUBLISH)
     @patch(IS_DEFINED, return_value=True)
     def test_publishes_opaque_nudge_to_per_type_channel(
-        self, mock_defined, mock_publish
+        self, mock_defined, mock_publish, mock_get_id
     ):
-        task_uuid = uuid.uuid4()
+        assert TaskManager.publish_entity_change(uuid.uuid4()) is True
 
-        assert TaskManager.publish_entity_change(task_uuid) is True
-
-        # One publish to the task type's channel, carrying ONLY opaque ids — no
-        # status or payload (the contract is general across all entity types).
+        # One publish to the task type's channel, carrying ONLY opaque ids (the
+        # integer primary key) — no status or payload (the contract is general
+        # across all entity types).
         mock_publish.assert_called_once()
         channel, message = mock_publish.call_args.args[:2]
         assert channel == "entity-changes:task"
-        assert json.loads(message) == {"entity_type": "task", "id": str(task_uuid)}
+        assert json.loads(message) == {"entity_type": "task", "id": 42}
 
+    @patch(GET_ID, return_value=None)
+    @patch(PUBLISH)
+    @patch(IS_DEFINED, return_value=True)
+    def test_missing_task_is_noop(self, mock_defined, mock_publish, mock_get_id):
+        assert TaskManager.publish_entity_change(uuid.uuid4()) is False
+        mock_publish.assert_not_called()
+
+    @patch(GET_ID, return_value=42)
     @patch(PUBLISH, side_effect=redis.RedisError("boom"))
     @patch(IS_DEFINED, return_value=True)
-    def test_redis_error_is_swallowed(self, mock_defined, mock_publish):
+    def test_redis_error_is_swallowed(self, mock_defined, mock_publish, mock_get_id):
         assert TaskManager.publish_entity_change(uuid.uuid4()) is False
 
 


### PR DESCRIPTION
### SUMMARY

Step 7 of the [GAQ→GTF epic](https://github.com/apache/superset/pull/43407) (targets `gaq-to-gtf`) — **realtime list views**, the headline capability of the new websocket transport. A list built on `useListViewResource` now live-patches its on-screen rows as the underlying entities change, with no manual refresh. The Task List is the first surface; any other list opts in with two args.

**Shared realtime client** (`src/middleware/realtime.ts`) — owns the single browser socket and fans the generic `{channel, payload}` envelope out to any number of subscribers, so features share one connection. Socket ownership is extracted out of `asyncEvent.ts`, which now simply subscribes for its tier-2 chart-data handler. The client is payload-agnostic (routes on `channel`) and best-effort (reconnects on close); connection auth is the `superset-ws-token` JWT cookie riding the handshake.

**`useListViewResource` realtime** (opt-in via `enableRealtime`, `realtimeIdField`) — subscribes to `entity-changes:<resource>`, ignores nudges for rows not currently displayed, **debounce-collects** the rest (~500ms) and issues **one batched fetch** of just those rows through the normal authorized list endpoint (`col:<idField> op:in`), merging them in place by id. Update-only (no new-row insertion, no full refetch/redraw), so:
- authz/RLS are unchanged — the socket only carries opaque ids; real data comes from the authorized REST endpoint;
- a burst of changes can't hammer the backend (one coalesced fetch per window);
- untouched rows keep their reference, so React only re-renders what changed.

**Task List = first surface** — realtime enabled with `realtimeIdField: 'uuid'` (tasks are UUID-facing). Tasks already emit `entity-changes:task` nudges at completion (shipped in 6a, #43431), so this works end-to-end with no new backend nudge. Added `uuid` to the task API `search_columns` so the batched refetch can filter by it.

**Known limitation / follow-up:** tasks currently nudge only on terminal completion (per 6a), so intermediate transitions (pending→in_progress, progress) don't yet live-update; emitting nudges on those transitions, and adding nudges at other entities' DAO/command commit points (dashboards/charts/datasets/…), are incremental follow-ups — each new list inherits realtime for free once its backend nudges land.

### TESTING INSTRUCTIONS

Automated (all green locally):
- `jest src/middleware/realtime.test.ts` — shared client: dispatch/subscribe/unsubscribe, malformed/handler-error isolation, enabled/disabled connect, reconnect-on-close, disconnect.
- `jest src/middleware/asyncEvent.test.ts` — refactored onto the shared client; tier-2 acceleration still settles/rejects/ignores correctly.
- `jest src/views/CRUD/hooks.test.tsx` — realtime nudge live-patches a displayed row in place (batched `col:id op:in` fetch + merge); nudges for off-screen rows are ignored.
- `pytest tests/unit_tests/tasks/` — 359 passed (search_columns addition).
- `tsc` / `eslint` / `ruff` / `pylint` clean.

Manual (with `WEBSOCKET_ENABLED`, `DISTRIBUTED_COORDINATION_CONFIG`, `superset-websocket` running same-host):
1. Open the Task List, trigger async work → completed task rows update their status/duration in place without a manual refresh, while the rest of the page stays put.
2. Kill the websocket server → the list still reflects state on its next normal load/refresh (best-effort degradation).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `WEBSOCKET_ENABLED` (realtime transport)
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
