### PR TITLE
fix: remove redundant 'tooltip' tooltip in scoping modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingTreePanel.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/CrossFilters/ScopingModal/ScopingTreePanel.tsx
@@ -22,7 +22,7 @@ import { t } from '@apache-superset/core/translation';
 import { isDefined, NativeFilterScope } from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { css, styled, useTheme } from '@apache-superset/core/theme';
-import { Select, Tooltip } from '@superset-ui/core/components';
+import { Select } from '@superset-ui/core/components';
 import { noOp } from 'src/utils/common';
 import ScopingTree from 'src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/ScopingTree';
 import {
@@ -33,7 +33,6 @@ import {
 } from 'src/dashboard/types';
 import { CHART_TYPE } from 'src/dashboard/util/componentTypes';
 import type { SelectOptionsType } from '@superset-ui/core/components';
-import { Icons } from '@superset-ui/core/components/Icons';
 import { NEW_CHART_SCOPING_ID } from './constants';
 
 interface ScopingTreePanelProps {
@@ -109,16 +108,6 @@ const ChartSelect = ({
             margin-bottom: 0;
           `}
         >{`${t('Chart')} *`}</InfoText>
-        <Tooltip title={t('Tooltip')} placement="top">
-          <Icons.InfoCircleOutlined
-            iconSize="xs"
-            css={css`
-              & > span {
-                line-height: 0;
-              }
-            `}
-          />
-        </Tooltip>
       </div>
       <Select
         data-test="select-chart"


### PR DESCRIPTION
### SUMMARY
Removes a 'tooltip' tooltip that was probably put there by mistake in `ScopingTreePanel.tsx`. There's a separate description below of what to do in the field.

Super low prio, but is odd to see when you encounter it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
<img width="524" height="220" alt="image" src="https://github.com/user-attachments/assets/a965643c-d61f-407d-883c-0be920a6e531" />

now:
<img width="522" height="153" alt="image" src="https://github.com/user-attachments/assets/19a424c7-de32-4674-9f36-be8197651177" />

### TESTING INSTRUCTIONS
- Open a dashboard
- Press the three dots in a chart container
- Open filter scoping
- Notice tooltip is gone

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
