### PR TITLE
fix(gtf): wait for the task lock instead of failing concurrent submits

### DIFF
--- a/superset-frontend/src/features/tasks/types.ts
+++ b/superset-frontend/src/features/tasks/types.ts
@@ -62,6 +62,10 @@ export interface TaskProperties {
   error_message: string | null;
   exception_type: string | null;
   stack_trace: string | null;
+
+  // Dedup tracking - times a submit joined this task instead of creating a new
+  // one (a new subscriber or an existing subscriber's resubmit); 0 when unique.
+  dedupe_count: number | null;
 }
 
 export interface Task {

--- a/superset-frontend/src/pages/TaskList/TaskList.test.tsx
+++ b/superset-frontend/src/pages/TaskList/TaskList.test.tsx
@@ -83,6 +83,7 @@ const mockTasks = [
       exception_type: null,
       stack_trace: null,
       timeout: null,
+      dedupe_count: 2,
     },
   },
   {
@@ -341,4 +342,13 @@ test('renders the dependency chain icon in Details for tasks with prerequisites'
   // "waiting on N" state is folded into that icon's warning color + popover
   // title — covered by TaskDependenciesPopover.test.tsx.
   expect(screen.getByRole('img', { name: 'link' })).toBeInTheDocument();
+});
+
+test('surfaces the dedupe count in Details for a reused task', async () => {
+  renderTaskList();
+  await screen.findByText('Export Data Task');
+
+  // The reused task (dedupe_count: 2) renders the copy icon + count in Details;
+  // unique tasks show nothing. (antd CopyOutlined -> role "img" name "copy".)
+  expect(screen.getByRole('img', { name: 'copy' })).toBeInTheDocument();
 });

--- a/superset-frontend/src/pages/TaskList/TaskList.test.tsx
+++ b/superset-frontend/src/pages/TaskList/TaskList.test.tsx
@@ -348,7 +348,7 @@ test('surfaces the dedupe count in Details for a reused task', async () => {
   renderTaskList();
   await screen.findByText('Export Data Task');
 
-  // The reused task (dedupe_count: 2) renders the copy icon + count in Details;
-  // unique tasks show nothing. (antd CopyOutlined -> role "img" name "copy".)
-  expect(screen.getByRole('img', { name: 'copy' })).toBeInTheDocument();
+  // The reused task (dedupe_count: 2) renders the plus icon + count in Details;
+  // unique tasks show nothing. (antd PlusOutlined -> role "img" name "plus".)
+  expect(screen.getByRole('img', { name: 'plus' })).toBeInTheDocument();
 });

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -503,7 +503,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                       gap: theme.sizeUnit,
                     }}
                   >
-                    <Icons.CopyOutlined iconSize="l" />
+                    <Icons.PlusOutlined iconSize="l" />
                     {dedupeCount}
                   </span>
                 </Tooltip>

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -429,6 +429,8 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
           const hasPayload = payload && Object.keys(payload).length > 0;
           const hasStackTrace = !!properties?.stack_trace;
           const hasDependencies = !!depends_on && depends_on.length > 0;
+          const dedupeCount = properties?.dedupe_count ?? 0;
+          const hasDedupe = dedupeCount > 0;
 
           // Show warning if timeout is set but no abort handler during execution
           // Only show for IN_PROGRESS (abort handler registers at runtime, not during PENDING)
@@ -441,7 +443,8 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
             !hasPayload &&
             !hasStackTrace &&
             !hasTimeoutWithoutHandler &&
-            !hasDependencies
+            !hasDependencies &&
+            !hasDedupe
           ) {
             return null;
           }
@@ -483,6 +486,27 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                   dependencies={depends_on}
                   waitingOn={waitingOn}
                 />
+              )}
+              {hasDedupe && (
+                <Tooltip
+                  title={t(
+                    'Deduplicated %s time(s): other submissions reused this ' +
+                      "task's result instead of running a new query.",
+                    dedupeCount,
+                  )}
+                  placement="top"
+                >
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: theme.sizeUnit,
+                    }}
+                  >
+                    <Icons.CopyOutlined iconSize="l" />
+                    {dedupeCount}
+                  </span>
+                </Tooltip>
               )}
             </div>
           );

--- a/superset/commands/tasks/submit.py
+++ b/superset/commands/tasks/submit.py
@@ -114,6 +114,15 @@ class SubmitTaskCommand(BaseCommand):
             stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
 
             if existing:
+                # Finding an existing task is itself a dedupe (work reused, not
+                # re-created), whether the caller becomes a new subscriber or
+                # resubmits as an existing one. Count it on the task's properties.
+                existing.update_properties(
+                    {
+                        "dedupe_count": existing.properties_dict.get("dedupe_count", 0)
+                        + 1
+                    }
+                )
                 # Join existing task - add subscriber if not already subscribed
                 if user_id and not existing.has_subscriber(user_id):
                     TaskDAO.add_subscriber(existing.id, user_id)
@@ -129,7 +138,7 @@ class SubmitTaskCommand(BaseCommand):
                     TaskDAO.add_guest_subscriber(existing.id, guest_key)
                     stats_logger.incr("gtf.task.subscribe")
                 else:
-                    # Same user submitted the same task - deduplication hit
+                    # Same subscriber resubmitted the same task - deduplication hit
                     stats_logger.incr("gtf.task.dedupe")
                     logger.debug(
                         "Deduplication hit for task: %s (user_id=%s)",

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -230,9 +230,10 @@ class TaskDAO(BaseDAO[Task]):
 
         task = cls.create(attributes=task_data)
 
-        # Set properties after creation via update_properties (handles caching)
-        if properties:
-            task.update_properties(properties)
+        # Set properties after creation via update_properties (handles caching).
+        # Seed dedupe_count so every task carries it from the start (bumped each
+        # time a later submit joins this task instead of creating a new one).
+        task.update_properties({"dedupe_count": 0, **(properties or {})})
 
         # Flush to get the task ID (auto-incremented primary key)
         db.session.flush()

--- a/superset/tasks/locks.py
+++ b/superset/tasks/locks.py
@@ -30,7 +30,6 @@ locking via DistributedLock.
 from __future__ import annotations
 
 import logging
-import time
 from contextlib import contextmanager
 from typing import Iterator
 
@@ -42,12 +41,14 @@ logger = logging.getLogger(__name__)
 # Task operations use a shorter TTL than the global default since
 # they complete quickly (just DB operations, no external calls)
 TASK_LOCK_TTL_SECONDS = 10
-# Wait (block-and-retry) for a held lock rather than failing fast: concurrent
-# submits of the SAME task must serialize so all-but-one JOIN the task the winner
-# creates. Wait past the TTL so a lock orphaned by a crashed holder is waited out
-# (it auto-expires) instead of erroring.
-TASK_LOCK_WAIT_SECONDS = TASK_LOCK_TTL_SECONDS + 2
-TASK_LOCK_RETRY_INTERVAL_SECONDS = 0.05
+# Wait for a held lock rather than failing fast: concurrent submits of the SAME
+# task must serialize so all-but-one JOIN the task the winner creates. Give the
+# wait comfortable headroom over the TTL (plus the stream block interval) so a
+# lock orphaned by a crashed holder is still waited out — the lock auto-expires
+# at the TTL and the next re-check acquires it — rather than timing out first.
+TASK_LOCK_WAIT_SECONDS = TASK_LOCK_TTL_SECONDS * 3
+# Poll cadence for the no-coordination-backend fallback (see wait_for_signal).
+TASK_LOCK_POLL_INTERVAL_SECONDS = 0.05
 
 
 @contextmanager
@@ -62,14 +63,20 @@ def task_lock(dedup_key: str) -> Iterator[None]:
     - Subscribe racing with cancel
     - Multiple concurrent cancel requests
 
-    When DISTRIBUTED_COORDINATION_CONFIG is configured, uses Redis SET NX EX
-    for efficient single-command locking. Otherwise falls back to
-    database-backed DistributedLock.
+    Waits for a held lock rather than failing fast — several charts can resolve
+    to the same query_cache_key (hence the same SHARED task and dedup_key) and
+    submit at once; the winner creates the task and the rest wait here, then join
+    it. The wait is delegated to ``CoordinationService.wait_for_signal``, which is
+    **event-driven** when a coordination backend is configured (it parks on the
+    lock's release-signal Redis Stream and retries the ``SET NX`` when the holder
+    releases — or on the periodic re-check that also covers a crashed holder,
+    whose lock auto-expires at the TTL) and **polls** the acquire otherwise. On
+    release we ``notify`` that stream so a waiter wakes immediately.
 
     :param dedup_key: Task deduplication key (from get_active_dedup_key)
     :yields: Nothing; used as context manager
-    :raises AcquireDistributedLockFailedException: If the lock is still held after
-        waiting out the TTL (only when a holder is genuinely stuck)
+    :raises TimeoutError: If the lock is still held after ``TASK_LOCK_WAIT_SECONDS``
+        (only when a holder is genuinely stuck)
 
     Example:
         dedup_key = get_active_dedup_key(TaskScope.SHARED, "report", "monthly")
@@ -80,28 +87,35 @@ def task_lock(dedup_key: str) -> Iterator[None]:
     # pylint: disable=import-outside-toplevel
     from superset.commands.distributed_lock.acquire import AcquireDistributedLock
     from superset.commands.distributed_lock.release import ReleaseDistributedLock
+    from superset.coordination.base import CoordinationService
 
     params = {"key": dedup_key}
+    release_channel = f"gtf:task:lock-released:{dedup_key}"
     acquire = AcquireDistributedLock("gtf:task", params, TASK_LOCK_TTL_SECONDS)
 
-    # Block-and-wait rather than fail fast. Several charts can resolve to the same
-    # query_cache_key (hence the same SHARED task and dedup_key) and submit at
-    # once; the winner creates the task and the rest must WAIT here, then join it —
-    # failing fast would surface a spurious "Lock already taken" error. Bounded by
-    # the TTL so a crashed holder's lock is waited out (auto-expiry), never forever.
-    deadline = time.monotonic() + TASK_LOCK_WAIT_SECONDS
-    while True:
+    def _try_acquire() -> AcquireDistributedLock | None:
+        # SET NX: acquire the lock, or None while another submit still holds it.
+        # (Re-runs reuse this acquisition's token, so release stays ownership-safe.)
         try:
             acquire.run()
-            break
+            return acquire
         except LockAlreadyHeldException:
-            if time.monotonic() >= deadline:
-                raise
-            time.sleep(TASK_LOCK_RETRY_INTERVAL_SECONDS)
+            return None
+
+    CoordinationService.wait_for_signal(
+        release_channel,
+        _try_acquire,
+        timeout=TASK_LOCK_WAIT_SECONDS,
+        poll_interval=TASK_LOCK_POLL_INTERVAL_SECONDS,
+    )
 
     logger.debug("Acquired task lock for key: %s", dedup_key)
     try:
         yield
     finally:
+        # Release (delete) BEFORE notifying, so a woken waiter sees the freed lock.
+        # notify() needs a backend; without one, waiters are on the poll fallback.
         ReleaseDistributedLock("gtf:task", params, token=acquire.token).run()
+        if CoordinationService.is_backend_defined():
+            CoordinationService.notify(release_channel)
         logger.debug("Released task lock for key: %s", dedup_key)

--- a/superset/tasks/locks.py
+++ b/superset/tasks/locks.py
@@ -30,10 +30,11 @@ locking via DistributedLock.
 from __future__ import annotations
 
 import logging
+import time
 from contextlib import contextmanager
 from typing import Iterator
 
-from superset.distributed_lock import DistributedLock
+from superset.exceptions import LockAlreadyHeldException
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,12 @@ logger = logging.getLogger(__name__)
 # Task operations use a shorter TTL than the global default since
 # they complete quickly (just DB operations, no external calls)
 TASK_LOCK_TTL_SECONDS = 10
+# Wait (block-and-retry) for a held lock rather than failing fast: concurrent
+# submits of the SAME task must serialize so all-but-one JOIN the task the winner
+# creates. Wait past the TTL so a lock orphaned by a crashed holder is waited out
+# (it auto-expires) instead of erroring.
+TASK_LOCK_WAIT_SECONDS = TASK_LOCK_TTL_SECONDS + 2
+TASK_LOCK_RETRY_INTERVAL_SECONDS = 0.05
 
 
 @contextmanager
@@ -61,7 +68,8 @@ def task_lock(dedup_key: str) -> Iterator[None]:
 
     :param dedup_key: Task deduplication key (from get_active_dedup_key)
     :yields: Nothing; used as context manager
-    :raises AcquireDistributedLockFailedException: If lock is already held
+    :raises AcquireDistributedLockFailedException: If the lock is still held after
+        waiting out the TTL (only when a holder is genuinely stuck)
 
     Example:
         dedup_key = get_active_dedup_key(TaskScope.SHARED, "report", "monthly")
@@ -69,13 +77,31 @@ def task_lock(dedup_key: str) -> Iterator[None]:
             # Create, subscribe, or cancel task here
             ...
     """
-    logger.debug("Acquiring task lock for key: %s", dedup_key)
+    # pylint: disable=import-outside-toplevel
+    from superset.commands.distributed_lock.acquire import AcquireDistributedLock
+    from superset.commands.distributed_lock.release import ReleaseDistributedLock
 
-    with DistributedLock(
-        namespace="gtf:task",
-        key=dedup_key,
-        ttl_seconds=TASK_LOCK_TTL_SECONDS,
-    ):
+    params = {"key": dedup_key}
+    acquire = AcquireDistributedLock("gtf:task", params, TASK_LOCK_TTL_SECONDS)
+
+    # Block-and-wait rather than fail fast. Several charts can resolve to the same
+    # query_cache_key (hence the same SHARED task and dedup_key) and submit at
+    # once; the winner creates the task and the rest must WAIT here, then join it —
+    # failing fast would surface a spurious "Lock already taken" error. Bounded by
+    # the TTL so a crashed holder's lock is waited out (auto-expiry), never forever.
+    deadline = time.monotonic() + TASK_LOCK_WAIT_SECONDS
+    while True:
+        try:
+            acquire.run()
+            break
+        except LockAlreadyHeldException:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(TASK_LOCK_RETRY_INTERVAL_SECONDS)
+
+    logger.debug("Acquired task lock for key: %s", dedup_key)
+    try:
         yield
-
-    logger.debug("Released task lock for key: %s", dedup_key)
+    finally:
+        ReleaseDistributedLock("gtf:task", params, token=acquire.token).run()
+        logger.debug("Released task lock for key: %s", dedup_key)

--- a/tests/integration_tests/tasks/commands/test_submit.py
+++ b/tests/integration_tests/tasks/commands/test_submit.py
@@ -122,6 +122,8 @@ def test_submit_task_joins_existing(app_context, login_as, get_user) -> None:
     )
     task1 = command1.run()
     assert task1.user_id == admin.id
+    # dedupe_count is seeded on creation and bumped when a submit joins this task.
+    assert task1.properties_dict.get("dedupe_count") == 0
 
     try:
         # Submit second task with same task_key and type
@@ -137,6 +139,8 @@ def test_submit_task_joins_existing(app_context, login_as, get_user) -> None:
         task2 = command2.run()
         assert task2.id == task1.id
         assert task2.uuid == task1.uuid
+        # The resubmit joined the existing task → counted as a dedupe.
+        assert task2.properties_dict.get("dedupe_count") == 1
     finally:
         # Cleanup
         db.session.delete(task1)

--- a/tests/unit_tests/tasks/test_locks.py
+++ b/tests/unit_tests/tasks/test_locks.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Unit tests for the GTF task_lock (block-and-wait acquisition)."""
+"""Unit tests for the GTF task_lock (wait-for-release acquisition)."""
+
+from typing import Any, Callable
 
 import pytest
 from pytest_mock import MockerFixture
@@ -23,53 +25,87 @@ from superset.exceptions import LockAlreadyHeldException
 
 ACQUIRE = "superset.commands.distributed_lock.acquire.AcquireDistributedLock"
 RELEASE = "superset.commands.distributed_lock.release.ReleaseDistributedLock"
+COORD = "superset.coordination.base.CoordinationService"
 
 
-def test_task_lock_waits_for_a_held_lock_then_acquires(
+def _drive_wait_for_signal(
+    _channel: str,
+    check: Callable[[], Any],
+    **_kwargs: Any,
+) -> Any:
+    """Faithful stand-in for wait_for_signal: re-run check() until satisfied.
+
+    Mirrors the real contract (block/poll, then re-run the source-of-truth check),
+    without a backend — so task_lock's acquire/release wiring is what's exercised.
+    """
+    while (result := check()) is None:
+        pass
+    return result
+
+
+def test_task_lock_waits_for_a_held_lock_then_acquires_and_notifies(
     mocker: MockerFixture,
 ) -> None:
-    """A held lock is retried (not failed) so a concurrent submit can join."""
+    """A held lock is retried (not failed); on release we free it and notify."""
     from superset.tasks.locks import task_lock
 
-    mocker.patch("superset.tasks.locks.time.sleep")
     acquire = mocker.patch(ACQUIRE).return_value
     acquire.token = "tok"  # noqa: S105
-    # Held for the first two attempts, then acquired.
+    # Held for the first two SET NX attempts, then acquired.
     acquire.run.side_effect = [
         LockAlreadyHeldException("Lock already taken"),
         LockAlreadyHeldException("Lock already taken"),
         None,
     ]
     release = mocker.patch(RELEASE)
+    coord = mocker.patch(COORD)
+    coord.wait_for_signal.side_effect = _drive_wait_for_signal
+    coord.is_backend_defined.return_value = True
 
     entered = False
     with task_lock("dedup-1"):
         entered = True
 
     assert entered
-    assert acquire.run.call_count == 3
-    # Released with the acquisition's own token (ownership-checked).
+    assert acquire.run.call_count == 3  # two "held", then acquired
+    # Released with the acquisition's own token, then the release stream notified.
     release.assert_called_once_with("gtf:task", {"key": "dedup-1"}, token="tok")  # noqa: S106
     release.return_value.run.assert_called_once()
+    coord.notify.assert_called_once_with("gtf:task:lock-released:dedup-1")
 
 
-def test_task_lock_reraises_when_still_held_past_the_deadline(
+def test_task_lock_skips_notify_without_a_coordination_backend(
     mocker: MockerFixture,
 ) -> None:
-    """A genuinely stuck lock (held past the wait window) surfaces the error."""
+    """With no backend there's no release stream to notify (waiters poll)."""
     from superset.tasks.locks import task_lock
 
-    mocker.patch("superset.tasks.locks.time.sleep")
-    # First monotonic() sets the deadline; the next is past it, so we give up.
-    mocker.patch("superset.tasks.locks.time.monotonic", side_effect=[0.0, 999.0])
-    mocker.patch(ACQUIRE).return_value.run.side_effect = LockAlreadyHeldException(
-        "Lock already taken"
-    )
-    release = mocker.patch(RELEASE)
+    acquire = mocker.patch(ACQUIRE).return_value
+    acquire.token = "tok"  # noqa: S105
+    acquire.run.side_effect = [None]
+    mocker.patch(RELEASE)
+    coord = mocker.patch(COORD)
+    coord.wait_for_signal.side_effect = _drive_wait_for_signal
+    coord.is_backend_defined.return_value = False
 
-    with pytest.raises(LockAlreadyHeldException):
-        with task_lock("dedup-2"):
+    with task_lock("dedup-2"):
+        pass
+
+    coord.notify.assert_not_called()
+
+
+def test_task_lock_propagates_wait_timeout(mocker: MockerFixture) -> None:
+    """A genuinely stuck lock (never freed) surfaces wait_for_signal's timeout."""
+    from superset.tasks.locks import task_lock
+
+    mocker.patch(ACQUIRE)
+    release = mocker.patch(RELEASE)
+    coord = mocker.patch(COORD)
+    coord.wait_for_signal.side_effect = TimeoutError("Timed out waiting")
+
+    with pytest.raises(TimeoutError):
+        with task_lock("dedup-3"):
             pass
 
-    # Never entered the critical section → nothing to release.
+    # Never acquired → nothing to release.
     release.return_value.run.assert_not_called()

--- a/tests/unit_tests/tasks/test_locks.py
+++ b/tests/unit_tests/tasks/test_locks.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for the GTF task_lock (block-and-wait acquisition)."""
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.exceptions import LockAlreadyHeldException
+
+ACQUIRE = "superset.commands.distributed_lock.acquire.AcquireDistributedLock"
+RELEASE = "superset.commands.distributed_lock.release.ReleaseDistributedLock"
+
+
+def test_task_lock_waits_for_a_held_lock_then_acquires(
+    mocker: MockerFixture,
+) -> None:
+    """A held lock is retried (not failed) so a concurrent submit can join."""
+    from superset.tasks.locks import task_lock
+
+    mocker.patch("superset.tasks.locks.time.sleep")
+    acquire = mocker.patch(ACQUIRE).return_value
+    acquire.token = "tok"  # noqa: S105
+    # Held for the first two attempts, then acquired.
+    acquire.run.side_effect = [
+        LockAlreadyHeldException("Lock already taken"),
+        LockAlreadyHeldException("Lock already taken"),
+        None,
+    ]
+    release = mocker.patch(RELEASE)
+
+    entered = False
+    with task_lock("dedup-1"):
+        entered = True
+
+    assert entered
+    assert acquire.run.call_count == 3
+    # Released with the acquisition's own token (ownership-checked).
+    release.assert_called_once_with("gtf:task", {"key": "dedup-1"}, token="tok")  # noqa: S106
+    release.return_value.run.assert_called_once()
+
+
+def test_task_lock_reraises_when_still_held_past_the_deadline(
+    mocker: MockerFixture,
+) -> None:
+    """A genuinely stuck lock (held past the wait window) surfaces the error."""
+    from superset.tasks.locks import task_lock
+
+    mocker.patch("superset.tasks.locks.time.sleep")
+    # First monotonic() sets the deadline; the next is past it, so we give up.
+    mocker.patch("superset.tasks.locks.time.monotonic", side_effect=[0.0, 999.0])
+    mocker.patch(ACQUIRE).return_value.run.side_effect = LockAlreadyHeldException(
+        "Lock already taken"
+    )
+    release = mocker.patch(RELEASE)
+
+    with pytest.raises(LockAlreadyHeldException):
+        with task_lock("dedup-2"):
+            pass
+
+    # Never entered the critical section → nothing to release.
+    release.return_value.run.assert_not_called()


### PR DESCRIPTION
### SUMMARY

Targets `gaq-to-gtf`. Loading a Deck.GL chart (and dashboards generally) could fail with a spurious `{"message": "Lock already taken"}` error.

Several charts — or a chart's identical queries — can resolve to the **same `query_cache_key`**, so they map to the same SHARED GTF task and the same `dedup_key`, and submit concurrently. `task_lock` acquired that dedup lock **fail-fast** (Redis `SET NX`), so the first submitter won the lock and created the task, while every other concurrent submitter — which should simply **join/subscribe** to that shared task — hit `LockAlreadyHeldException` and errored out, failing the chart.

Found while testing the **Deck.GL demo dashboard**, where three charts share the same query object — so all three resolve to one SHARED task and submit at once; the two that lost the lock race errored with "Lock already taken".

**The fix — wait for the lock instead of failing.** `task_lock` now blocks and waits, then joins the now-existing task. The wait is delegated to `CoordinationService.wait_for_signal`: **event-driven** on the lock's release-signal Redis Stream when a coordination backend is configured (release `notify()`s it), and a **poll** fallback otherwise — reusing the same await/notify mechanism GTF task-completion already uses. It's bounded (past the TTL) so a holder that crashed without releasing is waited out via the lock's auto-expiry rather than blocking forever, and released with the acquisition's own token (ownership-checked).

**Bonus — track and surface dedupe hits.** Every submit that joins an existing task (a new subscriber *or* an existing subscriber's resubmit) now bumps a `dedupe_count` on the task's `properties` (seeded to 0 at creation, no new column). When it's > 0 the Task List **Details** column shows a plus icon + the count with a tooltip, so you can see when one shared task served several chart requests.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Task List Details showing the `+1` dedupe indicator on hover:_

<img width="1192" height="575" alt="image" src="https://github.com/user-attachments/assets/c8537bfd-ba35-461c-9aba-736a522bb3a1" />

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/tasks/test_locks.py` — a held lock is retried then acquired (concurrent submit joins); a lock still held past the wait window re-raises; and `notify` is skipped without a coordination backend.
- `pytest tests/integration_tests/tasks/commands/test_submit.py -k joins_existing` — a resubmit joins the existing task and bumps `dedupe_count` (seeded 0 → 1).
- `npm run test -- src/pages/TaskList/TaskList.test.tsx` — the Details column shows the dedupe indicator when `dedupe_count > 0`.
- End-to-end: open the Deck.GL demo dashboard (or any dashboard whose charts share a query) with `GLOBAL_ASYNC_QUERIES` on — the charts load instead of erroring with "Lock already taken", and the shared task shows a dedupe count.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES`
- [x] Changes UI (Task List Details shows a dedupe count)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
