### PR TITLE
fix(mcp): honor and validate chart filters

### DIFF
--- a/superset/mcp_service/chart/chart_helpers.py
+++ b/superset/mcp_service/chart/chart_helpers.py
@@ -199,6 +199,8 @@ def apply_form_data_filters_to_query(
         query["where"] = where
     if having := form_data.get("having"):
         query["having"] = having
+    if extras := form_data.get("extras"):
+        query["extras"] = {**(query.get("extras") or {}), **extras}
 
 
 def _join_sql_clause(existing_clause: str, additional_clause: str) -> str:
@@ -255,6 +257,9 @@ def merge_form_data_filters_into_query(
                 query[clause] = _join_sql_clause(existing_clause, additional_clause)
             else:
                 query[clause] = additional_clause
+
+    if extras := form_data.get("extras"):
+        query["extras"] = {**(query.get("extras") or {}), **extras}
 
 
 def merge_extra_form_data_filters_into_query(

--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -2810,6 +2810,15 @@ class GetChartSqlRequest(BaseModel):
             "Can be used alone (without identifier) for unsaved charts."
         ),
     )
+    extra_form_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Extra form data to merge into the chart query before rendering SQL, "
+            "typically from dashboard native filters. Same format accepted by "
+            "get_chart_data. Format: "
+            '{"filters": [{"col": "country", "op": "IN", "val": ["US"]}]}'
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_identifier_or_form_data_key(self) -> "GetChartSqlRequest":

--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -62,6 +62,42 @@ from superset.utils.core import GenericDataType
 
 logger = logging.getLogger(__name__)
 
+
+def _requested_filter_columns(extra_form_data: dict[str, Any] | None) -> set[str]:
+    """Return simple column names explicitly requested through extra form data."""
+    if not extra_form_data:
+        return set()
+
+    columns: set[str] = set()
+    for filter_ in extra_form_data.get("filters", []):
+        if isinstance(filter_, dict) and isinstance(column := filter_.get("col"), str):
+            columns.add(column)
+    for filter_ in extra_form_data.get("adhoc_filters", []):
+        if (
+            isinstance(filter_, dict)
+            and filter_.get("expressionType") == "SIMPLE"
+            and isinstance(column := filter_.get("subject"), str)
+        ):
+            columns.add(column)
+    return columns
+
+
+def _rejected_requested_filter_columns(
+    result: Any, extra_form_data: dict[str, Any] | None
+) -> list[str]:
+    """Find request filters rejected by datasource query construction."""
+    if not isinstance(result, dict):
+        return []
+    requested = _requested_filter_columns(extra_form_data)
+    rejected = {
+        column
+        for query in result.get("queries", [])
+        for column in query.get("rejected_filter_columns", [])
+        if isinstance(column, str)
+    }
+    return sorted(requested & rejected)
+
+
 _GENERIC_TYPE_MAP: dict[int, str] = {
     GenericDataType.NUMERIC: "numeric",
     GenericDataType.STRING: "string",
@@ -685,6 +721,19 @@ async def get_chart_data(  # noqa: C901
                 command.validate()
                 result = command.run()
 
+            if rejected := _rejected_requested_filter_columns(
+                result, request.extra_form_data
+            ):
+                rejected_columns = ", ".join(rejected)
+                await ctx.warning(
+                    "Requested filters reference unknown dataset columns: %s"
+                    % rejected_columns
+                )
+                return ChartError(
+                    error=f"Unknown dataset column(s) in filters: {rejected_columns}",
+                    error_type="ValidationError",
+                )
+
             # Handle empty query results for certain chart types
             if not result or ("queries" not in result) or len(result["queries"]) == 0:
                 await ctx.warning(
@@ -979,7 +1028,7 @@ async def get_chart_data(  # noqa: C901
         )
 
 
-async def _query_from_form_data(
+async def _query_from_form_data(  # noqa: C901
     form_data: Dict[str, Any],
     request: GetChartDataRequest,
     ctx: Context,
@@ -1033,6 +1082,19 @@ async def _query_from_form_data(
             command = ChartDataCommand(query_context)
             command.validate()
             result = command.run()
+
+        if rejected := _rejected_requested_filter_columns(
+            result, request.extra_form_data
+        ):
+            rejected_columns = ", ".join(rejected)
+            await ctx.warning(
+                "Requested filters reference unknown dataset columns: %s"
+                % rejected_columns
+            )
+            return ChartError(
+                error=f"Unknown dataset column(s) in filters: {rejected_columns}",
+                error_type="ValidationError",
+            )
 
         if not result or "queries" not in result or len(result["queries"]) == 0:
             logger.warning(

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -176,13 +176,32 @@ def _sql_from_saved_query_context(
         qc_json["force"] = False
 
         if extra_form_data:
+            # Resolve the pieces of the saved context the merge depends on first.
+            # Failures here mean the context itself is stale, not that the
+            # request's filters are bad, so the caller should rebuild it from
+            # form_data rather than surfacing a validation error.
             try:
-                for query in qc_json.get("queries", []):
+                datasource_id = qc_json["datasource"]["id"]
+                datasource_type = qc_json["datasource"]["type"]
+                queries = qc_json.get("queries", [])
+                if not isinstance(queries, list):
+                    raise TypeError("queries must be a list")
+            except (AttributeError, KeyError, TypeError) as ex:
+                logger.warning(
+                    "Saved query context is unusable for chart %s; "
+                    "falling back to form_data: %s",
+                    chart.id,
+                    ex,
+                )
+                return None
+
+            try:
+                for query in queries:
                     merge_extra_form_data_filters_into_query(
                         query,
                         extra_form_data,
-                        qc_json["datasource"]["id"],
-                        qc_json["datasource"]["type"],
+                        datasource_id,
+                        datasource_type,
                     )
             except (AttributeError, KeyError, TypeError) as ex:
                 return ChartError(

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -192,10 +192,16 @@ def _sql_from_saved_query_context(
 
         try:
             query_context = ChartDataQueryContextSchema().load(qc_json)
-        except MarshmallowValidationError:
+        except MarshmallowValidationError as ex:
             # A saved query context can become stale as schemas evolve. Let the
             # caller rebuild it from form_data; malformed request filters will
             # still produce a ValidationError from that fallback path.
+            logger.warning(
+                "Saved query context validation failed for chart %s; "
+                "falling back to form_data: %s",
+                chart.id,
+                ex,
+            )
             return None
         query_context.result_type = ChartDataResultType.QUERY
         set_query_context_form_data(
@@ -280,7 +286,7 @@ def _sql_from_form_data(
         )
     except (AttributeError, KeyError, TypeError, MarshmallowValidationError) as ex:
         return ChartError(
-            error=f"Invalid extra_form_data: {ex}",
+            error=f"Invalid chart query data: {ex}",
             error_type="ValidationError",
         )
     set_query_context_form_data(

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -192,8 +192,11 @@ def _sql_from_saved_query_context(
 
         try:
             query_context = ChartDataQueryContextSchema().load(qc_json)
-        except MarshmallowValidationError as ex:
-            return ChartError(error=str(ex), error_type="ValidationError")
+        except MarshmallowValidationError:
+            # A saved query context can become stale as schemas evolve. Let the
+            # caller rebuild it from form_data; malformed request filters will
+            # still produce a ValidationError from that fallback path.
+            return None
         query_context.result_type = ChartDataResultType.QUERY
         set_query_context_form_data(
             query_context,

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -35,6 +35,7 @@ from superset.extensions import event_logger
 from superset.mcp_service.chart.chart_helpers import (
     build_query_context_from_form_data,
     extract_x_axis_col,
+    merge_extra_form_data_filters_into_query,
     resolve_groupby,
     resolve_metrics,
     resolve_metrics_and_groupby,
@@ -90,6 +91,7 @@ def _extract_x_axis_col(form_data: dict[str, Any]) -> str | None:
 def _build_query_context_from_form_data(
     form_data: dict[str, Any],
     chart: "Slice | None" = None,
+    extra_form_data: dict[str, Any] | None = None,
 ) -> Any:
     """Build a QueryContext from form_data with result_type=QUERY.
 
@@ -101,6 +103,7 @@ def _build_query_context_from_form_data(
     return build_query_context_from_form_data(
         form_data,
         chart=chart,
+        extra_form_data=extra_form_data,
         result_type=ChartDataResultType.QUERY,
         force=False,
     )
@@ -150,6 +153,7 @@ def _resolve_effective_form_data(
 
 def _sql_from_saved_query_context(
     chart: "Slice",
+    extra_form_data: dict[str, Any] | None = None,
 ) -> ChartSql | ChartError | None:
     """Try to extract SQL from a chart's saved query_context.
 
@@ -167,6 +171,15 @@ def _sql_from_saved_query_context(
         qc_json = utils_json.loads(chart.query_context)
         qc_json["result_type"] = ChartDataResultType.QUERY
         qc_json["force"] = False
+
+        if extra_form_data:
+            for query in qc_json.get("queries", []):
+                merge_extra_form_data_filters_into_query(
+                    query,
+                    extra_form_data,
+                    qc_json["datasource"]["id"],
+                    qc_json["datasource"]["type"],
+                )
 
         query_context = ChartDataQueryContextSchema().load(qc_json)
         query_context.result_type = ChartDataResultType.QUERY
@@ -235,11 +248,14 @@ def _resolve_datasource_name(
 def _sql_from_form_data(
     form_data: dict[str, Any],
     chart: "Slice | None",
+    extra_form_data: dict[str, Any] | None = None,
 ) -> ChartSql | ChartError:
     """Build SQL from form_data (fallback path)."""
     from superset.commands.chart.data.get_data_command import ChartDataCommand
 
-    query_context = _build_query_context_from_form_data(form_data, chart)
+    query_context = _build_query_context_from_form_data(
+        form_data, chart, extra_form_data
+    )
     command = ChartDataCommand(query_context)
     command.validate()
     result = command.run()
@@ -335,6 +351,8 @@ async def get_chart_sql(
     Supports:
     - Numeric ID or UUID lookup
     - form_data_key: get SQL for unsaved chart state from Explore view
+    - extra_form_data: preview SQL with dashboard-filter-style predicates merged
+      in, same format accepted by get_chart_data
 
     Example usage:
     ```json
@@ -382,7 +400,9 @@ async def _handle_chart_sql_request(
 
     # Handle unsaved chart (form_data_key only, no identifier)
     if not request.identifier and request.form_data_key:
-        return await _handle_unsaved_chart_sql(request.form_data_key, ctx)
+        return await _handle_unsaved_chart_sql(
+            request.form_data_key, ctx, request.extra_form_data
+        )
 
     # Find the chart by identifier
     if request.identifier is None:
@@ -425,7 +445,7 @@ async def _handle_chart_sql_request(
     # Try saved query_context first (faster, more accurate)
     with event_logger.log_context(action="mcp.get_chart_sql.build_query"):
         if not using_unsaved_state:
-            saved_result = _sql_from_saved_query_context(chart)
+            saved_result = _sql_from_saved_query_context(chart, request.extra_form_data)
             if saved_result is not None:
                 return saved_result
             await ctx.warning(
@@ -435,7 +455,9 @@ async def _handle_chart_sql_request(
 
         # Fallback: build query context from form_data
         try:
-            return _sql_from_form_data(effective_form_data, chart)
+            return _sql_from_form_data(
+                effective_form_data, chart, request.extra_form_data
+            )
         except (SupersetException, CommandException, ValueError) as e:
             await ctx.warning("Failed to build SQL from form_data: %s" % str(e))
             return ChartError(
@@ -445,7 +467,9 @@ async def _handle_chart_sql_request(
 
 
 async def _handle_unsaved_chart_sql(
-    form_data_key: str, ctx: Context
+    form_data_key: str,
+    ctx: Context,
+    extra_form_data: dict[str, Any] | None = None,
 ) -> ChartSql | ChartError:
     """Handle SQL retrieval for unsaved charts (form_data_key only)."""
     from superset.utils import json as utils_json
@@ -476,7 +500,9 @@ async def _handle_unsaved_chart_sql(
             )
 
         try:
-            return _sql_from_form_data(form_data, chart=None)
+            return _sql_from_form_data(
+                form_data, chart=None, extra_form_data=extra_form_data
+            )
         except (SupersetException, CommandException, ValueError) as e:
             await ctx.warning("Failed to generate SQL from form_data: %s" % str(e))
             return ChartError(

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -223,10 +223,14 @@ def _sql_from_saved_query_context(
             )
             return None
         query_context.result_type = ChartDataResultType.QUERY
+        # ChartDataDatasourceSchema only requires "id", so fall back to the
+        # chart's own datasource rather than raising on a context that the
+        # schema itself considers valid.
+        datasource_json = qc_json.get("datasource") or {}
         set_query_context_form_data(
             query_context,
-            qc_json["datasource"]["id"],
-            qc_json["datasource"]["type"],
+            datasource_json.get("id", chart.datasource_id),
+            datasource_json.get("type", chart.datasource_type),
         )
 
         command = ChartDataCommand(query_context)

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -254,7 +254,7 @@ def _sql_from_form_data(
     from superset.commands.chart.data.get_data_command import ChartDataCommand
 
     query_context = _build_query_context_from_form_data(
-        form_data, chart, extra_form_data
+        form_data, chart, extra_form_data=extra_form_data
     )
     command = ChartDataCommand(query_context)
     command.validate()
@@ -381,6 +381,14 @@ async def get_chart_sql(
         return ChartError(
             error=f"Failed to generate chart SQL: {e}",
             error_type="QueryGenerationFailed",
+        )
+    except KeyError as e:
+        # extra_form_data filter entries missing a required key (e.g. "col"
+        # or "op") raise KeyError while being normalized into adhoc filters.
+        logger.exception("Malformed extra_form_data filter in get_chart_sql")
+        return ChartError(
+            error=f"Invalid extra_form_data filter: missing required key {e}",
+            error_type="ValidationError",
         )
 
 

--- a/superset/mcp_service/chart/tool/get_chart_sql.py
+++ b/superset/mcp_service/chart/tool/get_chart_sql.py
@@ -23,11 +23,13 @@ import logging
 from typing import Any, TYPE_CHECKING
 
 from fastmcp import Context
+from marshmallow import ValidationError as MarshmallowValidationError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 if TYPE_CHECKING:
     from superset.models.slice import Slice
 
+from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
 from superset.commands.explore.form_data.parameters import CommandParameters
 from superset.exceptions import SupersetException, SupersetSecurityException
@@ -36,6 +38,7 @@ from superset.mcp_service.chart.chart_helpers import (
     build_query_context_from_form_data,
     extract_x_axis_col,
     merge_extra_form_data_filters_into_query,
+    resolve_form_data_datasource,
     resolve_groupby,
     resolve_metrics,
     resolve_metrics_and_groupby,
@@ -173,16 +176,30 @@ def _sql_from_saved_query_context(
         qc_json["force"] = False
 
         if extra_form_data:
-            for query in qc_json.get("queries", []):
-                merge_extra_form_data_filters_into_query(
-                    query,
-                    extra_form_data,
-                    qc_json["datasource"]["id"],
-                    qc_json["datasource"]["type"],
+            try:
+                for query in qc_json.get("queries", []):
+                    merge_extra_form_data_filters_into_query(
+                        query,
+                        extra_form_data,
+                        qc_json["datasource"]["id"],
+                        qc_json["datasource"]["type"],
+                    )
+            except (AttributeError, KeyError, TypeError) as ex:
+                return ChartError(
+                    error=f"Invalid extra_form_data filter: {ex}",
+                    error_type="ValidationError",
                 )
 
-        query_context = ChartDataQueryContextSchema().load(qc_json)
+        try:
+            query_context = ChartDataQueryContextSchema().load(qc_json)
+        except MarshmallowValidationError as ex:
+            return ChartError(error=str(ex), error_type="ValidationError")
         query_context.result_type = ChartDataResultType.QUERY
+        set_query_context_form_data(
+            query_context,
+            qc_json["datasource"]["id"],
+            qc_json["datasource"]["type"],
+        )
 
         command = ChartDataCommand(query_context)
         command.validate()
@@ -253,8 +270,20 @@ def _sql_from_form_data(
     """Build SQL from form_data (fallback path)."""
     from superset.commands.chart.data.get_data_command import ChartDataCommand
 
-    query_context = _build_query_context_from_form_data(
-        form_data, chart, extra_form_data=extra_form_data
+    try:
+        _, datasource_type = resolve_form_data_datasource(form_data, chart)
+        query_context = _build_query_context_from_form_data(
+            form_data, chart, extra_form_data=extra_form_data
+        )
+    except (AttributeError, KeyError, TypeError, MarshmallowValidationError) as ex:
+        return ChartError(
+            error=f"Invalid extra_form_data: {ex}",
+            error_type="ValidationError",
+        )
+    set_query_context_form_data(
+        query_context,
+        query_context.datasource.id,
+        datasource_type,
     )
     command = ChartDataCommand(query_context)
     command.validate()
@@ -381,14 +410,6 @@ async def get_chart_sql(
         return ChartError(
             error=f"Failed to generate chart SQL: {e}",
             error_type="QueryGenerationFailed",
-        )
-    except KeyError as e:
-        # extra_form_data filter entries missing a required key (e.g. "col"
-        # or "op") raise KeyError while being normalized into adhoc filters.
-        logger.exception("Malformed extra_form_data filter in get_chart_sql")
-        return ChartError(
-            error=f"Invalid extra_form_data filter: missing required key {e}",
-            error_type="ValidationError",
         )
 
 

--- a/tests/unit_tests/mcp_service/chart/test_chart_helpers.py
+++ b/tests/unit_tests/mcp_service/chart/test_chart_helpers.py
@@ -258,6 +258,19 @@ def test_merge_form_data_filters_into_query_applies_regular_overrides():
     assert query["having"] == "(SUM(num) > 10) AND (COUNT(*) > 1)"
 
 
+def test_filter_helpers_copy_relative_time_extras():
+    """Relative time anchors reach both saved and freshly built queries."""
+    extras = {"relative_start": "now", "relative_end": "today"}
+
+    fresh_query = {"extras": {"where": "country = 'US'"}}
+    apply_form_data_filters_to_query(fresh_query, {"extras": extras})
+    assert fresh_query["extras"] == {"where": "country = 'US'", **extras}
+
+    saved_query = {"extras": {"having": "COUNT(*) > 1"}}
+    merge_form_data_filters_into_query(saved_query, {"extras": extras})
+    assert saved_query["extras"] == {"having": "COUNT(*) > 1", **extras}
+
+
 def test_merge_extra_form_data_filters_into_query_adds_only_extra_predicates(
     monkeypatch,
 ):

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -41,8 +41,49 @@ from superset.mcp_service.chart.tool.get_chart_data import (
     _MAX_RECOMMENDATIONS,
     _query_from_form_data,
     _recommend_visualizations,
+    _rejected_requested_filter_columns,
+    _requested_filter_columns,
 )
 from superset.utils.core import GenericDataType
+
+
+def test_requested_filter_columns_supports_both_payload_shapes() -> None:
+    assert _requested_filter_columns(
+        {
+            "filters": [{"col": "country", "op": "==", "val": "USA"}],
+            "adhoc_filters": [
+                {
+                    "expressionType": "SIMPLE",
+                    "subject": "city",
+                    "operator": "==",
+                    "comparator": "New York",
+                },
+                {"expressionType": "SQL", "sqlExpression": "revenue > 0"},
+            ],
+        }
+    ) == {"country", "city"}
+
+
+def test_rejected_requested_filter_columns_ignores_saved_chart_filters() -> None:
+    result = {
+        "queries": [
+            {"rejected_filter_columns": ["missing_request", "stale_saved_filter"]}
+        ]
+    }
+
+    assert _rejected_requested_filter_columns(
+        result,
+        {
+            "adhoc_filters": [
+                {
+                    "expressionType": "SIMPLE",
+                    "subject": "missing_request",
+                    "operator": "==",
+                    "comparator": "value",
+                }
+            ]
+        },
+    ) == ["missing_request"]
 
 
 def _collect_groupby_extras(

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -1349,6 +1349,161 @@ class TestChartLookupEagerLoading:
             assert _extract_metrics_load_path(query_options[0]) == ["table", "metrics"]
 
 
+class TestSavedChartExtraFormDataFilters:
+    """Regression tests: extra_form_data filters passed alongside a saved
+    chart identifier must reach the executed query, not just the cached
+    form_data / unsaved-chart path already covered elsewhere.
+
+    A chart with a saved query_context is the common case (any chart that
+    has been opened and saved through Explore), so this is the primary path
+    exercised when a caller passes extra_form_data with a chart identifier.
+    """
+
+    def _chart(self) -> SimpleNamespace:
+        from superset.utils import json as utils_json
+
+        return SimpleNamespace(
+            id=9,
+            slice_name="Sales",
+            viz_type="table",
+            datasource_id=1,
+            datasource_type="table",
+            query_context=utils_json.dumps(
+                {
+                    "datasource": {"id": 1, "type": "table"},
+                    "queries": [
+                        {
+                            "columns": ["country"],
+                            "metrics": ["count"],
+                            "filters": [],
+                            "row_limit": 100,
+                        }
+                    ],
+                    "result_format": "json",
+                    "result_type": "full",
+                }
+            ),
+            params=None,
+        )
+
+    async def _run(self, extra_form_data: dict[str, Any], mcp_server: Any) -> Any:
+        from unittest.mock import patch
+
+        from fastmcp import Client
+
+        module = importlib.import_module(
+            "superset.mcp_service.chart.tool.get_chart_data"
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_load(self: Any, data: dict[str, Any]) -> Any:
+            captured["loaded_query_context_json"] = data
+            return SimpleNamespace(queries=[SimpleNamespace(filter=[])])
+
+        class _Command:
+            def __init__(self, query_context: Any) -> None: ...
+            def validate(self) -> None: ...
+            def run(self) -> dict[str, Any]:
+                return {
+                    "queries": [
+                        {
+                            "data": [{"country": "USA"}],
+                            "colnames": ["country"],
+                            "rowcount": 1,
+                        }
+                    ]
+                }
+
+        with (
+            patch.object(
+                module, "find_chart_by_identifier", return_value=self._chart()
+            ),
+            patch.object(
+                module,
+                "validate_chart_dataset",
+                return_value=SimpleNamespace(is_valid=True, warnings=[], error=None),
+            ),
+            patch(
+                "superset.commands.chart.data.get_data_command.ChartDataCommand",
+                _Command,
+            ),
+            patch(
+                "superset.charts.schemas.ChartDataQueryContextSchema.load",
+                fake_load,
+            ),
+        ):
+            async with Client(mcp_server) as client:
+                await client.call_tool(
+                    "get_chart_data",
+                    {
+                        "request": {
+                            "identifier": "9",
+                            "extra_form_data": extra_form_data,
+                        }
+                    },
+                )
+
+        return captured["loaded_query_context_json"]
+
+    @pytest.mark.asyncio
+    async def test_filters_key_reaches_executed_query(
+        self, mcp_server: Any, mock_auth: Any
+    ) -> None:
+        """extra_form_data using the native 'filters' format is applied."""
+        loaded = await self._run(
+            {"filters": [{"col": "country", "op": "==", "val": "USA"}]}, mcp_server
+        )
+        filters = loaded["queries"][0].get("filters", [])
+        assert {"col": "country", "op": "==", "val": "USA"} in filters
+
+    @pytest.mark.asyncio
+    async def test_adhoc_filters_key_reaches_executed_query(
+        self, mcp_server: Any, mock_auth: Any
+    ) -> None:
+        """extra_form_data using the 'adhoc_filters' format is also applied."""
+        loaded = await self._run(
+            {
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "expressionType": "SIMPLE",
+                        "subject": "country",
+                        "operator": "==",
+                        "comparator": "USA",
+                    }
+                ]
+            },
+            mcp_server,
+        )
+        filters = loaded["queries"][0].get("filters", [])
+        assert {"col": "country", "op": "==", "val": "USA"} in filters
+
+    @pytest.mark.asyncio
+    async def test_temporal_range_filter_reaches_executed_query(
+        self, mcp_server: Any, mock_auth: Any
+    ) -> None:
+        """A TEMPORAL_RANGE filter narrows the query, not just simple filters."""
+        loaded = await self._run(
+            {
+                "filters": [
+                    {
+                        "col": "order_date",
+                        "op": "TEMPORAL_RANGE",
+                        "val": "2024-01-01 : 2024-02-01",
+                    }
+                ]
+            },
+            mcp_server,
+        )
+        filters = loaded["queries"][0].get("filters", [])
+        assert {
+            "col": "order_date",
+            "op": "TEMPORAL_RANGE",
+            "val": "2024-01-01 : 2024-02-01",
+        } in filters
+
+
 class TestOAuthErrorRouting:
     """Query-time OAuth errors must reach the dedicated OAuth handlers.
 

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -44,6 +44,7 @@ from superset.mcp_service.chart.tool.get_chart_data import (
     _rejected_requested_filter_columns,
     _requested_filter_columns,
 )
+from superset.utils import json
 from superset.utils.core import GenericDataType
 
 
@@ -1427,7 +1428,12 @@ class TestSavedChartExtraFormDataFilters:
             params=None,
         )
 
-    async def _run(self, extra_form_data: dict[str, Any], mcp_server: Any) -> Any:
+    async def _run(
+        self,
+        extra_form_data: dict[str, Any],
+        mcp_server: Any,
+        rejected_filter_columns: list[str] | None = None,
+    ) -> tuple[Any, Any]:
         from unittest.mock import patch
 
         from fastmcp import Client
@@ -1452,6 +1458,7 @@ class TestSavedChartExtraFormDataFilters:
                             "data": [{"country": "USA"}],
                             "colnames": ["country"],
                             "rowcount": 1,
+                            "rejected_filter_columns": rejected_filter_columns or [],
                         }
                     ]
                 }
@@ -1475,7 +1482,7 @@ class TestSavedChartExtraFormDataFilters:
             ),
         ):
             async with Client(mcp_server) as client:
-                await client.call_tool(
+                tool_result = await client.call_tool(
                     "get_chart_data",
                     {
                         "request": {
@@ -1485,14 +1492,14 @@ class TestSavedChartExtraFormDataFilters:
                     },
                 )
 
-        return captured["loaded_query_context_json"]
+        return captured["loaded_query_context_json"], tool_result
 
     @pytest.mark.asyncio
     async def test_filters_key_reaches_executed_query(
         self, mcp_server: Any, mock_auth: Any
     ) -> None:
         """extra_form_data using the native 'filters' format is applied."""
-        loaded = await self._run(
+        loaded, _ = await self._run(
             {"filters": [{"col": "country", "op": "==", "val": "USA"}]}, mcp_server
         )
         filters = loaded["queries"][0].get("filters", [])
@@ -1503,7 +1510,7 @@ class TestSavedChartExtraFormDataFilters:
         self, mcp_server: Any, mock_auth: Any
     ) -> None:
         """extra_form_data using the 'adhoc_filters' format is also applied."""
-        loaded = await self._run(
+        loaded, _ = await self._run(
             {
                 "adhoc_filters": [
                     {
@@ -1525,7 +1532,7 @@ class TestSavedChartExtraFormDataFilters:
         self, mcp_server: Any, mock_auth: Any
     ) -> None:
         """A TEMPORAL_RANGE filter narrows the query, not just simple filters."""
-        loaded = await self._run(
+        loaded, _ = await self._run(
             {
                 "filters": [
                     {
@@ -1543,6 +1550,32 @@ class TestSavedChartExtraFormDataFilters:
             "op": "TEMPORAL_RANGE",
             "val": "2024-01-01 : 2024-02-01",
         } in filters
+
+    @pytest.mark.asyncio
+    async def test_unknown_adhoc_filter_column_returns_validation_error(
+        self, mcp_server: Any, mock_auth: Any
+    ) -> None:
+        """A rejected request filter must not return plausible unfiltered data."""
+        _, result = await self._run(
+            {
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "expressionType": "SIMPLE",
+                        "subject": "does_not_exist",
+                        "operator": "==",
+                        "comparator": "value",
+                    }
+                ]
+            },
+            mcp_server,
+            rejected_filter_columns=["does_not_exist"],
+        )
+        data = json.loads(result.content[0].text)
+
+        assert data["success"] is False
+        assert data["error_type"] == "ValidationError"
+        assert "does_not_exist" in data["error"]
 
 
 class TestOAuthErrorRouting:

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -1446,7 +1446,17 @@ class TestSavedChartExtraFormDataFilters:
 
         def fake_load(self: Any, data: dict[str, Any]) -> Any:
             captured["loaded_query_context_json"] = data
-            return SimpleNamespace(queries=[SimpleNamespace(filter=[])], form_data={})
+            # Mirror the QueryContext/QueryObject surface the tool relies on
+            # (set_query_context_form_data serializes every query object).
+            queries = [
+                SimpleNamespace(
+                    filter=query.get("filters", []),
+                    time_range=query.get("time_range"),
+                    to_dict=lambda query=query: dict(query),
+                )
+                for query in data.get("queries", [])
+            ]
+            return SimpleNamespace(queries=queries, form_data=data.get("form_data", {}))
 
         class _Command:
             def __init__(self, query_context: Any) -> None: ...
@@ -1573,9 +1583,9 @@ class TestSavedChartExtraFormDataFilters:
         )
         data = json.loads(result.content[0].text)
 
-        assert data["success"] is False
         assert data["error_type"] == "ValidationError"
         assert "does_not_exist" in data["error"]
+        assert "USA" not in result.content[0].text
 
 
 class TestOAuthErrorRouting:

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -1446,7 +1446,7 @@ class TestSavedChartExtraFormDataFilters:
 
         def fake_load(self: Any, data: dict[str, Any]) -> Any:
             captured["loaded_query_context_json"] = data
-            return SimpleNamespace(queries=[SimpleNamespace(filter=[])])
+            return SimpleNamespace(queries=[SimpleNamespace(filter=[])], form_data={})
 
         class _Command:
             def __init__(self, query_context: Any) -> None: ...

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1513,4 +1513,28 @@ class TestGetChartSqlTool:
 
             data = result.structured_content.get("result", result.structured_content)
             assert data["error_type"] == "ValidationError"
-            assert "Invalid chart query data" in data["error"]
+            # The saved query_context path names the offending input directly
+            # instead of deferring to the form_data fallback's generic message.
+            assert "Invalid extra_form_data filter" in data["error"]
+
+    def test_stale_query_context_falls_back_instead_of_erroring(self):
+        """A saved query_context missing "datasource" is stale, not bad input.
+
+        Filter merging needs the datasource id/type, so it cannot run. That must
+        hand control back to the caller (return None) so the SQL is rebuilt from
+        the chart's form_data — not surface a filter ValidationError.
+        """
+        from superset.utils import json as _json
+
+        mock_chart = Mock()
+        mock_chart.id = 41
+        mock_chart.query_context = _json.dumps(
+            {"queries": [{"columns": ["country"], "filters": []}]}
+        )
+
+        result = _get_chart_sql_mod._sql_from_saved_query_context(
+            mock_chart,
+            {"filters": [{"col": "country", "op": "==", "val": "USA"}]},
+        )
+
+        assert result is None

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1413,3 +1413,46 @@ class TestGetChartSqlTool:
             data = result.structured_content.get("result", result.structured_content)
             assert data["error_type"] == "DatasetNotAccessible"
             assert "Access denied" in data["error"]
+
+    @patch.object(_get_chart_sql_mod, "_sql_from_form_data")
+    @patch.object(_get_chart_sql_mod, "_get_cached_form_data")
+    @pytest.mark.asyncio
+    async def test_unsaved_chart_extra_form_data_reaches_sql_builder(
+        self, mock_cached, mock_form_data_sql, mcp_server
+    ):
+        """Regression test: extra_form_data must reach the SQL builder on the
+        form_data_key-only (unsaved chart) path too, not just the saved-chart
+        paths."""
+        from fastmcp import Client
+
+        from superset.utils import json as _json
+
+        cached_form_data = {"datasource_id": 1, "datasource_type": "table"}
+        mock_cached.return_value = _json.dumps(cached_form_data)
+        mock_form_data_sql.return_value = ChartSql(
+            chart_id=0,
+            chart_name=None,
+            sql="SELECT * FROM sales WHERE country = 'USA'",
+            language="sql",
+            datasource_name="sales",
+        )
+
+        extra_form_data = {"filters": [{"col": "country", "op": "==", "val": "USA"}]}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_chart_sql",
+                {
+                    "request": {
+                        "form_data_key": "cached-key",
+                        "extra_form_data": extra_form_data,
+                    }
+                },
+            )
+
+            data = result.structured_content.get("result", result.structured_content)
+            assert "WHERE country = 'USA'" in data["sql"]
+
+        mock_form_data_sql.assert_called_once_with(
+            cached_form_data, chart=None, extra_form_data=extra_form_data
+        )

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1150,7 +1150,7 @@ class TestSqlFromSavedQueryContextExtraFormData:
 
         assert query_context_json["queries"][0]["filters"] == []
 
-    def test_schema_validation_failure_uses_form_data_fallback(self):
+    def test_schema_validation_failure_uses_form_data_fallback(self, caplog):
         """A stale saved query context must not prevent form_data fallback."""
         from marshmallow import ValidationError
 
@@ -1160,18 +1160,20 @@ class TestSqlFromSavedQueryContextExtraFormData:
         from superset.utils import json as _json
 
         chart = Mock(
+            id=42,
             query_context=_json.dumps(
                 {
                     "datasource": {"id": 1, "type": "table"},
                     "queries": [{}],
                 }
-            )
+            ),
         )
         with patch(
             "superset.charts.schemas.ChartDataQueryContextSchema.load",
             side_effect=ValidationError("stale query context"),
         ):
             assert _sql_from_saved_query_context(chart) is None
+        assert "stale query context" in caplog.text
 
 
 class TestGetChartSqlTool:
@@ -1511,4 +1513,4 @@ class TestGetChartSqlTool:
 
             data = result.structured_content.get("result", result.structured_content)
             assert data["error_type"] == "ValidationError"
-            assert "extra_form_data filter" in data["error"]
+            assert "Invalid chart query data" in data["error"]

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1050,125 +1050,99 @@ class TestResolveDatasourceName:
         assert result == "combined_dataset"
 
 
+def _run_sql_from_saved_query_context(extra_form_data):
+    """Call _sql_from_saved_query_context with schema.load/ChartDataCommand
+    stubbed, and return the raw query_context_json dict that was handed to
+    ChartDataQueryContextSchema.load."""
+    from superset.mcp_service.chart.tool.get_chart_sql import (
+        _sql_from_saved_query_context,
+    )
+    from superset.utils import json as _json
+
+    chart = Mock()
+    chart.id = 10
+    chart.slice_name = "Sales"
+    chart.datasource_name = "sales"
+    chart.query_context = _json.dumps(
+        {
+            "datasource": {"id": 1, "type": "table"},
+            "queries": [{"columns": ["country"], "metrics": ["count"], "filters": []}],
+        }
+    )
+
+    captured = {}
+
+    def fake_load(self, data):
+        captured["query_context_json"] = data
+        fake_qc = Mock()
+        fake_qc.result_type = None
+        return fake_qc
+
+    class _Command:
+        def __init__(self, query_context):
+            pass
+
+        def validate(self):
+            pass
+
+        def run(self):
+            return {"queries": [{"query": "SELECT * FROM sales", "language": "sql"}]}
+
+    with (
+        patch(
+            "superset.charts.schemas.ChartDataQueryContextSchema.load",
+            fake_load,
+        ),
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand",
+            _Command,
+        ),
+    ):
+        _sql_from_saved_query_context(chart, extra_form_data=extra_form_data)
+
+    return captured["query_context_json"]
+
+
 class TestSqlFromSavedQueryContextExtraFormData:
     """Regression tests: extra_form_data must reach the query built from a
     chart's saved query_context, not just the request-supplied form_data."""
 
-    def test_real_column_filter_merged_before_schema_load(self):
-        """A filter on a real column ends up in the query handed to
-        ChartDataQueryContextSchema.load, for both the 'filters' and
-        'adhoc_filters' extra_form_data formats."""
-        from superset.mcp_service.chart.tool.get_chart_sql import (
-            _sql_from_saved_query_context,
+    def test_real_column_filter_via_filters_key(self):
+        """A filter on a real column, using the native 'filters' format,
+        ends up in the query handed to ChartDataQueryContextSchema.load."""
+        query_context_json = _run_sql_from_saved_query_context(
+            extra_form_data={"filters": [{"col": "country", "op": "==", "val": "USA"}]}
         )
-        from superset.utils import json as _json
 
-        chart = Mock()
-        chart.id = 10
-        chart.slice_name = "Sales"
-        chart.datasource_name = "sales"
-        chart.query_context = _json.dumps(
-            {
-                "datasource": {"id": 1, "type": "table"},
-                "queries": [
-                    {"columns": ["country"], "metrics": ["count"], "filters": []}
-                ],
+        filters = query_context_json["queries"][0].get("filters", [])
+        assert {"col": "country", "op": "==", "val": "USA"} in filters
+
+    def test_real_column_filter_via_adhoc_filters_key(self):
+        """A filter on a real column, using the Explore 'adhoc_filters'
+        format, ends up in the query handed to
+        ChartDataQueryContextSchema.load too."""
+        query_context_json = _run_sql_from_saved_query_context(
+            extra_form_data={
+                "adhoc_filters": [
+                    {
+                        "clause": "WHERE",
+                        "expressionType": "SIMPLE",
+                        "subject": "country",
+                        "operator": "==",
+                        "comparator": "USA",
+                    }
+                ]
             }
         )
 
-        captured = {}
-
-        def fake_load(self, data):
-            captured["query_context_json"] = data
-            fake_qc = Mock()
-            fake_qc.result_type = None
-            return fake_qc
-
-        class _Command:
-            def __init__(self, query_context):
-                pass
-
-            def validate(self):
-                pass
-
-            def run(self):
-                return {
-                    "queries": [{"query": "SELECT * FROM sales", "language": "sql"}]
-                }
-
-        with (
-            patch(
-                "superset.charts.schemas.ChartDataQueryContextSchema.load",
-                fake_load,
-            ),
-            patch(
-                "superset.commands.chart.data.get_data_command.ChartDataCommand",
-                _Command,
-            ),
-        ):
-            _sql_from_saved_query_context(
-                chart,
-                extra_form_data={
-                    "filters": [{"col": "country", "op": "==", "val": "USA"}]
-                },
-            )
-
-        filters = captured["query_context_json"]["queries"][0].get("filters", [])
+        filters = query_context_json["queries"][0].get("filters", [])
         assert {"col": "country", "op": "==", "val": "USA"} in filters
 
     def test_no_extra_form_data_leaves_query_unchanged(self):
         """Without extra_form_data, the saved query_context is used as-is."""
-        from superset.mcp_service.chart.tool.get_chart_sql import (
-            _sql_from_saved_query_context,
-        )
-        from superset.utils import json as _json
+        query_context_json = _run_sql_from_saved_query_context(extra_form_data=None)
 
-        chart = Mock()
-        chart.id = 10
-        chart.slice_name = "Sales"
-        chart.datasource_name = "sales"
-        chart.query_context = _json.dumps(
-            {
-                "datasource": {"id": 1, "type": "table"},
-                "queries": [
-                    {"columns": ["country"], "metrics": ["count"], "filters": []}
-                ],
-            }
-        )
-
-        captured = {}
-
-        def fake_load(self, data):
-            captured["query_context_json"] = data
-            fake_qc = Mock()
-            fake_qc.result_type = None
-            return fake_qc
-
-        class _Command:
-            def __init__(self, query_context):
-                pass
-
-            def validate(self):
-                pass
-
-            def run(self):
-                return {
-                    "queries": [{"query": "SELECT * FROM sales", "language": "sql"}]
-                }
-
-        with (
-            patch(
-                "superset.charts.schemas.ChartDataQueryContextSchema.load",
-                fake_load,
-            ),
-            patch(
-                "superset.commands.chart.data.get_data_command.ChartDataCommand",
-                _Command,
-            ),
-        ):
-            _sql_from_saved_query_context(chart, extra_form_data=None)
-
-        assert captured["query_context_json"]["queries"][0]["filters"] == []
+        assert query_context_json["queries"][0]["filters"] == []
 
 
 class TestGetChartSqlTool:
@@ -1456,3 +1430,56 @@ class TestGetChartSqlTool:
         mock_form_data_sql.assert_called_once_with(
             cached_form_data, chart=None, extra_form_data=extra_form_data
         )
+
+    @patch.object(_get_chart_sql_mod, "validate_chart_dataset")
+    @patch.object(_get_chart_sql_mod, "_find_chart_by_identifier")
+    @pytest.mark.asyncio
+    async def test_malformed_extra_form_data_filter_returns_clean_error(
+        self, mock_find, mock_validate, mcp_server
+    ):
+        """A malformed extra_form_data filter (missing 'op') must return a
+        structured ChartError, not crash with an unhandled KeyError.
+
+        Regression test: merge_extra_form_data_filters_into_query normalizes
+        filters via simple_filter_to_adhoc, which raises KeyError on a filter
+        entry missing "col" or "op". That KeyError previously propagated out
+        of get_chart_sql uncaught.
+        """
+        from fastmcp import Client
+
+        from superset.mcp_service.chart.chart_utils import DatasetValidationResult
+        from superset.utils import json as _json
+
+        mock_chart = Mock()
+        mock_chart.id = 40
+        mock_chart.slice_name = "Sales"
+        mock_chart.viz_type = "table"
+        mock_chart.query_context = _json.dumps(
+            {
+                "datasource": {"id": 1, "type": "table"},
+                "queries": [
+                    {"columns": ["country"], "metrics": ["count"], "filters": []}
+                ],
+            }
+        )
+        mock_find.return_value = mock_chart
+
+        mock_validate.return_value = DatasetValidationResult(
+            is_valid=True, dataset_id=1, dataset_name="ds", warnings=[]
+        )
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_chart_sql",
+                {
+                    "request": {
+                        "identifier": 40,
+                        # missing "op" — malformed filter entry
+                        "extra_form_data": {"filters": [{"col": "country"}]},
+                    }
+                },
+            )
+
+            data = result.structured_content.get("result", result.structured_content)
+            assert data["error_type"] == "ValidationError"
+            assert "extra_form_data filter" in data["error"]

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -86,6 +86,26 @@ class TestGetChartSqlRequestSchema:
         with pytest.raises(ValueError, match="At least one of"):
             GetChartSqlRequest()
 
+    def test_extra_form_data_defaults_to_none(self):
+        """extra_form_data is optional and defaults to None."""
+        request = GetChartSqlRequest(identifier=123)
+        assert request.extra_form_data is None
+
+    def test_extra_form_data_is_accepted(self):
+        """extra_form_data is a real field, not silently dropped.
+
+        Regression test: previously GetChartSqlRequest had no extra_form_data
+        field at all, so callers passing filters got no error and no effect —
+        get_chart_sql always rendered the chart's unfiltered baseline SQL.
+        """
+        request = GetChartSqlRequest(
+            identifier=123,
+            extra_form_data={"filters": [{"col": "country", "op": "==", "val": "USA"}]},
+        )
+        assert request.extra_form_data == {
+            "filters": [{"col": "country", "op": "==", "val": "USA"}]
+        }
+
 
 class TestExtractSqlFromResult:
     """Tests for the _extract_sql_from_result helper."""
@@ -462,6 +482,46 @@ class TestBuildQueryContextFromFormData:
         assert len(queries) == 1
         assert queries[0]["metrics"] == ["sum_revenue"]
         assert queries[0]["columns"] == ["product"]
+
+    @patch("superset.common.query_context_factory.QueryContextFactory")
+    @patch("superset.daos.datasource.DatasourceDAO.get_datasource")
+    def test_extra_form_data_merged_into_query(self, mock_get_ds, mock_factory_cls):
+        """extra_form_data (e.g. dashboard-style filters) reaches the rendered
+        query, not just chart.params.
+
+        Regression test: _build_query_context_from_form_data previously never
+        forwarded its caller's extra_form_data to build_query_context_from_form_data,
+        so get_chart_sql could not preview SQL with request-supplied filters applied.
+        """
+        mock_ds = Mock()
+        mock_ds.database.db_engine_spec.engine = "postgresql"
+        mock_get_ds.return_value = mock_ds
+
+        mock_factory = Mock()
+        mock_factory.create.return_value = Mock()
+        mock_factory_cls.return_value = mock_factory
+
+        form_data = {
+            "datasource_id": 1,
+            "datasource_type": "table",
+            "metrics": ["count"],
+            "groupby": ["country"],
+        }
+        extra_form_data = {"filters": [{"col": "country", "op": "==", "val": "USA"}]}
+
+        with patch(
+            "superset.common.chart_data.ChartDataResultType"
+        ) as mock_result_type:
+            mock_result_type.QUERY = "QUERY"
+            _build_query_context_from_form_data(
+                form_data, chart=None, extra_form_data=extra_form_data
+            )
+
+        call_kwargs = mock_factory.create.call_args[1]
+        queries = call_kwargs["queries"]
+        assert len(queries) == 1
+        filters = queries[0].get("filters", [])
+        assert {"col": "country", "op": "==", "val": "USA"} in filters
 
 
 class TestExtractXAxisCol:
@@ -990,6 +1050,127 @@ class TestResolveDatasourceName:
         assert result == "combined_dataset"
 
 
+class TestSqlFromSavedQueryContextExtraFormData:
+    """Regression tests: extra_form_data must reach the query built from a
+    chart's saved query_context, not just the request-supplied form_data."""
+
+    def test_real_column_filter_merged_before_schema_load(self):
+        """A filter on a real column ends up in the query handed to
+        ChartDataQueryContextSchema.load, for both the 'filters' and
+        'adhoc_filters' extra_form_data formats."""
+        from superset.mcp_service.chart.tool.get_chart_sql import (
+            _sql_from_saved_query_context,
+        )
+        from superset.utils import json as _json
+
+        chart = Mock()
+        chart.id = 10
+        chart.slice_name = "Sales"
+        chart.datasource_name = "sales"
+        chart.query_context = _json.dumps(
+            {
+                "datasource": {"id": 1, "type": "table"},
+                "queries": [
+                    {"columns": ["country"], "metrics": ["count"], "filters": []}
+                ],
+            }
+        )
+
+        captured = {}
+
+        def fake_load(self, data):
+            captured["query_context_json"] = data
+            fake_qc = Mock()
+            fake_qc.result_type = None
+            return fake_qc
+
+        class _Command:
+            def __init__(self, query_context):
+                pass
+
+            def validate(self):
+                pass
+
+            def run(self):
+                return {
+                    "queries": [{"query": "SELECT * FROM sales", "language": "sql"}]
+                }
+
+        with (
+            patch(
+                "superset.charts.schemas.ChartDataQueryContextSchema.load",
+                fake_load,
+            ),
+            patch(
+                "superset.commands.chart.data.get_data_command.ChartDataCommand",
+                _Command,
+            ),
+        ):
+            _sql_from_saved_query_context(
+                chart,
+                extra_form_data={
+                    "filters": [{"col": "country", "op": "==", "val": "USA"}]
+                },
+            )
+
+        filters = captured["query_context_json"]["queries"][0].get("filters", [])
+        assert {"col": "country", "op": "==", "val": "USA"} in filters
+
+    def test_no_extra_form_data_leaves_query_unchanged(self):
+        """Without extra_form_data, the saved query_context is used as-is."""
+        from superset.mcp_service.chart.tool.get_chart_sql import (
+            _sql_from_saved_query_context,
+        )
+        from superset.utils import json as _json
+
+        chart = Mock()
+        chart.id = 10
+        chart.slice_name = "Sales"
+        chart.datasource_name = "sales"
+        chart.query_context = _json.dumps(
+            {
+                "datasource": {"id": 1, "type": "table"},
+                "queries": [
+                    {"columns": ["country"], "metrics": ["count"], "filters": []}
+                ],
+            }
+        )
+
+        captured = {}
+
+        def fake_load(self, data):
+            captured["query_context_json"] = data
+            fake_qc = Mock()
+            fake_qc.result_type = None
+            return fake_qc
+
+        class _Command:
+            def __init__(self, query_context):
+                pass
+
+            def validate(self):
+                pass
+
+            def run(self):
+                return {
+                    "queries": [{"query": "SELECT * FROM sales", "language": "sql"}]
+                }
+
+        with (
+            patch(
+                "superset.charts.schemas.ChartDataQueryContextSchema.load",
+                fake_load,
+            ),
+            patch(
+                "superset.commands.chart.data.get_data_command.ChartDataCommand",
+                _Command,
+            ),
+        ):
+            _sql_from_saved_query_context(chart, extra_form_data=None)
+
+        assert captured["query_context_json"]["queries"][0]["filters"] == []
+
+
 class TestGetChartSqlTool:
     """Integration-style tests for the get_chart_sql MCP tool via Client."""
 
@@ -1093,6 +1274,61 @@ class TestGetChartSqlTool:
             data = result.structured_content.get("result", result.structured_content)
             assert "SELECT COUNT(*) FROM sales" in data["sql"]
             assert data["chart_id"] == 10
+
+    @patch.object(_get_chart_sql_mod, "_sql_from_form_data")
+    @patch.object(_get_chart_sql_mod, "_sql_from_saved_query_context")
+    @patch.object(_get_chart_sql_mod, "_resolve_effective_form_data")
+    @patch.object(_get_chart_sql_mod, "validate_chart_dataset")
+    @patch.object(_get_chart_sql_mod, "_find_chart_by_identifier")
+    @pytest.mark.asyncio
+    async def test_extra_form_data_reaches_saved_query_context_builder(
+        self,
+        mock_find,
+        mock_validate,
+        mock_resolve,
+        mock_saved_qc,
+        mock_form_data_sql,
+        mcp_server,
+    ):
+        """Regression test: request.extra_form_data must be forwarded to the
+        saved-query_context SQL builder, not silently dropped by the request
+        schema or ignored on the way to the builder call."""
+        from fastmcp import Client
+
+        from superset.mcp_service.chart.chart_utils import (
+            DatasetValidationResult,
+        )
+
+        mock_chart = Mock()
+        mock_chart.id = 11
+        mock_chart.slice_name = "Sales Chart"
+        mock_chart.viz_type = "table"
+        mock_find.return_value = mock_chart
+
+        mock_validate.return_value = DatasetValidationResult(
+            is_valid=True, dataset_id=1, dataset_name="ds", warnings=[]
+        )
+        mock_resolve.return_value = ({"metrics": ["count"]}, False)
+        mock_saved_qc.return_value = ChartSql(
+            chart_id=11,
+            chart_name="Sales Chart",
+            sql="SELECT COUNT(*) FROM sales WHERE country = 'USA'",
+            language="sql",
+            datasource_name="sales",
+        )
+
+        extra_form_data = {"filters": [{"col": "country", "op": "==", "val": "USA"}]}
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_chart_sql",
+                {"request": {"identifier": 11, "extra_form_data": extra_form_data}},
+            )
+
+            data = result.structured_content.get("result", result.structured_content)
+            assert "WHERE country = 'USA'" in data["sql"]
+
+        mock_saved_qc.assert_called_once_with(mock_chart, extra_form_data)
 
     @patch.object(_get_chart_sql_mod, "_sql_from_form_data")
     @patch.object(_get_chart_sql_mod, "_sql_from_saved_query_context")

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1050,7 +1050,7 @@ class TestResolveDatasourceName:
         assert result == "combined_dataset"
 
 
-def _run_sql_from_saved_query_context(extra_form_data):
+def _run_sql_from_saved_query_context(extra_form_data, datasource=None):
     """Call _sql_from_saved_query_context with schema.load/ChartDataCommand
     stubbed, and return the raw query_context_json dict that was handed to
     ChartDataQueryContextSchema.load."""
@@ -1063,9 +1063,13 @@ def _run_sql_from_saved_query_context(extra_form_data):
     chart.id = 10
     chart.slice_name = "Sales"
     chart.datasource_name = "sales"
+    chart.datasource_id = 7
+    chart.datasource_type = "query"
     chart.query_context = _json.dumps(
         {
-            "datasource": {"id": 1, "type": "table"},
+            "datasource": (
+                {"id": 1, "type": "table"} if datasource is None else datasource
+            ),
             "queries": [{"columns": ["country"], "metrics": ["count"], "filters": []}],
         }
     )
@@ -1149,6 +1153,16 @@ class TestSqlFromSavedQueryContextExtraFormData:
         query_context_json = _run_sql_from_saved_query_context(extra_form_data=None)
 
         assert query_context_json["queries"][0]["filters"] == []
+
+    def test_datasource_without_type_falls_back_to_the_chart(self):
+        """ChartDataDatasourceSchema only requires 'id', so a saved context
+        that omits 'type' is valid and must still render SQL."""
+        query_context_json = _run_sql_from_saved_query_context(
+            extra_form_data=None, datasource={"id": 1}
+        )
+
+        # id comes from the saved context; the missing type comes from the chart
+        assert query_context_json["_set_form_data_args"].args[1:] == (1, "query")
 
     def test_schema_validation_failure_uses_form_data_fallback(self, caplog):
         """A stale saved query context must not prevent form_data fallback."""

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1097,8 +1097,13 @@ def _run_sql_from_saved_query_context(extra_form_data):
             "superset.commands.chart.data.get_data_command.ChartDataCommand",
             _Command,
         ),
+        patch(
+            "superset.mcp_service.chart.tool.get_chart_sql.set_query_context_form_data"
+        ) as mock_set_form_data,
     ):
         _sql_from_saved_query_context(chart, extra_form_data=extra_form_data)
+
+    captured["query_context_json"]["_set_form_data_args"] = mock_set_form_data.call_args
 
     return captured["query_context_json"]
 
@@ -1116,6 +1121,7 @@ class TestSqlFromSavedQueryContextExtraFormData:
 
         filters = query_context_json["queries"][0].get("filters", [])
         assert {"col": "country", "op": "==", "val": "USA"} in filters
+        assert query_context_json["_set_form_data_args"].args[1:] == (1, "table")
 
     def test_real_column_filter_via_adhoc_filters_key(self):
         """A filter on a real column, using the Explore 'adhoc_filters'

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py
@@ -1150,6 +1150,29 @@ class TestSqlFromSavedQueryContextExtraFormData:
 
         assert query_context_json["queries"][0]["filters"] == []
 
+    def test_schema_validation_failure_uses_form_data_fallback(self):
+        """A stale saved query context must not prevent form_data fallback."""
+        from marshmallow import ValidationError
+
+        from superset.mcp_service.chart.tool.get_chart_sql import (
+            _sql_from_saved_query_context,
+        )
+        from superset.utils import json as _json
+
+        chart = Mock(
+            query_context=_json.dumps(
+                {
+                    "datasource": {"id": 1, "type": "table"},
+                    "queries": [{}],
+                }
+            )
+        )
+        with patch(
+            "superset.charts.schemas.ChartDataQueryContextSchema.load",
+            side_effect=ValidationError("stale query context"),
+        ):
+            assert _sql_from_saved_query_context(chart) is None
+
 
 class TestGetChartSqlTool:
     """Integration-style tests for the get_chart_sql MCP tool via Client."""


### PR DESCRIPTION
Recreates #43338, which GitHub auto-closed when its head fork was deleted. This version also rejects request filters that reference unknown dataset columns instead of returning unfiltered chart data.

---

### SUMMARY
`get_chart_sql`'s request schema had no `extra_form_data` field. Pydantic silently
drops unrecognized fields by default, so any filters passed alongside a chart
identifier were dropped before validation ever ran — the tool always rendered the
chart's unfiltered baseline SQL regardless of what was passed in.

`get_chart_data` merges valid `extra_form_data` via
`merge_extra_form_data_filters_into_query` / `build_query_context_from_form_data`.
However, datasource query construction reports filters naming unknown columns in
`rejected_filter_columns`, and the MCP tool previously ignored that signal and
returned the unfiltered result as a success. This PR intersects rejected columns
with the filters supplied by the current request and returns a `ValidationError`
naming them. It supports both `filters` and `adhoc_filters`, in saved-chart and
form-data fallback paths, without failing on unrelated stale saved filters.

This PR also adds `extra_form_data` to `GetChartSqlRequest` and wires it into both
of `get_chart_sql`'s SQL-construction paths (saved `query_context`, and the
`form_data` fallback), reusing the existing merge helpers. The shared helper update
preserves normalized relative-time extras (`relative_start` and `relative_end`) for
both chart-data and chart-SQL query construction.

### TESTING INSTRUCTIONS
- New unit tests in `tests/unit_tests/mcp_service/chart/tool/test_get_chart_sql.py`:
  - `GetChartSqlRequest` accepts and stores `extra_form_data` (previously silently
    dropped).
  - `_build_query_context_from_form_data` forwards `extra_form_data` to the query
    factory.
  - `_sql_from_saved_query_context` merges `extra_form_data` into the query handed
    to `ChartDataQueryContextSchema.load` before rendering SQL.
  - End-to-end: `request.extra_form_data` reaches the saved-query_context SQL
    builder and shows up in the rendered SQL.
- New unit tests in `tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py`
  cover valid `filters`, `adhoc_filters`, and `TEMPORAL_RANGE` overrides, plus the
  customer-reported unknown-column `adhoc_filters` case end-to-end through the MCP
  tool, asserting a named `ValidationError` instead of unfiltered chart data.
- CI Python unit suite is running against the rebased branch; the prior failure was fixed by providing `form_data` on the query-context test double.
- `pre-commit run --files <all PR-changed files>` — clean locally and in CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

