### PR TITLE
fix(chart): render ECharts charts at full resolution in download-as-image

### DIFF
--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -772,7 +772,11 @@ test('re-renders an ECharts canvas at PNG_SCALE pixel ratio so the export is cri
   const hiRes = document.createElement('canvas');
   hiRes.width = 800;
   hiRes.height = 600;
-  const renderToCanvas = jest.fn(() => hiRes);
+  let renderOpts: Record<string, unknown> | undefined;
+  const renderToCanvas = jest.fn((opts?: Record<string, unknown>) => {
+    renderOpts = opts;
+    return hiRes;
+  });
   mockGetInstanceByDom.mockReturnValue({ renderToCanvas });
 
   // Capture the cloned canvas backing store handed to dom-to-image
@@ -797,11 +801,10 @@ test('re-renders an ECharts canvas at PNG_SCALE pixel ratio so the export is cri
   // Instance recovered from the canvas's echarts-host ancestor...
   expect(mockGetInstanceByDom).toHaveBeenCalledWith(host);
   // ...and re-rendered at PNG_SCALE (2). No backgroundColor is forced, so the chart keeps its
-  // own background (matching the on-screen canvas).
-  expect(renderToCanvas).toHaveBeenCalledWith(
-    expect.objectContaining({ pixelRatio: 2 }),
-  );
-  expect(renderToCanvas.mock.calls[0][0]).not.toHaveProperty('backgroundColor');
+  // own configured background (matching the on-screen canvas).
+  expect(renderToCanvas).toHaveBeenCalled();
+  expect(renderOpts).toEqual(expect.objectContaining({ pixelRatio: 2 }));
+  expect(renderOpts).not.toHaveProperty('backgroundColor');
   // The cloned canvas dom-to-image serializes is the 2× high-res source
   expect(clonedCanvasWidth).toBe(800);
   expect(clonedCanvasHeight).toBe(600);

--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -88,6 +88,9 @@ function attachMockApi(
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // clearAllMocks does not clear a mockReturnValue, so reset the instance lookup explicitly to
+  // stop a return value leaking into any clone-path test added after the ECharts ones below.
+  mockGetInstanceByDom.mockReset();
   mockToJpeg.mockResolvedValue('data:image/jpeg;base64,test');
   mockToPng.mockResolvedValue('data:image/png;base64,test');
 });
@@ -793,10 +796,12 @@ test('re-renders an ECharts canvas at PNG_SCALE pixel ratio so the export is cri
 
   // Instance recovered from the canvas's echarts-host ancestor...
   expect(mockGetInstanceByDom).toHaveBeenCalledWith(host);
-  // ...and re-rendered at PNG_SCALE (2) on a transparent background
+  // ...and re-rendered at PNG_SCALE (2). No backgroundColor is forced, so the chart keeps its
+  // own background (matching the on-screen canvas).
   expect(renderToCanvas).toHaveBeenCalledWith(
-    expect.objectContaining({ pixelRatio: 2, backgroundColor: 'transparent' }),
+    expect.objectContaining({ pixelRatio: 2 }),
   );
+  expect(renderToCanvas.mock.calls[0][0]).not.toHaveProperty('backgroundColor');
   // The cloned canvas dom-to-image serializes is the 2× high-res source
   expect(clonedCanvasWidth).toBe(800);
   expect(clonedCanvasHeight).toBe(600);
@@ -808,7 +813,6 @@ test('re-renders an ECharts canvas at PNG_SCALE pixel ratio so the export is cri
 
 test('preserves a non-ECharts canvas at its on-screen resolution (no re-render)', async () => {
   const { drawImage, restore } = stubCanvasContext();
-  mockGetInstanceByDom.mockReturnValue(undefined);
 
   const container = document.createElement('div');
   const canvas = document.createElement('canvas');
@@ -832,9 +836,97 @@ test('preserves a non-ECharts canvas at its on-screen resolution (no re-render)'
   );
   await handler(syntheticEventFor(container));
 
-  // No echarts-host ancestor → the on-screen bitmap is copied 1:1, not re-rendered
+  // No echarts-host ancestor → echarts is never imported/consulted and the on-screen bitmap is
+  // copied 1:1.
+  expect(mockGetInstanceByDom).not.toHaveBeenCalled();
   expect(clonedCanvasWidth).toBe(400);
   expect(drawImage).toHaveBeenCalled();
+
+  restore();
+  document.body.removeChild(container);
+});
+
+test('falls back to a 1:1 copy when the ECharts instance is gone (getInstanceByDom returns undefined)', async () => {
+  const { drawImage, restore } = stubCanvasContext();
+  // Disposed / not-yet-initialised chart: the host is in the DOM but has no live instance.
+  mockGetInstanceByDom.mockReturnValue(undefined);
+
+  const container = document.createElement('div');
+  const host = document.createElement('div');
+  host.className = 'echarts-host';
+  const canvas = document.createElement('canvas');
+  canvas.width = 400;
+  canvas.height = 300;
+  host.appendChild(canvas);
+  container.appendChild(host);
+  document.body.appendChild(container);
+
+  let clonedCanvasWidth: number | undefined;
+  mockToPng.mockImplementation((cloneRoot: HTMLElement) => {
+    clonedCanvasWidth = cloneRoot.querySelector('canvas')?.width;
+    return Promise.resolve('data:image/png;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized(
+    'div',
+    'Sunburst',
+    false,
+    undefined,
+    { format: 'png' },
+  );
+  await handler(syntheticEventFor(container));
+
+  expect(mockGetInstanceByDom).toHaveBeenCalledWith(host);
+  // No instance → the on-screen bitmap is copied 1:1 and the export still completes
+  expect(clonedCanvasWidth).toBe(400);
+  expect(drawImage).toHaveBeenCalled();
+  expect(mockToPng).toHaveBeenCalled();
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
+
+  restore();
+  document.body.removeChild(container);
+});
+
+test('falls back to a 1:1 copy (and still exports) when renderToCanvas throws', async () => {
+  const { drawImage, restore } = stubCanvasContext();
+  // A valid but unhealthy instance (mid-dispose, errored chart) whose re-render throws.
+  const renderToCanvas = jest.fn(() => {
+    throw new Error('chart is disposing');
+  });
+  mockGetInstanceByDom.mockReturnValue({ renderToCanvas });
+
+  const container = document.createElement('div');
+  const host = document.createElement('div');
+  host.className = 'echarts-host';
+  const canvas = document.createElement('canvas');
+  canvas.width = 400;
+  canvas.height = 300;
+  host.appendChild(canvas);
+  container.appendChild(host);
+  document.body.appendChild(container);
+
+  let clonedCanvasWidth: number | undefined;
+  mockToPng.mockImplementation((cloneRoot: HTMLElement) => {
+    clonedCanvasWidth = cloneRoot.querySelector('canvas')?.width;
+    return Promise.resolve('data:image/png;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized(
+    'div',
+    'Sunburst',
+    false,
+    undefined,
+    { format: 'png' },
+  );
+  await handler(syntheticEventFor(container));
+
+  // The throw is swallowed per-canvas: the export completes via the on-screen 1:1 copy rather
+  // than aborting the whole capture.
+  expect(renderToCanvas).toHaveBeenCalled();
+  expect(clonedCanvasWidth).toBe(400);
+  expect(drawImage).toHaveBeenCalled();
+  expect(mockToPng).toHaveBeenCalled();
+  expect(mockAddWarningToast).not.toHaveBeenCalled();
 
   restore();
   document.body.removeChild(container);

--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import domToImage from 'dom-to-image-more';
+import { getInstanceByDom } from 'echarts/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
 import downloadAsImageOptimized, {
   waitForStableScrollHeight,
@@ -25,6 +26,11 @@ import downloadAsImageOptimized, {
 jest.mock('dom-to-image-more', () => ({
   __esModule: true,
   default: { toJpeg: jest.fn(), toPng: jest.fn() },
+}));
+
+jest.mock('echarts/core', () => ({
+  __esModule: true,
+  getInstanceByDom: jest.fn(),
 }));
 
 jest.mock('src/components/MessageToasts/actions', () => ({
@@ -38,6 +44,7 @@ jest.mock('@apache-superset/core/translation', () => ({
 const mockToJpeg = domToImage.toJpeg as jest.Mock;
 const mockToPng = domToImage.toPng as jest.Mock;
 const mockAddWarningToast = addWarningToast as jest.Mock;
+const mockGetInstanceByDom = getInstanceByDom as jest.Mock;
 
 // document.fonts.ready is not implemented in jsdom; provide a resolved promise
 Object.defineProperty(document, 'fonts', {
@@ -732,5 +739,137 @@ test('clone path falls back to white background when theme is absent', async () 
     expect.objectContaining({ bgcolor: undefined }),
   );
 
+  document.body.removeChild(container);
+});
+
+// jsdom does not implement HTMLCanvasElement.getContext, so stub a minimal 2d context.
+function stubCanvasContext() {
+  const drawImage = jest.fn();
+  const spy = jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+  return { drawImage, restore: () => spy.mockRestore() };
+}
+
+test('re-renders an ECharts canvas at PNG_SCALE pixel ratio so the export is crisp', async () => {
+  const { restore } = stubCanvasContext();
+
+  const container = document.createElement('div');
+  const host = document.createElement('div');
+  host.className = 'echarts-host';
+  const canvas = document.createElement('canvas');
+  // on-screen backing store: CSS 400×300 at devicePixelRatio 1
+  canvas.width = 400;
+  canvas.height = 300;
+  host.appendChild(canvas);
+  container.appendChild(host);
+  document.body.appendChild(container);
+
+  // Fake ECharts instance whose renderToCanvas returns a 2× (high-res) canvas
+  const hiRes = document.createElement('canvas');
+  hiRes.width = 800;
+  hiRes.height = 600;
+  const renderToCanvas = jest.fn(() => hiRes);
+  mockGetInstanceByDom.mockReturnValue({ renderToCanvas });
+
+  // Capture the cloned canvas backing store handed to dom-to-image
+  let clonedCanvasWidth: number | undefined;
+  let clonedCanvasHeight: number | undefined;
+  mockToPng.mockImplementation((cloneRoot: HTMLElement) => {
+    const c = cloneRoot.querySelector('canvas');
+    clonedCanvasWidth = c?.width;
+    clonedCanvasHeight = c?.height;
+    return Promise.resolve('data:image/png;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized(
+    'div',
+    'Sunburst',
+    false,
+    undefined,
+    { format: 'png' },
+  );
+  await handler(syntheticEventFor(container));
+
+  // Instance recovered from the canvas's echarts-host ancestor...
+  expect(mockGetInstanceByDom).toHaveBeenCalledWith(host);
+  // ...and re-rendered at PNG_SCALE (2) on a transparent background
+  expect(renderToCanvas).toHaveBeenCalledWith(
+    expect.objectContaining({ pixelRatio: 2, backgroundColor: 'transparent' }),
+  );
+  // The cloned canvas dom-to-image serializes is the 2× high-res source
+  expect(clonedCanvasWidth).toBe(800);
+  expect(clonedCanvasHeight).toBe(600);
+  expect(mockToPng).toHaveBeenCalled();
+
+  restore();
+  document.body.removeChild(container);
+});
+
+test('preserves a non-ECharts canvas at its on-screen resolution (no re-render)', async () => {
+  const { drawImage, restore } = stubCanvasContext();
+  mockGetInstanceByDom.mockReturnValue(undefined);
+
+  const container = document.createElement('div');
+  const canvas = document.createElement('canvas');
+  canvas.width = 400;
+  canvas.height = 300;
+  container.appendChild(canvas);
+  document.body.appendChild(container);
+
+  let clonedCanvasWidth: number | undefined;
+  mockToPng.mockImplementation((cloneRoot: HTMLElement) => {
+    clonedCanvasWidth = cloneRoot.querySelector('canvas')?.width;
+    return Promise.resolve('data:image/png;base64,test');
+  });
+
+  const handler = downloadAsImageOptimized(
+    'div',
+    'Deck Chart',
+    false,
+    undefined,
+    { format: 'png' },
+  );
+  await handler(syntheticEventFor(container));
+
+  // No echarts-host ancestor → the on-screen bitmap is copied 1:1, not re-rendered
+  expect(clonedCanvasWidth).toBe(400);
+  expect(drawImage).toHaveBeenCalled();
+
+  restore();
+  document.body.removeChild(container);
+});
+
+test('re-renders an ECharts host only once when it owns multiple canvas layers', async () => {
+  const { restore } = stubCanvasContext();
+
+  const container = document.createElement('div');
+  const host = document.createElement('div');
+  host.className = 'echarts-host';
+  // ECharts may add a second <canvas> for a hover/progressive layer
+  host.appendChild(document.createElement('canvas'));
+  host.appendChild(document.createElement('canvas'));
+  container.appendChild(host);
+  document.body.appendChild(container);
+
+  const hiRes = document.createElement('canvas');
+  hiRes.width = 800;
+  hiRes.height = 600;
+  const renderToCanvas = jest.fn(() => hiRes);
+  mockGetInstanceByDom.mockReturnValue({ renderToCanvas });
+
+  const handler = downloadAsImageOptimized(
+    'div',
+    'Sunburst',
+    false,
+    undefined,
+    { format: 'png' },
+  );
+  await handler(syntheticEventFor(container));
+
+  // Both canvases resolve to the same instance; the flattened render happens once
+  expect(renderToCanvas).toHaveBeenCalledTimes(1);
+
+  restore();
   document.body.removeChild(container);
 });

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -244,8 +244,9 @@ const preserveCanvasContent = (
   const originalCanvases = original.querySelectorAll('canvas');
   const clonedCanvases = clone.querySelectorAll('canvas');
   // `renderToCanvas` flattens all of an ECharts instance's zrender layers into a single canvas,
-  // so a host that owns several <canvas> layers (e.g. a hover layer) must be re-rendered once.
-  const renderedHosts = new WeakSet<Element>();
+  // so once a host is re-rendered its other <canvas> layers (e.g. a hover layer) are skipped;
+  // if the re-render throws, the host is marked 'failed' so each layer falls back to a 1:1 copy.
+  const hostRenderState = new Map<Element, 'rendered' | 'failed'>();
 
   originalCanvases.forEach((originalCanvas, i) => {
     const clonedCanvas = clonedCanvases[i] as HTMLCanvasElement | undefined;
@@ -255,25 +256,36 @@ const preserveCanvasContent = (
 
     // For ECharts (canvas renderer) charts such as sunburst, re-render the chart at a higher
     // pixel ratio instead of copying the on-screen bitmap, so the PNG path upscales a matching
-    // high-resolution source rather than stretching a low-resolution one.
+    // high-resolution source rather than stretching a low-resolution one. `getInstanceByDom` is
+    // only supplied on the PNG path, so JPEG (and non-ECharts canvases) keep the 1:1 copy below.
     const host = originalCanvas.closest(`.${ECHARTS_HOST_CLASS}`);
-    const instance = host ? getInstanceByDom?.(host as HTMLElement) : undefined;
+    const hostState = host ? hostRenderState.get(host) : undefined;
+    // Sibling layer of a host already re-rendered: the flattened render covers it.
+    if (hostState === 'rendered') return;
+    const instance =
+      host && hostState !== 'failed'
+        ? getInstanceByDom?.(host as HTMLElement)
+        : undefined;
     if (host && instance) {
-      // A secondary layer of an already re-rendered host is fully covered by the flattened
-      // render above; leave its blank clone untouched so the chart is not drawn twice.
-      if (renderedHosts.has(host)) return;
-      renderedHosts.add(host);
-      const hiResCanvas = instance.renderToCanvas({
-        pixelRatio: EXPORT_CANVAS_PIXEL_RATIO,
-        backgroundColor: 'transparent',
-      });
-      clonedCanvas.width = hiResCanvas.width;
-      clonedCanvas.height = hiResCanvas.height;
-      ctx.drawImage(hiResCanvas, 0, 0);
-      return;
+      try {
+        const hiResCanvas = instance.renderToCanvas({
+          pixelRatio: EXPORT_CANVAS_PIXEL_RATIO,
+        });
+        clonedCanvas.width = hiResCanvas.width;
+        clonedCanvas.height = hiResCanvas.height;
+        ctx.drawImage(hiResCanvas, 0, 0);
+        hostRenderState.set(host, 'rendered');
+        return;
+      } catch {
+        // A valid but unhealthy instance (mid-dispose, errored chart) can throw. Mark the host
+        // 'failed' and fall back to the on-screen 1:1 copy below so a single bad chart can never
+        // abort the whole export (e.g. a 20-chart dashboard capture).
+        hostRenderState.set(host, 'failed');
+      }
     }
 
-    // Non-ECharts canvases (deck.gl/WebGL and friends): preserve the on-screen bitmap as-is.
+    // Non-ECharts canvases (deck.gl/WebGL and friends), and the fallback when a re-render is
+    // unavailable or threw: preserve the on-screen bitmap as-is.
     clonedCanvas.width = originalCanvas.width;
     clonedCanvas.height = originalCanvas.height;
     ctx.drawImage(originalCanvas, 0, 0);
@@ -545,14 +557,19 @@ export default function downloadAsImageOptimized(
     // All other chart types: use the clone-based approach
     let cleanup: (() => void) | null = null;
 
-    // Canvas-rendered charts (e.g. ECharts sunburst) must be re-rendered at a higher pixel ratio
-    // for a crisp export. Pull in echarts lazily so it stays out of the core bundle; fall back to
-    // a 1:1 canvas copy if it is unavailable.
+    // Only the PNG path upscales the layout (transform: scale(PNG_SCALE)), so only there does a
+    // higher-resolution canvas help; JPEG keeps the throw-free 1:1 copy. Re-render ECharts
+    // (canvas renderer) charts, e.g. sunburst, at a higher pixel ratio so the upscale samples a
+    // matching source instead of stretching the on-screen bitmap. echarts is pulled in lazily —
+    // only when a chart is actually present — so it stays out of the core bundle; if the import
+    // fails the canvases fall back to a 1:1 copy.
     let getInstanceByDom: EChartsGetInstanceByDom | undefined;
-    try {
-      ({ getInstanceByDom } = await import('echarts/core'));
-    } catch {
-      // echarts not available in this context; canvases keep their on-screen resolution.
+    if (isPng && elementToPrint.querySelector(`.${ECHARTS_HOST_CLASS}`)) {
+      try {
+        ({ getInstanceByDom } = await import('echarts/core'));
+      } catch {
+        // echarts not available in this context; canvases keep their on-screen resolution.
+      }
     }
 
     try {

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -27,9 +27,22 @@ import { forceLoadAllCharts, restoreVirtualization } from './downloadUtils';
 
 const IMAGE_DOWNLOAD_QUALITY = 0.95;
 const PNG_SCALE = 2; // Higher quality for PNG
+// ECharts canvas charts (e.g. sunburst) bake their pixel detail into the on-screen backing
+// store (CSS size × devicePixelRatio). Copying that 1:1 and then letting the PNG path upscale
+// it via transform: scale(PNG_SCALE) only stretches the bitmap, producing a blurry export. To
+// keep the export crisp, these charts are re-rendered at this pixel ratio at capture time; it is
+// tied to PNG_SCALE so the re-render matches the scaled output box.
+const EXPORT_CANVAS_PIXEL_RATIO = PNG_SCALE;
+// The div passed to ECharts `init()` carries this class (source of truth:
+// plugins/plugin-chart-echarts/src/components/Echart.tsx `ECHARTS_HOST_CLASS`). It lets the
+// exporter recover the live ECharts instance for a canvas via `getInstanceByDom`.
+const ECHARTS_HOST_CLASS = 'echarts-host';
 export type BackgroundType = 'transparent' | 'solid';
 const TRANSPARENT_RGBA = 'transparent';
 const POLL_INTERVAL_MS = 100;
+
+// Resolved lazily via a dynamic import so echarts stays out of the core bundle.
+type EChartsGetInstanceByDom = typeof import('echarts/core').getInstanceByDom;
 
 // Tracks original cell styles to restore after capture
 type CellFixup = { el: HTMLElement; minHeight: string; overflow: string };
@@ -223,30 +236,58 @@ const processCloneForVisibility = (clone: HTMLElement) => {
     });
 };
 
-const preserveCanvasContent = (original: Element, clone: Element) => {
+const preserveCanvasContent = (
+  original: Element,
+  clone: Element,
+  getInstanceByDom?: EChartsGetInstanceByDom,
+) => {
   const originalCanvases = original.querySelectorAll('canvas');
   const clonedCanvases = clone.querySelectorAll('canvas');
+  // `renderToCanvas` flattens all of an ECharts instance's zrender layers into a single canvas,
+  // so a host that owns several <canvas> layers (e.g. a hover layer) must be re-rendered once.
+  const renderedHosts = new WeakSet<Element>();
 
   originalCanvases.forEach((originalCanvas, i) => {
-    if (originalCanvases[i] && clonedCanvases[i]) {
-      const clonedCanvas = clonedCanvases[i] as HTMLCanvasElement;
-      const ctx = clonedCanvas.getContext('2d');
-      if (ctx) {
-        clonedCanvas.width = originalCanvas.width;
-        clonedCanvas.height = originalCanvas.height;
-        ctx.drawImage(originalCanvas, 0, 0);
-      }
+    const clonedCanvas = clonedCanvases[i] as HTMLCanvasElement | undefined;
+    if (!clonedCanvas) return;
+    const ctx = clonedCanvas.getContext('2d');
+    if (!ctx) return;
+
+    // For ECharts (canvas renderer) charts such as sunburst, re-render the chart at a higher
+    // pixel ratio instead of copying the on-screen bitmap, so the PNG path upscales a matching
+    // high-resolution source rather than stretching a low-resolution one.
+    const host = originalCanvas.closest(`.${ECHARTS_HOST_CLASS}`);
+    const instance = host ? getInstanceByDom?.(host as HTMLElement) : undefined;
+    if (host && instance) {
+      // A secondary layer of an already re-rendered host is fully covered by the flattened
+      // render above; leave its blank clone untouched so the chart is not drawn twice.
+      if (renderedHosts.has(host)) return;
+      renderedHosts.add(host);
+      const hiResCanvas = instance.renderToCanvas({
+        pixelRatio: EXPORT_CANVAS_PIXEL_RATIO,
+        backgroundColor: 'transparent',
+      });
+      clonedCanvas.width = hiResCanvas.width;
+      clonedCanvas.height = hiResCanvas.height;
+      ctx.drawImage(hiResCanvas, 0, 0);
+      return;
     }
+
+    // Non-ECharts canvases (deck.gl/WebGL and friends): preserve the on-screen bitmap as-is.
+    clonedCanvas.width = originalCanvas.width;
+    clonedCanvas.height = originalCanvas.height;
+    ctx.drawImage(originalCanvas, 0, 0);
   });
 };
 
 const createEnhancedClone = (
   originalElement: Element,
   theme?: SupersetTheme,
+  getInstanceByDom?: EChartsGetInstanceByDom,
 ): { clone: HTMLElement; cleanup: () => void } => {
   const clone = originalElement.cloneNode(true) as HTMLElement;
   copyAllComputedStyles(originalElement, clone, theme);
-  preserveCanvasContent(originalElement, clone);
+  preserveCanvasContent(originalElement, clone, getInstanceByDom);
 
   const tempContainer = document.createElement('div');
   tempContainer.style.cssText = `
@@ -504,10 +545,21 @@ export default function downloadAsImageOptimized(
     // All other chart types: use the clone-based approach
     let cleanup: (() => void) | null = null;
 
+    // Canvas-rendered charts (e.g. ECharts sunburst) must be re-rendered at a higher pixel ratio
+    // for a crisp export. Pull in echarts lazily so it stays out of the core bundle; fall back to
+    // a 1:1 canvas copy if it is unavailable.
+    let getInstanceByDom: EChartsGetInstanceByDom | undefined;
+    try {
+      ({ getInstanceByDom } = await import('echarts/core'));
+    } catch {
+      // echarts not available in this context; canvases keep their on-screen resolution.
+    }
+
     try {
       const { clone, cleanup: cleanupFn } = createEnhancedClone(
         elementToPrint,
         theme,
+        getInstanceByDom,
       );
       cleanup = cleanupFn;
 

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -268,6 +268,9 @@ const preserveCanvasContent = (
         : undefined;
     if (host && instance) {
       try {
+        // No `backgroundColor` is passed, so renderToCanvas inherits the chart's own configured
+        // background (transparent when unset) — matching the on-screen canvas. The overall export
+        // background is applied separately via the dom-to-image `bgcolor` option.
         const hiResCanvas = instance.renderToCanvas({
           pixelRatio: EXPORT_CANVAS_PIXEL_RATIO,
         });


### PR DESCRIPTION
### SUMMARY

ECharts-rendered charts (which use the **canvas** renderer — e.g. **Sunburst**, and most modern ECharts charts) export **blurry / low-resolution** via **"Download as image" / "Export screenshot (png)"**. It's worst on standard‑DPI (1×) displays and when zooming into the exported PNG.

**Root cause.** `superset-frontend/src/utils/downloadAsImage.tsx` clones the chart DOM and copies each `<canvas>` **1:1** at its on-screen backing-store resolution (`preserveCanvasContent`). The PNG path then upscales the whole layout via `transform: scale(PNG_SCALE = 2)`. Vector/DOM content (SVG, text) re-rasterizes crisply at 2×, but a `<canvas>` is a bitmap: `dom-to-image-more` serializes it with `canvas.toDataURL()` and it is simply **stretched** by the transform. So a canvas chart can never gain detail — the export is capped at the on-screen canvas resolution (`CSS size × devicePixelRatio`), which on a 1× display is just the CSS size.

**Fix.** Re-render ECharts-backed canvases at export time instead of screen-scraping them:
- Recover the live ECharts instance from the canvas's `.echarts-host` ancestor via `echarts.getInstanceByDom(...)`.
- Replace the cloned canvas with `instance.renderToCanvas({ pixelRatio: PNG_SCALE, backgroundColor: 'transparent' })` — a true high-resolution re-render that the PNG path then samples 1:1.
- `echarts` is loaded with a **dynamic `import('echarts/core')`** so it stays out of the core bundle (charts are lazy plugins).
- Non-ECharts canvases (deck.gl / WebGL) keep the existing 1:1 copy as a fallback.
- Because `renderToCanvas` flattens all zrender layers into one canvas, each host is re-rendered **only once** (secondary hover-layer canvases are skipped).

Self-contained change in `downloadAsImage.tsx`; no plugin, API, or config changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Before:_ a downloaded Sunburst PNG is soft and pixelates on zoom.
_After:_ the Sunburst PNG is crisp and stays sharp when zoomed.

(Screenshots to be attached.)

### TESTING INSTRUCTIONS

1. In Explore, build a **Sunburst** chart (e.g. on the "Vehicle Sales" dataset).
2. Chart context menu → **Download → "Export screenshot (png)"** (solid or transparent).
3. Open the PNG and zoom in — the chart is now crisp instead of pixelated.
4. Regression: exporting tables (ag-grid), dashboards, and non-ECharts charts still works.

Unit tests:
```
cd superset-frontend
npm run test -- src/utils/downloadAsImage.test.ts
```
Added tests cover: ECharts canvas re-rendered at `PNG_SCALE` pixel ratio; non-ECharts canvas kept at on-screen resolution; a host with multiple canvas layers re-rendered only once.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI (improves the resolution of the exported chart image; no visible control change)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
