### PR TITLE
feat(gaq): minimum result-cache TTL for async chart-data queries

### DIFF
--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -57,6 +57,13 @@ class QueryContext:
     force: bool
     custom_cache_timeout: int | None
 
+    # Set by the async chart-data execution path (see
+    # superset.tasks.async_queries.execute_chart_query). The async flow caches a
+    # result and a follow-up request reads it back, so the result cache TTL is
+    # floored to GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL (see
+    # QueryContextProcessor.get_cache_timeout). Never set on the synchronous path.
+    is_async_execution: bool = False
+
     cache_values: dict[str, Any]
 
     _processor: QueryContextProcessor

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -570,7 +570,15 @@ class QueryContextProcessor:
              :meth:`QueryContext.get_cache_timeout`.
           4. ``DATA_CACHE_CONFIG["CACHE_DEFAULT_TIMEOUT"]``.
           5. ``CACHE_DEFAULT_TIMEOUT`` — global fallback.
+
+        For an async execution the result is cached then read back by a follow-up
+        request, so the resolved timeout is finally floored to
+        ``GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL`` to prevent a short TTL from evicting
+        the result before it is fetched (see :meth:`_apply_async_min_cache_ttl`).
         """
+        return self._apply_async_min_cache_ttl(self._resolve_cache_timeout())
+
+    def _resolve_cache_timeout(self) -> int:
         # Step 1: Request-level custom timeout (e.g., Force refresh bypass)
         if self._query_context.custom_cache_timeout is not None:
             return self._query_context.custom_cache_timeout
@@ -598,6 +606,21 @@ class QueryContextProcessor:
 
         # Step 5: Global fallback.
         return current_app.config["CACHE_DEFAULT_TIMEOUT"]
+
+    def _apply_async_min_cache_ttl(self, timeout: int) -> int:
+        """Floor an async execution's result-cache TTL (no-op otherwise).
+
+        Only applies when this query context runs on the async path; a longer
+        timeout is kept as-is, and ``0`` (flask-caching "cache forever") is already
+        above any floor so it is left untouched. Synchronous requests are never
+        floored, even when GLOBAL_ASYNC_QUERIES is enabled.
+        """
+        if self._query_context.is_async_execution is not True:
+            return timeout
+        min_ttl: int = current_app.config.get("GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL", 0)
+        if 0 < timeout < min_ttl:
+            return min_ttl
+        return timeout
 
     @staticmethod
     def _is_native_filter_options_query(form_data: dict[str, Any]) -> bool:

--- a/superset/config.py
+++ b/superset/config.py
@@ -2922,6 +2922,16 @@ GLOBAL_ASYNC_QUERIES_POLLING_DELAY = int(
     timedelta(milliseconds=500).total_seconds() * 1000
 )
 
+# Minimum cache TTL (seconds) for chart-data results produced by an *async*
+# request. The async flow caches each query's result and the client then
+# re-issues the request to read it back, so a cache TTL shorter than the round
+# trip could evict the result before it is fetched, hanging the chart. When a
+# query runs async, its result-cache TTL is floored to this value (a longer
+# slice/dataset/deployment TTL is kept as-is, and 0 — "cache forever" — is left
+# untouched). This floor applies ONLY to async execution; synchronous
+# ``/chart/data`` requests are unaffected even when GLOBAL_ASYNC_QUERIES is on.
+GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL = int(timedelta(minutes=5).total_seconds())
+
 # Deployment default for whether the UI runs chart-data queries asynchronously when
 # GLOBAL_ASYNC_QUERIES is enabled. This is a FRONTEND-ONLY policy input: async is
 # opt-in per request via an ``async_mode`` flag on ``/chart/data`` (an absent flag is

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -122,6 +122,9 @@ def execute_chart_query(
     """
     with override_user(_resolve_user(user_id, guest_token), force=False):
         query_context = load_serialized_query(serialized_query)
+        # Floor the result-cache TTL: async caches the result for a follow-up
+        # request to read back (see get_cache_timeout).
+        query_context.is_async_execution = True
         query_obj = query_context.queries[0]
         if totals_cache_key:
             _inject_contribution_totals(query_obj, totals_cache_key)

--- a/tests/unit_tests/common/test_async_min_cache_ttl.py
+++ b/tests/unit_tests/common/test_async_min_cache_ttl.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import MagicMock
+
+from flask import current_app
+from pytest_mock import MockerFixture
+
+from superset.common.query_context_processor import QueryContextProcessor
+
+
+def _processor(
+    *, is_async: bool, resolved_timeout: int | None
+) -> QueryContextProcessor:
+    """A processor over a stub context whose slice/datasource timeout is fixed."""
+    query_context = MagicMock()
+    query_context.custom_cache_timeout = None
+    query_context.form_data = {}
+    query_context.get_cache_timeout.return_value = resolved_timeout
+    query_context.is_async_execution = is_async
+    return QueryContextProcessor(query_context)
+
+
+def test_async_execution_floors_short_cache_timeout(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(current_app.config, {"GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL": 300})
+    # 60s < 300s floor → raised to the floor so the result survives until re-fetch.
+    assert _processor(is_async=True, resolved_timeout=60).get_cache_timeout() == 300
+
+
+def test_async_execution_keeps_longer_cache_timeout(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(current_app.config, {"GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL": 300})
+    # A longer configured timeout is not lowered.
+    assert _processor(is_async=True, resolved_timeout=3600).get_cache_timeout() == 3600
+
+
+def test_async_execution_leaves_zero_timeout_untouched(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(current_app.config, {"GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL": 300})
+    # 0 means "cache forever" (flask-caching), already above any floor.
+    assert _processor(is_async=True, resolved_timeout=0).get_cache_timeout() == 0
+
+
+def test_sync_execution_is_not_floored(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    mocker.patch.dict(current_app.config, {"GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL": 300})
+    # The floor applies only to async execution; a sync request keeps its timeout
+    # even when GLOBAL_ASYNC_QUERIES is enabled.
+    assert _processor(is_async=False, resolved_timeout=60).get_cache_timeout() == 60


### PR DESCRIPTION
### SUMMARY

Targets `gaq-to-gtf`. A short cache TTL can break the async chart-data flow: async runs each query, **caches** its result, and the client then re-issues the request to **read it from cache**. If the result-cache TTL is shorter than that round trip (task queue + execution + poll interval + re-request), the entry can be evicted before it's fetched, and the chart hangs / errors.

Add **`GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL`** (default **300s / 5 min**): when a query runs on the **async** path, its result-cache TTL is floored to this value.

- Applied in `QueryContextProcessor.get_cache_timeout`, gated on an `is_async_execution` flag set **only** by the async task (`execute_chart_query`). Synchronous `/chart/data` requests are **never** floored, even when `GLOBAL_ASYNC_QUERIES` is enabled — as requested.
- A longer slice/dataset/deployment timeout is kept as-is (it's a floor, not an override); `0` ("cache forever" in flask-caching) is left untouched.
- Doesn't affect the cache **key** (only the write TTL), so the client's sync re-request reads the same entry.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/common/test_async_min_cache_ttl.py` — async floors a short TTL (60→300), keeps a longer one (3600), leaves 0 untouched, and does **not** floor sync execution.
- `pytest tests/unit_tests/common/test_query_context_processor.py tests/unit_tests/tasks/test_async_queries.py` — unchanged behavior; mypy/ruff/pre-commit clean.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (the floor only applies on the async path)
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API (`GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL` config)
- [ ] Removes existing feature or API
