### PR TITLE
fix(navbar): use down-chevron icon consistently on all navbar dropdowns

### DIFF
--- a/superset-frontend/src/features/home/LanguagePicker.test.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.test.tsx
@@ -67,3 +67,13 @@ test('should render the items', async () => {
   expect(await screen.findByText('English')).toBeInTheDocument();
   expect(await screen.findByText('Italian')).toBeInTheDocument();
 });
+
+test('renders the down-chevron caret icon, not the caret glyph (regression #43531)', async () => {
+  render(<TestLanguagePicker {...mockedProps} />, {
+    useRouter: true,
+  });
+  const menuItem = await screen.findByRole('menuitem');
+  const caret = menuItem.querySelector('.ant-menu-item-icon');
+  expect(caret).toHaveClass('anticon-down');
+  expect(caret?.querySelector('svg')).toHaveAttribute('data-icon', 'down');
+});

--- a/superset-frontend/src/features/home/LanguagePicker.tsx
+++ b/superset-frontend/src/features/home/LanguagePicker.tsx
@@ -78,7 +78,7 @@ export const useLanguageMenuItems = ({
           <i className={`flag ${languages[locale]?.flag ?? 'us'}`} />
         </span>
       ),
-      icon: <Icons.CaretDownOutlined iconSize="xs" />,
+      icon: <Icons.DownOutlined iconSize="xs" />,
       children: items,
       className: 'submenu-with-caret',
       popupClassName: 'language-picker-popup',

--- a/superset-frontend/src/features/home/Menu.test.tsx
+++ b/superset-frontend/src/features/home/Menu.test.tsx
@@ -387,6 +387,20 @@ test('should render all the top navbar menu items', async () => {
   });
 });
 
+test('renders the down-chevron caret icon on top-level category dropdowns, not the caret glyph (regression #43531)', async () => {
+  useSelectorMock.mockReturnValue({ roles: user.roles });
+  render(<Menu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+  const sources = await screen.findByText('Sources');
+  const caret = sources.closest('li')?.querySelector('.ant-menu-item-icon');
+  expect(caret).toHaveClass('anticon-down');
+  expect(caret?.querySelector('svg')).toHaveAttribute('data-icon', 'down');
+});
+
 test('should render the top navbar child menu items', async () => {
   useSelectorMock.mockReturnValue({ roles: user.roles });
   const {

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -113,7 +113,7 @@ const StyledMainNav = styled(MainNav)`
         padding: 0 ${theme.sizeUnit * 4}px;
       }
 
-      [data-icon='caret-down'] {
+      [data-icon='down'] {
         color: ${theme.colorIcon};
         font-size: ${theme.sizeXS}px;
       }
@@ -330,7 +330,7 @@ export function Menu({
       key,
       label,
       ...(isMd && {
-        icon: <Icons.CaretDownOutlined iconSize="xs" />,
+        icon: <Icons.DownOutlined iconSize="xs" />,
         popupOffset: NAVBAR_MENU_POPUP_OFFSET,
       }),
       children: childItems,

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -115,6 +115,11 @@ const StyledMainNav = styled(MainNav)`
 
       [data-icon='down'] {
         color: ${theme.colorIcon};
+        /* sizeXS (an antd token, always computed) rather than fontSizeXS
+           (a Superset custom token seeded only via THEME_DEFAULT in
+           config.py) so this stays small in contexts that construct a
+           theme without that seed, e.g. Storybook and Jest. Both resolve
+           to the same 8px in the app's default theme. */
         font-size: ${theme.sizeXS}px;
       }
 

--- a/superset-frontend/src/features/home/Menu.tsx
+++ b/superset-frontend/src/features/home/Menu.tsx
@@ -113,6 +113,11 @@ const StyledMainNav = styled(MainNav)`
         padding: 0 ${theme.sizeUnit * 4}px;
       }
 
+      [data-icon='caret-down'] {
+        color: ${theme.colorIcon};
+        font-size: ${theme.sizeXS}px;
+      }
+
       &:hover,
       &.ant-menu-submenu-active {
         .ant-menu-title-content {
@@ -325,7 +330,7 @@ export function Menu({
       key,
       label,
       ...(isMd && {
-        icon: <Icons.DownOutlined iconSize="xs" />,
+        icon: <Icons.CaretDownOutlined iconSize="xs" />,
         popupOffset: NAVBAR_MENU_POPUP_OFFSET,
       }),
       children: childItems,

--- a/superset-frontend/src/features/home/RightMenu.test.tsx
+++ b/superset-frontend/src/features/home/RightMenu.test.tsx
@@ -384,6 +384,34 @@ test('If there is NOT a DB with allow_file_upload set as True the option should 
   );
 });
 
+test('renders the down-chevron caret icon on the "+" and Settings dropdowns, not the caret glyph (regression #43531)', async () => {
+  const mockedProps = createProps();
+  resetUseSelectorMock();
+  render(<RightMenu {...mockedProps} />, {
+    useRedux: true,
+    useQueryParams: true,
+    useRouter: true,
+    useTheme: true,
+  });
+
+  const newDropdownIcon = screen.getByTestId('new-dropdown-icon');
+  const newCaret = newDropdownIcon
+    .closest('li')
+    ?.querySelector('.ant-menu-item-icon');
+  expect(newCaret).toHaveClass('anticon-down');
+  expect(newCaret?.querySelector('svg')).toHaveAttribute('data-icon', 'down');
+
+  const settings = await screen.findByText(/Settings/i);
+  const settingsCaret = settings
+    .closest('li')
+    ?.querySelector('.ant-menu-item-icon');
+  expect(settingsCaret).toHaveClass('anticon-down');
+  expect(settingsCaret?.querySelector('svg')).toHaveAttribute(
+    'data-icon',
+    'down',
+  );
+});
+
 test('Logs out and clears local storage item redux', async () => {
   const mockedProps = createProps();
   resetUseSelectorMock();

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -614,7 +614,7 @@ const RightMenu = ({
         key: 'new-dropdown',
         label: <Icons.PlusOutlined data-test="new-dropdown-icon" />,
         className: 'submenu-with-caret',
-        icon: <Icons.CaretDownOutlined iconSize="xs" />,
+        icon: <Icons.DownOutlined iconSize="xs" />,
         children: buildNewDropdownItems(),
         popupOffset: NAVBAR_MENU_POPUP_OFFSET,
       });
@@ -631,7 +631,7 @@ const RightMenu = ({
     items.push({
       key: 'settings',
       label: t('Settings'),
-      icon: <Icons.CaretDownOutlined iconSize="xs" />,
+      icon: <Icons.DownOutlined iconSize="xs" />,
       children: buildSettingsMenuItems(),
       className: 'submenu-with-caret',
       popupOffset: NAVBAR_MENU_POPUP_OFFSET,
@@ -846,7 +846,7 @@ const RightMenu = ({
                 flex-direction: row-reverse;
                 height: 100%;
               }
-              [data-icon='caret-down'] {
+              [data-icon='down'] {
                 color: ${theme.colorIcon};
                 font-size: ${theme.sizeXS}px;
               }

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -846,6 +846,10 @@ const RightMenu = ({
                 flex-direction: row-reverse;
                 height: 100%;
               }
+              [data-icon='caret-down'] {
+                color: ${theme.colorIcon};
+                font-size: ${theme.sizeXS}px;
+              }
               &.ant-menu-submenu::after {
                 inset-inline: ${theme.sizeUnit}px;
               }

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -848,6 +848,12 @@ const RightMenu = ({
               }
               [data-icon='down'] {
                 color: ${theme.colorIcon};
+                /* sizeXS (an antd token, always computed) rather than
+                   fontSizeXS (a Superset custom token seeded only via
+                   THEME_DEFAULT in config.py) so this stays small in
+                   contexts that construct a theme without that seed, e.g.
+                   Storybook and Jest. Both resolve to the same 8px in the
+                   app's default theme. */
                 font-size: ${theme.sizeXS}px;
               }
               &.ant-menu-submenu::after {

--- a/superset-frontend/src/features/home/RightMenu.tsx
+++ b/superset-frontend/src/features/home/RightMenu.tsx
@@ -614,7 +614,7 @@ const RightMenu = ({
         key: 'new-dropdown',
         label: <Icons.PlusOutlined data-test="new-dropdown-icon" />,
         className: 'submenu-with-caret',
-        icon: <Icons.DownOutlined iconSize="xs" />,
+        icon: <Icons.CaretDownOutlined iconSize="xs" />,
         children: buildNewDropdownItems(),
         popupOffset: NAVBAR_MENU_POPUP_OFFSET,
       });
@@ -631,7 +631,7 @@ const RightMenu = ({
     items.push({
       key: 'settings',
       label: t('Settings'),
-      icon: <Icons.DownOutlined iconSize="xs" />,
+      icon: <Icons.CaretDownOutlined iconSize="xs" />,
       children: buildSettingsMenuItems(),
       className: 'submenu-with-caret',
       popupOffset: NAVBAR_MENU_POPUP_OFFSET,

--- a/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.test.tsx
@@ -271,4 +271,14 @@ describe('useThemeMenuItems', () => {
 
     expect(divider).toBeNull();
   });
+
+  test('renders the down-chevron caret icon, not the caret glyph (regression #43531)', async () => {
+    renderThemeMenu();
+
+    const menuItem = await screen.findByRole('menuitem');
+    const caret = menuItem.querySelector('.ant-menu-item-icon');
+
+    expect(caret).toHaveClass('anticon-down');
+    expect(caret?.querySelector('svg')).toHaveAttribute('data-icon', 'down');
+  });
 });

--- a/superset-frontend/src/hooks/useThemeMenuItems.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.tsx
@@ -136,7 +136,7 @@ export const useThemeMenuItems = ({
   return {
     key: 'theme-sub-menu',
     label: selectedThemeModeIcon,
-    icon: <Icons.CaretDownOutlined iconSize="xs" />,
+    icon: <Icons.DownOutlined iconSize="xs" />,
     className: 'submenu-with-caret',
     children,
     popupOffset: NAVBAR_MENU_POPUP_OFFSET,

--- a/superset-frontend/src/hooks/useThemeMenuItems.tsx
+++ b/superset-frontend/src/hooks/useThemeMenuItems.tsx
@@ -136,7 +136,7 @@ export const useThemeMenuItems = ({
   return {
     key: 'theme-sub-menu',
     label: selectedThemeModeIcon,
-    icon: <Icons.DownOutlined iconSize="xs" />,
+    icon: <Icons.CaretDownOutlined iconSize="xs" />,
     className: 'submenu-with-caret',
     children,
     popupOffset: NAVBAR_MENU_POPUP_OFFSET,


### PR DESCRIPTION
### SUMMARY
The navbar's dropdown indicators ("+", theme switcher, Settings, top-level nav categories, and the language picker) were inconsistent: some rendered the caret glyph (`Icons.CaretDownOutlined` / `anticon-caret-down`), others the chevron glyph (`Icons.DownOutlined` / `anticon-down`), and the caret glyph also rendered oversized relative to the chevron at the same `iconSize="xs"`.

This PR standardizes all five navbar dropdown indicators on `Icons.DownOutlined`, so each one renders `class="anticon anticon-down ant-menu-item-icon"`, and updates the sizing CSS selector in `Menu.tsx`/`RightMenu.tsx` from `[data-icon='caret-down']` to `[data-icon='down']` so the icon still renders small and muted (`theme.colorIcon` / `theme.sizeXS`).

Changed call sites:
- `Menu.tsx` — top-level nav category dropdowns (left side)
- `RightMenu.tsx` — "+" dropdown and Settings dropdown
- `useThemeMenuItems.tsx` — theme switcher dropdown
- `LanguagePicker.tsx` — language picker dropdown

**Note on review history:** earlier commits on this PR reverted three of these call sites back to `Icons.CaretDownOutlined` to match the pre-existing `LanguagePicker` convention, and a reviewer (@rebenitez1802) correctly flagged that the fourth (`Menu.tsx`) was inconsistent with that direction. Since then we determined the actual correct icon across all five dropdowns is the chevron (`anticon-down`), not the caret — this PR now applies that consistently everywhere, including `LanguagePicker.tsx`, rather than reverting to caret. Title updated per @aminghadersohi's note that this is a glyph swap, not an `iconSize` change (size is unchanged via the shared `sizeXS` token).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — see prior screenshots on this PR for the original oversized-caret regression; this change swaps the glyph used, not the size.

### TESTING INSTRUCTIONS
- Added a regression test to each of the four navbar files (`Menu.test.tsx`, `RightMenu.test.tsx` — covers both "+" and Settings, `LanguagePicker.test.tsx`, `useThemeMenuItems.test.tsx`) asserting the rendered caret has class `anticon-down` and `data-icon="down"`, not `anticon-caret-down`. Neither suite asserted icon identity before this PR, which is how the original regression (and the earlier caret/chevron flip-flop on this PR) went uncaught.
- `npx jest src/features/home/Menu.test.tsx src/features/home/RightMenu.test.tsx src/features/home/LanguagePicker.test.tsx src/hooks/useThemeMenuItems.test.tsx`: 84/84 passing
- `pre-commit run` on changed files: formatting/lint/stylelint pass (pre-existing, unrelated `Datasource/FoldersEditor/styles.tsx` type-check failure only, not touched by this PR)
- Manually verify: navbar "+", theme switcher, Settings, top-level category dropdowns, and language picker all show the same small `anticon-down` chevron

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
