### PR TITLE
feat(websocket): support JWT secret rotation

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -75,7 +75,7 @@ Enabling the realtime WebSocket transport (optional; accelerates completion, the
 `status_changes` interval poll remains the correctness backstop):
 
 ```python
-ENABLE_WEBSOCKET = True
+WEBSOCKET_ENABLE = True
 WEBSOCKET_URL = "ws://<same-host>:8080/"
 WEBSOCKET_JWT_SECRET = "<output of: openssl rand -base64 42>"
 ```
@@ -83,12 +83,15 @@ WEBSOCKET_JWT_SECRET = "<output of: openssl rand -base64 42>"
 The built-in Gamma role receives `can_read Realtime`; grant that permission to
 custom roles that should receive websocket notifications.
 
-Run the `superset-websocket` Node server on the **same host** (so its JWT
-channel cookie is shared) and point its `redis` config at the same instance as
-`DISTRIBUTED_COORDINATION_CONFIG`, plus `jwtSecret` / `jwtCookieName` matching
-the Flask config (`WEBSOCKET_JWT_SECRET` / `WEBSOCKET_JWT_COOKIE_NAME`, default
-`superset-ws-token`). The server is bundled in the official Superset image and
-launched via an alternate entrypoint — no separate image is required:
+Run the `superset-websocket` Node server on the **same browser-visible host**
+(so its JWT channel cookie is shared) and point its `redis` config at the same
+instance as `DISTRIBUTED_COORDINATION_CONFIG`, plus `jwtSecret` /
+`jwtCookieName` matching the Flask config (`WEBSOCKET_JWT_SECRET` /
+`WEBSOCKET_JWT_COOKIE_NAME`, default `superset-ws-token`). During websocket JWT
+secret rotation, set the websocket server's `previousJwtSecret` /
+`PREVIOUS_JWT_SECRET` to the old key while Flask continues minting cookies with
+`WEBSOCKET_JWT_SECRET`. The server is bundled in the official Superset image
+and launched via an alternate entrypoint — no separate image is required:
 `docker run <superset-image> /app/docker/entrypoints/run-websocket.sh` (or the
 opt-in `websocket` profile in `docker compose`). It now consumes Redis Pub/Sub
 channels (`entity-changes:*` broadcast nudges, `realtime:<channel_id>`

--- a/WEBSOCKET_K8S_OPERATOR_REQUIREMENTS.md
+++ b/WEBSOCKET_K8S_OPERATOR_REQUIREMENTS.md
@@ -1,0 +1,170 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# WebSocket Kubernetes Operator Requirements
+
+This note captures the expected Kubernetes deployment model for the
+`superset-websocket` realtime transport used by the GAQ-to-GTF migration.
+
+## Runtime Model
+
+Run `superset-websocket` as an independent Deployment and Service. It should not
+be modeled as a singleton, and it does not need to run as a sidecar in the
+Superset web pod.
+
+The service is stateless from the deployment perspective. Each replica owns only
+its local live WebSocket connections. There is no shared in-memory socket
+registry and no requirement for sticky sessions.
+
+Each browser WebSocket is a single upgraded HTTP connection. The ingress or load
+balancer chooses one websocket replica during the initial HTTP Upgrade, and all
+frames for that socket stay on that replica until the socket closes. If the
+browser reconnects, a new replica may be selected.
+
+## Routing Model
+
+Superset publishes one Redis Pub/Sub event for a realtime update. Every
+websocket replica subscribes to the same Pub/Sub channels and receives the same
+event.
+
+Each replica then performs local fanout only:
+
+1. Derive the target principal channel from the event's `subscribers`.
+2. Check the replica-local socket registry.
+3. Send the browser message only to matching sockets connected to that replica.
+4. Do nothing if the replica has no matching local sockets.
+
+This avoids producer-side routing to a specific replica. A singleton or Redis
+Stream consumer group would be the wrong shape for this fanout path because the
+selected consumer might not own the target socket. If event volume later makes
+"every replica receives every event" too expensive, the next architecture should
+be replica-specific routing backed by a shared connection directory.
+
+## Ingress Requirements
+
+The ingress must support WebSocket upgrades and long-lived upgraded
+connections. It should route the websocket endpoint on the same browser-visible
+host as the Superset web app so the HTTP-only websocket JWT cookie is sent with
+the upgrade request.
+
+For example, if Superset is served from:
+
+```text
+https://superset.example.com/
+```
+
+then `WEBSOCKET_URL` should use the same host:
+
+```python
+WEBSOCKET_URL = "wss://superset.example.com/<websocket-path>"
+```
+
+The websocket service should configure `ALLOWED_ORIGINS` to the Superset origin,
+for example:
+
+```text
+ALLOWED_ORIGINS=https://superset.example.com
+```
+
+## Auth Configuration
+
+Superset Flask app config:
+
+```python
+WEBSOCKET_ENABLE = True
+WEBSOCKET_URL = "wss://superset.example.com/<websocket-path>"
+WEBSOCKET_JWT_SECRET = "<current strong secret, >= 32 bytes>"
+WEBSOCKET_JWT_COOKIE_SECURE = True
+```
+
+The built-in Gamma role receives `can_read Realtime`; custom roles that should
+receive realtime notifications also need that permission. Superset mints the
+websocket JWT cookie only after this permission check passes.
+
+`superset-websocket` service config:
+
+```text
+JWT_SECRET=<same value as WEBSOCKET_JWT_SECRET>
+JWT_COOKIE_NAME=superset-ws-token
+PREVIOUS_JWT_SECRET=<old websocket JWT secret during rotation, optional>
+```
+
+The previous key is configured only on `superset-websocket`. The Flask app does
+not need it because Flask only mints new cookies with the current
+`WEBSOCKET_JWT_SECRET`. If Flask sees an old-key cookie on a later HTTP request,
+it treats it as stale and replaces it with a current-key cookie.
+
+## Secret Rotation
+
+Use a two-key overlap on the websocket service:
+
+1. Start with Flask and `superset-websocket` using the old key.
+2. Deploy `superset-websocket` with `JWT_SECRET=<new-key>` and
+   `PREVIOUS_JWT_SECRET=<old-key>`.
+3. Deploy Flask with `WEBSOCKET_JWT_SECRET=<new-key>`.
+4. Wait longer than `WEBSOCKET_JWT_EXPIRATION_SECONDS`, plus rollout and clock
+   skew margin.
+5. Remove `PREVIOUS_JWT_SECRET` from `superset-websocket`.
+
+This order avoids rejecting old cookies before Flask starts minting new ones.
+
+## Connection Lifetime And Draining
+
+WebSocket connections should be short-lived enough that pod recycling does not
+wait on long-lived sockets indefinitely. The current design bounds socket
+lifetime with the JWT expiration. The default Superset value is 15 minutes:
+
+```python
+WEBSOCKET_JWT_EXPIRATION_SECONDS = 900
+```
+
+Operators may lower this value for faster natural churn. The tradeoff is more
+browser reconnects and more JWT cookie minting.
+
+For pod termination, the operator should prefer the normal Kubernetes drain
+shape:
+
+1. Mark the pod unready so no new WebSocket upgrades are routed to it.
+2. Allow a short drain window if configured.
+3. Terminate remaining sockets; browsers reconnect to another replica.
+
+The realtime transport is lossy by design. Missed messages during reconnect or
+pod termination are reconciled by the frontend's polling fallback.
+
+## Redis Requirements
+
+`superset-websocket` must connect to the same Redis instance that Superset uses
+for `DISTRIBUTED_COORDINATION_CONFIG`.
+
+The websocket fanout path uses Redis Pub/Sub, not Redis Streams. Pub/Sub is
+acceptable here because realtime messages accelerate UI updates but do not carry
+correctness: every consuming feature still re-fetches or polls through
+authorized Superset APIs.
+
+## Scaling Notes
+
+Horizontal scaling is safe because replicas do not share mutable process state.
+HPA can scale the Deployment based on CPU, memory, ingress connection metrics,
+or future websocket-specific metrics.
+
+The main scaling cost is Pub/Sub broadcast amplification: every replica receives
+every realtime event. That is intentional for the first architecture because it
+keeps the websocket service stateless and avoids a distributed connection
+directory. If this becomes too expensive, introduce replica-specific routing as
+a separate design.

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -140,7 +140,7 @@ services:
   # Realtime WebSocket transport, launched from the official image via its
   # alternate entrypoint (no separate image needed). Opt-in — start it with
   # `docker compose --profile websocket up`. To actually use it, the Superset
-  # app must also set ENABLE_WEBSOCKET=true, WEBSOCKET_URL, and a matching
+  # app must also set WEBSOCKET_ENABLE=true, WEBSOCKET_URL, and a matching
   # WEBSOCKET_JWT_SECRET (== the JWT_SECRET below) in docker/.env-local.
   superset-websocket:
     build:
@@ -157,6 +157,8 @@ services:
       # Dev-only default; must match the app's WEBSOCKET_JWT_SECRET and be
       # replaced with a strong secret (>= 32 bytes) outside local development.
       JWT_SECRET: ${WEBSOCKET_JWT_SECRET:-dev-only-websocket-secret-change-me!}
+      # Optional verify-only old key for websocket JWT secret rotation.
+      PREVIOUS_JWT_SECRET: ${PREVIOUS_JWT_SECRET:-}
     restart: unless-stopped
     ports:
       - 8080:8080

--- a/docker/entrypoints/run-websocket.sh
+++ b/docker/entrypoints/run-websocket.sh
@@ -27,6 +27,8 @@
 # StatsD, etc.). The values that MUST match the Flask app's config are:
 #   JWT_SECRET      == WEBSOCKET_JWT_SECRET
 #   JWT_COOKIE_NAME == WEBSOCKET_JWT_COOKIE_NAME (default superset-ws-token)
+# Optional rotation setting:
+#   PREVIOUS_JWT_SECRET == old WEBSOCKET_JWT_SECRET accepted for verification
 # and the Redis connection (REDIS_HOST/REDIS_PORT/...) must point at the same
 # instance as the app's DISTRIBUTED_COORDINATION_CONFIG.
 set -e

--- a/docker/superset-websocket/config.example.json
+++ b/docker/superset-websocket/config.example.json
@@ -18,5 +18,6 @@
   "redisStreamPrefix": "async-events-",
   "jwtAlgorithms": ["HS256"],
   "jwtSecret": "CHANGE-ME-IN-PRODUCTION-GOTTA-BE-LONG-AND-SECRET",
+  "previousJwtSecret": "",
   "jwtCookieName": "async-token"
 }

--- a/superset-core/src/superset_core/tasks/types.py
+++ b/superset-core/src/superset_core/tasks/types.py
@@ -202,6 +202,17 @@ class TaskContext(ABC):
         ...
 
     @abstractmethod
+    def get_dependency_payloads(self) -> list[dict[str, Any]]:
+        """
+        Return payloads published by prerequisite tasks.
+
+        The payloads are returned in dependency edge order. They let dependent
+        task code consume small pieces of output metadata from tasks that have
+        already satisfied the DAG all-success gate.
+        """
+        ...
+
+    @abstractmethod
     def on_cleanup(self, handler: Callable[[], None]) -> Callable[[], None]:
         """
         Register a cleanup handler that runs when the task ends.

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -33,14 +33,14 @@ const CANCEL_ENDPOINT = 'glob:*/api/v1/task/*/cancel';
 const config = { GLOBAL_ASYNC_QUERIES_POLLING_DELAY: 20 };
 
 // Queue of status_changes responses the polling loop drains in order. The first
-// is the baseline (empty), then each poll consumes the next.
+// is an empty no-progress poll, then each poll consumes the next.
 let statusResponses: { statuses: Record<string, unknown>; cursor: string }[];
 
 const queueStatuses = (
   ...batches: Record<string, { status: string }>[]
 ): void => {
   statusResponses = [
-    { statuses: {}, cursor: '2020-01-01T00:00:00' }, // baseline
+    { statuses: {}, cursor: '2020-01-01T00:00:00' },
     ...batches.map((statuses, i) => ({
       statuses,
       cursor: `2020-01-01T00:00:0${i + 1}`,
@@ -79,6 +79,13 @@ test('re-issues the request once every query task succeeds', async () => {
 
   expect(refetch).toHaveBeenCalledTimes(1);
   expect(result).toEqual([{ rows: 1 }]);
+});
+
+test('does not poll status changes until a chart is awaiting async data', () => {
+  queueStatuses();
+  asyncEvent.init(config);
+
+  expect(fetchMock.callHistory.calls(STATUS_CHANGES_ENDPOINT)).toHaveLength(0);
 });
 
 test('waits for every task before re-issuing', async () => {
@@ -160,8 +167,7 @@ test('settles every request awaiting a deduplicated shared task', async () => {
 
 test('polls from the pre-task cursor returned in the 202', async () => {
   // The 202 carries a cursor captured before the tasks existed; the poll must
-  // use it (rewinding past the newer init baseline) so an early terminal can't
-  // be skipped.
+  // use it so an early terminal status can't be skipped.
   queueStatuses({ 'task-1': { status: 'success' } });
   asyncEvent.init(config);
 
@@ -221,7 +227,7 @@ test('restarts polling for a new job after going idle', async () => {
 });
 
 test('gives up (rejects) after the stale timeout with no progress', async () => {
-  queueStatuses(); // only the baseline — the awaited task never changes
+  queueStatuses(); // no terminal status for the awaited task
   asyncEvent.init({
     ...config,
     GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT: 40, // ms
@@ -241,8 +247,8 @@ describe('realtime WebSocket acceleration', () => {
   });
 
   test('a tier-2 message settles a waiting chart without a poll', async () => {
-    // No status batches queued (only the baseline), so completion can ONLY come
-    // from the socket message — proving the WS path settles on its own.
+    // No terminal status batches are queued, so completion can ONLY come from
+    // the socket message — proving the WS path settles on its own.
     queueStatuses();
     asyncEvent.init(config);
 

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -301,7 +301,7 @@ describe('realtime WebSocket acceleration', () => {
   });
 
   test('a tier-2 message is a no-op when async queries are disabled', () => {
-    // The shared socket connects whenever ENABLE_WEBSOCKET, independent of the
+    // The shared socket connects whenever WEBSOCKET_ENABLE, independent of the
     // GLOBAL_ASYNC_QUERIES flag, so a realtime message can arrive with no active
     // async flow — it must not throw (waiter registry stays an empty map).
     mockedIsFeatureEnabled.mockReturnValue(false);

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -375,7 +375,6 @@ export const init = (appConfig?: AppConfig) => {
 
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;
 
-  const generation = pollingGeneration;
   waitersByTaskId = new Map();
   cursor = null;
   pollingActive = false;
@@ -392,22 +391,9 @@ export const init = (appConfig?: AppConfig) => {
   currentPollDelayMs = pollingDelayMs;
   lastProgressAt = Date.now();
 
-  // Establish a baseline cursor before any chart query is triggered, so tasks
-  // created afterwards are all caught by the changed-since poll. The loop itself
-  // stays idle until the first waiter registers (ensurePolling), then stops again
-  // once every awaited task settles.
-  fetchStatusChanges({ task_type: CHART_QUERY_TASK_TYPE })
-    .then(({ cursor: baseline }) => {
-      // Seed the initial cursor only; never overwrite a value a waiter already
-      // rewound to its (older) pre-task cursor, or the poll could skip its tasks.
-      if (generation === pollingGeneration && cursor === null)
-        cursor = baseline;
-    })
-    .catch(err => {
-      // A missing baseline just means the first poll starts from "everything
-      // changed so far"; the >= cursor semantics still catch our tasks.
-      logging.warn('Failed to fetch async baseline cursor', err);
-    });
+  // Stay idle until a chart request returns 202. The 202 body includes a
+  // server-captured pre-task cursor, so polling does not need a startup
+  // baseline request.
 };
 
 init();

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -57,7 +57,7 @@ type StatusChangesResponse = {
 export type AsyncJob = { task_ids: string[]; cursor?: string | null };
 
 type AppConfig = {
-  ENABLE_WEBSOCKET?: boolean;
+  WEBSOCKET_ENABLE?: boolean;
   WEBSOCKET_URL?: string;
   GLOBAL_ASYNC_QUERIES_POLLING_DELAY?: number;
   GLOBAL_ASYNC_QUERIES_POLLING_MAX_DELAY?: number;
@@ -98,7 +98,7 @@ let pollingActive = false;
 // A SHARED task can be deduplicated across concurrent chart requests, so each task
 // id maps to a *set* of waiters (never overwrite an earlier subscriber).
 // Initialized eagerly (not just in init()): the shared realtime socket connects
-// whenever ENABLE_WEBSOCKET — independent of GLOBAL_ASYNC_QUERIES — so the
+// whenever WEBSOCKET_ENABLE — independent of GLOBAL_ASYNC_QUERIES — so the
 // subscribed handler may run applyStatus even when async queries are off, and
 // must find a map rather than undefined.
 let waitersByTaskId: Map<string, Set<Waiter>> = new Map();
@@ -370,7 +370,7 @@ export const init = (appConfig?: AppConfig) => {
   // (Re)connect the shared realtime socket whenever the websocket transport is
   // enabled — independent of GLOBAL_ASYNC_QUERIES, since realtime list views
   // (tier-1 entity-change nudges) ride the same socket. Idempotent: a no-op when
-  // ENABLE_WEBSOCKET is false, and supersedes any prior socket otherwise.
+  // WEBSOCKET_ENABLE is false, and supersedes any prior socket otherwise.
   connectRealtime(config);
 
   if (!isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) return;

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -102,9 +102,8 @@ let pollingActive = false;
 // subscribed handler may run applyStatus even when async queries are off, and
 // must find a map rather than undefined.
 let waitersByTaskId: Map<string, Set<Waiter>> = new Map();
-// Server-issued watermark: fetched as a baseline at init (before any chart query
-// is triggered) so no task created afterwards is missed, then advanced by each
-// poll. Always the server's own clock, never the browser's.
+// Server-issued watermark: seeded from a chart request's 202 pre-task cursor
+// and advanced by each poll. Always the server's own clock, never the browser's.
 let cursor: string | null;
 // Incremented on every init() so an in-flight poll can detect it is stale and
 // stop instead of scheduling a second loop or mutating fresh state.

--- a/superset-frontend/src/middleware/realtime.test.ts
+++ b/superset-frontend/src/middleware/realtime.test.ts
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 const ENABLED = {
-  ENABLE_WEBSOCKET: true,
+  WEBSOCKET_ENABLE: true,
   WEBSOCKET_URL: 'ws://localhost:8080/',
 };
 
@@ -117,7 +117,7 @@ test('a throwing handler does not break other handlers', () => {
 });
 
 test('does not open a socket when disabled', () => {
-  connectRealtime({ ENABLE_WEBSOCKET: false, WEBSOCKET_URL: 'ws://x/' });
+  connectRealtime({ WEBSOCKET_ENABLE: false, WEBSOCKET_URL: 'ws://x/' });
   expect(FakeWebSocket.instances).toHaveLength(0);
 });
 

--- a/superset-frontend/src/middleware/realtime.test.ts
+++ b/superset-frontend/src/middleware/realtime.test.ts
@@ -30,13 +30,17 @@ import {
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
 
+  readyState = 0;
+
   onmessage: ((event: { data: string }) => void) | null = null;
 
   onclose: (() => void) | null = null;
 
   onerror: (() => void) | null = null;
 
-  close = jest.fn();
+  close = jest.fn(() => {
+    this.readyState = 3;
+  });
 
   constructor(public url: string) {
     FakeWebSocket.instances.push(this);
@@ -138,6 +142,14 @@ test('opens a socket when enabled and routes its messages to handlers', () => {
     channel: 'realtime:user:1',
     payload: { ok: true },
   });
+});
+
+test('keeps the active socket when reconnecting with the same config', () => {
+  connectRealtime(ENABLED);
+  connectRealtime(ENABLED);
+
+  expect(FakeWebSocket.instances).toHaveLength(1);
+  expect(FakeWebSocket.instances[0].close).not.toHaveBeenCalled();
 });
 
 test('reconnects after the socket closes', () => {

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -53,6 +53,8 @@ type RealtimeConfig = {
 // server's own subscribe retry). The socket is best-effort, so a generous
 // delay is fine — each feature's poll/fetch covers the gap.
 const RECONNECT_DELAY_MS = 5000;
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
 
 let socket: WebSocket | undefined;
 let reconnectTimeoutId: number;
@@ -120,6 +122,9 @@ const openSocket = (thisGeneration: number): void => {
   ws.onerror = () => {};
 };
 
+const hasActiveSocket = (): boolean =>
+  socket?.readyState === WS_CONNECTING || socket?.readyState === WS_OPEN;
+
 const teardownSocket = (): void => {
   if (reconnectTimeoutId) clearTimeout(reconnectTimeoutId);
   if (socket) {
@@ -145,11 +150,23 @@ const teardownSocket = (): void => {
  */
 export const connectRealtime = (config?: RealtimeConfig): void => {
   const conf = config ?? getBootstrapData().common.conf;
+  const nextEnabled = Boolean(conf?.WEBSOCKET_ENABLE);
+  const nextUrl = conf?.WEBSOCKET_URL;
+
+  if (
+    started &&
+    enabled === nextEnabled &&
+    url === nextUrl &&
+    (!nextEnabled || hasActiveSocket())
+  ) {
+    return;
+  }
+
   teardownSocket();
   generation += 1;
   started = true;
-  enabled = Boolean(conf?.WEBSOCKET_ENABLE);
-  url = conf?.WEBSOCKET_URL;
+  enabled = nextEnabled;
+  url = nextUrl;
   openSocket(generation);
 };
 

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -45,7 +45,7 @@ export interface RealtimeMessage {
 type RealtimeHandler = (message: RealtimeMessage) => void;
 
 type RealtimeConfig = {
-  ENABLE_WEBSOCKET?: boolean;
+  WEBSOCKET_ENABLE?: boolean;
   WEBSOCKET_URL?: string;
 };
 
@@ -140,7 +140,7 @@ const teardownSocket = (): void => {
 /**
  * (Re)configure and (re)connect the shared socket. Idempotent and safe to call
  * repeatedly (e.g. from app bootstrap): it supersedes any prior socket. Reads
- * `ENABLE_WEBSOCKET` / `WEBSOCKET_URL` from bootstrap config when none is
+ * `WEBSOCKET_ENABLE` / `WEBSOCKET_URL` from bootstrap config when none is
  * passed. A no-op (and tears down any existing socket) when disabled.
  */
 export const connectRealtime = (config?: RealtimeConfig): void => {
@@ -148,7 +148,7 @@ export const connectRealtime = (config?: RealtimeConfig): void => {
   teardownSocket();
   generation += 1;
   started = true;
-  enabled = Boolean(conf?.ENABLE_WEBSOCKET);
+  enabled = Boolean(conf?.WEBSOCKET_ENABLE);
   url = conf?.WEBSOCKET_URL;
   openSocket(generation);
 };

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -29,9 +29,9 @@ events out to JWT-bound socket routing keys.
 - Node.js 12+ (not tested with older versions)
 - Redis 5+
 
-To use realtime push, enable it in the Superset backend (`ENABLE_WEBSOCKET`,
+To use realtime push, enable it in the Superset backend (`WEBSOCKET_ENABLE`,
 `WEBSOCKET_URL`, `WEBSOCKET_JWT_SECRET`; see below) and run this server on the
-same host.
+same browser-visible host.
 
 ## Architecture
 
@@ -68,8 +68,10 @@ messages use the derived browser channel (`realtime:user:42` or
 When a user's browser connects, it does so over HTTP, including the JWT
 authentication cookie set by the Flask app (`WEBSOCKET_JWT_COOKIE_NAME`, default
 `superset-ws-token`). _Because authentication is cookie-based, the WebSocket
-server must run on the same host as the web application._ The server verifies
-the JWT with the shared secret (`jwtSecret` / `WEBSOCKET_JWT_SECRET`).
+server must be served from the same browser-visible host as the web
+application._ In Kubernetes this is expected to run cleanly as a separate
+Deployment/Service behind an ingress that supports WebSocket upgrades. The
+server verifies the JWT with the shared secret (`jwtSecret` / `JWT_SECRET`).
 Superset mints the token only after the request principal has `can_read` on the
 `Realtime` resource. The token carries `aud`, `iss`, `sub`, `principal_type`,
 `channel`, and `exp`; the server rejects tokens whose channel does not match the
@@ -82,6 +84,23 @@ browser tabs); all matching messages are sent to all of them. Because permission
 is checked when Superset mints the JWT and when the websocket server accepts the
 upgrade, revocation after minting is bounded by the token lifetime; the Superset
 default is 15 minutes.
+
+During websocket JWT secret rotation, the websocket service can accept both the
+current key (`jwtSecret` / `JWT_SECRET`) and one previous verify-only key
+(`previousJwtSecret` / `PREVIOUS_JWT_SECRET`). The Flask app does not need the
+previous key: it keeps minting new cookies with `WEBSOCKET_JWT_SECRET`, and any
+cookie signed by the old key is replaced on the next HTTP response. Keep the
+previous key configured on the websocket service until old cookies and open
+sockets have aged out, then remove it.
+
+The service is stateless apart from process-local live socket handles. Each
+replica subscribes to the same Redis Pub/Sub channels, receives the same lossy
+events, and forwards only to matching sockets connected to that replica. Sticky
+sessions are not required; reconnecting to another replica reuses the JWT cookie
+and binds the socket to the same principal channel. Short websocket JWT
+lifetimes keep connection lifetime bounded for pod recycling; if a pod is
+terminated before expiry, connected browsers reconnect and polling reconciles
+missed events.
 
 ### Connection Management
 
@@ -132,14 +151,14 @@ the JWT cookie uses `SameSite=None`.
 Enable realtime push in the Superset Flask app (in `superset_config.py`):
 
 ```python
-ENABLE_WEBSOCKET = True
+WEBSOCKET_ENABLE = True
 WEBSOCKET_URL = "ws://<host>:<port>/"
 WEBSOCKET_JWT_SECRET = "<a strong random secret, >= 32 bytes>"
 ```
 
 The built-in `Gamma` role receives `can_read` on `Realtime`; grant that
 permission to any additional roles that should receive websocket notifications.
-Without that permission, Superset masks `ENABLE_WEBSOCKET` to `False` for the
+Without that permission, Superset masks `WEBSOCKET_ENABLE` to `False` for the
 request and does not mint the websocket JWT cookie.
 
 Note that the WebSocket server must be run on the same hostname (different port)
@@ -149,13 +168,14 @@ Note also that `localhost` and `127.0.0.1` are not considered the same host. For
 example, if you're pointing your browser to `localhost:<port>` for Superset,
 then the WebSocket url will need to be configured as `localhost:<port>`.
 
-The following values must match between the Flask app config and this server's
-`config.json` (or its environment-variable overrides):
+The following auth values must be coordinated between the Flask app config and
+this server's `config.json` (or its environment-variable overrides):
 
-| Flask app config              | WebSocket server config       |
-| ----------------------------- | ----------------------------- |
-| `WEBSOCKET_JWT_SECRET`        | `jwtSecret` / `JWT_SECRET`    |
-| `WEBSOCKET_JWT_COOKIE_NAME`   | `jwtCookieName` / `JWT_COOKIE_NAME` |
+| Purpose                     | Flask app config            | WebSocket server config                     |
+| --------------------------- | --------------------------- | ------------------------------------------- |
+| Current signing/verify key  | `WEBSOCKET_JWT_SECRET`      | `jwtSecret` / `JWT_SECRET`                  |
+| Previous verify-only key    | not needed                  | `previousJwtSecret` / `PREVIOUS_JWT_SECRET` |
+| Cookie name                 | `WEBSOCKET_JWT_COOKIE_NAME` | `jwtCookieName` / `JWT_COOKIE_NAME`         |
 
 The Redis connection (`redis` / `REDIS_*`) must point at the same Redis instance
 Superset publishes to (`DISTRIBUTED_COORDINATION_CONFIG`). The Pub/Sub channel
@@ -200,14 +220,17 @@ an alternate entrypoint, so no separate image is required:
 ```bash
 docker run --rm -p 8080:8080 \
   -e JWT_SECRET="<same value as the app's WEBSOCKET_JWT_SECRET, >= 32 bytes>" \
+  -e PREVIOUS_JWT_SECRET="<old websocket JWT secret during rotation, optional>" \
   -e REDIS_HOST=<redis-host> \
   apache/superset:<tag> /app/docker/entrypoints/run-websocket.sh
 ```
 
 Configure it with the same environment variables as the standalone server (see
 `src/config.ts`); `JWT_SECRET` / `JWT_COOKIE_NAME` must match the Flask app's
-`WEBSOCKET_JWT_SECRET` / `WEBSOCKET_JWT_COOKIE_NAME`, and the Redis connection
-must point at the same instance as `DISTRIBUTED_COORDINATION_CONFIG`.
+`WEBSOCKET_JWT_SECRET` / `WEBSOCKET_JWT_COOKIE_NAME`,
+`PREVIOUS_JWT_SECRET` can hold the prior websocket JWT secret during rotation,
+and the Redis connection must point at the same instance as
+`DISTRIBUTED_COORDINATION_CONFIG`.
 
 With `docker compose`, start it via the opt-in `websocket` profile:
 

--- a/superset-websocket/config.example.json
+++ b/superset-websocket/config.example.json
@@ -17,6 +17,7 @@
   },
   "jwtAlgorithms": ["HS256"],
   "jwtSecret": "CHANGE-ME",
+  "previousJwtSecret": "",
   "jwtCookieName": "superset-ws-token",
   "allowedOrigins": []
 }

--- a/superset-websocket/config.test.json
+++ b/superset-websocket/config.test.json
@@ -9,5 +9,6 @@
     "globalTags": []
   },
   "jwtSecret": "test123-test123-test123-test123-test123-test123-test123",
+  "previousJwtSecret": "old123-old123-old123-old123-old123-old123-old123",
   "jwtCookieName": "test-ws-token"
 }

--- a/superset-websocket/package.json
+++ b/superset-websocket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "superset-websocket",
   "version": "0.0.1",
-  "description": "Websocket sidecar application for Superset",
+  "description": "Websocket server application for Superset",
   "type": "module",
   "main": "dist/index.cjs",
   "scripts": {

--- a/superset-websocket/spec/config.test.ts
+++ b/superset-websocket/spec/config.test.ts
@@ -25,6 +25,9 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   expect(config.jwtSecret).toEqual(
     'test123-test123-test123-test123-test123-test123-test123',
   );
+  expect(config.previousJwtSecret).toEqual(
+    'old123-old123-old123-old123-old123-old123-old123',
+  );
   expect(config.redis.host).toEqual('127.0.0.1');
   expect(config.redis.port).toEqual(6379);
   expect(config.redis.password).toEqual('some pwd');
@@ -35,6 +38,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   expect(config.statsd.globalTags).toEqual([]);
 
   process.env.JWT_SECRET = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  process.env.PREVIOUS_JWT_SECRET = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
   process.env.REDIS_HOST = '10.10.10.10';
   process.env.REDIS_PORT = '6380';
   process.env.REDIS_PASSWORD = 'admin';
@@ -47,6 +51,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   config = buildConfig();
 
   expect(config.jwtSecret).toEqual('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  expect(config.previousJwtSecret).toEqual('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
   expect(config.redis.host).toEqual('10.10.10.10');
   expect(config.redis.port).toEqual(6380);
   expect(config.redis.password).toEqual('admin');
@@ -57,6 +62,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   expect(config.statsd.globalTags).toEqual(['tag-1', 'tag-2']);
 
   delete process.env.JWT_SECRET;
+  delete process.env.PREVIOUS_JWT_SECRET;
   delete process.env.REDIS_HOST;
   delete process.env.REDIS_PORT;
   delete process.env.REDIS_PASSWORD;

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -807,6 +807,16 @@ describe('server', () => {
       expect(wssUpgradeSpy).toHaveBeenCalled();
     });
 
+    test('valid upgrade with previous JWT secret', async () => {
+      const validToken = signRealtimeToken({}, config.previousJwtSecret);
+      const request = getRequest(validToken, 'http://localhost');
+
+      server.httpUpgrade(request, socket, Buffer.alloc(5));
+
+      expect(socketDestroySpy).not.toHaveBeenCalled();
+      expect(wssUpgradeSpy).toHaveBeenCalled();
+    });
+
     describe('origin validation', () => {
       afterEach(() => {
         server.opts.allowedOrigins = [];

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -44,6 +44,7 @@ type ConfigType = {
   redis: RedisConfig;
   jwtAlgorithms: string[];
   jwtSecret: string;
+  previousJwtSecret: string;
   jwtCookieName: string;
   jwtChannelIdKey: string;
   allowedOrigins: string[];
@@ -64,6 +65,7 @@ function defaultConfig(): ConfigType {
     logFilename: 'app.log',
     jwtAlgorithms: ['HS256'],
     jwtSecret: '',
+    previousJwtSecret: '',
     jwtCookieName: 'superset-ws-token',
     jwtChannelIdKey: 'channel',
     allowedOrigins: [],
@@ -139,6 +141,7 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
     LOG_TO_FILE: val => (config.logToFile = toBoolean(val)),
     LOG_FILENAME: val => (config.logFilename = val),
     JWT_SECRET: val => (config.jwtSecret = val),
+    PREVIOUS_JWT_SECRET: val => (config.previousJwtSecret = val),
     JWT_COOKIE_NAME: val => (config.jwtCookieName = val),
     ALLOWED_ORIGINS: val => (config.allowedOrigins = toStringArray(val)),
     SOCKET_RESPONSE_TIMEOUT_MS: val =>

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -301,6 +301,7 @@ export const sendToChannel = (
     logger.debug(`channel ${channel} is unknown, skipping`);
     return;
   }
+  let sentCount = 0;
   channels[channel].sockets.forEach(socketId => {
     const socketInstance: SocketInstance = sockets[socketId];
     if (!socketInstance) return cleanChannel(channel);
@@ -328,6 +329,7 @@ export const sendToChannel = (
     }
     try {
       socketInstance.ws.send(strData);
+      sentCount += 1;
     } catch (err) {
       statsd.increment('ws_client_send_error');
       logger.debug(`Error sending to socket: ${err}`);
@@ -335,6 +337,9 @@ export const sendToChannel = (
       cleanChannel(channel);
     }
   });
+  logger.debug(
+    `Forwarded message ${message.channel} to ${sentCount} socket(s) on channel ${channel}`,
+  );
 };
 
 /**

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -110,17 +110,27 @@ export const statsd = new StatsD({
   },
 });
 
-// enforce JWT secret length
-if (startServer && opts.jwtSecret.length < 32) {
-  logger.error('Please provide a JWT secret at least 32 bytes long');
-  process.exit(1);
-}
+const validateConfiguredJwtSecret = (
+  secret: string,
+  name: string,
+  required = false,
+) => {
+  if (!secret && !required) return;
+  if (secret.length < 32) {
+    logger.error(`Please provide a ${name} at least 32 bytes long`);
+    process.exit(1);
+  }
+  if (secret.startsWith('CHANGE-ME')) {
+    logger.warn(
+      `It appears your ${name} in your config.json is insecure. ` +
+        'DO NOT USE IN PRODUCTION',
+    );
+  }
+};
 
-if (startServer && opts.jwtSecret.startsWith('CHANGE-ME')) {
-  logger.warn(
-    'It appears your secret in your config.json is insecure. ' +
-      'DO NOT USE IN PRODUCTION',
-  );
+if (startServer) {
+  validateConfiguredJwtSecret(opts.jwtSecret, 'JWT secret', true);
+  validateConfiguredJwtSecret(opts.previousJwtSecret, 'previous JWT secret');
 }
 
 export const buildRedisOpts = (baseConfig: RedisConfig) => {
@@ -489,17 +499,35 @@ export const subscribeToChannels = async (): Promise<void> => {
 /**
  * Verify and parse a realtime JWT cookie from an HTTP request.
  */
+const verifyRealtimeJwt = (token: string): RealtimeJwtPayload => {
+  let lastError: unknown;
+  const acceptedSecrets = [opts.jwtSecret, opts.previousJwtSecret].filter(
+    secret => secret.length > 0,
+  );
+
+  for (const secret of acceptedSecrets) {
+    try {
+      return jwt.verify(token, secret, {
+        algorithms: opts.jwtAlgorithms as Algorithm[],
+        audience: REALTIME_JWT_AUDIENCE,
+        complete: false,
+        issuer: REALTIME_JWT_ISSUER,
+      }) as RealtimeJwtPayload;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  if (lastError instanceof Error) throw lastError;
+  throw new Error('JWT verification failed');
+};
+
 const readSocketIdentity = (request: http.IncomingMessage): SocketIdentity => {
   const cookies = parseCookie(request.headers.cookie || '');
   const token = cookies[opts.jwtCookieName];
 
   if (!token) throw new Error('JWT not present');
-  const jwtPayload = jwt.verify(token, opts.jwtSecret, {
-    algorithms: opts.jwtAlgorithms as Algorithm[],
-    audience: REALTIME_JWT_AUDIENCE,
-    complete: false,
-    issuer: REALTIME_JWT_ISSUER,
-  }) as RealtimeJwtPayload;
+  const jwtPayload = verifyRealtimeJwt(token);
   const channelId = jwtPayload[opts.jwtChannelIdKey];
   const subject = jwtPayload.sub;
   const principalType = jwtPayload.principal_type;

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -56,6 +56,8 @@ class QueryContext:
     result_format: ChartDataResultFormat
     force: bool
     custom_cache_timeout: int | None
+    contribution_queries: list[int]
+    contribution_totals_idx: int | None
 
     # Set by the async chart-data execution path (see
     # superset.tasks.async_queries.execute_chart_query). The async flow caches a
@@ -92,7 +94,41 @@ class QueryContext:
         self.force = force
         self.custom_cache_timeout = custom_cache_timeout
         self.cache_values = cache_values
+        (
+            self.contribution_queries,
+            self.contribution_totals_idx,
+        ) = self._normalize_contribution_totals()
         self._processor = QueryContextProcessor(self)
+
+    def _normalize_contribution_totals(self) -> tuple[list[int], int | None]:
+        """Normalize contribution totals before any cache key is computed."""
+        queries_needing_totals: list[int] = []
+        totals_idx: int | None = None
+
+        for index, query in enumerate(self.queries):
+            if any(
+                post_processing.get("operation") == "contribution"
+                for post_processing in query.post_processing or []
+            ):
+                queries_needing_totals.append(index)
+
+            if (
+                totals_idx is None
+                and not query.columns
+                and query.metrics
+                and not query.post_processing
+            ):
+                totals_idx = index
+
+        if queries_needing_totals and totals_idx is not None:
+            self.queries[totals_idx].row_limit = None
+            raw_queries = self.cache_values.get("queries", [])
+            if totals_idx < len(raw_queries) and isinstance(
+                raw_queries[totals_idx], dict
+            ):
+                raw_queries[totals_idx]["row_limit"] = None
+
+        return queries_needing_totals, totals_idx
 
     def get_data(
         self,
@@ -145,11 +181,13 @@ class QueryContext:
 
         Returns the indices of queries whose contribution post-processing needs a
         shared totals row, and the index of the totals query itself (or ``None``).
-        As a side effect the totals query's ``row_limit`` is cleared so its cache
-        key matches the entry its dependents read — see the synchronous equivalent
-        in ``QueryContextProcessor.get_payload_result``.
+        The normalization is idempotent and runs at construction time as well.
         """
-        return self._processor._prepare_contribution_totals()
+        (
+            self.contribution_queries,
+            self.contribution_totals_idx,
+        ) = self._normalize_contribution_totals()
+        return self.contribution_queries, self.contribution_totals_idx
 
     def get_df_payload(
         self,

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -56,6 +56,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         result_format: ChartDataResultFormat | None = None,
         force: bool = False,
         custom_cache_timeout: int | None = None,
+        preserve_null_row_limit: bool = False,
     ) -> QueryContext:
         datasource_model_instance = None
         if datasource:
@@ -88,6 +89,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                         "BaseDatasource", datasource_model_instance
                     ),
                     server_pagination=server_pagination,
+                    preserve_null_row_limit=preserve_null_row_limit,
                     **query_obj,
                 ),
             )

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -455,6 +455,11 @@ class QueryContextProcessor:
         if queries_needing_totals and totals_idx is not None:
             totals_query = self._query_context.queries[totals_idx]
             totals_query.row_limit = None
+            raw_queries = self._query_context.cache_values.get("queries", [])
+            if totals_idx < len(raw_queries) and isinstance(
+                raw_queries[totals_idx], dict
+            ):
+                raw_queries[totals_idx]["row_limit"] = None
 
         return queries_needing_totals, totals_idx
 

--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -37,13 +37,6 @@ if TYPE_CHECKING:
     from superset.daos.datasource import DatasourceDAO
 
 
-class _RowLimitUnset:
-    """Sentinel distinguishing omitted row_limit from explicit null."""
-
-
-_ROW_LIMIT_UNSET = _RowLimitUnset()
-
-
 class QueryObjectFactory:  # pylint: disable=too-few-public-methods
     _config: dict[str, Any]
     _datasource_dao: DatasourceDAO
@@ -61,11 +54,12 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         parent_result_type: ChartDataResultType,
         datasource: DatasourceDict | None = None,
         extras: dict[str, Any] | None = None,
-        row_limit: int | None | _RowLimitUnset = _ROW_LIMIT_UNSET,
+        row_limit: int | None = None,
         time_range: str | None = None,
         time_shift: str | None = None,
         server_pagination: bool | None = None,
         datasource_model_instance: BaseDatasource | None = None,
+        preserve_null_row_limit: bool = False,
         **kwargs: Any,
     ) -> QueryObject:
         if datasource_model_instance is None and datasource:
@@ -81,7 +75,10 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
 
         # Process row limit taking server pagination into account
         row_limit = self._process_row_limit(
-            row_limit, result_type, server_pagination=server_pagination
+            row_limit,
+            result_type,
+            server_pagination=server_pagination,
+            preserve_null_row_limit=preserve_null_row_limit,
         )
 
         processed_time_range = self._process_time_range(
@@ -116,18 +113,20 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
 
     def _process_row_limit(
         self,
-        row_limit: int | None | _RowLimitUnset,
+        row_limit: int | None,
         result_type: ChartDataResultType,
         server_pagination: bool | None = None,
+        preserve_null_row_limit: bool = False,
     ) -> int | None:
         """Process row limit taking into account server pagination.
 
         :param row_limit: The requested row limit
         :param result_type: The type of result being processed
         :param server_pagination: Whether server-side pagination is enabled
+        :param preserve_null_row_limit: Whether explicit null means no limit
         :return: The processed row limit
         """
-        if row_limit is None:
+        if row_limit is None and preserve_null_row_limit:
             return None
 
         default_row_limit = (
@@ -135,13 +134,8 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
             if result_type == ChartDataResultType.SAMPLES
             else self._config["ROW_LIMIT"]
         )
-        requested_limit = (
-            default_row_limit
-            if row_limit is _ROW_LIMIT_UNSET or row_limit == 0
-            else cast(int, row_limit)
-        )
         return apply_max_row_limit(
-            requested_limit,
+            row_limit or default_row_limit,
             server_pagination=server_pagination,
         )
 

--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -37,6 +37,13 @@ if TYPE_CHECKING:
     from superset.daos.datasource import DatasourceDAO
 
 
+class _RowLimitUnset:
+    """Sentinel distinguishing omitted row_limit from explicit null."""
+
+
+_ROW_LIMIT_UNSET = _RowLimitUnset()
+
+
 class QueryObjectFactory:  # pylint: disable=too-few-public-methods
     _config: dict[str, Any]
     _datasource_dao: DatasourceDAO
@@ -54,7 +61,7 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         parent_result_type: ChartDataResultType,
         datasource: DatasourceDict | None = None,
         extras: dict[str, Any] | None = None,
-        row_limit: int | None = None,
+        row_limit: int | None | _RowLimitUnset = _ROW_LIMIT_UNSET,
         time_range: str | None = None,
         time_shift: str | None = None,
         server_pagination: bool | None = None,
@@ -109,10 +116,10 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
 
     def _process_row_limit(
         self,
-        row_limit: int | None,
+        row_limit: int | None | _RowLimitUnset,
         result_type: ChartDataResultType,
         server_pagination: bool | None = None,
-    ) -> int:
+    ) -> int | None:
         """Process row limit taking into account server pagination.
 
         :param row_limit: The requested row limit
@@ -120,13 +127,21 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         :param server_pagination: Whether server-side pagination is enabled
         :return: The processed row limit
         """
+        if row_limit is None:
+            return None
+
         default_row_limit = (
             self._config["SAMPLES_ROW_LIMIT"]
             if result_type == ChartDataResultType.SAMPLES
             else self._config["ROW_LIMIT"]
         )
+        requested_limit = (
+            default_row_limit
+            if row_limit is _ROW_LIMIT_UNSET or row_limit == 0
+            else cast(int, row_limit)
+        )
         return apply_max_row_limit(
-            row_limit or default_row_limit,
+            requested_limit,
             server_pagination=server_pagination,
         )
 

--- a/superset/common/query_serialization.py
+++ b/superset/common/query_serialization.py
@@ -39,7 +39,7 @@ no custom encoder.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING, TypedDict
+from typing import Any, NotRequired, TYPE_CHECKING, TypedDict
 
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
 from superset.utils.core import DatasourceDict
@@ -58,6 +58,19 @@ class SerializedQuery(TypedDict):
     result_format: str
     force: bool
     custom_cache_timeout: int | None
+    preserve_null_row_limit: NotRequired[bool]
+
+
+def _preserve_null_row_limit(
+    query_context: "QueryContext",
+    query_index: int,
+) -> bool:
+    raw_query = query_context.cache_values["queries"][query_index]
+    return (
+        "row_limit" in raw_query
+        and raw_query["row_limit"] is None
+        and query_context.queries[query_index].row_limit is None
+    )
 
 
 def serialize_query(query_context: "QueryContext", query_index: int) -> SerializedQuery:
@@ -73,7 +86,7 @@ def serialize_query(query_context: "QueryContext", query_index: int) -> Serializ
     :returns: a JSON-safe :class:`SerializedQuery`
     """
     cache_values = query_context.cache_values
-    return SerializedQuery(
+    payload = SerializedQuery(
         datasource=cache_values["datasource"],
         query=cache_values["queries"][query_index],
         form_data=query_context.form_data,
@@ -82,6 +95,9 @@ def serialize_query(query_context: "QueryContext", query_index: int) -> Serializ
         force=query_context.force,
         custom_cache_timeout=query_context.custom_cache_timeout,
     )
+    if _preserve_null_row_limit(query_context, query_index):
+        payload["preserve_null_row_limit"] = True
+    return payload
 
 
 def load_serialized_query(payload: SerializedQuery) -> "QueryContext":
@@ -97,12 +113,27 @@ def load_serialized_query(payload: SerializedQuery) -> "QueryContext":
     """
     from superset.common.query_context_factory import QueryContextFactory
 
-    return QueryContextFactory().create(
+    factory = QueryContextFactory()
+    result_type = ChartDataResultType(payload["result_type"])
+    result_format = ChartDataResultFormat(payload["result_format"])
+    if payload.get("preserve_null_row_limit"):
+        return factory.create(
+            datasource=payload["datasource"],
+            queries=[payload["query"]],
+            form_data=payload["form_data"],
+            result_type=result_type,
+            result_format=result_format,
+            force=payload["force"],
+            custom_cache_timeout=payload["custom_cache_timeout"],
+            preserve_null_row_limit=True,
+        )
+
+    return factory.create(
         datasource=payload["datasource"],
         queries=[payload["query"]],
         form_data=payload["form_data"],
-        result_type=ChartDataResultType(payload["result_type"]),
-        result_format=ChartDataResultFormat(payload["result_format"]),
+        result_type=result_type,
+        result_format=result_format,
         force=payload["force"],
         custom_cache_timeout=payload["custom_cache_timeout"],
     )

--- a/superset/config.py
+++ b/superset/config.py
@@ -2973,10 +2973,12 @@ GLOBAL_ASYNC_QUERIES_DEFAULT = True
 # The JWT authenticates the socket connection and binds it to its channel; the
 # server delivers targeted task-status events only to matching principal
 # sockets. Set a strong random WEBSOCKET_JWT_SECRET (>= 32 bytes) in production.
+# The websocket server can be configured with a previous validation secret
+# during rotations; the Flask app always mints new cookies with the current key.
 # The websocket server validates the signed token at connection time and
 # terminates sockets after JWT expiry, so post-mint permission revocation is
 # bounded by this lifetime plus the server ping interval.
-ENABLE_WEBSOCKET = False
+WEBSOCKET_ENABLE = False
 WEBSOCKET_URL = "ws://127.0.0.1:8080/"
 WEBSOCKET_JWT_SECRET = CHANGE_ME_WEBSOCKET_JWT_SECRET
 WEBSOCKET_JWT_COOKIE_NAME = "superset-ws-token"  # noqa: S105

--- a/superset/daos/base.py
+++ b/superset/daos/base.py
@@ -207,6 +207,10 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
     """
     Child classes can register base filtering to be applied to all filter methods
     """
+    force_fetch: ClassVar[bool] = False
+    """
+    Child classes can force ORM fetch helpers to refresh already-loaded rows.
+    """
     id_column_name: ClassVar[str] = "id"
     uuid_column_name: ClassVar[str] = "uuid"
 
@@ -226,17 +230,29 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         )[0]
 
     @classmethod
+    def _query(cls, force_fetch: bool | None = None) -> Query:
+        """
+        Return a model query, optionally refreshing identity-map instances.
+        """
+        query = db.session.query(cls.model_cls)
+        should_force_fetch = cls.force_fetch if force_fetch is None else force_fetch
+        if should_force_fetch:
+            query = query.populate_existing()
+        return query
+
+    @classmethod
     def find_by_id_or_uuid(
         cls,
         model_id_or_uuid: str,
         skip_base_filter: bool = False,
         *,
         skip_visibility_filter: bool = False,
+        force_fetch: bool | None = None,
     ) -> T | None:
         """
         Find a model by id or uuid, if defined applies `base_filter`
         """
-        query = db.session.query(cls.model_cls)
+        query = cls._query(force_fetch)
         if skip_visibility_filter:
             query = query.execution_options(
                 **{SKIP_VISIBILITY_FILTER_CLASSES: {cls.model_cls}}
@@ -306,6 +322,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         query_options: list[Any] | None = None,
         *,
         skip_visibility_filter: bool = False,
+        force_fetch: bool | None = None,
     ) -> T | None:
         """
         Private method to find a model by any column value.
@@ -317,11 +334,12 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             skip_visibility_filter: Whether to skip the soft-delete visibility filter
             query_options: SQLAlchemy query options (e.g., joinedload,
                 subqueryload) to apply to the query for eager loading
+            force_fetch: Whether to refresh already-loaded identity-map instances
 
         Returns:
             Model instance or None if not found
         """
-        query = db.session.query(cls.model_cls)
+        query = cls._query(force_fetch)
         if skip_visibility_filter:
             query = query.execution_options(
                 **{SKIP_VISIBILITY_FILTER_CLASSES: {cls.model_cls}}
@@ -354,6 +372,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         query_options: list[Any] | None = None,
         *,
         skip_visibility_filter: bool = False,
+        force_fetch: bool | None = None,
     ) -> T | None:
         """
         Find a model by ID using specified or default ID column.
@@ -366,6 +385,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                 subqueryload) to apply to the query for eager loading
             skip_visibility_filter: Keyword-only. Whether to skip the
                 soft-delete visibility filter
+            force_fetch: Whether to refresh already-loaded identity-map instances
 
         Returns:
             Model instance or None if not found
@@ -377,6 +397,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
             skip_base_filter,
             query_options,
             skip_visibility_filter=skip_visibility_filter,
+            force_fetch=force_fetch,
         )
 
     @classmethod
@@ -387,6 +408,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         id_column: str | None = None,
         *,
         skip_visibility_filter: bool = False,
+        force_fetch: bool | None = None,
     ) -> list[T]:
         """
         Find a List of models by a list of ids, if defined applies `base_filter`
@@ -397,6 +419,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
                          (defaults to id_column_name)
         :param skip_visibility_filter: Keyword-only. If true, skip the
             soft-delete visibility filter so soft-deleted rows are returned
+        :param force_fetch: Whether to refresh already-loaded identity-map instances
         """
         column = id_column or cls.id_column_name
         id_col = getattr(cls.model_cls, column, None)
@@ -423,7 +446,7 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         if not converted_ids:
             return []
 
-        query = db.session.query(cls.model_cls)
+        query = cls._query(force_fetch)
         if skip_visibility_filter:
             query = query.execution_options(
                 **{SKIP_VISIBILITY_FILTER_CLASSES: {cls.model_cls}}
@@ -442,22 +465,28 @@ class BaseDAO(CoreBaseDAO[T], Generic[T]):
         return results
 
     @classmethod
-    def find_all(cls, skip_base_filter: bool = False) -> list[T]:
+    def find_all(
+        cls, skip_base_filter: bool = False, *, force_fetch: bool | None = None
+    ) -> list[T]:
         """
         Get all that fit the `base_filter`
         """
-        query = db.session.query(cls.model_cls)
+        query = cls._query(force_fetch)
         query = cls._apply_base_filter(query, skip_base_filter)
         return query.all()
 
     @classmethod
     def find_one_or_none(
-        cls, skip_base_filter: bool = False, **filter_by: Any
+        cls,
+        skip_base_filter: bool = False,
+        *,
+        force_fetch: bool | None = None,
+        **filter_by: Any,
     ) -> T | None:
         """
         Get the first that fit the `base_filter`
         """
-        query = db.session.query(cls.model_cls)
+        query = cls._query(force_fetch)
         query = cls._apply_base_filter(query, skip_base_filter)
         return query.filter_by(**filter_by).one_or_none()
 

--- a/superset/daos/database.py
+++ b/superset/daos/database.py
@@ -85,6 +85,7 @@ class DatabaseDAO(BaseDAO[Database]):
         query_options: list[Any] | None = None,
         *,
         skip_visibility_filter: bool = False,
+        force_fetch: bool | None = None,
     ) -> Database | None:
         """
         Find a database by id, eagerly loading the SSH tunnel relationship.
@@ -92,7 +93,7 @@ class DatabaseDAO(BaseDAO[Database]):
         all_options = [joinedload(Database.ssh_tunnel)]
         if query_options:
             all_options.extend(query_options)
-        query = db.session.query(cls.model_cls).options(*all_options)
+        query = cls._query(force_fetch).options(*all_options)
         if skip_visibility_filter:
             query = query.execution_options(
                 **{SKIP_VISIBILITY_FILTER_CLASSES: {cls.model_cls}}

--- a/superset/daos/semantic_layer.py
+++ b/superset/daos/semantic_layer.py
@@ -53,8 +53,10 @@ class SemanticLayerDAO(BaseDAO[SemanticLayer], AbstractSemanticLayerDAO):
             return None
 
     @classmethod
-    def find_all(cls, skip_base_filter: bool = False) -> list[SemanticLayer]:
-        query = db.session.query(SemanticLayer)
+    def find_all(
+        cls, skip_base_filter: bool = False, *, force_fetch: bool | None = None
+    ) -> list[SemanticLayer]:
+        query = cls._query(force_fetch)
         query = cls._apply_base_filter(query, skip_base_filter)
         if not security_manager.can_access_all_datasources():
             perms = security_manager.user_view_menu_names("datasource_access")

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -54,6 +54,10 @@ class TaskDAO(BaseDAO[Task]):
     """
 
     base_filter = TaskFilter
+    # Task rows are cross-worker state. A Celery worker can hold a ``Task``
+    # instance while another worker commits a status transition for the same row,
+    # so TaskDAO entity lookups refresh identity-map instances by default.
+    force_fetch = True
 
     @classmethod
     def get_status(cls, task_uuid: UUID) -> str | None:
@@ -68,7 +72,7 @@ class TaskDAO(BaseDAO[Task]):
         :returns: Task status string, or None if task not found or not accessible
         """
         # Start with query on Task model so base filter can be applied
-        query = db.session.query(Task)
+        query = cls._query()
         query = cls._apply_base_filter(query)
         query = query.filter(Task.uuid == task_uuid)
 
@@ -173,7 +177,7 @@ class TaskDAO(BaseDAO[Task]):
         )
 
         # Simple single-column query with unique index
-        return db.session.query(Task).filter(Task.dedup_key == dedup_key).one_or_none()
+        return cls._query().filter(Task.dedup_key == dedup_key).one_or_none()
 
     @classmethod
     def create_task(
@@ -519,7 +523,7 @@ class TaskDAO(BaseDAO[Task]):
         """
         if not uuids:
             return []
-        return db.session.query(Task).filter(Task.uuid.in_(uuids)).all()
+        return cls._query().filter(Task.uuid.in_(uuids)).all()
 
     @classmethod
     def add_dependencies(cls, task_id: int, depends_on_task_ids: list[int]) -> None:

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -552,6 +552,36 @@ class TaskDAO(BaseDAO[Task]):
         )
 
     @classmethod
+    def get_dependency_payloads(cls, task_uuid: UUID) -> list[dict[str, Any]]:
+        """
+        Return payload dictionaries for a task's prerequisite dependencies.
+
+        The query reads scalar payload columns through the dependency table so
+        task code observes committed prerequisite output without relying on
+        identity-map state from an earlier relationship load.
+
+        :param task_uuid: UUID of the dependent task
+        :returns: prerequisite payloads in dependency edge order
+        """
+        task_id = (
+            db.session.query(Task.id).filter(Task.uuid == task_uuid).scalar_subquery()
+        )
+        rows = (
+            db.session.query(Task.payload)
+            .join(TaskDependency, TaskDependency.depends_on_task_id == Task.id)
+            .filter(TaskDependency.task_id == task_id)
+            .order_by(TaskDependency.id.asc())
+            .all()
+        )
+        payloads: list[dict[str, Any]] = []
+        for (payload,) in rows:
+            try:
+                payloads.append(json.loads(payload or "{}"))
+            except (json.JSONDecodeError, TypeError):
+                payloads.append({})
+        return payloads
+
+    @classmethod
     def set_properties_and_payload(
         cls,
         task_uuid: UUID,

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -1137,13 +1137,13 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
     def check_websocket_secret(self) -> None:
         """Refuse to start with a default/weak websocket JWT secret when enabled."""
-        if not self.config.get("ENABLE_WEBSOCKET"):
+        if not self.config.get("WEBSOCKET_ENABLE"):
             return
         secret = self.config.get("WEBSOCKET_JWT_SECRET") or ""
         if secret != CHANGE_ME_WEBSOCKET_JWT_SECRET and len(secret) >= 32:
             return
         self._log_config_warning(
-            "ENABLE_WEBSOCKET is on but WEBSOCKET_JWT_SECRET is the default "
+            "WEBSOCKET_ENABLE is on but WEBSOCKET_JWT_SECRET is the default "
             "placeholder or shorter than 32 bytes.\n"
             "The default is publicly known; a weak secret lets an attacker forge "
             "channel tokens and subscribe to another user's private channel.\n"
@@ -1153,7 +1153,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         if self.superset_app.debug or self.superset_app.config["TESTING"] or is_test():
             return
         logger.error(
-            "Refusing to start: insecure WEBSOCKET_JWT_SECRET with ENABLE_WEBSOCKET"
+            "Refusing to start: insecure WEBSOCKET_JWT_SECRET with WEBSOCKET_ENABLE"
         )
         sys.exit(1)
 
@@ -1631,7 +1631,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
 
     def configure_websocket(self) -> None:
         """Mint the websocket channel-token cookie when the transport is enabled."""
-        if self.config.get("ENABLE_WEBSOCKET"):
+        if self.config.get("WEBSOCKET_ENABLE"):
             from superset.websocket.channel import register_ws_channel_cookie
 
             register_ws_channel_cookie(self.superset_app)

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -34,6 +34,7 @@ from superset.exceptions import SupersetException
 from superset.extensions import (
     security_manager,
 )
+from superset.tasks.ambient_context import get_context
 from superset.tasks.decorators import task
 from superset.utils.core import override_user
 
@@ -54,6 +55,7 @@ logger = logging.getLogger(__name__)
 # is no coordinator task). The atomic unit is a QueryObject, not chart-specific, so the
 # type is versioned to allow the serialization/execution contract to evolve.
 CHART_QUERY_TASK = "superset.query_object_v1"
+CACHE_KEY_PAYLOAD_KEY = "cache_key"
 
 
 def _resolve_user(user_id: int | None, guest_token: "GuestToken | None") -> User:
@@ -103,6 +105,21 @@ def _inject_contribution_totals(
             post_processing.setdefault("options", {})["contribution_totals"] = totals
 
 
+def _get_dependency_cache_key() -> str:
+    """
+    Return the cache key published by a prerequisite chart-data task.
+
+    A dependent task reaches this point only after the scheduler's all-success
+    dependency gate has passed, so prerequisite payloads are expected to contain
+    any output metadata their task body committed.
+    """
+    for payload in get_context().get_dependency_payloads():
+        cache_key = payload.get(CACHE_KEY_PAYLOAD_KEY)
+        if isinstance(cache_key, str):
+            return cache_key
+    raise SupersetException("Prerequisite task did not publish a cache key")
+
+
 # No timeout is set on these tasks yet: GTF enforces a timeout by aborting the
 # task, but chart-data queries have no abort handler to cancel the underlying
 # warehouse query, so a timeout would only mark the task failed while the query
@@ -112,7 +129,7 @@ def execute_chart_query(
     serialized_query: SerializedQuery,
     user_id: int | None = None,
     guest_token: "GuestToken | None" = None,
-    totals_cache_key: str | None = None,
+    requires_totals: bool = False,
 ) -> None:
     """Execute a single chart-data query and cache it under its query_cache_key.
 
@@ -127,10 +144,12 @@ def execute_chart_query(
         # request to read back (see get_cache_timeout).
         query_context.is_async_execution = True
         query_obj = query_context.queries[0]
-        if totals_cache_key:
-            _inject_contribution_totals(query_obj, totals_cache_key)
+        if requires_totals:
+            _inject_contribution_totals(query_obj, _get_dependency_cache_key())
         # Executes on cache miss and writes CacheRegion.DATA under query_cache_key.
-        query_context.get_df_payload_result(query_obj)
+        result = query_context.get_df_payload_result(query_obj)
+        if cache_key := result.payload.get(CACHE_KEY_PAYLOAD_KEY):
+            get_context().update_task(payload={CACHE_KEY_PAYLOAD_KEY: cache_key})
 
 
 def _query_task_cache_key(query_context: "QueryContext", index: int) -> str | None:
@@ -183,14 +202,15 @@ def submit_chart_data_query_tasks(
     queries = query_context.queries
     # Contribution queries normalize against a shared totals row. Identify the coupling
     # (this also clears the totals query's row_limit so its cache key matches the entry
-    # its dependents read) and compute the totals key up front.
+    # its dependents read).
     needs_totals, totals_idx = query_context.prepare_contribution_totals()
-    totals_key: str | None = None
-    if needs_totals and totals_idx is not None:
-        # Mirror the row_limit normalization into the raw serialized dict so the totals
-        # task caches under the same key its dependents (and the re-request) compute.
-        query_context.cache_values["queries"][totals_idx]["row_limit"] = None
-        totals_key = _query_task_cache_key(query_context, totals_idx)
+
+    query_cache_keys = [
+        _query_task_cache_key(query_context, index) for index in range(len(queries))
+    ]
+    serialized_queries = [
+        serialize_query(query_context, index) for index in range(len(queries))
+    ]
 
     def _task_name(index: int) -> str | None:
         """A human-friendly Task List label from the in-memory QueryContext.
@@ -215,12 +235,12 @@ def submit_chart_data_query_tasks(
         depends_on: "list[CoreTask | UUID | str] | None" = None,
     ) -> "Task":
         return execute_chart_query.schedule(
-            serialize_query(query_context, index),
+            serialized_queries[index],
             user_id,
             guest_token,
-            totals_key if index in needs_totals else None,
+            index in needs_totals,
             options=TaskOptions(
-                task_key=_query_task_cache_key(query_context, index),
+                task_key=query_cache_keys[index],
                 task_name=_task_name(index),
                 depends_on=depends_on,
             ),

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -212,6 +212,9 @@ def submit_chart_data_query_tasks(
         serialize_query(query_context, index) for index in range(len(queries))
     ]
 
+    def _needs_prerequisite_totals(index: int) -> bool:
+        return totals_idx is not None and index != totals_idx and index in needs_totals
+
     def _task_name(index: int) -> str | None:
         """A human-friendly Task List label from the in-memory QueryContext.
 
@@ -238,7 +241,7 @@ def submit_chart_data_query_tasks(
             serialized_queries[index],
             user_id,
             guest_token,
-            index in needs_totals,
+            _needs_prerequisite_totals(index),
             options=TaskOptions(
                 task_key=query_cache_keys[index],
                 task_name=_task_name(index),
@@ -252,11 +255,9 @@ def submit_chart_data_query_tasks(
         tasks[totals_idx] = _schedule(totals_idx)
     for index in range(len(queries)):
         if index not in tasks:
-            depends_on: "list[CoreTask | UUID | str] | None" = (
-                [tasks[totals_idx]]
-                if index in needs_totals and totals_idx is not None
-                else None
-            )
+            depends_on: "list[CoreTask | UUID | str] | None" = None
+            if totals_idx is not None and _needs_prerequisite_totals(index):
+                depends_on = [tasks[totals_idx]]
             tasks[index] = _schedule(index, depends_on=depends_on)
 
     return {

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -233,6 +233,17 @@ class TaskContext(CoreTaskContext):
                     self._deferred_flush_timer.daemon = True
                     self._deferred_flush_timer.start()
 
+    def get_dependency_payloads(self) -> list[dict[str, Any]]:
+        """
+        Return payloads published by prerequisite tasks.
+
+        Reads through the DAO so callers observe committed prerequisite output
+        after the DAG gate has accepted those tasks as successful.
+        """
+        from superset.daos.tasks import TaskDAO
+
+        return TaskDAO.get_dependency_payloads(self._task_uuid)
+
     def _write_to_db(self) -> None:
         """
         Write current cached state to database.

--- a/superset/views/base.py
+++ b/superset/views/base.py
@@ -95,7 +95,7 @@ FRONTEND_CONF_KEYS = (
     "GLOBAL_ASYNC_QUERIES_POLLING_MAX_DELAY",
     "GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT",
     "GLOBAL_ASYNC_QUERIES_DEFAULT",
-    "ENABLE_WEBSOCKET",
+    "WEBSOCKET_ENABLE",
     "WEBSOCKET_URL",
     "SQL_VALIDATORS_BY_ENGINE",
     "SQLALCHEMY_DOCS_URL",
@@ -660,10 +660,10 @@ def common_bootstrap_payload() -> dict[str, Any]:
     locale_str = str(locale) if locale else None
     payload = dict(cached_common_bootstrap_data(utils.get_user_id(), locale_str))
     frontend_config = payload.get("conf")
-    if isinstance(frontend_config, dict) and frontend_config.get("ENABLE_WEBSOCKET"):
+    if isinstance(frontend_config, dict) and frontend_config.get("WEBSOCKET_ENABLE"):
         payload["conf"] = {
             **frontend_config,
-            "ENABLE_WEBSOCKET": can_access_realtime_notifications(),
+            "WEBSOCKET_ENABLE": can_access_realtime_notifications(),
         }
     # The language pack itself is NOT embedded in the payload: spa.html loads
     # it through the content-addressed /language_pack/<lang>/<version>/script.js

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -109,7 +109,7 @@ class TestQueryObjectFactory:
         assert query_object.row_limit == 100
         assert query_object.row_offset == 200
 
-    def test_query_context_explicit_null_limit(
+    def test_query_context_null_limit_uses_default(
         self,
         query_object_factory: QueryObjectFactory,
         raw_query_context: dict[str, Any],
@@ -118,6 +118,21 @@ class TestQueryObjectFactory:
         raw_query_object["row_limit"] = None
         query_object = query_object_factory.create(
             raw_query_context["result_type"], **raw_query_object
+        )
+
+        assert query_object.row_limit == 5000
+
+    def test_query_context_can_preserve_explicit_null_limit(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["row_limit"] = None
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"],
+            preserve_null_row_limit=True,
+            **raw_query_object,
         )
 
         assert query_object.row_limit is None

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -109,6 +109,32 @@ class TestQueryObjectFactory:
         assert query_object.row_limit == 100
         assert query_object.row_offset == 200
 
+    def test_query_context_explicit_null_limit(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["row_limit"] = None
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+
+        assert query_object.row_limit is None
+
+    def test_query_context_zero_limit_uses_default(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["row_limit"] = 0
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+
+        assert query_object.row_limit == 5000
+
     def test_query_context_null_post_processing_op(
         self,
         query_object_factory: QueryObjectFactory,

--- a/tests/unit_tests/common/test_query_serialization.py
+++ b/tests/unit_tests/common/test_query_serialization.py
@@ -72,6 +72,26 @@ def test_serialized_query_is_json_safe() -> None:
     assert json.loads(json.dumps(payload)) == payload
 
 
+def test_serialize_query_does_not_preserve_defaulted_null_row_limit(
+    mocker: MockerFixture,
+) -> None:
+    ctx = mocker.MagicMock()
+    ctx.cache_values = {
+        "datasource": {"id": 1, "type": "table"},
+        "queries": [{"row_limit": None}],
+    }
+    ctx.queries = [mocker.MagicMock(row_limit=5000)]
+    ctx.form_data = None
+    ctx.result_type = ChartDataResultType.FULL
+    ctx.result_format = ChartDataResultFormat.JSON
+    ctx.force = False
+    ctx.custom_cache_timeout = None
+
+    payload = serialize_query(ctx, 0)
+
+    assert "preserve_null_row_limit" not in payload
+
+
 def test_load_serialized_query_rebuilds_via_factory(mocker: MockerFixture) -> None:
     factory_cls = mocker.patch(
         "superset.common.query_context_factory.QueryContextFactory"
@@ -158,6 +178,7 @@ def test_contribution_totals_round_trip_preserves_cache_key(
     serialized = serialize_query(query_context, totals_idx)
     rebuilt = load_serialized_query(serialized)
 
+    assert serialized["preserve_null_row_limit"] is True
     assert serialized["query"]["row_limit"] is None
     assert rebuilt.queries[0].row_limit is None
     assert rebuilt.query_cache_key(rebuilt.queries[0]) == totals_key

--- a/tests/unit_tests/common/test_query_serialization.py
+++ b/tests/unit_tests/common/test_query_serialization.py
@@ -93,3 +93,71 @@ def test_load_serialized_query_rebuilds_via_factory(mocker: MockerFixture) -> No
         force=True,
         custom_cache_timeout=42,
     )
+
+
+def test_contribution_totals_round_trip_preserves_cache_key(
+    mocker: MockerFixture,
+) -> None:
+    from superset.common.query_context_factory import QueryContextFactory
+
+    datasource = mocker.MagicMock()
+    datasource.uid = "table__1"
+    datasource.cache_timeout = None
+    datasource.changed_on = None
+    datasource.get_extra_cache_keys.return_value = []
+    datasource.database.extra = "{}"
+    datasource.database.impersonate_user = False
+    datasource.database.db_engine_spec.get_impersonation_key.return_value = None
+    mocker.patch(
+        "superset.common.query_context_factory.DatasourceDAO.get_datasource",
+        return_value=datasource,
+    )
+    mocker.patch(
+        "superset.common.query_context_processor.security_manager.get_rls_cache_key",
+        return_value=None,
+    )
+
+    contribution = {
+        "operation": "contribution",
+        "options": {
+            "columns": ["sum__num"],
+            "rename_columns": ["%sum__num"],
+        },
+    }
+    query_context = QueryContextFactory().create(
+        datasource={"id": 1, "type": "table"},
+        queries=[
+            {
+                "columns": ["state"],
+                "metrics": ["sum__num"],
+                "orderby": [],
+                "post_processing": [contribution],
+                "row_limit": 100,
+                "row_offset": 0,
+            },
+            {
+                "columns": [],
+                "metrics": ["sum__num"],
+                "orderby": [],
+                "post_processing": [],
+                "row_limit": 0,
+                "row_offset": 0,
+            },
+        ],
+        result_type=ChartDataResultType.FULL,
+        result_format=ChartDataResultFormat.JSON,
+    )
+    totals_idx = query_context.contribution_totals_idx
+
+    assert query_context.contribution_queries == [0]
+    assert totals_idx == 1
+    assert query_context.queries[totals_idx].row_limit is None
+    assert query_context.cache_values["queries"][totals_idx]["row_limit"] is None
+
+    totals_key = query_context.query_cache_key(query_context.queries[totals_idx])
+    serialized = serialize_query(query_context, totals_idx)
+    rebuilt = load_serialized_query(serialized)
+
+    assert serialized["query"]["row_limit"] is None
+    assert rebuilt.queries[0].row_limit is None
+    assert rebuilt.query_cache_key(rebuilt.queries[0]) == totals_key

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -113,6 +113,33 @@ def test_find_by_task_key_active(session_with_task: Session) -> None:
     assert result.dependencies == []
 
 
+def test_find_one_or_none_refreshes_stale_task(session_with_task: Session) -> None:
+    """TaskDAO fetches refresh identity-map state after external-style updates."""
+    from superset.daos.tasks import TaskDAO
+
+    create_task(session_with_task, task_uuid=TASK_UUID, task_key="stale-task")
+
+    loaded = TaskDAO.find_one_or_none(uuid=TASK_UUID, skip_base_filter=True)
+    assert loaded is not None
+    assert loaded.status == TaskStatus.PENDING.value
+
+    TaskDAO.conditional_status_update(
+        task_uuid=TASK_UUID,
+        new_status=TaskStatus.IN_PROGRESS,
+        expected_status=TaskStatus.PENDING,
+        set_started_at=True,
+    )
+
+    # The atomic update uses synchronize_session=False, matching worker status
+    # transitions. Without force_fetch, the identity-map instance remains stale.
+    assert loaded.status == TaskStatus.PENDING.value
+
+    refreshed = TaskDAO.find_one_or_none(uuid=TASK_UUID, skip_base_filter=True)
+
+    assert refreshed is loaded
+    assert refreshed.status == TaskStatus.IN_PROGRESS.value
+
+
 def test_find_by_task_key_not_found(session_with_task: Session) -> None:
     """Test finding task by task_key returns None when not found"""
     from superset.daos.tasks import TaskDAO

--- a/tests/unit_tests/initialization/check_websocket_secret_test.py
+++ b/tests/unit_tests/initialization/check_websocket_secret_test.py
@@ -30,7 +30,7 @@ def _make_initializer(
     *, enabled: bool, secret: str | None, debug: bool = False, testing: bool = False
 ) -> SupersetAppInitializer:
     init = object.__new__(SupersetAppInitializer)
-    init.config = {"ENABLE_WEBSOCKET": enabled, "WEBSOCKET_JWT_SECRET": secret}
+    init.config = {"WEBSOCKET_ENABLE": enabled, "WEBSOCKET_JWT_SECRET": secret}
     app = MagicMock()
     app.debug = debug
     app.config = {"TESTING": testing}

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -19,7 +19,10 @@
 from unittest import mock
 from uuid import uuid4
 
+import pytest
 from pytest_mock import MockerFixture
+
+from superset.common.query_serialization import SerializedQuery
 
 
 def _fake_query_context(num_queries: int, contribution_idx: int | None = None):
@@ -37,6 +40,18 @@ def _fake_query_context(num_queries: int, contribution_idx: int | None = None):
     else:
         ctx.prepare_contribution_totals.return_value = ([], None)
     return ctx
+
+
+def _serialized_query() -> SerializedQuery:
+    return SerializedQuery(
+        datasource={"id": 1, "type": "table"},
+        query={"metrics": ["count"], "columns": ["name"], "time_range": "No filter"},
+        form_data=None,
+        result_type="full",
+        result_format="json",
+        force=False,
+        custom_cache_timeout=None,
+    )
 
 
 def _patch_schedule(mocker: MockerFixture):
@@ -77,10 +92,10 @@ def test_fan_out_schedules_one_task_per_query(mocker: MockerFixture) -> None:
     assert result["task_ids"] == [str(s["task"].uuid) for s in scheduled]
     # ...plus a status-poll cursor captured before the tasks were scheduled.
     assert isinstance(result["cursor"], str)
-    # Independent queries carry no dependency and no totals key.
+    # Independent queries carry no dependency and do not read dependency payloads.
     for call in scheduled:
         assert call["kwargs"]["options"].depends_on is None
-        assert call["args"][3] is None  # totals_cache_key
+        assert call["args"][3] is False  # requires_totals
 
 
 def test_contribution_query_depends_on_totals(mocker: MockerFixture) -> None:
@@ -95,14 +110,101 @@ def test_contribution_query_depends_on_totals(mocker: MockerFixture) -> None:
     # Totals query (index 0) is scheduled first with no dependency.
     totals_call = scheduled[0]
     assert totals_call["kwargs"]["options"].depends_on is None
-    # The totals query's row_limit is normalized so its key matches the entry
-    # its dependents read.
-    assert ctx.cache_values["queries"][0]["row_limit"] is None
+    assert totals_call["args"][3] is False  # requires_totals
 
-    # The contribution query depends on the totals task and receives its key.
+    # The contribution query depends on the totals task and reads its payload.
     dep_call = next(c for c in scheduled if c["args"][0] == {"query": 1})
     assert dep_call["kwargs"]["options"].depends_on == [totals_call["task"]]
-    assert dep_call["args"][3] == "key-0"  # totals_cache_key
+    assert dep_call["args"][3] is True  # requires_totals
+
+
+def test_execute_chart_query_publishes_cache_key_payload(
+    mocker: MockerFixture,
+) -> None:
+    from superset.tasks.async_queries import execute_chart_query
+
+    query_obj = mocker.MagicMock()
+    query_context = mocker.MagicMock()
+    query_context.queries = [query_obj]
+    query_context.get_df_payload_result.return_value.payload = {
+        "cache_key": "chart-cache-key"
+    }
+    task_context = mocker.MagicMock()
+
+    mocker.patch(
+        "superset.tasks.async_queries._resolve_user",
+        return_value=mocker.MagicMock(),
+    )
+    mocker.patch("superset.tasks.async_queries.override_user")
+    mocker.patch(
+        "superset.tasks.async_queries.load_serialized_query",
+        return_value=query_context,
+    )
+    mocker.patch(
+        "superset.tasks.async_queries.get_context",
+        return_value=task_context,
+    )
+
+    execute_chart_query.func(_serialized_query(), user_id=7)
+
+    query_context.get_df_payload_result.assert_called_once_with(query_obj)
+    task_context.update_task.assert_called_once_with(
+        payload={"cache_key": "chart-cache-key"}
+    )
+
+
+def test_execute_chart_query_reads_totals_key_from_dependency_payload(
+    mocker: MockerFixture,
+) -> None:
+    from superset.tasks.async_queries import execute_chart_query
+
+    query_obj = mocker.MagicMock()
+    query_context = mocker.MagicMock()
+    query_context.queries = [query_obj]
+    query_context.get_df_payload_result.return_value.payload = {
+        "cache_key": "main-cache-key"
+    }
+    task_context = mocker.MagicMock()
+    task_context.get_dependency_payloads.return_value = [
+        {"cache_key": "totals-cache-key"}
+    ]
+    inject = mocker.patch("superset.tasks.async_queries._inject_contribution_totals")
+
+    mocker.patch(
+        "superset.tasks.async_queries._resolve_user",
+        return_value=mocker.MagicMock(),
+    )
+    mocker.patch("superset.tasks.async_queries.override_user")
+    mocker.patch(
+        "superset.tasks.async_queries.load_serialized_query",
+        return_value=query_context,
+    )
+    mocker.patch(
+        "superset.tasks.async_queries.get_context",
+        return_value=task_context,
+    )
+
+    execute_chart_query.func(_serialized_query(), user_id=7, requires_totals=True)
+
+    inject.assert_called_once_with(query_obj, "totals-cache-key")
+    task_context.update_task.assert_called_once_with(
+        payload={"cache_key": "main-cache-key"}
+    )
+
+
+def test_get_dependency_cache_key_requires_payload(mocker: MockerFixture) -> None:
+    from superset.exceptions import SupersetException
+    from superset.tasks.async_queries import _get_dependency_cache_key
+
+    task_context = mocker.MagicMock()
+    task_context.get_dependency_payloads.return_value = [{}]
+    mocker.patch(
+        "superset.tasks.async_queries.get_context",
+        return_value=task_context,
+    )
+
+    with pytest.raises(SupersetException):
+        _get_dependency_cache_key()
 
 
 def test_guest_token_forwarded(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -25,18 +25,22 @@ from pytest_mock import MockerFixture
 from superset.common.query_serialization import SerializedQuery
 
 
-def _fake_query_context(num_queries: int, contribution_idx: int | None = None):
+def _fake_query_context(
+    num_queries: int,
+    contribution_idx: int | None = None,
+    totals_idx: int | None = 0,
+):
     """Build a MagicMock QueryContext with ``num_queries`` queries.
 
     When ``contribution_idx`` is set, ``prepare_contribution_totals`` reports that
-    query as contribution-coupled with query 0 as the totals query.
+    query as using contribution post-processing, optionally coupled to ``totals_idx``.
     """
     ctx = mock.MagicMock()
     ctx.queries = [mock.MagicMock(name=f"q{i}") for i in range(num_queries)]
     ctx.cache_values = {"queries": [{"i": i} for i in range(num_queries)]}
     ctx.query_cache_key.side_effect = lambda q: f"key-{ctx.queries.index(q)}"
     if contribution_idx is not None:
-        ctx.prepare_contribution_totals.return_value = ([contribution_idx], 0)
+        ctx.prepare_contribution_totals.return_value = ([contribution_idx], totals_idx)
     else:
         ctx.prepare_contribution_totals.return_value = ([], None)
     return ctx
@@ -116,6 +120,21 @@ def test_contribution_query_depends_on_totals(mocker: MockerFixture) -> None:
     dep_call = next(c for c in scheduled if c["args"][0] == {"query": 1})
     assert dep_call["kwargs"]["options"].depends_on == [totals_call["task"]]
     assert dep_call["args"][3] is True  # requires_totals
+
+
+def test_contribution_query_without_totals_runs_locally(
+    mocker: MockerFixture,
+) -> None:
+    from superset.tasks.async_queries import submit_chart_data_query_tasks
+
+    scheduled = _patch_schedule(mocker)
+    ctx = _fake_query_context(1, contribution_idx=0, totals_idx=None)
+
+    submit_chart_data_query_tasks(ctx, user_id=7)
+
+    assert len(scheduled) == 1
+    assert scheduled[0]["kwargs"]["options"].depends_on is None
+    assert scheduled[0]["args"][3] is False  # requires_totals
 
 
 def test_execute_chart_query_publishes_cache_key_payload(

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -220,3 +220,76 @@ class TestPersistDependencies:
         # find_by_uuids received normalized UUIDs, not entities/strings
         (resolved,), _ = dao.find_by_uuids.call_args
         assert set(resolved) == {u1, u2, u3}
+
+
+def test_task_context_get_dependency_payloads_uses_dao() -> None:
+    from superset.tasks.context import TaskContext
+
+    task = _task()
+    task.properties_dict = {}
+    task.payload_dict = {}
+    with patch("superset.tasks.context.current_app") as current_app:
+        current_app.config = {"TASK_PROGRESS_UPDATE_THROTTLE_INTERVAL": 0}
+        current_app._get_current_object.side_effect = RuntimeError()
+        ctx = TaskContext(task)
+
+    with patch("superset.daos.tasks.TaskDAO.get_dependency_payloads") as get_payloads:
+        get_payloads.return_value = [{"cache_key": "parent-cache-key"}]
+
+        assert ctx.get_dependency_payloads() == [{"cache_key": "parent-cache-key"}]
+
+    get_payloads.assert_called_once_with(task.uuid)
+
+
+def test_task_dao_get_dependency_payloads(app_context) -> None:
+    from superset.daos.tasks import TaskDAO
+    from superset.extensions import db
+    from superset.models.task_dependencies import TaskDependency
+    from superset.models.task_subscribers import TaskSubscriber
+    from superset.models.tasks import Task
+
+    parent_one = TaskDAO.create_task(
+        task_type="test.parent",
+        task_key=str(uuid4()),
+        scope="shared",
+        payload={"cache_key": "first"},
+    )
+    parent_two = TaskDAO.create_task(
+        task_type="test.parent",
+        task_key=str(uuid4()),
+        scope="shared",
+        payload={"cache_key": "second"},
+    )
+    child = TaskDAO.create_task(
+        task_type="test.child",
+        task_key=str(uuid4()),
+        scope="shared",
+    )
+    db.session.flush()
+    TaskDAO.add_dependencies(child.id, [parent_one.id, parent_two.id])
+    db.session.commit()
+
+    try:
+        assert TaskDAO.get_dependency_payloads(child.uuid) == [
+            {"cache_key": "first"},
+            {"cache_key": "second"},
+        ]
+
+        parent_two.payload = "{not-json"
+        db.session.commit()
+
+        assert TaskDAO.get_dependency_payloads(child.uuid) == [
+            {"cache_key": "first"},
+            {},
+        ]
+    finally:
+        db.session.query(TaskDependency).filter(
+            TaskDependency.task_id == child.id
+        ).delete(synchronize_session=False)
+        db.session.query(TaskSubscriber).filter(
+            TaskSubscriber.task_id.in_([parent_one.id, parent_two.id, child.id])
+        ).delete(synchronize_session=False)
+        db.session.query(Task).filter(
+            Task.id.in_([parent_one.id, parent_two.id, child.id])
+        ).delete(synchronize_session=False)
+        db.session.commit()

--- a/tests/unit_tests/views/test_base.py
+++ b/tests/unit_tests/views/test_base.py
@@ -80,7 +80,7 @@ def test_common_bootstrap_payload_masks_websocket_without_realtime_permission(
 
     cached = {
         "conf": {
-            "ENABLE_WEBSOCKET": True,
+            "WEBSOCKET_ENABLE": True,
             "WEBSOCKET_URL": "ws://localhost:8080/",
         }
     }
@@ -98,8 +98,8 @@ def test_common_bootstrap_payload_masks_websocket_without_realtime_permission(
     ):
         result = common_bootstrap_payload()
 
-    assert result["conf"]["ENABLE_WEBSOCKET"] is False
-    assert cached["conf"]["ENABLE_WEBSOCKET"] is True
+    assert result["conf"]["WEBSOCKET_ENABLE"] is False
+    assert cached["conf"]["WEBSOCKET_ENABLE"] is True
 
 
 def test_common_bootstrap_payload_exposes_websocket_with_realtime_permission(
@@ -110,7 +110,7 @@ def test_common_bootstrap_payload_exposes_websocket_with_realtime_permission(
     with (
         patch(
             "superset.views.base.cached_common_bootstrap_data",
-            return_value={"conf": {"ENABLE_WEBSOCKET": True}},
+            return_value={"conf": {"WEBSOCKET_ENABLE": True}},
         ),
         patch(
             "superset.views.base.can_access_realtime_notifications",
@@ -121,7 +121,7 @@ def test_common_bootstrap_payload_exposes_websocket_with_realtime_permission(
     ):
         result = common_bootstrap_payload()
 
-    assert result["conf"]["ENABLE_WEBSOCKET"] is True
+    assert result["conf"]["WEBSOCKET_ENABLE"] is True
 
 
 def test_default_map_renderer_is_exposed_to_frontend_config() -> None:

--- a/tests/unit_tests/websocket/test_channel.py
+++ b/tests/unit_tests/websocket/test_channel.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import jwt
@@ -146,7 +147,7 @@ def _make_ws_app():
 
     app = Flask(__name__)
     app.config.update(
-        ENABLE_WEBSOCKET=True,
+        WEBSOCKET_ENABLE=True,
         WEBSOCKET_JWT_SECRET="x" * 40,
         WEBSOCKET_JWT_COOKIE_NAME="superset-ws-token",
         WEBSOCKET_JWT_COOKIE_SECURE=False,
@@ -181,6 +182,37 @@ def test_cookie_reminted_when_principal_changes(mocker) -> None:
 
     # A different principal on the same client must re-mint (not keep user:1).
     mocker.patch.object(channel, "get_user_id", return_value=2)
+    assert _ws_set_cookies(client.get("/_ws_probe"))
+
+
+def test_cookie_signed_with_old_secret_is_reminted_with_current_secret(mocker) -> None:
+    from superset.websocket import channel
+    from superset.websocket.permissions import (
+        REALTIME_NOTIFICATION_JWT_AUDIENCE,
+        REALTIME_NOTIFICATION_JWT_ISSUER,
+    )
+
+    client = _make_ws_app().test_client()
+    mocker.patch.object(channel, "can_access_realtime_notifications", return_value=True)
+    mocker.patch.object(
+        channel.security_manager, "get_current_guest_user_if_guest", return_value=None
+    )
+    mocker.patch.object(channel, "get_user_id", return_value=1)
+
+    old_key_token = jwt.encode(
+        {
+            "channel": "user:1",
+            "principal_type": "user",
+            "sub": "1",
+            "aud": REALTIME_NOTIFICATION_JWT_AUDIENCE,
+            "iss": REALTIME_NOTIFICATION_JWT_ISSUER,
+            "exp": datetime.now(tz=timezone.utc) + timedelta(hours=1),
+        },
+        "y" * 40,
+        algorithm="HS256",
+    )
+    client.set_cookie("superset-ws-token", old_key_token)
+
     assert _ws_set_cookies(client.get("/_ws_probe"))
 
 


### PR DESCRIPTION
### SUMMARY
Adds verify-only websocket JWT secret rotation support to the `superset-websocket` service. The Flask app continues minting realtime cookies with `WEBSOCKET_JWT_SECRET`. The Node websocket service validates against its active verifier secret (`JWT_SECRET` / `jwtSecret`) and, during rotation, an optional previous verify-only key (`PREVIOUS_JWT_SECRET` / `previousJwtSecret`). The previous key is service-local websocket config; the Flask app does not need it because it only mints new tokens with the active secret.

This also renames the Superset-side enable flag from `ENABLE_WEBSOCKET` to `WEBSOCKET_ENABLE` so the websocket config surface is consistently `WEBSOCKET_*` before the feature branch merges.

The frontend realtime client now treats duplicate initialization with the same websocket config as idempotent. This avoids closing and replacing an already-active socket during bootstrap, which otherwise produces noisy browser console failures even though the replacement socket succeeds.

The websocket server now emits a debug log after forwarding a message to local sockets. The log includes the outbound browser channel and socket count, but not the payload.

The async chart-data middleware also stays idle until a chart request actually returns HTTP 202. Websocket mode still keeps polling as the correctness fallback while waiting for async tasks, but it no longer performs a startup `/api/v1/task/status_changes` request when there is no async chart activity.

This now also fixes chained GTF task execution for async chart-data queries. Dependent tasks are enqueued immediately and wait for prerequisite tasks before claiming execution. A dependent worker can load a prerequisite as `pending` while another worker later commits it as `success`; without a forced refresh, SQLAlchemy can return the stale identity-map object forever and the dependent task never reaches the executor body. `BaseDAO` now supports an opt-in `force_fetch` query mode, and `TaskDAO` enables it by default because task rows are cross-worker mutable state.

Chained chart-data tasks also carry the output metadata needed by contribution-mode queries. Contribution totals normalization runs on the `QueryContext` before any `query_cache_key` is computed. The totals task publishes its actual DATA cache key in task payload; dependent contribution tasks read prerequisite payloads via `TaskContext.get_dependency_payloads()` and use that key to inject totals. Contribution post-processing without a synthetic totals query, such as pie-chart share calculations, remains local and does not read dependency payloads. This intentionally exposes only dependency payload dictionaries, not full task ORM objects, keeping the internal DAG API limited while still allowing tasks to pass small pieces of context forward.

One compatibility compromise remains here: serialized query payloads can carry an internal `preserve_null_row_limit` marker so a normalized synthetic totals query with `row_limit: null` rehydrates with the same cache key, while ordinary external/query-context `row_limit: null` values keep the previous default-limit behavior. This is not ideal API shape, but it keeps the GAQ-to-GTF bridge narrow and avoids regressions in the legacy query-context interface. The future Semantic Query based interface should represent this directly instead of inheriting this shortcoming.

The docs now spell out the Kubernetes deployment model: run `superset-websocket` as a horizontally scalable, stateless Deployment/Service, not a singleton. Each browser socket is owned by exactly one replica after HTTP Upgrade; Redis Pub/Sub events are broadcast to all websocket replicas, and each replica fans out only to matching sockets it owns locally. Sticky sessions are not required, and polling remains the correctness backstop for reconnects/drains.

A separate `WEBSOCKET_K8S_OPERATOR_REQUIREMENTS.md` captures the operator requirements for ingress, auth config, secret rotation, short-lived sockets, draining, Redis, and HPA/scaling tradeoffs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
From the repo root:

```bash
pytest tests/unit_tests/websocket/test_channel.py tests/unit_tests/views/test_base.py tests/unit_tests/initialization/check_websocket_secret_test.py
pytest tests/unit_tests/daos/test_tasks.py tests/unit_tests/tasks/test_dependencies.py tests/unit_tests/tasks/test_manager.py tests/unit_tests/databases/dao/dao_tests.py tests/unit_tests/semantic_layers/dao_test.py
pytest tests/unit_tests/tasks/test_async_queries.py tests/unit_tests/tasks/test_dependencies.py tests/unit_tests/common/test_query_object_factory.py tests/unit_tests/common/test_query_serialization.py tests/unit_tests/common/test_query_context_processor.py tests/unit_tests/common/test_query_context_processor_timing.py
npm --prefix superset-websocket run test
npm --prefix superset-websocket run type
```

From `superset-frontend/`:

```bash
npm run test -- src/middleware/realtime.test.ts src/middleware/asyncEvent.test.ts
```

Also run:

```bash
pre-commit run
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
