### PR TITLE
chore: remove two stale codecov ignore paths

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,7 @@ codecov:
         after_n_builds: 4
 ignore:
   - "superset/migrations/versions/*.py"
-  - "superset-frontend/packages/superset-ui-demo/**/*"
   - "**/*.stories.tsx"
-  - "**/*.stories.jsx"
 coverage:
   status:
     project:


### PR DESCRIPTION
### SUMMARY

`.codecov.yml` ignores two patterns that match nothing in the tree:

- `superset-frontend/packages/superset-ui-demo/**/*` (the package was removed in 981b370fe9, February 2026)
- `**/*.stories.jsx` (no `.stories.jsx` files remain since the same commit, stories are `.tsx` now and the `**/*.stories.tsx` line above already covers them)

### TESTING INSTRUCTIONS

    ls superset-frontend/packages | grep ui-demo   # empty
    git ls-files '*.stories.jsx'                   # empty

### ADDITIONAL INFORMATION

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.