### PR TITLE
fix(explore): catch TemplateError when validating access for query-backed form_data

### DIFF
--- a/superset/explore/form_data/api.py
+++ b/superset/explore/form_data/api.py
@@ -30,6 +30,7 @@ from superset.commands.temporary_cache.exceptions import (
     TemporaryCacheResourceNotFoundError,
 )
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
+from superset.exceptions import SupersetTemplateException
 from superset.explore.form_data.schemas import FormDataPostSchema, FormDataPutSchema
 from superset.extensions import event_logger
 from superset.views.base_api import BaseSupersetApi, requires_json, statsd_metrics
@@ -110,6 +111,8 @@ class ExploreFormDataRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))
 
     @expose("/form_data/<string:key>", methods=("PUT",))
     @protect()
@@ -183,6 +186,8 @@ class ExploreFormDataRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))
 
     @expose("/form_data/<string:key>", methods=("GET",))
     @protect()
@@ -234,6 +239,8 @@ class ExploreFormDataRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))
 
     @expose("/form_data/<string:key>", methods=("DELETE",))
     @protect()
@@ -286,3 +293,5 @@ class ExploreFormDataRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except TemporaryCacheResourceNotFoundError as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))

--- a/superset/explore/utils.py
+++ b/superset/explore/utils.py
@@ -16,6 +16,8 @@
 # under the License.
 from typing import Optional
 
+from jinja2.exceptions import TemplateError
+
 from superset import security_manager
 from superset.commands.chart.exceptions import (
     ChartAccessDeniedError,
@@ -33,6 +35,7 @@ from superset.commands.exceptions import (
 from superset.daos.chart import ChartDAO
 from superset.daos.dataset import DatasetDAO
 from superset.daos.query import QueryDAO
+from superset.exceptions import SupersetTemplateException
 from superset.utils.core import DatasourceType
 
 
@@ -53,7 +56,13 @@ def check_query_access(query_id: int) -> Optional[bool]:
         # Access checks below, no need to validate them twice as they can be expensive.
         query = QueryDAO.find_by_id(query_id, skip_base_filter=True)
         if query:
-            security_manager.raise_for_access(query=query)
+            try:
+                security_manager.raise_for_access(query=query)
+            except TemplateError as ex:
+                # raise_for_access() Jinja-renders the query's SQL to resolve
+                # the tables it touches; a malformed template surfaces here as
+                # a raw jinja2 exception rather than a Superset one.
+                raise SupersetTemplateException(str(ex)) from ex
             return True
     raise QueryNotFoundValidationError()
 

--- a/tests/unit_tests/explore/utils_test.py
+++ b/tests/unit_tests/explore/utils_test.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from flask_appbuilder.security.sqla.models import User
+from jinja2.exceptions import TemplateSyntaxError
 from pytest import raises  # noqa: PT013
 from pytest_mock import MockerFixture
 
@@ -30,7 +31,7 @@ from superset.commands.exceptions import (
     DatasourceNotFoundValidationError,
     QueryNotFoundValidationError,
 )
-from superset.exceptions import SupersetSecurityException
+from superset.exceptions import SupersetSecurityException, SupersetTemplateException
 from superset.utils.core import DatasourceType, override_user
 
 dataset_find_by_id = "superset.daos.dataset.DatasetDAO.find_by_id"
@@ -338,6 +339,28 @@ def test_query_has_access(mocker: MockerFixture) -> None:
         )
         is True
     )
+
+
+def test_query_malformed_jinja_template(mocker: MockerFixture) -> None:
+    """
+    ``raise_for_access(query=...)`` Jinja-renders the query's SQL to resolve
+    the tables it touches. A malformed template must surface as a
+    ``SupersetTemplateException``, not the raw ``jinja2`` exception.
+    """
+    from superset.explore.utils import check_datasource_access
+    from superset.models.sql_lab import Query
+
+    mocker.patch(query_find_by_id, return_value=Query())
+    mocker.patch(
+        raise_for_access,
+        side_effect=TemplateSyntaxError("unexpected end of template", lineno=1),
+    )
+
+    with raises(SupersetTemplateException):  # noqa: PT012
+        check_datasource_access(
+            datasource_id=1,
+            datasource_type=DatasourceType.QUERY,
+        )
 
 
 def test_query_no_access(mocker: MockerFixture, client) -> None:


### PR DESCRIPTION
### SUMMARY
`ExploreFormDataRestApi` (the cache backing chart Explore / Drill-by state) lets a client reference a SQL Lab query as the chart's datasource (`datasource_type=query`). Access to that datasource is validated via `superset.explore.utils.check_query_access`, which calls `security_manager.raise_for_access(query=query)`. When the query hasn't been executed yet (or was edited after last execution), that call falls back to Jinja-rendering the query's raw SQL (`process_jinja_sql`) to resolve the tables it references — the exact same rendering step already known to raise `jinja2.exceptions.TemplateError` for malformed templates (see #42366, #42401, and the more recent #43423/#43433 in the tag-access-check family).

Unlike those command-layer call sites, this one had no `except TemplateError` at all, so the raw jinja2 exception propagated straight through `CreateFormDataCommand`/`GetFormDataCommand`/`UpdateFormDataCommand`/`DeleteFormDataCommand` (none of which catch anything but `SQLAlchemyError`) up to `ExploreFormDataRestApi`, landing as an opaque, unclassified 500 from all four `POST`/`PUT`/`GET`/`DELETE /api/v1/explore/form_data` handlers.

### PROBLEM
A user-controlled input (a saved SQL Lab query with malformed Jinja templating, referenced as a chart's datasource) can trigger a raw `jinja2.exceptions.TemplateError` that surfaces as an unclassified 500, instead of a proper 4xx `SupersetException`.

### FIX
- `superset/explore/utils.py::check_query_access` now catches `TemplateError` around the `raise_for_access(query=query)` call and re-raises it as `SupersetTemplateException` (existing, 422 — no new exception class needed), preserving the original message.
- `superset/explore/form_data/api.py` maps `SupersetTemplateException` to a proper `ex.status` response in all four `ExploreFormDataRestApi` handlers, mirroring the existing `except SupersetTemplateException as ex: return self.response(ex.status, message=str(ex))` idiom already used in `superset/datasets/api.py`.

No behavior change for any other exception type or datasource type.

### TESTING INSTRUCTIONS
- New unit test `tests/unit_tests/explore/utils_test.py::test_query_malformed_jinja_template`: mocks `raise_for_access` to raise `jinja2.exceptions.TemplateSyntaxError` and asserts `check_datasource_access` now raises `SupersetTemplateException` instead. Verified this test fails on pre-fix code (raw `TemplateSyntaxError` propagates) and passes post-fix.
- `ruff check` / `ruff format --check` clean on all changed files.
- Full `tests/unit_tests/explore/` and `tests/unit_tests/commands/explore/` suites pass (24 tests).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API