### PR TITLE
fix(number-format): preserve custom smart formatter id

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/number-format/factories/createSmartNumberFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/number-format/factories/createSmartNumberFormatter.ts
@@ -64,9 +64,8 @@ export default function createSmartNumberFormatter(
     description,
     formatFunc: value => `${getSign(value)}${formatValue(value)}`,
     id:
-      id || signed
-        ? NumberFormats.SMART_NUMBER_SIGNED
-        : NumberFormats.SMART_NUMBER,
+      id ??
+      (signed ? NumberFormats.SMART_NUMBER_SIGNED : NumberFormats.SMART_NUMBER),
     label: label ?? 'Adaptive formatter',
   });
 }

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSmartNumberFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createSmartNumberFormatter.test.ts
@@ -24,6 +24,12 @@ describe('createSmartNumberFormatter(options)', () => {
     const formatter = createSmartNumberFormatter();
     expect(formatter).toBeInstanceOf(NumberFormatter);
   });
+  test('uses the supplied formatter id regardless of signed option', () => {
+    expect(createSmartNumberFormatter({ id: 'custom' }).id).toBe('custom');
+    expect(
+      createSmartNumberFormatter({ id: 'custom-signed', signed: true }).id,
+    ).toBe('custom-signed');
+  });
   describe('using default options', () => {
     const formatter = createSmartNumberFormatter();
     test('formats 0 correctly', () => {


### PR DESCRIPTION
### SUMMARY

`createSmartNumberFormatter` treated `id || signed` as the ternary condition, so any supplied formatter ID was replaced with a built-in smart-number ID. This preserves a supplied ID and only selects the signed or unsigned default when `id` is absent.

Regression coverage verifies custom IDs with both signed modes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this fixes formatter metadata without changing UI rendering.

### TESTING INSTRUCTIONS

- `npm test -- packages/superset-ui-core/test/number-format/factories/createSmartNumberFormatter.test.ts --runInBand` - 23 passed
- `npx tsc --build packages/superset-ui-core/tsconfig.json`
- `npx oxfmt <changed files> --check`
- `npx oxlint --config oxlint.json --quiet <changed files>`

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43430
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
