### PR TITLE
fix(cockroachdb): replace abandoned cockroachdb package with sqlalchemy-cockroachdb

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -25,6 +25,7 @@ assists people when migrating to a new version.
 ## Next
 
 - `SAMPLES_ROW_LIMIT` is now the default for `/datasource/samples` requests without a valid explicit `per_page`, rather than a hard per-request ceiling; explicit limits are honored up to the existing global row-limit ceiling, matching `/chart/data` SAMPLES requests.
+- The `cockroachdb` extra (`pip install apache-superset[cockroachdb]`) now installs `sqlalchemy-cockroachdb` instead of the abandoned `cockroachdb` package, whose SQLAlchemy dialect could not be imported under SQLAlchemy 2.0. Existing environments with the old package installed should `pip uninstall cockroachdb && pip install sqlalchemy-cockroachdb` (or simply reinstall the extra) to restore CockroachDB connectivity.
 
 ### MCP tool results preserve stored string values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,13 @@ bigquery = [
     "google-cloud-bigquery>=3.42.3",
 ]
 clickhouse = ["clickhouse-connect>=1.7.2, <2.0"]
-cockroachdb = ["cockroachdb>=0.3.5, <0.4"]
+# The `cockroachdb` PyPI package (last released 2021) is abandoned and its
+# SQLAlchemy dialect cannot even import under SQLAlchemy 2.0 (it references
+# sqlalchemy.dialects.postgresql.psycopg2.PGCompiler_psycopg2, removed in
+# 2.0). sqlalchemy-cockroachdb is the actively maintained replacement,
+# already linked from CockroachDbEngineSpec.metadata's docs_url, and
+# registers the same `cockroachdb` SQLAlchemy dialect entry point.
+cockroachdb = ["sqlalchemy-cockroachdb>=2.0.0, <3"]
 crate = ["sqlalchemy-cratedb>=0.43.1, <1"]
 # sqlalchemy-d1's only release (0.1.0, Nov 2025) pins sqlalchemy<2,>=1.4,
 # explicitly excluding SQLAlchemy 2.0. See superset/db_engine_specs/d1.py's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,11 @@ clickhouse = ["clickhouse-connect>=1.7.2, <2.0"]
 # 2.0). sqlalchemy-cockroachdb is the actively maintained replacement,
 # already linked from CockroachDbEngineSpec.metadata's docs_url, and
 # registers the same `cockroachdb` SQLAlchemy dialect entry point.
-cockroachdb = ["sqlalchemy-cockroachdb>=2.0.0, <3"]
+# sqlalchemy-cockroachdb depends only on SQLAlchemy itself, not on a DBAPI
+# driver, so psycopg2-binary is pinned alongside it (matching the `postgres`
+# extra) to keep this extra self-contained -- CockroachDB speaks the
+# PostgreSQL wire protocol, so psycopg2 is what actually opens connections.
+cockroachdb = ["sqlalchemy-cockroachdb>=2.0.0, <3", "psycopg2-binary==2.9.12"]
 crate = ["sqlalchemy-cratedb>=0.43.1, <1"]
 # sqlalchemy-d1's only release (0.1.0, Nov 2025) pins sqlalchemy<2,>=1.4,
 # explicitly excluding SQLAlchemy 2.0. See superset/db_engine_specs/d1.py's

--- a/requirements/development.in
+++ b/requirements/development.in
@@ -16,5 +16,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
--e .[development,bigquery,druid,duckdb,fastmcp,gevent,gsheets,mysql,postgres,presto,prophet,trino,thumbnails]
+-e .[development,bigquery,cockroachdb,druid,duckdb,fastmcp,gevent,gsheets,mysql,postgres,presto,prophet,trino,thumbnails]
 -e ./superset-extensions-cli[test]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -962,9 +962,12 @@ sqlalchemy==2.0.52
     #   marshmallow-sqlalchemy
     #   shillelagh
     #   sqlalchemy-bigquery
+    #   sqlalchemy-cockroachdb
     #   sqlalchemy-continuum
     #   sqlalchemy-utils
 sqlalchemy-bigquery==1.17.2
+    # via apache-superset
+sqlalchemy-cockroachdb==2.0.4
     # via apache-superset
 sqlalchemy-continuum==1.7.0
     # via

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -44,7 +44,7 @@ class CockroachDbEngineSpec(PostgresEngineSpec):
             DatabaseCategory.TRADITIONAL_RDBMS,
             DatabaseCategory.OPEN_SOURCE,
         ],
-        "pypi_packages": ["cockroachdb"],
+        "pypi_packages": ["sqlalchemy-cockroachdb"],
         "connection_string": "cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable",
         "default_port": 26257,
         "docs_url": "https://github.com/cockroachdb/sqlalchemy-cockroachdb",

--- a/superset/db_engine_specs/cockroachdb.py
+++ b/superset/db_engine_specs/cockroachdb.py
@@ -44,7 +44,7 @@ class CockroachDbEngineSpec(PostgresEngineSpec):
             DatabaseCategory.TRADITIONAL_RDBMS,
             DatabaseCategory.OPEN_SOURCE,
         ],
-        "pypi_packages": ["sqlalchemy-cockroachdb"],
+        "pypi_packages": ["sqlalchemy-cockroachdb", "psycopg2"],
         "connection_string": "cockroachdb://root@{hostname}:{port}/{database}?sslmode=disable",
         "default_port": 26257,
         "docs_url": "https://github.com/cockroachdb/sqlalchemy-cockroachdb",

--- a/tests/unit_tests/db_engine_specs/test_crdb.py
+++ b/tests/unit_tests/db_engine_specs/test_crdb.py
@@ -42,3 +42,19 @@ def test_convert_dttm(
     )
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_dialect_loads_under_installed_sqlalchemy() -> None:
+    """
+    ``create_engine`` resolves and imports the ``cockroachdb`` SQLAlchemy
+    dialect entry point without connecting anywhere. This is a regression
+    test for the ``cockroachdb`` PyPI package (last released 2021, replaced
+    by ``sqlalchemy-cockroachdb`` -- see the ``cockroachdb`` extra in
+    pyproject.toml): its dialect referenced
+    ``sqlalchemy.dialects.postgresql.psycopg2.PGCompiler_psycopg2``, which
+    SQLAlchemy 2.0 removed, so merely constructing an engine raised
+    ``ImportError`` before any connection was attempted.
+    """
+    from sqlalchemy import create_engine
+
+    create_engine("cockroachdb://root@localhost:26257/defaultdb?sslmode=disable")


### PR DESCRIPTION
### SUMMARY
`pyproject.toml`'s `cockroachdb` extra installs the `cockroachdb` PyPI package (last released in 2021, abandoned since). Its SQLAlchemy dialect imports `sqlalchemy.dialects.postgresql.psycopg2.PGCompiler_psycopg2`, which SQLAlchemy 2.0 removed — so merely constructing a `cockroachdb://` engine raises `ImportError` before any connection is attempted:

```
ImportError: cannot import name 'PGCompiler_psycopg2' from
'sqlalchemy.dialects.postgresql.psycopg2'
```

This has been broken since the SQLAlchemy 2.0 bump (#42803, 2026-08-13, discussion #40273) landed, and nothing catches it: `cockroachdb` isn't part of the default dev/CI install, and the existing `test_crdb.py` only exercises `convert_dttm()` — a pure function — never a real engine. Found while building a testcontainers-based CI pilot and actually connecting to a live CockroachDB instance.

The actively maintained replacement is `sqlalchemy-cockroachdb` (currently 2.0.4, versioned to track SQLAlchemy compatibility) — already linked from `CockroachDbEngineSpec.metadata["docs_url"]`, just never wired up as the actual dependency. It registers the same `cockroachdb` SQLAlchemy dialect entry point, so no engine spec code changes are needed beyond the `pypi_packages` metadata.

### TESTING INSTRUCTIONS
Added `test_dialect_loads_under_installed_sqlalchemy`, which constructs a `cockroachdb://` engine (no live connection needed — dialect loading fails before any network I/O). Verified directly:
```
pip install "cockroachdb>=0.3.5,<0.4"   # old package
pytest tests/unit_tests/db_engine_specs/test_crdb.py::test_dialect_loads_under_installed_sqlalchemy
# FAILED - ImportError

pip uninstall -y cockroachdb
pip install "sqlalchemy-cockroachdb>=2.0.0,<3"   # this PR's fix
pytest tests/unit_tests/db_engine_specs/test_crdb.py
# 4 passed
```
Also connected end-to-end against a real CockroachDB container (`cockroachdb/cockroach:v24.1.1` via testcontainers) and ran `select version()` successfully with the fix in place.

Added `cockroachdb` to the default dev install (`requirements/development.in`) so this dialect keeps getting exercised going forward instead of silently drifting again.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [x] Removes existing feature or API (the dead `cockroachdb` package dependency; replaced 1:1 with the maintained package covering the same SQLAlchemy dialect)
