### PR TITLE
chore(superset-core): add __init__.py to semantic_layers

### DIFF
--- a/superset-core/src/superset_core/semantic_layers/__init__.py
+++ b/superset-core/src/superset_core/semantic_layers/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Semantic layer contracts for extension authors."""


### PR DESCRIPTION
### SUMMARY

`superset_core/semantic_layers` is the only subpackage under `superset_core` without an `__init__.py`. Its six
siblings — `common`, `extensions`, `mcp`, `queries`, `rest_api`, `tasks` — all have one, so `semantic_layers`
resolves as an implicit namespace package while the rest are regular packages. This adds one for consistency,
and gives the subpackage somewhere to carry a docstring.

To be explicit, because the asymmetry looks like it might be: **this is not a packaging fix.**
`[tool.setuptools.packages.find]` defaults to `namespaces = true`, so setuptools already discovers the
directory and ships every module in it. I verified that by building a wheel with the file removed, installing
it into a clean virtualenv, and importing `superset_core.semantic_layers.types` successfully — it works, with
the subpackage resolving as a namespace package.

So this is a tidy-up rather than a bug fix, and reasonable to close if you'd rather not churn the file. The
only practical differences are the docstring and the ability to add re-exports later.

### TESTING INSTRUCTIONS

`python -c "import superset_core.semantic_layers.types"` before and after — both succeed. To confirm the
packaging claim independently:

```bash
cd superset-core
python -m build --wheel -o /tmp/dist .
unzip -l /tmp/dist/*.whl | grep semantic_layers   # all modules present either way
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
