### PR TITLE
fix(themes): render brand spinner SVG via <img> data URI

### DIFF
--- a/superset/templates/superset/spa.html
+++ b/superset/templates/superset/spa.html
@@ -144,11 +144,14 @@
         {% set tokens = theme_tokens | default({}) %}
         {% set spinner_style = "width: 70px; height: auto; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);" %}
 
-        {% if spinner_svg %}
-          <!-- Inline SVG: Either custom theme SVG or default spinner -->
-          <div style="{{ spinner_style }}">
-            {{ spinner_svg | safe }}
-          </div>
+        {% if spinner_svg_data_uri %}
+          <!-- data URI: SVG renders as a passive image, no script execution -->
+          <img
+            src="{{ spinner_svg_data_uri }}"
+            alt=""
+            aria-label="Loading"
+            style="{{ spinner_style }}"
+          />
         {% elif tokens.get('brandSpinnerUrl') %}
           <!-- Custom URL from theme -->
           <img

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -744,6 +744,15 @@ def _ensure_static_assets_prefix(url_or_path: str) -> str:
     return f"{normalized_prefix}{url_or_path}"
 
 
+def _svg_to_data_uri(svg: str | None) -> str | None:
+    """Encode SVG markup as a base64 data URI, or ``None`` if no SVG is given."""
+    if not svg:
+        return None
+    return "data:image/svg+xml;base64," + base64.b64encode(svg.encode("utf-8")).decode(
+        "ascii"
+    )
+
+
 def get_spa_template_context(
     entry: str | None = "spa",
     extra_bootstrap_data: dict[str, Any] | None = None,
@@ -815,11 +824,7 @@ def get_spa_template_context(
 
     # Serve the spinner as an <img> data URI (see spa.html). SVG loaded via <img>
     # can't execute scripts, so rendering doesn't depend on sanitize_svg_content.
-    spinner_svg_data_uri = None
-    if spinner_svg:
-        spinner_svg_data_uri = "data:image/svg+xml;base64," + base64.b64encode(
-            spinner_svg.encode("utf-8")
-        ).decode("ascii")
+    spinner_svg_data_uri = _svg_to_data_uri(spinner_svg)
 
     # Determine default title using the (potentially updated) brandAppName
     default_title = theme_tokens.get("brandAppName", "Superset")

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import base64
 import copy
 import functools
 import logging
@@ -812,6 +813,14 @@ def get_spa_template_context(
         # No custom URL either, use default SVG
         spinner_svg = get_default_spinner_svg()
 
+    # Serve the spinner as an <img> data URI (see spa.html). SVG loaded via <img>
+    # can't execute scripts, so rendering doesn't depend on sanitize_svg_content.
+    spinner_svg_data_uri = None
+    if spinner_svg:
+        spinner_svg_data_uri = "data:image/svg+xml;base64," + base64.b64encode(
+            spinner_svg.encode("utf-8")
+        ).decode("ascii")
+
     # Determine default title using the (potentially updated) brandAppName
     default_title = theme_tokens.get("brandAppName", "Superset")
 
@@ -826,7 +835,7 @@ def get_spa_template_context(
         ),
         "theme_tokens": theme_tokens,
         "dark_theme_bg": dark_theme_bg,
-        "spinner_svg": spinner_svg,
+        "spinner_svg_data_uri": spinner_svg_data_uri,
         "default_title": default_title,
         **get_language_pack_template_context(payload.get("common") or {}),
         **template_kwargs,

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -745,8 +745,13 @@ def _ensure_static_assets_prefix(url_or_path: str) -> str:
 
 
 def _svg_to_data_uri(svg: str | None) -> str | None:
-    """Encode SVG markup as a base64 data URI, or ``None`` if no SVG is given."""
-    if not svg:
+    """Encode SVG markup as a base64 data URI, or ``None`` if no SVG is given.
+
+    A malformed theme (hand-edited config or a stale database row) could
+    supply a truthy non-string value here; treat that as absent rather than
+    raising, since raising would 500 every SPA render.
+    """
+    if not isinstance(svg, str) or not svg:
         return None
     return "data:image/svg+xml;base64," + base64.b64encode(svg.encode("utf-8")).decode(
         "ascii"

--- a/tests/unit_tests/views/test_base_theme_helpers.py
+++ b/tests/unit_tests/views/test_base_theme_helpers.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import base64
 from unittest.mock import MagicMock, mock_open, patch
 
 from superset.themes.types import ThemeMode
@@ -23,6 +24,7 @@ from superset.views.base import (
     _load_theme_from_model,
     _merge_theme_dicts,
     _process_theme,
+    _svg_to_data_uri,
     get_theme_bootstrap_data,
 )
 
@@ -1117,6 +1119,66 @@ class TestGetDefaultSpinnerSvg:
         assert result is not None
         assert "<svg" in result
         assert "morphPath" in result
+
+
+class TestSvgToDataUri:
+    """Test _svg_to_data_uri (see #43504: <img> data URI spinner rendering)"""
+
+    def test_string_input_encoded_as_data_uri(self):
+        """A valid SVG string is base64-encoded into a data URI"""
+        svg = "<svg>ok</svg>"
+        result = _svg_to_data_uri(svg)
+        assert result == (
+            "data:image/svg+xml;base64,"
+            + base64.b64encode(svg.encode("utf-8")).decode("ascii")
+        )
+
+    def test_none_input_returns_none(self):
+        assert _svg_to_data_uri(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _svg_to_data_uri("") is None
+
+    def test_non_string_input_returns_none(self):
+        """A malformed theme (hand-edited config or a stale database row)
+        could supply a truthy non-string value; it must be treated as
+        absent rather than raising and 500ing SPA rendering."""
+        assert _svg_to_data_uri(True) is None  # noqa: FBT003
+        assert _svg_to_data_uri(123) is None
+        assert _svg_to_data_uri({"not": "a string"}) is None
+
+
+class TestSpinnerSvgDataUri:
+    """Regression test for #43503: brandSpinnerSvg must reach spa.html only
+    as a base64 data URI, never as raw markup that could be inlined."""
+
+    @patch("superset.views.base.get_spa_payload")
+    @patch("superset.views.base.app")
+    def test_custom_svg_rendered_only_as_data_uri(self, mock_app, mock_payload):
+        from superset.views.base import get_spa_template_context
+
+        mock_app.config = {}
+        malicious_svg = '<svg onload="alert(1)"><script>alert(1)</script></svg>'
+        mock_payload.return_value = {
+            "common": {
+                "theme": {
+                    "default": {
+                        "token": {"brandSpinnerSvg": malicious_svg},
+                    }
+                }
+            }
+        }
+
+        result = get_spa_template_context("app")
+
+        # The template no longer receives a raw "spinner_svg" it could
+        # render with `| safe`; only the encoded data URI is passed.
+        assert "spinner_svg" not in result
+        assert result["spinner_svg_data_uri"].startswith("data:image/svg+xml;base64,")
+        decoded = base64.b64decode(
+            result["spinner_svg_data_uri"].split(",", 1)[1]
+        ).decode("utf-8")
+        assert decoded == malicious_svg
 
 
 class TestThemeCacheInvalidation:


### PR DESCRIPTION
### SUMMARY

The app/login spinner inlined a theme's `brandSpinnerSvg` with `{{ spinner_svg | safe }}` in `spa.html`, so XSS safety relied entirely on the regex denylist `sanitize_svg_content`. That field is admin-set and system-default, shown to every user (including the logged-out login page), and regex SVG sanitization is bypassable.

This renders the spinner as an `<img src="data:image/svg+xml;base64,...">` instead. An SVG loaded via `<img>` can't execute scripts, so rendering no longer depends on the sanitizer. It's the same approach the React `Loading` component already uses, and the spinner looks identical.

I raised the underlying issue with the security team first; they see it as a hardening item and suggested a public issue + PR.

### TESTING INSTRUCTIONS

1. Set `ENABLE_UI_THEME_ADMINISTRATION = True`. As admin, create a theme whose `brandSpinnerSvg` contains a marker (e.g. an `onload=` / `<script>` payload) and set it as the system default.
2. Load `/login` while logged out. Before: the SVG (with the injected markup) is inline in the DOM. After: it's an `<img>` data URI with no inline SVG, and the spinner looks the same.
3. Confirm the default spinner (no custom theme) is unchanged.

Fixes #43503
