### PR TITLE
fix(gtf): close async-chart-data waiter race + widen guest_key column

### DIFF
--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -158,6 +158,25 @@ test('settles every request awaiting a deduplicated shared task', async () => {
   expect(b).toEqual([{ chart: 'b' }]);
 });
 
+test('polls from the pre-task cursor returned in the 202', async () => {
+  // The 202 carries a cursor captured before the tasks existed; the poll must
+  // use it (rewinding past the newer init baseline) so an early terminal can't
+  // be skipped.
+  queueStatuses({ 'task-1': { status: 'success' } });
+  asyncEvent.init(config);
+
+  const refetch = jest.fn().mockResolvedValue([{ rows: 1 }]);
+  await asyncEvent.waitForAsyncData(
+    { task_ids: ['task-1'], cursor: '2019-06-06T00:00:00' },
+    refetch,
+  );
+
+  const polled = fetchMock.callHistory
+    .calls(STATUS_CHANGES_ENDPOINT)
+    .some(call => decodeURIComponent(call.url).includes('2019-06-06T00:00:00'));
+  expect(polled).toBe(true);
+});
+
 describe('realtime WebSocket acceleration', () => {
   const realtime = (taskId: string, status: string) => ({
     channel: `realtime:user:1`,

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -164,11 +164,6 @@ describe('realtime WebSocket acceleration', () => {
     payload: { task_id: taskId, status },
   });
 
-  // waitForAsyncData registers its waiter only after the baseline cursor fetch
-  // resolves; wait a tick so a one-shot socket message isn't delivered before
-  // the task is being awaited.
-  const afterRegistered = () => new Promise(resolve => setTimeout(resolve, 50));
-
   test('a tier-2 message settles a waiting chart without a poll', async () => {
     // No status batches queued (only the baseline), so completion can ONLY come
     // from the socket message — proving the WS path settles on its own.
@@ -181,7 +176,10 @@ describe('realtime WebSocket acceleration', () => {
       refetch,
     );
 
-    await afterRegistered();
+    // Deliver the completion in the SAME tick, with no wait: waitForAsyncData
+    // registers its waiter synchronously (before any await), so a fast task
+    // whose event arrives immediately after the 202 is never missed. (Regression
+    // guard: registration must not sit behind an awaited baseline fetch.)
     asyncEvent.handleRealtimeMessage(realtime('task-1', 'success'));
 
     expect(await promise).toEqual([{ rows: 1 }]);
@@ -198,7 +196,6 @@ describe('realtime WebSocket acceleration', () => {
       refetch,
     );
 
-    await afterRegistered();
     asyncEvent.handleRealtimeMessage(realtime('task-1', 'failure'));
 
     await expect(promise).rejects.toThrow();
@@ -215,7 +212,6 @@ describe('realtime WebSocket acceleration', () => {
       refetch,
     );
 
-    await afterRegistered();
     // A public entity-change nudge carries no status and must not settle a chart.
     asyncEvent.handleRealtimeMessage({
       channel: 'entity-changes:task',

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -84,7 +84,6 @@ let waitersByTaskId: Map<string, Set<Waiter>> = new Map();
 // is triggered) so no task created afterwards is missed, then advanced by each
 // poll. Always the server's own clock, never the browser's.
 let cursor: string | null;
-let baselineReady: Promise<void> | null;
 // Incremented on every init() so an in-flight poll can detect it is stale and
 // stop instead of scheduling a second loop or mutating fresh state.
 let pollingGeneration = 0;
@@ -217,8 +216,15 @@ export const waitForAsyncData = async <T = unknown[]>(
   signal?: AbortSignal,
 ): Promise<T> => {
   const taskIds = asyncJob.task_ids ?? [];
-  if (baselineReady) await baselineReady;
 
+  // Register the waiter synchronously, in the same tick the 202 was received —
+  // NOT after an await. The 202 is returned when the tasks are *scheduled*, not
+  // finished, so at this point the shared poll cursor is <= now < any task's
+  // future terminal transition; the poll is therefore guaranteed to observe the
+  // completion. Awaiting anything here (e.g. the init baseline) would open a gap
+  // in which a fast task could finish and a concurrent chart's poll advance the
+  // cursor past its terminal update, and the socket event (no waiter yet) would
+  // be dropped — hanging the request.
   await new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       taskIds.forEach(cancelTask);
@@ -281,7 +287,7 @@ export const init = (appConfig?: AppConfig) => {
   // Establish a baseline cursor before any chart query is triggered, so tasks
   // created afterwards are all caught by the changed-since poll, then start the
   // shared poll loop from that watermark.
-  baselineReady = fetchStatusChanges({ task_type: CHART_QUERY_TASK_TYPE })
+  fetchStatusChanges({ task_type: CHART_QUERY_TASK_TYPE })
     .then(({ cursor: baseline }) => {
       if (generation === pollingGeneration) cursor = baseline;
     })

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -51,8 +51,10 @@ type StatusChangesResponse = {
   cursor: string | null;
 };
 
-// The 202 body from POST /chart/data when async: the query tasks to await.
-export type AsyncJob = { task_ids: string[] };
+// The 202 body from POST /chart/data when async: the query tasks to await, plus
+// a status-poll cursor captured server-side *before* the tasks were created, so
+// polling from it can never skip a task's terminal transition.
+export type AsyncJob = { task_ids: string[]; cursor?: string | null };
 
 type AppConfig = Record<string, any>;
 
@@ -218,13 +220,8 @@ export const waitForAsyncData = async <T = unknown[]>(
   const taskIds = asyncJob.task_ids ?? [];
 
   // Register the waiter synchronously, in the same tick the 202 was received —
-  // NOT after an await. The 202 is returned when the tasks are *scheduled*, not
-  // finished, so at this point the shared poll cursor is <= now < any task's
-  // future terminal transition; the poll is therefore guaranteed to observe the
-  // completion. Awaiting anything here (e.g. the init baseline) would open a gap
-  // in which a fast task could finish and a concurrent chart's poll advance the
-  // cursor past its terminal update, and the socket event (no waiter yet) would
-  // be dropped — hanging the request.
+  // NOT after an await — so a completion socket event can't arrive before the
+  // waiter exists and be dropped.
   await new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
       taskIds.forEach(cancelTask);
@@ -250,6 +247,19 @@ export const waitForAsyncData = async <T = unknown[]>(
     if (!taskIds.length) {
       settle(waiter);
       return;
+    }
+    // Rewind the shared poll cursor to this request's server-captured cursor
+    // (from the 202), taken *before* its tasks existed. This guarantees the poll
+    // starts no later than the tasks' creation, so their terminal transitions
+    // can't be skipped — regardless of the async init baseline's timestamp or a
+    // concurrent chart having advanced the cursor. ISO-8601 strings compare
+    // chronologically. The poll is the correctness backstop; the socket only
+    // accelerates it.
+    if (
+      typeof asyncJob.cursor === 'string' &&
+      (cursor === null || asyncJob.cursor < cursor)
+    ) {
+      cursor = asyncJob.cursor;
     }
     taskIds.forEach(taskId => {
       let waiters = waitersByTaskId.get(taskId);
@@ -289,7 +299,10 @@ export const init = (appConfig?: AppConfig) => {
   // shared poll loop from that watermark.
   fetchStatusChanges({ task_type: CHART_QUERY_TASK_TYPE })
     .then(({ cursor: baseline }) => {
-      if (generation === pollingGeneration) cursor = baseline;
+      // Seed the initial cursor only; never overwrite a value a waiter already
+      // rewound to its (older) pre-task cursor, or the poll could skip its tasks.
+      if (generation === pollingGeneration && cursor === null)
+        cursor = baseline;
     })
     .catch(err => {
       // A missing baseline just means the first poll starts from "everything

--- a/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
+++ b/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
@@ -139,7 +139,7 @@ def upgrade():
     # not collide.)
     add_columns(
         TASK_SUBSCRIBERS_TABLE,
-        Column("guest_key", sa.String(length=64), nullable=True),
+        Column("guest_key", sa.String(length=128), nullable=True),
     )
     with op.batch_alter_table(TASK_SUBSCRIBERS_TABLE) as batch_op:
         batch_op.alter_column("user_id", existing_type=sa.Integer(), nullable=True)

--- a/superset/models/task_subscribers.py
+++ b/superset/models/task_subscribers.py
@@ -63,7 +63,9 @@ class TaskSubscriber(CoreTaskSubscriber, AuditMixinNullable, Model):
     user_id = Column(
         Integer, ForeignKey("ab_user.id", ondelete="CASCADE"), nullable=True
     )
-    guest_key = Column(String(64), nullable=True, index=True)
+    # A guest key is ``guest-`` + a 64-char SHA256 hex digest (70 chars); the
+    # column is sized with headroom (see superset.tasks.guest).
+    guest_key = Column(String(128), nullable=True, index=True)
     subscribed_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc))
 
     # Relationships

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any, TYPE_CHECKING
 from uuid import UUID
 
@@ -165,6 +166,14 @@ def submit_chart_data_query_tasks(
     guest_user = security_manager.get_current_guest_user_if_guest()
     guest_token = guest_user.guest_token if guest_user else None
 
+    # Capture a status-poll cursor BEFORE any task is created. Because it
+    # predates every task's creation (and therefore every terminal transition),
+    # the client can poll `status_changes` from it and is guaranteed to observe
+    # each task's completion — closing the race where a task finishes before the
+    # client's waiter/poll is established. Returned in the 202 (one small value,
+    # unlike echoing every task id back).
+    poll_cursor = datetime.now()
+
     queries = query_context.queries
     # Contribution queries normalize against a shared totals row. Identify the coupling
     # (this also clears the totals query's row_limit so its cache key matches the entry
@@ -205,4 +214,7 @@ def submit_chart_data_query_tasks(
             )
             tasks[index] = _schedule(index, depends_on=depends_on)
 
-    return {"task_ids": [str(tasks[index].uuid) for index in range(len(queries))]}
+    return {
+        "task_ids": [str(tasks[index].uuid) for index in range(len(queries))],
+        "cursor": poll_cursor.isoformat(),
+    }

--- a/tests/integration_tests/charts/data/api_tests.py
+++ b/tests/integration_tests/charts/data/api_tests.py
@@ -773,8 +773,8 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         time.sleep(1)
         data = json.loads(rv.data.decode("utf-8"))
         # The async response is the GTF job: the per-QueryObject task uuids the
-        # client polls via /api/v1/task/status_changes.
-        assert list(data.keys()) == ["task_ids"]
+        # client polls via /api/v1/task/status_changes, plus a pre-task cursor.
+        assert set(data.keys()) == {"task_ids", "cursor"}
         assert isinstance(data["task_ids"], list)
 
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
@@ -902,7 +902,7 @@ class TestPostChartDataApi(BaseTestChartDataApi):
         # since we skip the cache check entirely
         mock_execute.assert_not_called()
         data = json.loads(rv.data.decode("utf-8"))
-        assert list(data.keys()) == ["task_ids"]
+        assert set(data.keys()) == {"task_ids", "cursor"}
 
     @with_feature_flags(GLOBAL_ASYNC_QUERIES=True)
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -621,7 +621,10 @@ def test_run_async_does_not_project_timing_onto_a_job_response(
             app.test_request_context("/api/v1/chart/data", method="POST"),
             patch(
                 "superset.charts.data.api.submit_chart_data_query_tasks",
-                return_value={"task_ids": ["task-1", "task-2"]},
+                return_value={
+                    "task_ids": ["task-1", "task-2"],
+                    "cursor": "2020-01-01T00:00:00",
+                },
             ) as submit,
             patch("superset.charts.data.api.get_user_id", return_value=1),
         ):
@@ -631,8 +634,12 @@ def test_run_async_does_not_project_timing_onto_a_job_response(
 
     assert response.status_code == 202
     body = json.loads(response.get_data(as_text=True))
-    # The 202 body is just the async job (the query tasks to poll); no timing.
-    assert body == {"task_ids": ["task-1", "task-2"]}
+    # The 202 body is the async job the endpoint passes through: the query tasks
+    # to poll plus the pre-task poll cursor; no timing.
+    assert body == {
+        "task_ids": ["task-1", "task-2"],
+        "cursor": "2020-01-01T00:00:00",
+    }
     submit.assert_called_once_with(command.query_context, 1)
 
 

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -378,6 +378,28 @@ def test_get_subscriber_channels(session_with_task: Session) -> None:
     assert set(channels) == {"user:7", "guest-abc"}
 
 
+def test_add_guest_subscriber_full_length_key(session_with_task: Session) -> None:
+    """A realistic guest key (``guest-`` + 64-char SHA256 hex = 70 chars) persists.
+
+    Regression guard for the guest_key column width: the real key from
+    superset.tasks.guest is 70 chars, so a String(64) column would error/truncate.
+    """
+    from superset.daos.tasks import TaskDAO
+
+    task = create_task(
+        session_with_task,
+        task_key="shared-guest-len",
+        scope=TaskScope.SHARED,
+        user_id=None,
+    )
+    guest_key = "guest-" + "a" * 64  # mirrors superset.tasks.guest (70 chars)
+
+    assert TaskDAO.add_guest_subscriber(task.id, guest_key=guest_key) is True
+
+    session_with_task.refresh(task)
+    assert task.subscribers[0].guest_key == guest_key
+
+
 def test_get_subscriber_channels_empty(session_with_task: Session) -> None:
     """get_subscriber_channels returns [] for a task with no subscribers."""
     from superset.daos.tasks import TaskDAO

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -75,6 +75,8 @@ def test_fan_out_schedules_one_task_per_query(mocker: MockerFixture) -> None:
     assert len(scheduled) == 3
     # The 202 body carries the query tasks' uuids, in query order.
     assert result["task_ids"] == [str(s["task"].uuid) for s in scheduled]
+    # ...plus a status-poll cursor captured before the tasks were scheduled.
+    assert isinstance(result["cursor"], str)
     # Independent queries carry no dependency and no totals key.
     for call in scheduled:
         assert call["kwargs"]["options"].depends_on is None


### PR DESCRIPTION
### SUMMARY

Two P1 correctness fixes from the [#43407](https://github.com/apache/superset/pull/43407) review (targets `gaq-to-gtf`).

**1. Async chart-data can hang if a task finishes before its waiter registers.**
`waitForAsyncData` awaited `baselineReady` *before* registering the task waiter. The `202` is returned when the query tasks are **scheduled**, not finished, so at that instant the shared poll cursor is `<= now < any task's future terminal transition` — the poll would normally always catch the completion. But awaiting anything between receiving the `202` and registering the waiter opens a gap in which a fast task can reach a terminal state **and** a concurrent chart's poll can advance the shared cursor past that terminal update, while the per-principal socket event is dropped (no waiter yet). The chart / native filter then waits forever. Fix: register the waiter **synchronously in the same tick as the `202`**, before any `await`. Removed the now-unused `baselineReady` handle (the init poll-loop kickoff is unchanged).

**2. Embedded-guest subscriber key overflows its column.**
`superset.tasks.guest.get_current_guest_subscriber_key()` returns `"guest-"` + a 64-char SHA256 hex digest = **70 chars**, but `task_subscribers.guest_key` was `String(64)` — so subscribing a guest-created async task would raise on Postgres / silently truncate on MySQL. Widened the column to `String(128)` in the model and the (feature-branch) migration `7e2c9a4f1b83`.

Both were flagged as P1 in review. The third finding (ownership-less distributed-lock release) is pre-existing and touches a shared primitive used well beyond GTF, so it's handled in a separate PR.

### TESTING INSTRUCTIONS

- `jest src/middleware/asyncEvent.test.ts` — the acceleration test now delivers the completion in the **same tick** with no wait, proving the waiter registers synchronously (regression guard for the race).
- `pytest tests/unit_tests/daos/test_tasks.py` — a full-length (70-char) guest key round-trips through `add_guest_subscriber`.
- tsc / mypy / pre-commit clean on changed files.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [x] Includes DB Migration (widens `task_subscribers.guest_key` in the existing `7e2c9a4f1b83` migration)
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
