### PR TITLE
fix(ocient): update GIS test fixtures for pyocient's relocated geo types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,8 +218,12 @@ motherduck = ["apache-superset[duckdb]"]
 mysql = ["mysqlclient>=2.2.8, <3"]
 ocient = [
     # Closed-source vendor package with no public changelog; permissive
-    # unpinned sqlalchemy>=1.4 declared, but SQLAlchemy 2.0 support is
-    # unverified. Lower confidence than the other bumps in this PR.
+    # unpinned sqlalchemy>=1.4 declared. Verified compatible with SQLAlchemy
+    # 2.0 against pyocient>=3.9.0 (discussion #40273): dialect construction,
+    # error extraction, and GIS-type sanitization all pass under 2.0.52. Note
+    # pyocient 3.9.0 relocated its geo-type classes from private top-level
+    # names (pyocient._STPoint) to public ones under pyocient.api
+    # (pyocient.api.STPoint), which is unrelated to the SQLAlchemy bump.
     "sqlalchemy-ocient>=3.0.0, <4",
     "pyocient>=3.9.0, <4",
     "shapely",

--- a/tests/unit_tests/db_engine_specs/test_ocient.py
+++ b/tests/unit_tests/db_engine_specs/test_ocient.py
@@ -229,7 +229,12 @@ def _generate_gis_type_sanitization_test_cases() -> list[
     if not ocient_is_installed():
         return []
 
-    from pyocient import _STLinestring, _STPoint, _STPolygon, TypeCodes
+    from pyocient import TypeCodes
+    from pyocient.api import (
+        STLinestring as _STLinestring,
+        STPoint as _STPoint,
+        STPolygon as _STPolygon,
+    )
 
     return [
         (
@@ -296,7 +301,7 @@ def _generate_gis_type_sanitization_test_cases() -> list[
         (
             "empty_polygon",
             TypeCodes.ST_POLYGON,
-            _STPolygon(exterior=[], holes=[]),
+            _STPolygon(exterior=[], holes=[], fullFlag=False),
             {
                 "geometry": None,
                 "properties": {},
@@ -311,6 +316,7 @@ def _generate_gis_type_sanitization_test_cases() -> list[
                     _STPoint(long=t[0], lat=t[1]) for t in [(1, 0), (1, 1), (1, 0)]
                 ],
                 holes=[],
+                fullFlag=False,
             ),
             {
                 "geometry": {
@@ -332,6 +338,7 @@ def _generate_gis_type_sanitization_test_cases() -> list[
                     [_STPoint(long=t[0], lat=t[1]) for t in [(2, 0), (2, 1), (2, 0)]],
                     [_STPoint(long=t[0], lat=t[1]) for t in [(3, 0), (3, 1), (3, 0)]],
                 ],
+                fullFlag=False,
             ),
             {
                 "geometry": {
@@ -352,6 +359,7 @@ def _generate_gis_type_sanitization_test_cases() -> list[
             _STPolygon(
                 exterior=[_STPoint(long=t[0], lat=t[1]) for t in [(1, 0)]],
                 holes=[],
+                fullFlag=False,
             ),
             {
                 "geometry": {
@@ -368,6 +376,7 @@ def _generate_gis_type_sanitization_test_cases() -> list[
             _STPolygon(
                 exterior=[_STPoint(long=t[0], lat=t[1]) for t in [(1, 0), (0, 1)]],
                 holes=[],
+                fullFlag=False,
             ),
             {
                 "geometry": {
@@ -400,7 +409,7 @@ def test_gis_type_sanitization(
 
 @pytest.mark.skipif(not ocient_is_installed(), reason="requires ocient dependencies")
 def test_point_list_to_wkt() -> None:
-    from pyocient import _STPoint
+    from pyocient.api import STPoint as _STPoint
 
     wkt = _point_list_to_wkt(
         [_STPoint(long=t[0], lat=t[1]) for t in [(2, 0), (2, 1), (2, 0)]]


### PR DESCRIPTION
### SUMMARY
`pyocient>=3.9.0` moved its `ST_*` geometry classes from private top-level names (`pyocient._STPoint`) to public ones under `pyocient.api` (`pyocient.api.STPoint`), and `STPolygon` gained a required `fullFlag` parameter. `test_ocient.py`'s GIS sanitization tests still imported the old private names, so the test module failed to even collect whenever the `ocient` extras were actually installed — invisible in standard CI since `pyocient` isn't a default test dependency, only surfacing when someone installs `apache-superset[ocient]` and runs the suite.

This was found while verifying the SQLAlchemy 2.0 compatibility of the `ocient` extra, which #42542 flagged as "unverified" (discussion #40273). With the fixtures fixed, all 21 tests in the module pass under SQLAlchemy 2.0.52 — confirming the driver itself is fine under 2.0; the break was purely a pyocient-side rename unrelated to the SQLAlchemy bump. Updated the confidence note in `pyproject.toml` accordingly.

### TESTING INSTRUCTIONS
```
pip install "sqlalchemy-ocient>=3.0.0,<4" "pyocient>=3.9.0,<4" shapely geojson
pytest tests/unit_tests/db_engine_specs/test_ocient.py -q
```
21 passed, 0 failed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
