### PR TITLE
fix: downgrade deprecated query_object field warnings to info

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -323,9 +323,12 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
 
     def _rename_deprecated_fields(self, kwargs: dict[str, Any]) -> None:
         # rename deprecated fields
+        # Logged at info: a chart saved before the field was renamed hits this
+        # on every render, so a warning would repeat for as long as the chart
+        # is not resaved, without anything new to report.
         for field in DEPRECATED_FIELDS:
             if field.old_name in kwargs:
-                logger.warning(
+                logger.info(
                     "The field `%s` is deprecated, please use `%s` instead.",
                     field.old_name,
                     field.new_name,
@@ -333,7 +336,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                 value = kwargs[field.old_name]
                 if value:
                     if hasattr(self, field.new_name):
-                        logger.warning(
+                        logger.info(
                             "The field `%s` is already populated, "
                             "replacing value with contents from `%s`.",
                             field.new_name,
@@ -343,9 +346,10 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
 
     def _move_deprecated_extra_fields(self, kwargs: dict[str, Any]) -> None:
         # move deprecated extras fields to extras
+        # Logged at info: same rationale as `_rename_deprecated_fields` above.
         for field in DEPRECATED_EXTRAS_FIELDS:
             if field.old_name in kwargs:
-                logger.warning(
+                logger.info(
                     "The field `%s` is deprecated and should "
                     "be passed to `extras` via the `%s` property.",
                     field.old_name,
@@ -354,7 +358,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                 value = kwargs[field.old_name]
                 if value:
                     if hasattr(self.extras, field.new_name):
-                        logger.warning(
+                        logger.info(
                             "The field `%s` is already populated in "
                             "`extras`, replacing value with contents "
                             "from `%s`.",


### PR DESCRIPTION
**Decisions made that were not in the instructions**
None.

## What

`QueryObject._rename_deprecated_fields` and `_move_deprecated_extra_fields` log at `WARNING` when a query context still uses a renamed/legacy field (`groupby`, `granularity_sqla`, `timeseries_limit`, `timeseries_limit_metric`, or the `extras` `where`/`having` fields).

These methods run in `QueryObject.__init__`, i.e. on every render of a chart. A chart saved before the field was renamed will hit this warning on every single render until it's resaved — an indefinite repeat with nothing new to report each time.

## Change

Downgrade these four `logger.warning` calls to `logger.info`. No behavior change beyond log level — the deprecated fields are still renamed/moved exactly as before.

This mirrors the rationale already established in the same file for `_get_post_processing`'s "unsupported option" log line, which was deliberately kept at `info` for the identical reason (see the comment directly above it). Added a matching comment above each changed block.

## Test plan

- `uvx ruff@0.9.7 check` and `format --check` clean on the changed file.
- No existing tests assert on the log level of these methods (grepped `tests/` for `_rename_deprecated_fields`, `_move_deprecated_extra_fields`, `DEPRECATED_FIELDS`, `DEPRECATED_EXTRAS_FIELDS` — no hits), so no test changes needed; behavior (renaming/moving the fields) is unchanged.