### PR TITLE
feat(datasource): headless query API for Explorable datasources

### DIFF
--- a/superset-core/src/superset_core/semantic_layers/types.py
+++ b/superset-core/src/superset_core/semantic_layers/types.py
@@ -146,6 +146,8 @@ class Operator(str, enum.Enum):
     NOT_IN = "NOT IN"
     LIKE = "LIKE"
     NOT_LIKE = "NOT LIKE"
+    ILIKE = "ILIKE"
+    NOT_ILIKE = "NOT ILIKE"
     IS_NULL = "IS NULL"
     IS_NOT_NULL = "IS NOT NULL"
     ADHOC = "ADHOC"

--- a/superset/common/chart_data.py
+++ b/superset/common/chart_data.py
@@ -25,6 +25,7 @@ class ChartDataResultFormat(StrEnum):
     CSV = "csv"
     JSON = "json"
     XLSX = "xlsx"
+    ARROW = "arrow"
 
     @classmethod
     def table_like(cls) -> set["ChartDataResultFormat"]:

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -403,6 +403,9 @@ class QueryContextProcessor:
     def get_data(
         self, df: pd.DataFrame, coltypes: list[GenericDataType]
     ) -> str | bytes | list[dict[str, Any]]:
+        if self._query_context.result_format == ChartDataResultFormat.ARROW:
+            return self._to_arrow_ipc(df)
+
         if self._query_context.result_format in ChartDataResultFormat.table_like():
             include_index = not isinstance(df.index, pd.RangeIndex)
             columns = list(df.columns)
@@ -428,6 +431,22 @@ class QueryContextProcessor:
             return result or ""
 
         return df.to_dict(orient="records")
+
+    @staticmethod
+    def _to_arrow_ipc(df: pd.DataFrame) -> bytes:
+        """Serialize to an Arrow IPC stream for throughput-sensitive callers.
+
+        Serialization happens at response time rather than in the cache, so
+        Arrow and JSON requests for the same query share cache entries and no
+        cache-key versioning is needed.
+        """
+        import pyarrow as pa
+
+        table = pa.Table.from_pandas(df, preserve_index=False)
+        sink = pa.BufferOutputStream()
+        with pa.ipc.new_stream(sink, table.schema) as writer:
+            writer.write_table(table)
+        return sink.getvalue().to_pybytes()
 
     def _prepare_contribution_totals(self) -> tuple[list[int], int | None]:
         """

--- a/superset/common/tabular_query.py
+++ b/superset/common/tabular_query.py
@@ -1,0 +1,377 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Name-based tabular querying for any Explorable datasource.
+
+Shared by the REST query endpoint and the MCP query tools so the resolve →
+validate → build → execute sequence exists once. The REST endpoint owns this
+contract; other surfaces adapt to it.
+
+Type dispatch is deliberately absent: ``Explorable.get_query_result`` already
+routes datasets to SQL execution and semantic views to the semantic-layer
+mapper, so callers pass the datasource type as data and never branch on it.
+"""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+from superset.charts.data.form_data import set_query_context_form_data
+from superset.common.chart_data import ChartDataResultFormat
+from superset.daos.datasource import DatasourceDAO
+from superset.superset_typing import Column, Metric
+from superset.utils.core import DatasourceType, FilterOperator
+
+if TYPE_CHECKING:
+    from superset.explorables.base import Explorable
+
+
+# (column name, descending) — mirrors SemanticQuery's OrderTuple, which pairs a
+# metric/dimension with an OrderDirection.
+OrderSpec = tuple[str, bool]
+
+
+class TabularQueryValidationError(ValueError):
+    """Raised when a request cannot be satisfied by the target datasource."""
+
+
+@dataclass
+class ResolvedExplorable:
+    """A datasource resolved and authorized, with its queryable name sets."""
+
+    explorable: Explorable
+    display_name: str
+    time_column: str | None
+    valid_dimensions: set[str]
+    valid_metrics: set[str]
+    dttm_columns: set[str] = field(default_factory=set)
+    warnings: list[str] = field(default_factory=list)
+
+    def resolve_grain_column(
+        self, time_column: str | None, dimensions: Sequence[Column] | None
+    ) -> str | None:
+        """Pick the column a requested time grain should bucket.
+
+        Precedence: an explicit ``time_column``, else a temporal name already
+        listed in ``dimensions`` (the natural way to ask for buckets), else the
+        column a ``time_range`` resolved to.
+        """
+        if time_column:
+            return time_column
+        for dimension in dimensions or []:
+            if isinstance(dimension, str) and dimension in self.dttm_columns:
+                return dimension
+        return self.time_column
+
+
+def validate_names(
+    requested: Sequence[str],
+    valid: set[str],
+    kind: str,
+    *,
+    empty_hint: str | None = None,
+    list_valid_on_miss: bool = False,
+    full_list_hint: str = "call get_dataset_info for the full list",
+) -> list[str]:
+    """Return error messages for names not found in *valid*.
+
+    Includes close-match suggestions when available. When *valid* is empty,
+    appends *empty_hint* instead of a useless fuzzy match. When no close
+    match exists and *list_valid_on_miss* is set, lists the valid names so
+    the caller does not have to guess again; *full_list_hint* names the tool
+    to call when the valid list is truncated.
+    """
+    errors: list[str] = []
+    for name in requested:
+        if name not in valid:
+            msg = f"Unknown {kind}: '{name}'"
+            if not valid:
+                if empty_hint:
+                    msg += f". {empty_hint}"
+            else:
+                suggestions = difflib.get_close_matches(name, valid, n=3, cutoff=0.6)
+                if suggestions:
+                    msg += f". Did you mean: {', '.join(suggestions)}?"
+                elif list_valid_on_miss:
+                    shown = sorted(valid)[:10]
+                    more = len(valid) - len(shown)
+                    suffix = f" (and {more} more; {full_list_hint})" if more > 0 else ""
+                    msg += f". Valid {kind}s: {', '.join(shown)}{suffix}"
+            errors.append(msg)
+    return errors
+
+
+def _display_name(explorable: Explorable) -> str:
+    """Best available human label; ``Explorable`` does not mandate one."""
+    for attr in ("table_name", "name"):
+        if value := getattr(explorable, attr, None):
+            return str(value)
+    return f"{explorable.type} {explorable.id}"
+
+
+def _resolve_time_column(
+    explorable: Explorable,
+    display_name: str,
+    time_column: str | None,
+    has_time_range: bool,
+) -> str | None:
+    """Resolve and validate the temporal column a time range applies to.
+
+    Datasets carry ``main_dttm_col``; semantic views do not, so fall back to
+    the first datetime dimension. Only inferred when a time range was given —
+    an unfiltered query must not acquire a temporal axis it did not ask for.
+    """
+    valid_columns = {column.column_name for column in explorable.columns}
+    dttm_columns = [
+        column.column_name for column in explorable.columns if column.is_dttm
+    ]
+
+    resolved = time_column
+    if resolved is None and has_time_range:
+        resolved = getattr(explorable, "main_dttm_col", None) or (
+            dttm_columns[0] if dttm_columns else None
+        )
+        if not resolved:
+            raise TabularQueryValidationError(
+                "time_range was provided but no temporal column is configured "
+                f"on '{display_name}'. Set time_column explicitly."
+            )
+
+    if resolved is not None and resolved not in set(dttm_columns):
+        if resolved in valid_columns:
+            raise TabularQueryValidationError(
+                f"time_column '{resolved}' on '{display_name}' is not marked "
+                "as a datetime column."
+            )
+        raise TabularQueryValidationError(
+            f"Unknown time_column: '{resolved}' on '{display_name}'."
+        )
+    return resolved
+
+
+def resolve_explorable(
+    datasource_type: DatasourceType | str,
+    datasource_id: int,
+    *,
+    time_column: str | None = None,
+    has_time_range: bool = False,
+) -> ResolvedExplorable:
+    """Look up a datasource, authorize it, and collect its queryable names.
+
+    Raises ``DatasourceNotFound`` / ``DatasourceTypeNotSupportedError`` from
+    the DAO and ``SupersetSecurityException`` from the access check; callers
+    map these to their own transport's error shape.
+    """
+    explorable: Explorable = DatasourceDAO.get_datasource(
+        DatasourceType(datasource_type), datasource_id
+    )
+    explorable.raise_for_access()
+
+    display_name = _display_name(explorable)
+    return ResolvedExplorable(
+        explorable=explorable,
+        display_name=display_name,
+        time_column=_resolve_time_column(
+            explorable, display_name, time_column, has_time_range
+        ),
+        valid_dimensions={column.column_name for column in explorable.columns},
+        valid_metrics={metric.metric_name for metric in explorable.metrics},
+        dttm_columns={
+            column.column_name for column in explorable.columns if column.is_dttm
+        },
+    )
+
+
+NO_METRICS_HINT = (
+    "This datasource has no metrics defined. Query dimensions only, or add a "
+    "saved metric to the datasource."
+)
+
+
+def validate_query_names(
+    valid_metrics: set[str],
+    valid_dimensions: set[str],
+    *,
+    metrics: Sequence[Metric] | None = None,
+    dimensions: Sequence[Column] | None = None,
+    filters: Sequence[dict[str, Any]] | None = None,
+    order_names: Sequence[str] | None = None,
+    metrics_empty_hint: str | None = None,
+) -> list[str]:
+    """Validate every name in a request against the datasource's definitions.
+
+    Takes plain name sets rather than a resolved datasource so callers that
+    resolve differently — the MCP tools use per-type DAOs — can share it.
+
+    Ad-hoc metrics and columns are dicts rather than names and are skipped
+    here: datasets accept them, and semantic views reject them downstream in
+    the mapper, which owns that rule.
+    """
+    errors: list[str] = []
+    errors.extend(
+        validate_names(
+            [name for name in (dimensions or []) if isinstance(name, str)],
+            valid_dimensions,
+            "dimension",
+        )
+    )
+    errors.extend(
+        validate_names(
+            [name for name in (metrics or []) if isinstance(name, str)],
+            valid_metrics,
+            "metric",
+            empty_hint=metrics_empty_hint or NO_METRICS_HINT,
+            list_valid_on_miss=True,
+        )
+    )
+    errors.extend(
+        validate_names(
+            [
+                clause["col"]
+                for clause in (filters or [])
+                if isinstance(clause.get("col"), str)
+            ],
+            valid_dimensions,
+            "filter column",
+        )
+    )
+    if order_names:
+        errors.extend(
+            validate_names(
+                order_names,
+                valid_dimensions | valid_metrics,
+                "order_by",
+            )
+        )
+    return errors
+
+
+def build_query_dict(
+    *,
+    time_column: str | None = None,
+    metrics: Sequence[Metric] | None = None,
+    dimensions: Sequence[Column] | None = None,
+    filters: Sequence[dict[str, Any]] | None = None,
+    time_range: str | None = None,
+    time_grain: str | None = None,
+    grain_column: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+    order: Sequence[OrderSpec] | None = None,
+) -> dict[str, Any]:
+    """Assemble a QueryObject-shaped dict from a name-based request.
+
+    Parameter names follow ``SemanticQuery`` (``limit``, ``offset``, ``order``)
+    rather than ``QueryObject``; the translation to ``row_limit`` /
+    ``row_offset`` / ``orderby`` happens here so the request vocabulary stays
+    independent of the execution model.
+    """
+    query_filters: list[dict[str, Any]] = list(filters or [])
+    if time_range and time_column:
+        query_filters.append(
+            {
+                "col": time_column,
+                "op": FilterOperator.TEMPORAL_RANGE.value,
+                "val": time_range,
+            }
+        )
+
+    query_columns: list[Column] = list(dimensions or [])
+    if time_grain and grain_column:
+        # A grain only takes effect on a BASE_AXIS adhoc column
+        # (`SqlaTable.adhoc_column_to_sqla` gates on it); `extras.time_grain_sqla`
+        # alone is read by the semantic-layer mapper but ignored for datasets.
+        query_columns = [
+            column
+            for column in query_columns
+            if not (isinstance(column, str) and column == grain_column)
+        ]
+        query_columns.insert(
+            0,
+            {
+                "label": grain_column,
+                "sqlExpression": grain_column,
+                "columnType": "BASE_AXIS",
+                "timeGrain": time_grain,
+            },
+        )
+
+    query_dict: dict[str, Any] = {
+        "filters": query_filters,
+        "columns": query_columns,
+        "metrics": list(metrics or []),
+        "row_limit": limit,
+        # QueryObject.order_desc drives series-limit ordering, which has no
+        # per-column form; take the leading direction as its intent.
+        "order_desc": order[0][1] if order else True,
+    }
+    if offset:
+        query_dict["row_offset"] = offset
+    if time_column:
+        query_dict["granularity"] = time_column
+    if time_grain:
+        # Consumed by the semantic-layer mapper, which matches it against each
+        # dimension's exposed grains.
+        query_dict["extras"] = {"time_grain_sqla": time_grain}
+    if order:
+        # QueryObject.orderby is (name, ascending); the wire carries per-column
+        # descending flags, so invert each one rather than applying a single
+        # direction to every column.
+        query_dict["orderby"] = [(name, not descending) for name, descending in order]
+    return query_dict
+
+
+def execute_tabular_query(
+    datasource_id: int,
+    datasource_type: str,
+    query_dict: dict[str, Any],
+    *,
+    result_format: ChartDataResultFormat = ChartDataResultFormat.JSON,
+    use_cache: bool = True,
+    force: bool = False,
+    cache_timeout: int | None = None,
+) -> dict[str, Any]:
+    """Execute via the standard pipeline and return the command payload.
+
+    Entering at ``QueryContextFactory`` rather than below it is what keeps
+    caching, RLS, post-processing, and event logging intact.
+    ``ChartDataCommand.validate`` is the authorization gate.
+    """
+    # Imported here: both modules pull in the datasource stack, which imports
+    # this one during app setup.
+    from superset.commands.chart.data.get_data_command import ChartDataCommand
+    from superset.common.query_context_factory import QueryContextFactory
+
+    query_context = QueryContextFactory().create(
+        datasource={"id": datasource_id, "type": datasource_type},
+        queries=[query_dict],
+        form_data={},
+        result_format=result_format,
+        force=force or not use_cache,
+        custom_cache_timeout=cache_timeout,
+    )
+    # Without this, Jinja macros such as {{ current_username() }} cannot see
+    # the query context and virtual datasets render differently than they do
+    # through the chart data API.
+    set_query_context_form_data(query_context, datasource_id, datasource_type)
+
+    command = ChartDataCommand(query_context)
+    command.validate()
+    return command.run()

--- a/superset/config.py
+++ b/superset/config.py
@@ -378,6 +378,9 @@ WTF_CSRF_ENABLED = True
 # Add endpoints that need to be exempt from CSRF protection
 WTF_CSRF_EXEMPT_LIST = [
     "superset.charts.data.api.data",
+    # Headless query endpoint for token-authenticated API clients, exempted for
+    # the same reason as the chart data endpoint above.
+    "superset.datasource.api.query",
     "superset.dashboards.api.cache_dashboard_screenshot",
     "superset.views.core.log",
     "superset.views.datasource.views.samples",

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -18,22 +18,38 @@ import hashlib
 import logging
 from typing import Any
 
-from flask import current_app as app, request
+from flask import current_app as app, request, Response
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.api.schemas import get_list_schema
+from marshmallow import ValidationError
 
 from superset import event_logger, is_feature_enabled, security_manager
 from superset.commands.datasource.list import GetCombinedDatasourceListCommand
+from superset.commands.exceptions import CommandException
+from superset.common.chart_data import ChartDataResultFormat
+from superset.common.tabular_query import (
+    build_query_dict,
+    execute_tabular_query,
+    resolve_explorable,
+    ResolvedExplorable,
+    TabularQueryValidationError,
+    validate_query_names,
+)
 from superset.connectors.sqla.models import BaseDatasource
 from superset.daos.datasource import DatasourceDAO
 from superset.daos.exceptions import DatasourceNotFound, DatasourceTypeNotSupportedError
-from superset.exceptions import SupersetSecurityException
+from superset.datasource.schemas import DatasourceQuerySchema
+from superset.exceptions import (
+    QueryObjectValidationError,
+    SupersetSecurityException,
+)
 from superset.extensions import cache_manager
 from superset.superset_typing import FlaskResponse
 from superset.utils import json
 from superset.utils.core import (
     apply_max_row_limit,
     DatasourceType,
+    FilterOperator,
     parse_boolean_string,
     SqlExpressionType,
 )
@@ -42,14 +58,31 @@ from superset.views.base_api import BaseSupersetApi, statsd_metrics
 logger = logging.getLogger(__name__)
 
 
+class _HttpError(Exception):
+    """Carries an HTTP status out of the shared resolve helper."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
 class DatasourceRestApi(BaseSupersetApi):
     allow_browser_login = True
     class_permission_name = "Datasource"
     method_permission_name = {
         "combined_list": "read",
+        # Both new routes share can_query. Notably `datasource_info` is NOT
+        # named `get`: PUBLIC_ROLE_PERMISSIONS already grants
+        # ("can_get", "Datasource") for chart rendering, so a method named
+        # `get` would expose datasource metadata to unauthenticated users
+        # wherever PUBLIC_ROLE_LIKE = "Public".
+        "query": "query",
+        "datasource_info": "query",
     }
     resource_name = "datasource"
     openapi_spec_tag = "Datasources"
+    openapi_spec_component_schemas = (DatasourceQuerySchema,)
 
     @expose(
         "/<datasource_type>/<int:datasource_id>/column/<column_name>/values/",
@@ -521,6 +554,252 @@ class DatasourceRestApi(BaseSupersetApi):
         )
         cache_manager.data_cache.set(cache_key, result, timeout=timeout)
 
+        return self.response(200, result=result)
+
+    def _resolve_for_query(
+        self, datasource_type: str, datasource_id: int, payload: dict[str, Any]
+    ) -> ResolvedExplorable:
+        """Resolve + authorize, translating DAO/security errors to HTTP."""
+        if DatasourceType(
+            datasource_type
+        ) == DatasourceType.SEMANTIC_VIEW and not is_feature_enabled("SEMANTIC_LAYERS"):
+            raise _HttpError(404, "Semantic views are not enabled.")
+        try:
+            return resolve_explorable(
+                datasource_type,
+                datasource_id,
+                time_column=payload.get("time_column"),
+                has_time_range=bool(payload.get("time_range")),
+            )
+        except DatasourceTypeNotSupportedError as ex:
+            raise _HttpError(400, ex.message) from ex
+        except DatasourceNotFound as ex:
+            raise _HttpError(404, ex.message) from ex
+        except SupersetSecurityException as ex:
+            raise _HttpError(403, ex.message) from ex
+        except TabularQueryValidationError as ex:
+            raise _HttpError(400, str(ex)) from ex
+
+    @expose("/<datasource_type>/<int:datasource_id>/query", methods=("POST",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.query",
+        log_to_statsd=False,
+    )
+    def query(self, datasource_type: str, datasource_id: int) -> FlaskResponse:
+        """Query a datasource using metric and dimension names.
+        ---
+        post:
+          summary: Query a datasource by its semantic definitions
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: datasource_type
+          - in: path
+            schema:
+              type: integer
+            name: datasource_id
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DatasourceQuerySchema'
+          responses:
+            200:
+              description: Query result
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: array
+                        items:
+                          type: object
+                application/vnd.apache.arrow.stream:
+                  schema:
+                    type: string
+                    format: binary
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        try:
+            payload = DatasourceQuerySchema().load(request.json or {})
+        except ValidationError as ex:
+            return self.response_400(message=ex.messages)
+        except ValueError:
+            return self.response(
+                400, message=f"Invalid datasource type: {datasource_type}"
+            )
+
+        try:
+            resolved = self._resolve_for_query(datasource_type, datasource_id, payload)
+        except _HttpError as ex:
+            return self.response(ex.status, message=ex.message)
+        except ValueError:
+            return self.response(
+                400, message=f"Invalid datasource type: {datasource_type}"
+            )
+
+        if errors := validate_query_names(
+            resolved.valid_metrics,
+            resolved.valid_dimensions,
+            metrics=payload["metrics"],
+            dimensions=payload["dimensions"],
+            filters=payload["filters"],
+            order_names=[term["column"] for term in payload["order"]],
+        ):
+            return self.response_400(message="; ".join(errors))
+
+        return self._execute_and_respond(resolved, payload)
+
+    def _execute_and_respond(
+        self, resolved: ResolvedExplorable, payload: dict[str, Any]
+    ) -> FlaskResponse:
+        """Run the query and render it in the requested result format."""
+        grain_column = resolved.resolve_grain_column(
+            payload["time_column"], payload["dimensions"]
+        )
+        if payload["time_grain"] and not grain_column:
+            # Silently dropping the grain would return unbucketed rows that look
+            # correct, so refuse instead.
+            return self.response_400(
+                message=(
+                    "time_grain requires a temporal column. Set time_column, "
+                    "include a datetime dimension, or provide time_range."
+                )
+            )
+
+        query_dict = build_query_dict(
+            time_column=resolved.time_column,
+            metrics=payload["metrics"],
+            dimensions=payload["dimensions"],
+            filters=payload["filters"],
+            time_range=payload["time_range"],
+            time_grain=payload["time_grain"],
+            grain_column=grain_column,
+            limit=payload["limit"],
+            offset=payload["offset"],
+            order=[(term["column"], term["descending"]) for term in payload["order"]],
+        )
+        result_format = payload["result_format"]
+
+        try:
+            result = execute_tabular_query(
+                int(resolved.explorable.id),
+                str(resolved.explorable.type),
+                query_dict,
+                result_format=result_format,
+                use_cache=payload["use_cache"],
+                force=payload["force"],
+                cache_timeout=payload["cache_timeout"],
+            )
+        except SupersetSecurityException as ex:
+            return self.response(403, message=ex.message)
+        except (TabularQueryValidationError, QueryObjectValidationError) as ex:
+            return self.response_400(message=str(ex))
+        except CommandException as ex:
+            return self.response_400(message=ex.message or str(ex))
+
+        queries = result.get("queries") or []
+        if result_format == ChartDataResultFormat.ARROW:
+            if len(queries) != 1:
+                return self.response_400(
+                    message="Arrow result format supports exactly one query."
+                )
+            return Response(
+                queries[0]["data"],
+                mimetype="application/vnd.apache.arrow.stream",
+            )
+        return self.response(200, result=queries)
+
+    @expose("/<datasource_type>/<int:datasource_id>", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.datasource_info"
+        ),
+        log_to_statsd=False,
+    )
+    def datasource_info(
+        self, datasource_type: str, datasource_id: int
+    ) -> FlaskResponse:
+        """Get datasource metadata and query capabilities.
+        ---
+        get:
+          summary: Get datasource metadata and capabilities
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: datasource_type
+          - in: path
+            schema:
+              type: integer
+            name: datasource_id
+          responses:
+            200:
+              description: Datasource metadata plus a capabilities block
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        try:
+            resolved = self._resolve_for_query(datasource_type, datasource_id, {})
+        except _HttpError as ex:
+            return self.response(ex.status, message=ex.message)
+        except ValueError:
+            return self.response(
+                400, message=f"Invalid datasource type: {datasource_type}"
+            )
+
+        datasource = resolved.explorable
+        features = sorted(
+            feature.value
+            for feature in getattr(
+                getattr(datasource, "implementation", None), "features", set()
+            )
+        )
+        result = dict(datasource.data)
+        result["capabilities"] = {
+            "is_rls_supported": datasource.is_rls_supported,
+            "query_language": datasource.query_language,
+            "supports_samples": getattr(datasource, "supports_samples", True),
+            "supports_drill_to_detail": getattr(
+                datasource, "supports_drill_to_detail", True
+            ),
+            # Datasets accept ad-hoc metrics; semantic views reject them in the
+            # mapper, since the provider owns metric definitions.
+            "supports_adhoc_metrics": DatasourceType(datasource_type)
+            != DatasourceType.SEMANTIC_VIEW,
+            "time_grains": datasource.get_time_grains(),
+            "supported_operators": [op.value for op in FilterOperator],
+            "features": features,
+        }
         return self.response(200, result=result)
 
     @expose("/", methods=("GET",))

--- a/superset/datasource/schemas.py
+++ b/superset/datasource/schemas.py
@@ -14,15 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Marshmallow schemas for the combined datasource list endpoint."""
+"""Marshmallow schemas for the datasource list and query endpoints."""
 
 from __future__ import annotations
 
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, validates_schema, ValidationError
+from marshmallow.validate import Range
 
+from superset.charts.schemas import ChartDataFilterSchema
+from superset.common.chart_data import ChartDataResultFormat
 from superset.connectors.sqla.models import SqlaTable
 from superset.semantic_layers.models import SemanticView
 from superset.subjects.schemas import SubjectResponseSchema
+
+# Matches the MCP query tools' ceiling so the two surfaces agree. The server
+# additionally clamps via apply_max_row_limit against ROW_LIMIT.
+MAX_ROW_LIMIT = 50_000
 
 
 class _ChangedBySchema(Schema):
@@ -140,3 +147,103 @@ class SemanticViewListSchema(Schema):
 
     def get_changed_on_utc(self, obj: SemanticView) -> str:
         return obj.changed_on_utc()
+
+
+class DatasourceQueryOrderSchema(Schema):
+    """One ordering term, mirroring SemanticQuery's OrderTuple."""
+
+    column = fields.String(
+        required=True,
+        metadata={"description": "Metric or dimension name to sort by."},
+    )
+    descending = fields.Boolean(
+        load_default=True,
+        metadata={"description": "Sort this column descending."},
+    )
+
+
+class DatasourceQuerySchema(Schema):
+    """Name-based query request for POST /datasource/<type>/<id>/query.
+
+    Field names mirror the semantic-layer vocabulary (``dimensions``,
+    ``metrics``) rather than Explore's (``columns``); translation to the
+    QueryObject shape happens in ``superset.common.tabular_query``.
+    """
+
+    # Raw, not String: Metric/Column are `AdhocMetric | str` and
+    # `AdhocColumn | str`, so ad-hoc expressions are accepted for datasets
+    # exactly as ChartDataQueryObjectSchema accepts them. Semantic views
+    # reject ad-hoc metrics downstream, in the mapper that owns that rule.
+    metrics = fields.List(
+        fields.Raw(),
+        load_default=list,
+        metadata={
+            "description": "Saved metric names, or ad-hoc metric objects "
+            "(datasets only). See ChartDataAdhocMetricSchema."
+        },
+    )
+    dimensions = fields.List(
+        fields.Raw(),
+        load_default=list,
+        metadata={"description": "Dimension/column names to group by."},
+    )
+    filters = fields.List(
+        fields.Nested(ChartDataFilterSchema),
+        load_default=list,
+        metadata={"description": "Filters to apply, AND-ed together."},
+    )
+    time_range = fields.String(
+        allow_none=True,
+        load_default=None,
+        metadata={"description": "e.g. 'Last 30 days' or '2024-01-01 : 2024-12-31'."},
+    )
+    time_column = fields.String(
+        allow_none=True,
+        load_default=None,
+        metadata={
+            "description": "Temporal column the time range applies to. Inferred "
+            "from the datasource when omitted."
+        },
+    )
+    time_grain = fields.String(
+        allow_none=True,
+        load_default=None,
+        metadata={"description": "ISO 8601 duration, e.g. 'P1D' or 'PT1H'."},
+    )
+    limit = fields.Integer(
+        allow_none=True,
+        load_default=None,
+        validate=[Range(min=1, max=MAX_ROW_LIMIT)],
+        metadata={
+            "description": "Rows to return. Also clamped server-side by ROW_LIMIT."
+        },
+    )
+    offset = fields.Integer(
+        load_default=0,
+        validate=[Range(min=0)],
+        metadata={"description": "Rows to skip, for pagination."},
+    )
+    order = fields.List(
+        fields.Nested(DatasourceQueryOrderSchema),
+        load_default=list,
+        metadata={
+            "description": "Ordering terms, applied in sequence. Each carries its "
+            "own direction."
+        },
+    )
+    result_format = fields.Enum(
+        ChartDataResultFormat,
+        by_value=True,
+        load_default=ChartDataResultFormat.JSON,
+        metadata={
+            "description": "'json' (default) or 'arrow' for an Arrow IPC stream."
+        },
+    )
+    use_cache = fields.Boolean(load_default=True)
+    force = fields.Boolean(load_default=False)
+    cache_timeout = fields.Integer(allow_none=True, load_default=None)
+
+    @validates_schema
+    def validate_not_empty(self, data: dict[str, object], **_kwargs: object) -> None:
+        if not data.get("metrics") and not data.get("dimensions"):
+            raise ValidationError("Provide at least one metric or dimension.")

--- a/superset/explorables/base.py
+++ b/superset/explorables/base.py
@@ -485,6 +485,16 @@ class Explorable(Protocol):
     # Optional Properties
     # =========================================================================
 
+    def raise_for_access(self) -> None:
+        """
+        Raise if the current user may not access this explorable.
+
+        Implemented by every explorable and relied on by callers before any
+        query is built, so it belongs on the protocol.
+
+        :raises SupersetSecurityException: if access is denied
+        """
+
     @property
     def is_rls_supported(self) -> bool:
         """

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -31,8 +31,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import joinedload, subqueryload
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
-from superset.charts.data.form_data import set_query_context_form_data
 from superset.commands.exceptions import CommandException
+from superset.common.tabular_query import (
+    build_query_dict,
+    execute_tabular_query,
+    validate_query_names,
+)
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import DataColumn, PerformanceMetadata
@@ -50,7 +54,6 @@ from superset.mcp_service.privacy import (
 )
 from superset.mcp_service.utils.cache_utils import get_cache_status_from_result
 from superset.mcp_service.utils.oauth2_utils import build_oauth2_redirect_message
-from superset.mcp_service.utils.query_utils import validate_names
 from superset.mcp_service.utils.response_utils import format_data_columns
 
 logger = logging.getLogger(__name__)
@@ -114,8 +117,6 @@ async def query_dataset(  # noqa: C901
     )
 
     try:
-        from superset.commands.chart.data.get_data_command import ChartDataCommand
-        from superset.common.query_context_factory import QueryContextFactory
         from superset.connectors.sqla.models import SqlaTable
 
         # ------------------------------------------------------------------
@@ -175,30 +176,15 @@ async def query_dataset(  # noqa: C901
         valid_columns = {c.column_name for c in dataset.columns}
         valid_metrics = {m.metric_name for m in dataset.metrics}
 
-        validation_errors: list[str] = []
-        validation_errors.extend(
-            validate_names(request.columns, valid_columns, "column")
+        validation_errors: list[str] = validate_query_names(
+            valid_metrics,
+            valid_columns,
+            metrics=request.metrics,
+            dimensions=request.columns,
+            filters=[{"col": f.col} for f in request.filters],
+            order_names=request.order_by,
+            metrics_empty_hint=_NO_SAVED_METRICS_HINT,
         )
-        validation_errors.extend(
-            validate_names(
-                request.metrics,
-                valid_metrics,
-                "metric",
-                empty_hint=_NO_SAVED_METRICS_HINT,
-                list_valid_on_miss=True,
-            )
-        )
-        # Validate filter column names against dataset columns
-        filter_cols = [f.col for f in request.filters]
-        validation_errors.extend(
-            validate_names(filter_cols, valid_columns, "filter column")
-        )
-        # Validate order_by names against columns + metrics
-        if request.order_by:
-            valid_orderby = valid_columns | valid_metrics
-            validation_errors.extend(
-                validate_names(request.order_by, valid_orderby, "order_by")
-            )
 
         if validation_errors:
             error_msg = "; ".join(validation_errors)
@@ -274,20 +260,16 @@ async def query_dataset(  # noqa: C901
         # Step 4: Build query dict
         # ------------------------------------------------------------------
         await ctx.report_progress(3, 5, "Building query")
-        query_dict: dict[str, Any] = {
-            "filters": query_filters,
-            "columns": request.columns,
-            "metrics": request.metrics,
-            "row_limit": request.row_limit,
-            "order_desc": request.order_desc,
-        }
-        if granularity:
-            query_dict["granularity"] = granularity
-        if request.order_by:
-            # OrderBy = tuple[Metric | Column, bool] where bool is ascending
-            query_dict["orderby"] = [
-                (col, not request.order_desc) for col in request.order_by
-            ]
+        # time_range is not passed through: the TEMPORAL_RANGE clause is already
+        # in query_filters above, alongside the effective_filters bookkeeping.
+        query_dict: dict[str, Any] = build_query_dict(
+            time_column=granularity,
+            metrics=request.metrics,
+            dimensions=request.columns,
+            filters=query_filters,
+            limit=request.row_limit,
+            order=[(name, request.order_desc) for name in (request.order_by or [])],
+        )
 
         await ctx.debug("Query dict keys: %s" % (sorted(query_dict.keys()),))
 
@@ -298,24 +280,14 @@ async def query_dataset(  # noqa: C901
         start_time = time.time()
 
         with event_logger.log_context(action="mcp.query_dataset.execute"):
-            factory = QueryContextFactory()
-            # datasource_type is "table" because this tool queries SqlaTable
-            # datasets (Superset's built-in semantic layer). External semantic
-            # layers (dbt, Snowflake Cortex, etc.) use "semantic_view" and have
-            # a different query path — see SemanticView + mapper.py.
-            query_context = factory.create(
-                datasource={"id": dataset.id, "type": "table"},
-                queries=[query_dict],
-                form_data={},
-                force=not request.use_cache or request.force_refresh,
-                custom_cache_timeout=request.cache_timeout,
+            result = execute_tabular_query(
+                dataset.id,
+                "table",
+                query_dict,
+                use_cache=request.use_cache,
+                force=request.force_refresh,
+                cache_timeout=request.cache_timeout,
             )
-
-            set_query_context_form_data(query_context, dataset.id, "table")
-
-            command = ChartDataCommand(query_context)
-            command.validate()
-            result = command.run()
 
         query_duration_ms = int((time.time() - start_time) * 1000)
 

--- a/superset/mcp_service/semantic_layer/tool/get_table.py
+++ b/superset/mcp_service/semantic_layer/tool/get_table.py
@@ -31,6 +31,11 @@ from sqlalchemy.exc import SQLAlchemyError
 from superset_core.mcp.decorators import tool, ToolAnnotations
 
 from superset.commands.exceptions import CommandException
+from superset.common.tabular_query import (
+    build_query_dict,
+    execute_tabular_query,
+    validate_query_names,
+)
 from superset.exceptions import OAuth2Error, OAuth2RedirectError, SupersetException
 from superset.extensions import event_logger
 from superset.mcp_service.chart.schemas import PerformanceMetadata
@@ -46,7 +51,6 @@ from superset.mcp_service.semantic_layer.schemas import (
 )
 from superset.mcp_service.utils.cache_utils import get_cache_status_from_result
 from superset.mcp_service.utils.oauth2_utils import build_oauth2_redirect_message
-from superset.mcp_service.utils.query_utils import validate_names
 from superset.mcp_service.utils.response_utils import format_data_columns
 
 logger = logging.getLogger(__name__)
@@ -191,30 +195,15 @@ def _validate_request_names(
     request: GetTableRequest, valid_columns: set[str], valid_metrics: set[str]
 ) -> list[str]:
     """Validate requested dimensions, metrics, filters, and order_by names."""
-    validation_errors: list[str] = []
-    validation_errors.extend(
-        validate_names(request.dimensions, valid_columns, "dimension")
+    return validate_query_names(
+        valid_metrics,
+        valid_columns,
+        metrics=request.metrics,
+        dimensions=request.dimensions,
+        filters=[{"col": f.col} for f in request.filters],
+        order_names=request.order_by,
+        metrics_empty_hint=_NO_METRICS_HINT,
     )
-    validation_errors.extend(
-        validate_names(
-            request.metrics,
-            valid_metrics,
-            "metric",
-            empty_hint=_NO_METRICS_HINT,
-            list_valid_on_miss=True,
-            full_list_hint="call list_metrics for the full list",
-        )
-    )
-    filter_cols = [f.col for f in request.filters]
-    validation_errors.extend(
-        validate_names(filter_cols, valid_columns, "filter column")
-    )
-    if request.order_by:
-        valid_orderby = valid_columns | valid_metrics
-        validation_errors.extend(
-            validate_names(request.order_by, valid_orderby, "order_by")
-        )
-    return validation_errors
 
 
 def _build_query_dict(
@@ -222,28 +211,15 @@ def _build_query_dict(
     time_col: str | None,
 ) -> dict[str, Any]:
     """Assemble the query dict for QueryContextFactory."""
-    filters: list[dict[str, Any]] = [
-        {"col": f.col, "op": f.op, "val": f.val} for f in request.filters
-    ]
-    if request.time_range and time_col:
-        filters.append(
-            {"col": time_col, "op": "TEMPORAL_RANGE", "val": request.time_range}
-        )
-
-    query_dict: dict[str, Any] = {
-        "filters": filters,
-        "columns": request.dimensions,
-        "metrics": request.metrics,
-        "row_limit": request.row_limit,
-        "order_desc": request.order_desc,
-    }
-    if time_col:
-        query_dict["granularity"] = time_col
-    if request.order_by:
-        query_dict["orderby"] = [
-            (col, not request.order_desc) for col in request.order_by
-        ]
-    return query_dict
+    return build_query_dict(
+        time_column=time_col,
+        metrics=request.metrics,
+        dimensions=request.dimensions,
+        filters=[{"col": f.col, "op": f.op, "val": f.val} for f in request.filters],
+        time_range=request.time_range,
+        limit=request.row_limit,
+        order=[(name, request.order_desc) for name in request.order_by],
+    )
 
 
 def _build_response(
@@ -316,9 +292,6 @@ async def _run_get_table_query(
     datasource_type: str,
 ) -> GetTableResponse | SemanticLayerError:
     """Resolve, validate, execute, and format a get_table request."""
-    from superset.commands.chart.data.get_data_command import ChartDataCommand
-    from superset.common.query_context_factory import QueryContextFactory
-
     await ctx.report_progress(1, 5, "Resolving data source")
     resolved = (
         _resolve_builtin_dataset(request)
@@ -348,16 +321,13 @@ async def _run_get_table_query(
     start_time = time.time()
 
     with event_logger.log_context(action="mcp.get_table.execute"):
-        factory = QueryContextFactory()
-        query_context = factory.create(
-            datasource={"id": datasource_id, "type": datasource_type},
-            queries=[query_dict],
-            form_data={},
-            force=not request.use_cache or request.force_refresh,
+        result = execute_tabular_query(
+            datasource_id,
+            datasource_type,
+            query_dict,
+            use_cache=request.use_cache,
+            force=request.force_refresh,
         )
-        command = ChartDataCommand(query_context)
-        command.validate()
-        result = command.run()
 
     query_duration_ms = int((time.time() - start_time) * 1000)
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1772,6 +1772,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         "can_external_metadata_by_name",
         "can_read",
         "can_get_drill_info",
+        # Datasource querying is a read operation. Without this, Datasource
+        # being in GAMMA_READ_ONLY_MODEL_VIEWS makes _is_alpha_only withhold
+        # can_query from Gamma.
+        "can_query",
     }
 
     ALPHA_ONLY_PERMISSIONS = {

--- a/superset/semantic_layers/mapper.py
+++ b/superset/semantic_layers/mapper.py
@@ -699,20 +699,6 @@ def _convert_query_object_filter(
 
     value = _coerce_filter_value(value, dimension)
 
-    # Map QueryObject operators to semantic layer operators. The Operator enum
-    # exposes only LIKE (case-sensitive), so case-insensitive variants are
-    # rejected up front rather than silently collapsed: doing so leaves the
-    # actual case handling at the mercy of the semantic backend's collation
-    # and silently diverges from the operator the dashboard author chose.
-    if operator_str in {
-        FilterOperator.ILIKE.value,
-        FilterOperator.NOT_ILIKE.value,
-    }:
-        raise ValueError(
-            f"Operator {operator_str} (case-insensitive match) is not supported "
-            "by Semantic Views; use the case-sensitive LIKE/NOT_LIKE instead."
-        )
-
     operator_mapping = {
         FilterOperator.EQUALS.value: Operator.EQUALS,
         FilterOperator.NOT_EQUALS.value: Operator.NOT_EQUALS,
@@ -724,6 +710,11 @@ def _convert_query_object_filter(
         FilterOperator.NOT_IN.value: Operator.NOT_IN,
         FilterOperator.LIKE.value: Operator.LIKE,
         FilterOperator.NOT_LIKE.value: Operator.NOT_LIKE,
+        # Case-insensitive matching is passed through to the provider, which
+        # resolves it per its own collation rules. Providers that cannot
+        # express ILIKE should advertise that via a SemanticViewFeature.
+        FilterOperator.ILIKE.value: Operator.ILIKE,
+        FilterOperator.NOT_ILIKE.value: Operator.NOT_ILIKE,
         FilterOperator.IS_NULL.value: Operator.IS_NULL,
         FilterOperator.IS_NOT_NULL.value: Operator.IS_NOT_NULL,
     }

--- a/tests/unit_tests/common/test_tabular_query.py
+++ b/tests/unit_tests/common/test_tabular_query.py
@@ -1,0 +1,312 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for the shared name-based tabular query core."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from superset.common.tabular_query import (
+    build_query_dict,
+    TabularQueryValidationError,
+    validate_names,
+    validate_query_names,
+)
+from superset.superset_typing import AdhocColumn, AdhocMetric
+
+
+def _column(name: str, is_dttm: bool = False) -> MagicMock:
+    column = MagicMock()
+    column.column_name = name
+    column.is_dttm = is_dttm
+    return column
+
+
+def test_build_query_dict_synthesizes_temporal_filter() -> None:
+    """A time_range becomes a TEMPORAL_RANGE clause on the resolved column."""
+    query_dict = build_query_dict(
+        time_column="ds",
+        metrics=["count"],
+        dimensions=["region"],
+        time_range="Last 30 days",
+    )
+
+    assert query_dict["granularity"] == "ds"
+    assert {
+        "col": "ds",
+        "op": "TEMPORAL_RANGE",
+        "val": "Last 30 days",
+    } in query_dict["filters"]
+
+
+def test_build_query_dict_time_range_without_column_adds_no_filter() -> None:
+    """Without a resolved temporal column there is nothing to filter on."""
+    query_dict = build_query_dict(metrics=["count"], time_range="Last 30 days")
+
+    assert query_dict["filters"] == []
+    assert "granularity" not in query_dict
+
+
+def test_build_query_dict_time_grain_emits_base_axis_column() -> None:
+    """A grain only applies via a BASE_AXIS adhoc column.
+
+    ``SqlaTable.adhoc_column_to_sqla`` gates grain handling on
+    ``columnType == "BASE_AXIS"``; ``extras.time_grain_sqla`` alone is read by
+    the semantic-layer mapper but silently ignored for datasets.
+    """
+    query_dict = build_query_dict(
+        time_column="ds", metrics=["count"], time_grain="P1D", grain_column="ds"
+    )
+
+    assert query_dict["columns"][0] == {
+        "label": "ds",
+        "sqlExpression": "ds",
+        "columnType": "BASE_AXIS",
+        "timeGrain": "P1D",
+    }
+    # Still emitted for the semantic-view path.
+    assert query_dict["extras"] == {"time_grain_sqla": "P1D"}
+
+
+def test_build_query_dict_grain_replaces_plain_dimension() -> None:
+    """Naming the temporal column as a dimension must not duplicate it."""
+    query_dict = build_query_dict(
+        metrics=["count"],
+        dimensions=["ds", "gender"],
+        time_grain="P1M",
+        grain_column="ds",
+    )
+
+    assert query_dict["columns"][0]["columnType"] == "BASE_AXIS"
+    assert query_dict["columns"][1] == "gender"
+    assert "ds" not in [c for c in query_dict["columns"] if isinstance(c, str)]
+
+
+def test_build_query_dict_grain_without_column_is_not_applied() -> None:
+    """No grain column means no BASE_AXIS column; the API rejects this case."""
+    query_dict = build_query_dict(metrics=["count"], time_grain="P1D")
+
+    assert query_dict["columns"] == []
+
+
+def test_resolve_grain_column_precedence() -> None:
+    from superset.common.tabular_query import ResolvedExplorable
+
+    resolved = ResolvedExplorable(
+        explorable=MagicMock(),
+        display_name="sales",
+        time_column="ds",
+        valid_dimensions={"ds", "created", "gender"},
+        valid_metrics={"count"},
+        dttm_columns={"ds", "created"},
+    )
+
+    # Explicit time_column wins.
+    assert resolved.resolve_grain_column("created", ["ds"]) == "created"
+    # Else a temporal dimension already requested.
+    assert resolved.resolve_grain_column(None, ["gender", "created"]) == "created"
+    # Else whatever time_range resolved to.
+    assert resolved.resolve_grain_column(None, ["gender"]) == "ds"
+
+
+def test_resolve_grain_column_returns_none_when_no_temporal() -> None:
+    from superset.common.tabular_query import ResolvedExplorable
+
+    resolved = ResolvedExplorable(
+        explorable=MagicMock(),
+        display_name="sales",
+        time_column=None,
+        valid_dimensions={"gender"},
+        valid_metrics={"count"},
+        dttm_columns=set(),
+    )
+
+    assert resolved.resolve_grain_column(None, ["gender"]) is None
+
+
+def test_build_query_dict_maps_limit_offset_to_query_object_names() -> None:
+    """The wire uses SemanticQuery's limit/offset; QueryObject wants row_*."""
+    assert build_query_dict(metrics=["count"], limit=25)["row_limit"] == 25
+    assert "row_offset" not in build_query_dict(metrics=["count"])
+    assert build_query_dict(metrics=["count"], offset=100)["row_offset"] == 100
+
+
+def test_build_query_dict_orderby_inverts_each_direction() -> None:
+    """QueryObject.orderby is (name, ascending); the wire sends descending."""
+    query_dict = build_query_dict(
+        metrics=["count"],
+        dimensions=["region"],
+        order=[("count", True), ("region", False)],
+    )
+
+    assert query_dict["orderby"] == [("count", False), ("region", True)]
+
+
+def test_build_query_dict_order_desc_follows_leading_term() -> None:
+    """order_desc drives series-limit ordering, which has no per-column form."""
+    assert (
+        build_query_dict(metrics=["count"], order=[("count", False)])["order_desc"]
+        is False
+    )
+    assert (
+        build_query_dict(metrics=["count"], order=[("count", True)])["order_desc"]
+        is True
+    )
+    assert build_query_dict(metrics=["count"])["order_desc"] is True
+
+
+def test_build_query_dict_passes_adhoc_metrics_through() -> None:
+    """Ad-hoc metric dicts survive untouched; datasets accept them."""
+    adhoc: AdhocMetric = {
+        "expressionType": "SQL",
+        "sqlExpression": "SUM(a)/SUM(b)",
+        "label": "Ratio",
+    }
+    assert build_query_dict(metrics=["count", adhoc])["metrics"] == ["count", adhoc]
+
+
+def test_validate_query_names_reports_unknown_names() -> None:
+    """Unknown names are named back to the caller, per kind."""
+    errors = validate_query_names(
+        {"revenue"},
+        {"region"},
+        metrics=["revenu"],
+        dimensions=["regionn"],
+        filters=[{"col": "bogus_col"}],
+        order_names=["bogus_order"],
+    )
+
+    joined = "; ".join(errors)
+    assert "Unknown metric: 'revenu'" in joined
+    assert "Unknown dimension: 'regionn'" in joined
+    assert "Unknown filter column: 'bogus_col'" in joined
+    assert "Unknown order_by: 'bogus_order'" in joined
+
+
+def test_validate_query_names_accepts_valid_names() -> None:
+    assert (
+        validate_query_names(
+            {"revenue"},
+            {"region"},
+            metrics=["revenue"],
+            dimensions=["region"],
+            filters=[{"col": "region"}],
+            order_names=["revenue"],
+        )
+        == []
+    )
+
+
+def test_validate_query_names_skips_adhoc_expressions() -> None:
+    """Ad-hoc metrics/columns are dicts, not names, so they bypass name checks.
+
+    Semantic views reject them downstream in the mapper, which owns that rule.
+    """
+    adhoc_metric: AdhocMetric = {"expressionType": "SQL", "sqlExpression": "SUM(a)"}
+    adhoc_column: AdhocColumn = {
+        "sqlExpression": "LOWER(region)",
+        "label": "region_lc",
+    }
+
+    assert (
+        validate_query_names(
+            set(), set(), metrics=[adhoc_metric], dimensions=[adhoc_column]
+        )
+        == []
+    )
+
+
+def test_validate_names_suggests_close_matches() -> None:
+    (error,) = validate_names(["sum__sale"], {"sum__sales"}, "metric")
+    assert "Did you mean: sum__sales?" in error
+
+
+def test_validate_names_hints_when_no_metrics_defined() -> None:
+    (error,) = validate_names(
+        ["anything"], set(), "metric", empty_hint="No metrics here."
+    )
+    assert "No metrics here." in error
+
+
+def test_validate_names_lists_valid_when_no_close_match() -> None:
+    (error,) = validate_names(["zzz"], {"revenue"}, "metric", list_valid_on_miss=True)
+    assert "Valid metrics: revenue" in error
+
+
+def test_resolve_time_column_rejects_non_temporal_column() -> None:
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("region"), _column("ds", is_dttm=True)]
+
+    with pytest.raises(TabularQueryValidationError, match="not marked as a datetime"):
+        _resolve_time_column(explorable, "sales", "region", False)
+
+
+def test_resolve_time_column_rejects_unknown_column() -> None:
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("ds", is_dttm=True)]
+
+    with pytest.raises(TabularQueryValidationError, match="Unknown time_column"):
+        _resolve_time_column(explorable, "sales", "nope", False)
+
+
+def test_resolve_time_column_infers_from_main_dttm_col() -> None:
+    """Datasets carry main_dttm_col; it wins over positional inference."""
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("created", is_dttm=True), _column("ds", is_dttm=True)]
+    explorable.main_dttm_col = "ds"
+
+    assert _resolve_time_column(explorable, "sales", None, True) == "ds"
+
+
+def test_resolve_time_column_falls_back_to_first_datetime_dimension() -> None:
+    """Semantic views have no main_dttm_col, so the first dttm column is used."""
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("region"), _column("event_time", is_dttm=True)]
+    explorable.main_dttm_col = None
+
+    assert _resolve_time_column(explorable, "view", None, True) == "event_time"
+
+
+def test_resolve_time_column_requires_one_when_time_range_given() -> None:
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("region")]
+    explorable.main_dttm_col = None
+
+    with pytest.raises(TabularQueryValidationError, match="no temporal column"):
+        _resolve_time_column(explorable, "view", None, True)
+
+
+def test_resolve_time_column_not_inferred_without_time_range() -> None:
+    """An unfiltered query must not acquire a temporal axis it did not ask for."""
+    from superset.common.tabular_query import _resolve_time_column
+
+    explorable = MagicMock()
+    explorable.columns = [_column("ds", is_dttm=True)]
+    explorable.main_dttm_col = "ds"
+
+    assert _resolve_time_column(explorable, "sales", None, False) is None

--- a/tests/unit_tests/datasource/test_query_api.py
+++ b/tests/unit_tests/datasource/test_query_api.py
@@ -1,0 +1,171 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Unit tests for the datasource query endpoint's schema and wiring."""
+
+import pandas as pd
+import pytest
+from marshmallow import ValidationError
+
+from superset.common.chart_data import ChartDataResultFormat
+
+
+@pytest.fixture
+def schema():
+    from superset.datasource.schemas import DatasourceQuerySchema
+
+    return DatasourceQuerySchema()
+
+
+def test_defaults_to_json_result_format(schema) -> None:
+    """JSON is the primary contract; Arrow is an explicit opt-in."""
+    loaded = schema.load({"metrics": ["count"]})
+
+    assert loaded["result_format"] == ChartDataResultFormat.JSON
+    assert loaded["offset"] == 0
+    assert loaded["order"] == []
+    assert loaded["use_cache"] is True
+    assert loaded["force"] is False
+
+
+def test_accepts_arrow_result_format(schema) -> None:
+    loaded = schema.load({"metrics": ["count"], "result_format": "arrow"})
+
+    assert loaded["result_format"] == ChartDataResultFormat.ARROW
+
+
+def test_accepts_adhoc_metric_objects(schema) -> None:
+    """metrics is Raw because Metric is `AdhocMetric | str`."""
+    adhoc = {
+        "expressionType": "SQL",
+        "sqlExpression": "SUM(a)/SUM(b)",
+        "label": "Ratio",
+    }
+    assert schema.load({"metrics": [adhoc]})["metrics"] == [adhoc]
+
+
+def test_rejects_empty_request(schema) -> None:
+    """A query with neither metrics nor dimensions has nothing to select."""
+    with pytest.raises(ValidationError, match="at least one metric or dimension"):
+        schema.load({})
+
+
+def test_time_grain_accepted_without_explicit_axis(schema) -> None:
+    """The schema cannot know which dimensions are temporal, so grain
+    resolution is validated in the API against the datasource's columns."""
+    assert schema.load({"metrics": ["count"], "time_grain": "P1D"})["time_grain"] == (
+        "P1D"
+    )
+    loaded = schema.load(
+        {"metrics": ["count"], "dimensions": ["ds"], "time_grain": "P1M"}
+    )
+    assert loaded["time_grain"] == "P1M"
+
+
+def test_rejects_limit_above_cap(schema) -> None:
+    with pytest.raises(ValidationError):
+        schema.load({"metrics": ["count"], "limit": 500_000})
+
+
+def test_rejects_negative_offset(schema) -> None:
+    with pytest.raises(ValidationError):
+        schema.load({"metrics": ["count"], "offset": -1})
+
+
+def test_order_carries_per_column_direction(schema) -> None:
+    """Mirrors SemanticQuery's OrderTuple rather than one flag for all columns."""
+    loaded = schema.load(
+        {
+            "metrics": ["count"],
+            "order": [{"column": "count"}, {"column": "region", "descending": False}],
+        }
+    )
+
+    assert loaded["order"] == [
+        {"column": "count", "descending": True},
+        {"column": "region", "descending": False},
+    ]
+
+
+def test_order_requires_a_column(schema) -> None:
+    with pytest.raises(ValidationError):
+        schema.load({"metrics": ["count"], "order": [{"descending": True}]})
+
+
+def test_rejects_unknown_filter_operator(schema) -> None:
+    """Filters reuse ChartDataFilterSchema, which validates against
+    FilterOperator."""
+    with pytest.raises(ValidationError):
+        schema.load(
+            {"metrics": ["count"], "filters": [{"col": "a", "op": "NOPE", "val": 1}]}
+        )
+
+
+def test_accepts_ilike_operator(schema) -> None:
+    """ILIKE is a valid wire operator and now reaches semantic views too."""
+    loaded = schema.load(
+        {"metrics": ["count"], "filters": [{"col": "a", "op": "ILIKE", "val": "%x%"}]}
+    )
+    assert loaded["filters"][0]["op"] == "ILIKE"
+
+
+def test_query_routes_registered(app) -> None:
+    rules = {
+        rule.rule
+        for rule in app.url_map.iter_rules()
+        if "/api/v1/datasource" in rule.rule
+    }
+
+    assert "/api/v1/datasource/<datasource_type>/<int:datasource_id>/query" in rules
+    assert "/api/v1/datasource/<datasource_type>/<int:datasource_id>" in rules
+
+
+def test_both_new_routes_share_can_query(app) -> None:
+    """Sharing can_query keeps the metadata route off can_get, which
+    PUBLIC_ROLE_PERMISSIONS already grants for chart rendering."""
+    from superset.datasource.api import DatasourceRestApi
+
+    assert DatasourceRestApi.method_permission_name["query"] == "query"
+    assert DatasourceRestApi.method_permission_name["datasource_info"] == "query"
+
+
+def test_can_query_is_gamma_readable(app) -> None:
+    """Without this, Datasource being in GAMMA_READ_ONLY_MODEL_VIEWS makes
+    _is_alpha_only withhold can_query from Gamma."""
+    from superset.security.manager import SupersetSecurityManager
+
+    assert "can_query" in SupersetSecurityManager.READ_ONLY_PERMISSION
+    assert "Datasource" in SupersetSecurityManager.GAMMA_READ_ONLY_MODEL_VIEWS
+
+
+def test_arrow_is_not_export_gated() -> None:
+    """Arrow is a programmatic transport, not a human file export, so it stays
+    out of table_like() and its can_export_data / can_csv gate."""
+    assert ChartDataResultFormat.ARROW not in ChartDataResultFormat.table_like()
+
+
+def test_arrow_serializer_round_trips() -> None:
+    import pyarrow as pa
+
+    from superset.common.query_context_processor import QueryContextProcessor
+
+    df = pd.DataFrame({"region": ["EMEA", "APAC"], "sales": [10, 20]})
+    payload = QueryContextProcessor._to_arrow_ipc(df)
+
+    assert isinstance(payload, bytes)
+    restored = pa.ipc.open_stream(payload).read_all().to_pandas()
+    pd.testing.assert_frame_equal(restored, df)

--- a/tests/unit_tests/semantic_layers/mapper_test.py
+++ b/tests/unit_tests/semantic_layers/mapper_test.py
@@ -376,26 +376,34 @@ def test_convert_query_object_filter_in(mock_datasource: MagicMock) -> None:
     }
 
 
-def test_convert_query_object_filter_ilike_rejected(
+def test_convert_query_object_filter_ilike(
     mock_datasource: MagicMock,
 ) -> None:
     """
-    Case-insensitive operators are rejected explicitly rather than silently
-    collapsed into LIKE — that collapse would let the backend's collation
-    decide case sensitivity, silently diverging from the filter the dashboard
-    author selected.
+    Case-insensitive operators map through to the provider, which resolves
+    them per its own collation rules. Providers unable to express ILIKE should
+    advertise that through a SemanticViewFeature rather than having the mapper
+    reject the operator for every provider.
     """
     all_dimensions = {
         dim.name: dim for dim in mock_datasource.implementation.dimensions
     }
-    for op in (FilterOperator.ILIKE.value, FilterOperator.NOT_ILIKE.value):
+    for op, expected in (
+        (FilterOperator.ILIKE.value, Operator.ILIKE),
+        (FilterOperator.NOT_ILIKE.value, Operator.NOT_ILIKE),
+    ):
         filter_: ValidatedQueryObjectFilterClause = {
             "op": op,
             "col": "category",
             "val": "%book%",
         }
-        with pytest.raises(ValueError, match="case-insensitive"):
-            _convert_query_object_filter(filter_, all_dimensions)
+        result = _convert_query_object_filter(filter_, all_dimensions)
+        assert result is not None
+        assert len(result) == 1
+        converted = next(iter(result))
+        assert converted.operator == expected
+        assert converted.column == all_dimensions["category"]
+        assert converted.value == "%book%"
 
 
 def test_convert_query_object_filter_is_null(mock_datasource: MagicMock) -> None:


### PR DESCRIPTION
### SUMMARY

Superset has no REST API for querying a datasource by its semantic definitions. The only
option today is `POST /api/v1/chart/data`, which is built for the Explore UI: callers must
hand-construct a `query_context` including `BASE_AXIS`/`SERIES` adhoc columns and
`post_processing` chains, get no validation of metric or dimension names, and couple
themselves to a payload whose shape follows frontend needs. In practice external consumers
reverse-engineer a `query_context` from a saved chart's `form_data`, which breaks on
viz-type changes.

This adds `POST /api/v1/datasource/<type>/<id>/query`, taking a name-based payload of
`metrics`, `dimensions`, `filters`, `time_range`, `time_grain`, `limit`/`offset` and
`order`, plus `GET /api/v1/datasource/<type>/<id>` for metadata and capabilities. Both
live on the existing `DatasourceRestApi`, which already serves this URL shape for
`/compatible` and `/column/<col>/values/`. No new execution machinery: the endpoint enters
the pipeline at `QueryContextFactory`, so caching, RLS, post-processing and row-limit
clamping are unchanged, and `Explorable.get_query_result` already dispatches datasets to SQL
and semantic views to the semantic-layer mapper — so there is no type-dispatch layer.

Two things a reviewer may want to weigh in on. First, the resolve/validate/build/execute
sequence moves into `superset/common/tabular_query.py` and the two MCP tools
(`get_table`, `query_dataset`) are refactored onto it. They had already drifted — only
`query_dataset` called `set_query_context_form_data`, so identical queries against a
Jinja-templated virtual dataset returned different results through the two tools. Their
existing unit tests pass unmodified, which is the evidence the refactor is
behaviour-preserving. Second, `can_query on Datasource` is added to `READ_ONLY_PERMISSION`
so Gamma receives it; `Datasource` is in `GAMMA_READ_ONLY_MODEL_VIEWS`, so otherwise
`_is_alpha_only` withholds it. `can_get_column_values` and `can_compatible` on this same
class appear to have that pre-existing problem — happy to fix separately.

### TESTING INSTRUCTIONS

Unit tests: `pytest tests/unit_tests/datasource tests/unit_tests/common/test_tabular_query.py`,
plus `pytest tests/unit_tests/mcp_service tests/unit_tests/semantic_layers` to confirm the
refactor and the `ILIKE` change.

Manually, against the examples data:

```bash
TOKEN=$(curl -s -X POST http://127.0.0.1:8088/api/v1/security/login \
  -H 'Content-Type: application/json' \
  -d '{"username":"admin","password":"admin","provider":"db"}' \
  | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')

# saved metric + dimension
curl -s -X POST http://127.0.0.1:8088/api/v1/datasource/table/<birth_names_id>/query \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"metrics":["count"],"dimensions":["gender"]}'

# ad-hoc metric (datasets only)
curl -s -X POST .../query -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"metrics":[{"expressionType":"SQL","sqlExpression":"SUM(num_boys)*1.0/SUM(num)","label":"boy_ratio"}],"dimensions":["gender"]}'

# time grain — expect DATETIME(ds,'start of year') and a matching GROUP BY
curl -s -X POST .../query -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"metrics":["count"],"dimensions":["ds"],"time_grain":"P1Y","limit":3}'

# Arrow opt-in — expect application/vnd.apache.arrow.stream
curl -s -X POST .../query -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"metrics":["count"],"dimensions":["gender"],"result_format":"arrow"}' -o out.arrow -D -

# capabilities
curl -s http://127.0.0.1:8088/api/v1/datasource/table/<id> -H "Authorization: Bearer $TOKEN"
```

Expected failure modes: unknown metric → 400 naming it with a suggestion; `time_grain` with
no temporal column → 400; ad-hoc metric against a `semantic_view` → 400 naming the metric;
`semantic_view` with `SEMANTIC_LAYERS` off → 404; unauthenticated → 401.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #37535
- [ ] Required feature flags: none for `table`; `semantic_view` requires `SEMANTIC_LAYERS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API