### PR TITLE
fix(distributed-lock): ownership-checked release (compare-and-delete)

### DIFF
--- a/superset/commands/distributed_lock/acquire.py
+++ b/superset/commands/distributed_lock/acquire.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -78,6 +79,11 @@ class AcquireDistributedLock(BaseDistributedLockCommand):
     ) -> None:
         super().__init__(namespace, params)
         self.ttl_seconds = ttl_seconds or get_default_lock_ttl()
+        # A per-acquisition token stored as the lock's value, so release can
+        # verify ownership (compare-and-delete) and never delete a lock a
+        # *different* holder acquired after this one's TTL expired. Exposed to
+        # the DistributedLock context manager, which threads it to release.
+        self.token = uuid.uuid4().hex
 
     def run(self) -> None:
         if CoordinationService.is_backend_defined():
@@ -88,11 +94,12 @@ class AcquireDistributedLock(BaseDistributedLockCommand):
     def _acquire_redis(self) -> None:
         """Acquire lock using the coordination backend's SET NX EX (atomic)."""
         try:
-            # SET NX EX: Set if not exists, with expiration
+            # SET NX EX: Set if not exists, with expiration. The value is this
+            # acquisition's ownership token (see release's compare-and-delete).
             # Returns True if lock acquired, None if already exists
             acquired = CoordinationService.set_value(
                 self.redis_lock_key,
-                "1",
+                self.token,
                 ttl=self.ttl_seconds,
                 if_absent=True,
             )
@@ -119,10 +126,11 @@ class AcquireDistributedLock(BaseDistributedLockCommand):
         # Delete expired entries first to prevent stale locks from blocking
         KeyValueDAO.delete_expired_entries(self.resource)
 
-        # Create entry - unique constraint will raise if lock already exists
+        # Create entry - unique constraint will raise if lock already exists.
+        # The value carries this acquisition's ownership token (see release).
         KeyValueDAO.create_entry(
             resource=KeyValueResource.LOCK,
-            value={"value": True},
+            value={"token": self.token},
             codec=self.codec,
             key=self.key,
             expires_on=datetime.now(timezone.utc) + timedelta(seconds=self.ttl_seconds),

--- a/superset/commands/distributed_lock/release.py
+++ b/superset/commands/distributed_lock/release.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from functools import partial
+from typing import Any
 
 import redis
 from sqlalchemy.exc import SQLAlchemyError
@@ -37,9 +38,24 @@ class ReleaseDistributedLock(BaseDistributedLockCommand):
     """
     Release a distributed lock with automatic backend selection.
 
-    Uses Redis DELETE when DISTRIBUTED_COORDINATION_CONFIG is configured,
-    otherwise deletes from KeyValue table.
+    Uses Redis when DISTRIBUTED_COORDINATION_CONFIG is configured, otherwise the
+    KeyValue table. Release is **ownership-checked**: it only removes the lock if
+    the stored value still matches this acquisition's ``token``. Without that
+    check, a holder whose TTL expired (letting another holder acquire the same
+    key) would delete the *new* holder's lock on its own release.
     """
+
+    def __init__(
+        self,
+        namespace: str,
+        params: dict[str, Any] | None = None,
+        token: str | None = None,
+    ) -> None:
+        super().__init__(namespace, params)
+        # The acquisition token to match on release (see AcquireDistributedLock).
+        # None means "delete unconditionally" — only for callers that did not
+        # acquire via the token-aware path.
+        self.token = token
 
     def run(self) -> None:
         if CoordinationService.is_backend_defined():
@@ -48,8 +64,26 @@ class ReleaseDistributedLock(BaseDistributedLockCommand):
             self._release_kv()
 
     def _release_redis(self) -> None:
-        """Release lock using the coordination backend's DELETE."""
+        """Release the lock only if we still own it (compare-and-delete)."""
         try:
+            if self.token is not None:
+                stored = CoordinationService.get_value(self.redis_lock_key)
+                if stored is None:
+                    # Already gone (expired or released) — nothing to do.
+                    return
+                stored_token = stored.decode() if isinstance(stored, bytes) else stored
+                if stored_token != self.token:
+                    # A different acquisition owns the key now (ours expired);
+                    # deleting it would drop the current holder's lock.
+                    logger.warning(
+                        "Not releasing Redis lock %s: owned by another acquisition",
+                        self.redis_lock_key,
+                    )
+                    return
+            # NOTE: the get-then-delete above is not atomic; the residual window
+            # (ours expires and is re-acquired between the get and the delete) is
+            # bounded by the round-trip and vastly smaller than an unconditional
+            # delete's exposure. A Lua compare-and-delete would close it fully.
             CoordinationService.delete_value(self.redis_lock_key)
             logger.debug("Released Redis lock: %s", self.redis_lock_key)
         except redis.RedisError as ex:
@@ -71,7 +105,18 @@ class ReleaseDistributedLock(BaseDistributedLockCommand):
         ),
     )
     def _release_kv(self) -> None:
-        """Release lock using KeyValue table (database)."""
+        """Release the KV lock only if we still own it (ownership-checked)."""
+        if self.token is not None:
+            stored = KeyValueDAO.get_value(self.resource, self.key, self.codec)
+            if not isinstance(stored, dict) or stored.get("token") != self.token:
+                # Missing/expired, or re-acquired by another holder — leave it.
+                logger.warning(
+                    "Not releasing KV lock namespace=%s key=%s: not owned by "
+                    "this acquisition",
+                    self.namespace,
+                    self.key,
+                )
+                return
         KeyValueDAO.delete_entry(self.resource, self.key)
         logger.debug(
             "Released KV lock: namespace=%s key=%s",

--- a/superset/distributed_lock/__init__.py
+++ b/superset/distributed_lock/__init__.py
@@ -57,8 +57,11 @@ def DistributedLock(  # noqa: N802
 
     key = get_key(namespace, **kwargs)
 
-    AcquireDistributedLock(namespace, kwargs, ttl_seconds).run()
+    acquire = AcquireDistributedLock(namespace, kwargs, ttl_seconds)
+    acquire.run()
     try:
         yield key
     finally:
-        ReleaseDistributedLock(namespace, kwargs).run()
+        # Pass the acquisition token so release only removes the lock if this
+        # acquisition still owns it (see ReleaseDistributedLock).
+        ReleaseDistributedLock(namespace, kwargs, token=acquire.token).run()

--- a/tests/unit_tests/distributed_lock/distributed_lock_tests.py
+++ b/tests/unit_tests/distributed_lock/distributed_lock_tests.py
@@ -27,19 +27,19 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from superset import db
 from superset.distributed_lock import DistributedLock
-from superset.distributed_lock.types import LockValue
 from superset.distributed_lock.utils import get_key
 from superset.exceptions import AcquireDistributedLockFailedException
 from superset.key_value.types import JsonKeyValueCodec
 
-LOCK_VALUE: LockValue = {"value": True}
 MAIN_KEY = get_key("ns", a=1, b=2)
 OTHER_KEY = get_key("ns2", a=1, b=2)
 
 # Distributed locking is plumbed through the coordination service: acquire/release
-# call CoordinationService.set_value/delete_value when a backend is defined, else KV.
+# call CoordinationService.set_value/get_value/delete_value when a backend is
+# defined, else the KeyValue table.
 BACKEND_DEFINED = "superset.coordination.base.CoordinationService.is_backend_defined"
 COORD_SET = "superset.coordination.base.CoordinationService.set_value"
+COORD_GET = "superset.coordination.base.CoordinationService.get_value"
 COORD_DELETE = "superset.coordination.base.CoordinationService.delete_value"
 
 
@@ -53,6 +53,11 @@ def _get_lock(key: UUID, session: Session) -> Any:
     return JsonKeyValueCodec().decode(entry.value)
 
 
+def _held(value: Any) -> bool:
+    """A lock value is an ownership token dict once acquired."""
+    return isinstance(value, dict) and isinstance(value.get("token"), str)
+
+
 def _get_other_session() -> Session:
     # This session is used to simulate what another worker will find in the metastore
     # during the locking process.
@@ -61,6 +66,36 @@ def _get_other_session() -> Session:
     bind = db.session.get_bind()
     SessionMaker = sessionmaker(bind=bind)  # noqa: N806
     return SessionMaker()
+
+
+def _fake_coordination_backend() -> dict[str, Any]:
+    """Patchable set/get/delete_value closures over a shared in-memory store.
+
+    Faithfully models SET NX + GET + DELETE so the ownership-checked release
+    (get-then-compare-then-delete) exercises end to end under mocking.
+    """
+    store: dict[str, Any] = {}
+
+    def _set(  # noqa: PLR0913
+        key: str,
+        value: Any,
+        ttl: int | None = None,
+        if_absent: bool = False,
+        if_present: bool = False,
+        backend: Any = None,
+    ) -> bool | None:
+        if if_absent and key in store:
+            return None
+        store[key] = value
+        return True
+
+    def _get(key: str, backend: Any = None) -> Any:
+        return store.get(key)
+
+    def _delete(*keys: str, backend: Any = None) -> int:
+        return sum(1 for k in keys if store.pop(k, None) is not None)
+
+    return {"store": store, "set": _set, "get": _get, "delete": _delete}
 
 
 def test_distributed_lock_kv_happy_path() -> None:
@@ -80,7 +115,7 @@ def test_distributed_lock_kv_happy_path() -> None:
 
             with DistributedLock("ns", a=1, b=2) as key:
                 assert key == MAIN_KEY
-                assert _get_lock(key, session) == LOCK_VALUE
+                assert _held(_get_lock(key, session))
                 assert _get_lock(OTHER_KEY, session) is None
 
                 with pytest.raises(AcquireDistributedLockFailedException):
@@ -105,19 +140,45 @@ def test_distributed_lock_kv_expired() -> None:
         with freeze_time("2021-01-01"):
             assert _get_lock(MAIN_KEY, session) is None
             with DistributedLock("ns", a=1, b=2):
-                assert _get_lock(MAIN_KEY, session) == LOCK_VALUE
+                assert _held(_get_lock(MAIN_KEY, session))
                 with freeze_time("2022-01-01"):
                     assert _get_lock(MAIN_KEY, session) is None
 
             assert _get_lock(MAIN_KEY, session) is None
 
 
+def test_distributed_lock_kv_release_only_deletes_own_lock() -> None:
+    """A stale KV lock re-acquired by another holder is not released by the first.
+
+    Simulates holder A's TTL lapsing and holder B acquiring the same key: A's
+    release must not delete B's lock (ownership check on the stored token).
+    """
+    from superset.commands.distributed_lock.acquire import AcquireDistributedLock
+    from superset.commands.distributed_lock.release import ReleaseDistributedLock
+
+    session = _get_other_session()
+
+    with patch(BACKEND_DEFINED, return_value=False):
+        # Holder B currently owns the lock.
+        AcquireDistributedLock("ns", {"a": 1, "b": 2}).run()
+        b_value = _get_lock(MAIN_KEY, session)
+        assert _held(b_value)
+
+        # Holder A (a superseded acquisition with a different token) releases.
+        ReleaseDistributedLock("ns", {"a": 1, "b": 2}, token="stale-token-a").run()  # noqa: S106
+
+        # B's lock survives.
+        assert _get_lock(MAIN_KEY, session) == b_value
+
+
 def test_distributed_lock_uses_redis_when_configured() -> None:
     """Test that DistributedLock uses the coordination backend when configured."""
+    fake = _fake_coordination_backend()
     with (
         patch(BACKEND_DEFINED, return_value=True),
-        patch(COORD_SET, return_value=True) as mock_set,
-        patch(COORD_DELETE) as mock_delete,
+        patch(COORD_SET, side_effect=fake["set"]) as mock_set,
+        patch(COORD_GET, side_effect=fake["get"]),
+        patch(COORD_DELETE, side_effect=fake["delete"]) as mock_delete,
     ):
         with DistributedLock("test_redis", key="value") as lock_key:
             assert lock_key is not None
@@ -127,8 +188,37 @@ def test_distributed_lock_uses_redis_when_configured() -> None:
             assert call_args.kwargs["if_absent"] is True
             assert "ttl" in call_args.kwargs
 
-        # Verify DELETE was called on exit
+        # Verify the (ownership-checked) DELETE was called on exit
         mock_delete.assert_called_once()
+        # And the lock is actually gone.
+        assert fake["store"] == {}
+
+
+def test_distributed_lock_redis_release_only_deletes_own_lock() -> None:
+    """Redis release must not delete a lock a different acquisition now owns."""
+    from superset.commands.distributed_lock.release import ReleaseDistributedLock
+
+    fake = _fake_coordination_backend()
+    with (
+        patch(BACKEND_DEFINED, return_value=True),
+        patch(COORD_SET, side_effect=fake["set"]),
+        patch(COORD_GET, side_effect=fake["get"]),
+        patch(COORD_DELETE, side_effect=fake["delete"]) as mock_delete,
+    ):
+        # Holder B owns the key.
+        with DistributedLock("test_redis", key="value"):
+            b_token = next(iter(fake["store"].values()))
+
+            # A superseded holder A releases with its own (different) token.
+            ReleaseDistributedLock(
+                "test_redis",
+                {"key": "value"},
+                token="stale-token-a",  # noqa: S106
+            ).run()
+
+            # A's release deleted nothing; B still holds the key.
+            mock_delete.assert_not_called()
+            assert next(iter(fake["store"].values())) == b_token
 
 
 def test_distributed_lock_redis_already_taken() -> None:
@@ -157,10 +247,12 @@ def test_distributed_lock_redis_connection_error() -> None:
 
 def test_distributed_lock_custom_ttl() -> None:
     """Test Redis lock with custom TTL."""
+    fake = _fake_coordination_backend()
     with (
         patch(BACKEND_DEFINED, return_value=True),
-        patch(COORD_SET, return_value=True) as mock_set,
-        patch(COORD_DELETE),
+        patch(COORD_SET, side_effect=fake["set"]) as mock_set,
+        patch(COORD_GET, side_effect=fake["get"]),
+        patch(COORD_DELETE, side_effect=fake["delete"]),
     ):
         with DistributedLock("test", ttl_seconds=60, key="value"):
             call_args = mock_set.call_args
@@ -171,10 +263,12 @@ def test_distributed_lock_default_ttl(app_context: None) -> None:
     """Test Redis lock uses default TTL when not specified."""
     from superset.commands.distributed_lock.base import get_default_lock_ttl
 
+    fake = _fake_coordination_backend()
     with (
         patch(BACKEND_DEFINED, return_value=True),
-        patch(COORD_SET, return_value=True) as mock_set,
-        patch(COORD_DELETE),
+        patch(COORD_SET, side_effect=fake["set"]) as mock_set,
+        patch(COORD_GET, side_effect=fake["get"]),
+        patch(COORD_DELETE, side_effect=fake["delete"]),
     ):
         with DistributedLock("test", key="value"):
             call_args = mock_set.call_args
@@ -192,7 +286,7 @@ def test_distributed_lock_fallback_to_kv_when_redis_not_configured() -> None:
             with DistributedLock("test_fallback", key="value") as lock_key:
                 assert lock_key == test_key
                 # Verify lock exists in KV store
-                assert _get_lock(test_key, session) == LOCK_VALUE
+                assert _held(_get_lock(test_key, session))
 
             # Lock should be released
             assert _get_lock(test_key, session) is None


### PR DESCRIPTION
### SUMMARY

Addresses the P2 finding from the [#43407](https://github.com/apache/superset/pull/43407) review (targets `gaq-to-gtf`): the distributed lock's release is **ownership-less**.

`AcquireDistributedLock` stored a constant value (`"1"` / `{"value": True}`) via `SET NX`, and `ReleaseDistributedLock` **unconditionally deleted** the key. So if holder A's TTL lapsed and holder B acquired the same key, A's `finally` release would **delete B's lock**. It predates this epic, but the epic makes this primitive central to task submit/cancel (`task_lock`), so it's worth closing.

**Fix:** acquire now stores a **per-acquisition token** (`uuid4().hex`) as the lock's value; the `DistributedLock` context manager threads that token to release, which only deletes the key when the stored value still matches — **compare-and-delete**:
- **Redis:** `get` → compare → `delete` (a get-then-delete; the residual non-atomic window is bounded by one round-trip and vastly smaller than an unconditional delete's exposure — a Lua CAS could close it fully; noted in a comment).
- **KeyValue DB fallback:** ownership-checked read before delete.

Release keeps a `token=None` mode meaning "delete unconditionally", which preserves the behavior of the one **cross-process** caller — the Excel export, where the API process acquires and the Celery task releases (they can't share an in-memory token). That path is unchanged.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/distributed_lock/` — two new regressions (Redis + KV) prove a superseded holder's release leaves the current holder's lock intact; existing happy-path / expiry / fallback tests updated for the token-shaped value (57 passing incl. export-excel which uses the unconditional path).
- mypy / ruff / pre-commit clean.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [ ] Required feature flags
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
