### PR TITLE
chore(ci): drop inert SQLALCHEMY_WARN_20 flag from unit-test CI

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -53,12 +53,6 @@ jobs:
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["current"]') || fromJSON('["current", "next"]') }}
     env:
       PYTHONPATH: ${{ github.workspace }}
-      # Promotes the SQLAlchemy 2.0 deprecation warnings already locked in as
-      # errors via pytest.ini's `filterwarnings` to actually run in CI, so a
-      # regression on those fails the build instead of relying on a
-      # contributor remembering to set this locally. See the migration
-      # battleplan: https://github.com/apache/superset/discussions/40273
-      SQLALCHEMY_WARN_20: "1"
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
### SUMMARY
The `SQLALCHEMY_WARN_20` env var in `superset-python-unittest.yml` only had effect under SQLAlchemy 1.4, where it promoted 2.0-migration deprecation warnings to errors. The SQLAlchemy 2.0 bump landed in #42803 and has been stable on master since; under SQLAlchemy 2.0.52 this flag is a silent no-op. Removing it as the cleanup step called out in the migration battleplan (discussion #40273).

### TESTING INSTRUCTIONS
CI itself is the test — unit tests should behave identically with the flag removed since it does nothing under the currently-pinned SQLAlchemy version.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
