### PR TITLE
fix(pivot-table): include synthesized subtotal/grand-total values in conditional-formatting extremes

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/plugin/transformProps.ts
@@ -219,9 +219,19 @@ export default function transformProps(chartProps: ChartProps<QueryFormData>) {
       config.colorScheme !== ColorSchemeEnum.Green &&
       config.colorScheme !== ColorSchemeEnum.Red,
   );
+  // Conditional-formatting extremes (min/max) must be computed from every
+  // rollup level that actually gets rendered -- leaf rows, subtotals, and
+  // the grand total -- not just the leaf-level `mainQuery.data`. Subtotal
+  // and grand-total values are synthesized client-side into `data` above
+  // and never appear in `mainQuery.data`, so a color scale built only from
+  // `mainQuery.data` can be miscalibrated: a large grand-total value can
+  // fall outside the scale's range and silently fail to receive a color,
+  // while smaller leaf-level values within range render as expected.
+  // See #43084.
+  const allLevelRecords = data.flatMap(level => level.data);
   const metricColorFormatters = getColorFormatters(
     pivotConditionalFormatting,
-    mainQuery.data,
+    allLevelRecords,
     theme,
   );
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/plugin/transformProps.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { ChartProps, QueryFormData } from '@superset-ui/core';
+import { Comparator } from '@superset-ui/chart-controls';
 import { supersetTheme } from '@apache-superset/core/theme';
 import transformProps from '../../src/plugin/transformProps';
 import { MetricsLayoutEnum, QueryData } from '../../src/types';
@@ -451,4 +452,74 @@ test('additive metrics: synthesizes rollup levels from a single leaf query', () 
     { region: 'US', v: 10 },
     { region: 'EU', v: 5 },
   ]);
+});
+
+test('conditional formatting extremes include synthesized subtotal/grand-total values (#43084)', () => {
+  // Regression test: the color scale's min/max must be calibrated against
+  // every rendered rollup level (leaf + grand total here), not just the
+  // raw leaf-level query result. Before the fix, `metricColorFormatters`
+  // was built from `mainQuery.data` alone (leaf rows only: v = 10, 5), so
+  // the grand-total value (v = 15) fell outside the scale's calibrated
+  // range and silently received no color -- exactly the anomaly reported
+  // in #43084.
+  const additiveFormattingFormData = {
+    ...formData,
+    combineMetric: false,
+    transposePivot: false,
+    metricsLayout: MetricsLayoutEnum.ROWS,
+    groupbyRows: ['region'],
+    groupbyColumns: [],
+    colTotals: true,
+    rowTotals: true,
+    metrics: [
+      {
+        expressionType: 'SIMPLE',
+        aggregate: 'SUM',
+        column: { column_name: 'v' },
+        label: 'v',
+      },
+    ],
+    conditionalFormatting: [
+      {
+        colorScheme: '#ACE1C4',
+        column: 'v',
+        operator: Comparator.None,
+      },
+    ],
+  };
+  const additiveFormattingChartProps = new ChartProps<QueryFormData>({
+    formData: additiveFormattingFormData as unknown as QueryFormData,
+    width: 800,
+    height: 600,
+    queriesData: [
+      {
+        data: [
+          { region: 'US', v: 10 },
+          { region: 'EU', v: 5 },
+        ],
+        colnames: ['region', 'v'],
+        coltypes: [1, 0],
+      },
+    ],
+    hooks: { setDataMask },
+    filterState: { selectedFilters: {} },
+    datasource: { verboseMap: {}, columnFormats: {} },
+    theme: supersetTheme,
+  });
+
+  const result = transformProps(additiveFormattingChartProps);
+  const grand = result.data.find(
+    (d: QueryData) =>
+      d.groupby.rows.length === 0 && d.groupby.columns.length === 0,
+  )!;
+  expect(grand.data[0].v).toBe(15);
+
+  const vFormatter = result.metricColorFormatters.find(
+    (f: { column: string }) => f.column === 'v',
+  )!;
+  // The grand-total value (15) must be recognized as within the scale's
+  // range and receive a color -- it must NOT be undefined.
+  expect(vFormatter.getColorFromValue(15)).toBeDefined();
+  // A leaf value should still get a color too.
+  expect(vFormatter.getColorFromValue(10)).toBeDefined();
 });


### PR DESCRIPTION
### SUMMARY

Fixes the conditional-formatting coloring anomaly described in #43084, where cells within the same column receive background colors that don't correctly reflect their relative magnitude.

**Root cause:** `metricColorFormatters` in `transformProps.ts` computed the color scale's min/max ("extremes") from `mainQuery.data`, which only contains the raw leaf-level backend query result. Subtotal and grand-total values are synthesized separately on the client (`synthesizeAdditiveLevels` / `splitGroupingSetsResult`) into a different `data` array — the one that's actually rendered — and those values never fed into the color scale calculation.

As a result, a grand-total value large enough to exceed the leaf-level range would fall outside the comparator's calibrated bounds and silently receive no color, while smaller leaf-level values within range rendered correctly. This is visible in the issue's screenshot: `-3.06M` and `-2.67M` (grand-total row) were left uncolored while smaller negative values like `-193k` and `-370k` in the same columns were correctly highlighted.

**Fix:** build the color formatters from every synthesized rollup level (`data.flatMap(level => level.data)`) instead of `mainQuery.data` alone, so the scale's extremes account for every value that actually gets rendered — leaf rows, subtotals, and grand totals.

### BEFORE/AFTER

Before: grand-total cells with large magnitudes were skipped by conditional formatting while smaller leaf-level cells in the same column were colored (see screenshot in #43084).

After: all cells, including subtotals/grand totals, are evaluated against a color scale calibrated on the full range of rendered values.

### TESTING INSTRUCTIONS

- Added a regression test in `transformProps.test.ts`: builds a pivot table with a grand total (15) larger than any leaf value (10, 5), and asserts the grand total receives a color under a full-range (`Comparator.None`) conditional-formatting rule — the exact scenario that silently failed before this fix.
- Full pivot-table plugin suite passes locally: `npm test -- plugins/plugin-chart-pivot-table` → 9 suites passed, 109 tests passed.

Note: this PR addresses only the conditional-formatting anomaly (Issue #43084, part 1). The row-label-truncation feature request in the same issue is a separate concern and is not included here.