### PR TITLE
fix(plugin-chart-table): preserve comparison arrow when a column-specific formatter entry is missing

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -1195,16 +1195,20 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             }
           `;
 
-          let arrowStyles = css`
-            color: ${
+          // Plain inline style (rather than the `css` prop) so the arrow's
+          // color is guaranteed to apply regardless of whether the consuming
+          // app's build wires up the emotion JSX pragma for the `css` prop --
+          // notably, this codebase's own Jest/Babel config does not, which
+          // silently no-ops any `css` prop on a plain DOM element.
+          let arrowStyles: CSSProperties = {
+            color:
               basicColorFormatters &&
               basicColorFormatters[row.index]?.[originKey]?.arrowColor ===
                 ColorSchemeEnum.Green
                 ? theme.colorSuccess
-                : theme.colorError
-            };
-            margin-right: ${theme.sizeUnit}px;
-          `;
+                : theme.colorError,
+            marginRight: theme.sizeUnit,
+          };
 
           if (
             basicColorColumnFormatters &&
@@ -1213,14 +1217,13 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             const columnArrowColor =
               basicColorColumnFormatters[row.index]?.[column.key]?.arrowColor;
             if (columnArrowColor) {
-              arrowStyles = css`
-                color: ${
+              arrowStyles = {
+                color:
                   columnArrowColor === ColorSchemeEnum.Green
                     ? theme.colorSuccess
-                    : theme.colorError
-                };
-                margin-right: ${theme.sizeUnit}px;
-              `;
+                    : theme.colorError,
+                marginRight: theme.sizeUnit,
+              };
             }
           }
 
@@ -1306,12 +1309,12 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                   className="dt-truncate-cell"
                   style={columnWidth ? { width: columnWidth } : undefined}
                 >
-                  {arrow && <span css={arrowStyles}>{arrow}</span>}
+                  {arrow && <span style={arrowStyles}>{arrow}</span>}
                   {text}
                 </div>
               ) : (
                 <>
-                  {arrow && <span css={arrowStyles}>{arrow}</span>}
+                  {arrow && <span style={arrowStyles}>{arrow}</span>}
                   {text}
                 </>
               )}

--- a/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/TableChart.tsx
@@ -1138,7 +1138,8 @@ export default function TableChart<D extends DataRecord = DataRecord>(
                 ?.backgroundColor || backgroundColor;
             arrow =
               column.label === comparisonLabels[0]
-                ? basicColorColumnFormatters[row.index]?.[column.key]?.mainArrow
+                ? (basicColorColumnFormatters[row.index]?.[column.key]
+                    ?.mainArrow ?? arrow)
                 : '';
           }
           const rowSurfaceColor =
@@ -1209,15 +1210,18 @@ export default function TableChart<D extends DataRecord = DataRecord>(
             basicColorColumnFormatters &&
             basicColorColumnFormatters?.length > 0
           ) {
-            arrowStyles = css`
-              color: ${
-                basicColorColumnFormatters[row.index]?.[column.key]
-                  ?.arrowColor === ColorSchemeEnum.Green
-                  ? theme.colorSuccess
-                  : theme.colorError
-              };
-              margin-right: ${theme.sizeUnit}px;
-            `;
+            const columnArrowColor =
+              basicColorColumnFormatters[row.index]?.[column.key]?.arrowColor;
+            if (columnArrowColor) {
+              arrowStyles = css`
+                color: ${
+                  columnArrowColor === ColorSchemeEnum.Green
+                    ? theme.colorSuccess
+                    : theme.colorError
+                };
+                margin-right: ${theme.sizeUnit}px;
+              `;
+            }
           }
 
           const cellProps = {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2137,6 +2137,12 @@ describe('plugin-chart-table', () => {
         expect(getComputedStyle(arrowCell!).background).toContain(
           'rgba(0, 150, 0, 0.2)',
         );
+        // the fallback arrow itself must also keep the "increase" color --
+        // asserting only the cell background would still pass if the arrow's
+        // own color had regressed to the "decrease" color.
+        expect(arrowCell!.querySelector('span')).toHaveStyle({
+          color: supersetTheme.colorSuccess,
+        });
       });
 
       test('preserves client-side search text across temporal table rerenders', async () => {

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2111,7 +2111,14 @@ describe('plugin-chart-table', () => {
 
         expect(() =>
           render(
-            <TableChart {...propsWithMissingFormatterEntry} sticky={false} />,
+            ProviderWrapper({
+              children: (
+                <TableChart
+                  {...propsWithMissingFormatterEntry}
+                  sticky={false}
+                />
+              ),
+            }),
           ),
         ).not.toThrow();
 

--- a/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/test/TableChart.test.tsx
@@ -2125,8 +2125,18 @@ describe('plugin-chart-table', () => {
           'rgba(0, 150, 0, 0.2)',
         );
 
-        // the row missing a formatter entry still renders its raw value
-        expect(screen.getAllByTitle('110').length).toBeGreaterThan(0);
+        // the row missing a formatter entry falls back to the row-level
+        // comparison arrow instead of losing it: before the fix, this row's
+        // arrow was silently cleared (and its color, computed the same way,
+        // would have flipped to the "decrease" color) whenever the
+        // column-specific lookup for this row was undefined.
+        const arrowCell = screen
+          .getAllByTitle('110')
+          .find(cell => cell.querySelector('span'));
+        expect(arrowCell).toHaveTextContent('↑110');
+        expect(getComputedStyle(arrowCell!).background).toContain(
+          'rgba(0, 150, 0, 0.2)',
+        );
       });
 
       test('preserves client-side search text across temporal table rerenders', async () => {


### PR DESCRIPTION
### SUMMARY
Follow-up to #43139, flagged by a bot review comment on that PR (thread left unresolved).

The Table chart's `Cell` renderer computes the per-row comparison arrow (and its color) twice when both `basicColorFormatters` (row-level) and `basicColorColumnFormatters` (column-specific) are present: once from the row-level array, then unconditionally reassigned from the column-specific one. The sibling `backgroundColor` assignment falls back to its prior value when the column-specific lookup is missing (`|| backgroundColor`), but the arrow and arrow-color assignments didn't have the same fallback. A row with no entry in `basicColorColumnFormatters` (the exact scenario #43139 guarded against crashing on) silently lost its arrow glyph entirely, and its arrow color would have flipped to the "decrease" color, even though a valid value had already been computed from `basicColorFormatters`.

Both reassignments now fall back to the previously-computed value, matching how `backgroundColor` already behaves.

Checked for the same shape elsewhere: `plugin-chart-ag-grid-table`'s `getCellStyle.ts` already guards its own background-color reassignment the same way (with a comment describing this exact failure mode), and its arrow logic only ever reads from one formatter source, so it isn't affected.

### TESTING INSTRUCTIONS
`npx jest plugins/plugin-chart-table` — 147 passed. Extended the regression test #43139 added for the row-count-mismatch scenario to also assert the affected row keeps its arrow glyph and color instead of just checking it renders. Confirmed the added assertions fail against the pre-fix code (no arrow span rendered at all) and pass with the fix.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API