### PR TITLE
fix(dashboard): resolve metric Label in Chart Data (View as table) results grid

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1757,6 +1757,8 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
             "columns.column_name",
             "columns.verbose_name",
             "columns.groupby",
+            "metrics.metric_name",
+            "metrics.verbose_name",
         ]
         dataset_schema = DatasetDrillInfoSchema()
 

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -479,6 +479,11 @@ class DatasetColumnDrillInfoSchema(Schema):
     verbose_name = fields.String(required=False)
 
 
+class DatasetMetricDrillInfoSchema(Schema):
+    metric_name = fields.String(required=True)
+    verbose_name = fields.String(required=False)
+
+
 class UserSchema(Schema):
     first_name = fields.String()
     last_name = fields.String()
@@ -488,6 +493,7 @@ class UserSchema(Schema):
 class DatasetDrillInfoSchema(Schema):
     id = fields.Integer()
     columns = fields.List(fields.Nested(DatasetColumnDrillInfoSchema))
+    metrics = fields.List(fields.Nested(DatasetMetricDrillInfoSchema))
     table_name = fields.String()
     editors = fields.List(fields.Nested(SubjectResponseSchema))
     created_by = fields.Nested(UserSchema)
@@ -503,6 +509,9 @@ class DatasetDrillInfoSchema(Schema):
         """
         Clear API response to avoid exposing sensitive information for embedded users,
         and filter columns to only include those with groupby=True for drill operations.
+        Metrics are passed through unfiltered since they are used to resolve display
+        labels (e.g. for the dashboard "View as table" results grid) rather than for
+        drill-by dimension selection.
         """
         dimensions = {
             col.column_name
@@ -516,5 +525,9 @@ class DatasetDrillInfoSchema(Schema):
         ]
 
         if security_manager.is_guest_user():
-            return {"id": serialized["id"], "columns": serialized["columns"]}
+            return {
+                "id": serialized["id"],
+                "columns": serialized["columns"],
+                "metrics": serialized.get("metrics", []),
+            }
         return serialized

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3375,6 +3375,17 @@ class TestDatasetApi(SupersetTestCase):
                     groupby=False,
                 ),
             ],
+            metrics=[
+                SqlMetric(
+                    metric_name="sum__value",
+                    expression="SUM(value)",
+                    verbose_name="Yearly Total",
+                ),
+                SqlMetric(
+                    metric_name="count",
+                    expression="COUNT(*)",
+                ),
+            ],
             fetch_metadata=False,
         )
 
@@ -3398,6 +3409,13 @@ class TestDatasetApi(SupersetTestCase):
         assert result["columns"] == [
             {"column_name": "category", "verbose_name": "Category Column"},
             {"column_name": "region", "verbose_name": None},
+        ]
+        # Metrics must also carry their verbose_name so that consumers (e.g.
+        # the dashboard "View as table" results grid) can resolve a metric's
+        # friendly Label instead of falling back to its technical name.
+        assert result["metrics"] == [
+            {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
+            {"metric_name": "count", "verbose_name": None},
         ]
 
         self.items_to_delete = [dataset]
@@ -3509,6 +3527,13 @@ class TestDatasetApi(SupersetTestCase):
                     groupby=True,
                 ),
             ],
+            metrics=[
+                SqlMetric(
+                    metric_name="sum__value",
+                    expression="SUM(value)",
+                    verbose_name="Yearly Total",
+                ),
+            ],
             fetch_metadata=False,
         )
         chart = self.insert_chart("Test Embedded Chart", dataset.id)
@@ -3534,6 +3559,9 @@ class TestDatasetApi(SupersetTestCase):
                 "columns": [
                     {"column_name": "category", "verbose_name": "Category Column"},
                     {"column_name": "region", "verbose_name": None},
+                ],
+                "metrics": [
+                    {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
                 ],
             }
 


### PR DESCRIPTION
### SUMMARY
On a dashboard, opening a chart's context menu → "View as table" (the Chart Data modal, `ResultsPaneOnDashboard`) showed a metric's raw technical name (e.g. `sum__num`) as the results-grid column header instead of its friendly Label (verbose_name), even though the chart itself rendered the Label correctly and even for a full-permission Admin user.

Root cause: the results-grid header comes from `columnDisplayNames?.[key] ?? key` in `useGridResultTable`, fed by `datasetWithVerboseMap?.verbose_map` in `SliceHeaderControls`, which is built by the `useDatasetDrillInfo` hook (`superset-frontend/src/hooks/apiResources/datasets.ts`). That hook's `createVerboseMap()` already correctly merges both `dataset.columns` and `dataset.metrics` into the map — so the frontend logic was not the problem.

The actual bug is on the backend: `GET /api/v1/dataset/<pk>/drill_info/` (`superset/datasets/api.py`) only ever selected `columns.column_name`/`columns.verbose_name` and `DatasetDrillInfoSchema` (`superset/datasets/schemas.py`) had no `metrics` field at all. This endpoint was purpose-built for the Drill-to-Detail "drill by" dimension picker, which is inherently columns-only, but it was reused to source `verbose_map` for the results grid. Since the API response never included a `metrics` key, `dataset?.metrics` was always `undefined` on the frontend, so metric verbose names were silently dropped — independent of the viewer's Drill-to-Detail permission.

Fix: add `metrics.metric_name`/`metrics.verbose_name` to the drill_info select columns and add a `metrics` field (via a new `DatasetMetricDrillInfoSchema`) to `DatasetDrillInfoSchema`, passed through unfiltered (unlike columns, which stay dimension-only for drill-by purposes) and included in the guest-user response branch as well, since metric labels aren't sensitive.

No frontend changes were needed — `createVerboseMap`/`useDatasetDrillInfo` already handle metrics correctly once the API sends them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (backend API fix; see Shortcut ticket SC-115797 for repro screenshots)

### TESTING INSTRUCTIONS
- Create a dataset with a metric that has a Label (verbose_name) set, e.g. `sum__num` → "Yearly Total".
- Build a chart from it and add it to a dashboard.
- Confirm the chart itself shows "Yearly Total".
- Open the chart's context menu → "View as table" and confirm the results-grid column header now shows "Yearly Total" instead of `sum__num`.
- `pytest tests/integration_tests/datasets/api_tests.py -k drill_info`

### ADDITIONAL INFORMATION
- [x] Has associated issue: SC-115797
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API