### PR TITLE
fix(tasks): don't re-raise validation-class errors in async chart-data cache task (SC-118140)

### DIFF
--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -106,6 +106,10 @@ def load_chart_data_into_cache(
 ) -> None:
     # pylint: disable=import-outside-toplevel
     from superset.commands.chart.data.get_data_command import ChartDataCommand
+    from superset.commands.chart.exceptions import (
+        ChartDataCacheLoadError,
+        ChartDataQueryFailedError,
+    )
 
     with override_user(_load_user_from_job_metadata(job_metadata), force=False):
         try:
@@ -123,6 +127,20 @@ def load_chart_data_into_cache(
         except SoftTimeLimitExceeded as ex:
             _handle_soft_time_limit(job_metadata, ex, "loading chart data")
             raise
+        except (ChartDataCacheLoadError, ChartDataQueryFailedError) as ex:
+            # These map to 422/400 in the synchronous chart/data endpoint (see
+            # ChartDataRestApi._get_data_response) - expected, client-facing
+            # validation failures (e.g. a chart still referencing columns a
+            # customer has since dropped from the dataset), not application
+            # bugs. The failure is already delivered to the client via
+            # update_job below; re-raising would only surface it a second
+            # time as an unhandled Celery task exception.
+            logger.info("Chart data query failed while loading into cache: %s", ex)
+            async_query_manager.update_job(
+                job_metadata,
+                async_query_manager.STATUS_ERROR,
+                errors=sanitize_error_dicts([{"message": str(ex.message)}]),
+            )
         except Exception as ex:
             # Extract SIP-40 style errors when available
             if isinstance(ex, SupersetErrorException):

--- a/tests/integration_tests/tasks/async_queries_tests.py
+++ b/tests/integration_tests/tasks/async_queries_tests.py
@@ -110,8 +110,11 @@ class TestAsyncQueries(SupersetTestCase):
             "status": "pending",
             "errors": [],
         }
-        with pytest.raises(ChartDataQueryFailedError):
-            load_chart_data_into_cache(job_metadata, query_context)
+        # ChartDataQueryFailedError mirrors the synchronous chart/data endpoint's
+        # 400 (see ChartDataRestApi._get_data_response) - an expected validation
+        # failure, not a bug, so the task reports it via update_job and does not
+        # re-raise (see superset/tasks/async_queries.py).
+        load_chart_data_into_cache(job_metadata, query_context)
 
         mock_run_command.assert_called_once_with(cache=True)
         errors = [{"message": "Error: foo"}]

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -69,10 +69,14 @@ def test_load_chart_data_into_cache_with_error(
 
 @mock.patch("superset.tasks.async_queries.security_manager")
 @mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
 @mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
 def test_load_chart_data_into_cache_with_query_failed_error_does_not_reraise(
-    mock_query_context_schema_cls, mock_async_query_manager, mock_security_manager
-):
+    mock_query_context_schema_cls: mock.MagicMock,
+    mock_command_cls: mock.MagicMock,
+    mock_async_query_manager: mock.MagicMock,
+    mock_security_manager: mock.MagicMock,
+) -> None:
     """
     ChartDataQueryFailedError maps to a 400 in the synchronous chart/data
     endpoint (see ChartDataRestApi._get_data_response) - an expected,
@@ -87,11 +91,13 @@ def test_load_chart_data_into_cache_with_query_failed_error_does_not_reraise(
     job_metadata = {"user_id": 1}
     form_data: dict[str, Any] = {}
     err_message = "Columns missing in dataset: ['foo']"
-    err = ChartDataQueryFailedError(_(err_message))
 
     mock_security_manager.get_user_by_id.return_value = mock.MagicMock()
     mock_async_query_manager.STATUS_ERROR = "error"
-    mock_query_context_schema_cls.return_value.load.side_effect = err
+    mock_query_context_schema_cls.return_value.load.return_value = mock.MagicMock()
+    mock_command_cls.return_value.run.side_effect = ChartDataQueryFailedError(
+        _(err_message)
+    )
 
     # Should not raise.
     load_chart_data_into_cache(job_metadata, form_data)

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -21,7 +21,10 @@ import pytest
 from celery.exceptions import SoftTimeLimitExceeded
 from flask_babel import lazy_gettext as _
 
-from superset.commands.chart.exceptions import ChartDataQueryFailedError
+from superset.commands.chart.exceptions import (
+    ChartDataCacheLoadError,
+    ChartDataQueryFailedError,
+)
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
     OAuth2RedirectError,
@@ -43,7 +46,7 @@ def test_load_chart_data_into_cache_with_error(
     job_metadata = {"user_id": 1}
     form_data = {}
     err_message = "Something went wrong"
-    err = ChartDataQueryFailedError(_(err_message))
+    err = RuntimeError(err_message)
 
     mock_user = mock.MagicMock()
     mock_query_context_schema = mock.MagicMock()
@@ -54,13 +57,77 @@ def test_load_chart_data_into_cache_with_error(
 
     mock_query_context_schema.load.side_effect = err
 
-    with pytest.raises(ChartDataQueryFailedError):
+    with pytest.raises(RuntimeError):
         load_chart_data_into_cache(job_metadata, form_data)
 
     expected_errors = [{"message": err_message}]
 
     mock_async_query_manager.update_job.assert_called_once_with(
         job_metadata, "error", errors=expected_errors
+    )
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_with_query_failed_error_does_not_reraise(
+    mock_query_context_schema_cls, mock_async_query_manager, mock_security_manager
+):
+    """
+    ChartDataQueryFailedError maps to a 400 in the synchronous chart/data
+    endpoint (see ChartDataRestApi._get_data_response) - an expected,
+    client-facing validation failure (e.g. a chart still referencing columns
+    a customer has since dropped from the dataset), not an application bug.
+    The task must still report it to the client via update_job, but must not
+    re-raise it - that would surface it a second time as an unhandled Celery
+    task exception.
+    """
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data: dict[str, Any] = {}
+    err_message = "Columns missing in dataset: ['foo']"
+    err = ChartDataQueryFailedError(_(err_message))
+
+    mock_security_manager.get_user_by_id.return_value = mock.MagicMock()
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value.load.side_effect = err
+
+    # Should not raise.
+    load_chart_data_into_cache(job_metadata, form_data)
+
+    mock_async_query_manager.update_job.assert_called_once_with(
+        job_metadata, "error", errors=[{"message": err_message}]
+    )
+
+
+@mock.patch("superset.tasks.async_queries.security_manager")
+@mock.patch("superset.tasks.async_queries.async_query_manager")
+@mock.patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
+@mock.patch("superset.tasks.async_queries.ChartDataQueryContextSchema")
+def test_load_chart_data_into_cache_with_cache_load_error_does_not_reraise(
+    mock_query_context_schema_cls: mock.MagicMock,
+    mock_command_cls: mock.MagicMock,
+    mock_async_query_manager: mock.MagicMock,
+    mock_security_manager: mock.MagicMock,
+) -> None:
+    """Same as above, for the sibling 422-mapped ChartDataCacheLoadError."""
+    from superset.tasks.async_queries import load_chart_data_into_cache
+
+    job_metadata = {"user_id": 1}
+    form_data: dict[str, Any] = {}
+    err_message = "Cache load failed"
+
+    mock_security_manager.get_user_by_id.return_value = mock.MagicMock()
+    mock_async_query_manager.STATUS_ERROR = "error"
+    mock_query_context_schema_cls.return_value.load.return_value = mock.MagicMock()
+    mock_command_cls.return_value.run.side_effect = ChartDataCacheLoadError(err_message)
+
+    # Should not raise.
+    load_chart_data_into_cache(job_metadata, form_data)
+
+    mock_async_query_manager.update_job.assert_called_once_with(
+        job_metadata, "error", errors=[{"message": err_message}]
     )
 
 


### PR DESCRIPTION
## Summary

**Sentry:** [SUPERSET-PYTHON-13JV](https://preset-inc.sentry.io/issues/7500766563/) — 908 events / 0 users over the trailing 14 days, chronic since 2026-05-22, still actively firing.

### Root cause

`load_chart_data_into_cache` (the Celery task backing `GLOBAL_ASYNC_QUERIES` chart loads) catches every exception from `ChartDataCommand.run()` in one generic `except Exception` block that reports the failure to the client via `async_query_manager.update_job(...)` and then unconditionally re-raises.

For `ChartDataQueryFailedError` — raised when a chart still references columns that have since been dropped from its dataset (customer-side schema drift, not a Superset bug) — this is inconsistent with how the codebase already treats the *same exception type* in the synchronous path: `ChartDataRestApi._get_data_response` explicitly maps `ChartDataQueryFailedError` to a 400 (and its sibling `ChartDataCacheLoadError` to 422), i.e. these are already classified elsewhere as expected, client-facing validation failures, not server bugs.

Because the async task always re-raises, Celery's default task-exception handling (and the Sentry Celery integration) captures every occurrence as an unhandled ERROR, even though `update_job` has already delivered a clean error to the client. This task is fire-and-forget (`apply_async`, no `.get()`, no retry policy, no result-backend consumer), so nothing depends on the task's own exception/FAILURE state for these two exception types.

### Fix

Add a dedicated `except (ChartDataCacheLoadError, ChartDataQueryFailedError)` branch before the generic handler in `superset/tasks/async_queries.py`: still call `update_job(..., STATUS_ERROR, ...)` so client-facing behavior is unchanged, log at INFO, and don't re-raise. All other exception types — including genuinely unexpected ones and the SIP-40 `SupersetErrorException`/`SupersetErrorsException` family — are untouched and still re-raise exactly as before.

## Tradeoffs

This changes failure-mode semantics for these two exception types specifically: the Celery task now completes without raising even though the underlying chart query failed (the client still sees the error via `update_job`/the job-status poll, unchanged). I verified no code path inspects this task's own exception/result state — it's fire-and-forget with no retry policy — so this should be safe, but flagging it explicitly since it's a real behavior change, not a pure log-level tweak.

## Testing

- `ruff check` / `ruff format --check` clean on both touched files.
- `pytest tests/unit_tests/tasks/test_async_queries.py` — 9/9 passing: repointed the existing generic-error test at a plain `RuntimeError` (it was incidentally using `ChartDataQueryFailedError` as a stand-in for "some exception"), and added two new tests asserting `ChartDataQueryFailedError` and `ChartDataCacheLoadError` are reported via `update_job` but do not re-raise.
- Full app-context suite unusable in this shared clone (missing `superset_core`, known local env issue) — ran the target file directly with `superset-core` added to `PYTHONPATH`.

## Follow-ups

None identified — the fix is self-contained to this one task.

Shortcut: [sc-118140](https://app.shortcut.com/preset/story/118140)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** self-review (Claude Code, Codex unavailable — platform outage) caught that the unit-test-only local verification missed an integration test (`tests/integration_tests/tasks/async_queries_tests.py::test_load_chart_data_into_cache_error`) still asserting the old re-raise behavior — would have failed CI. Fixed in a follow-up commit to match the new no-reraise contract; confirmed via manual trace + ruff (the integration suite itself isn't runnable in this environment, a local `parameterized` package gap unrelated to this change).