### PR TITLE
fix(security): let Alpha/Gamma open Settings → Info

### DIFF
--- a/superset/views/user_info.py
+++ b/superset/views/user_info.py
@@ -24,11 +24,21 @@ from .base import BaseSupersetView
 
 
 class UserInfoView(BaseSupersetView):
+    """SPA shell for the signed-in user's own profile page.
+
+    Uses ``can_userinfo on UserInfo`` rather than ``can_read on user`` /
+    ``User``. The latter is Admin-only (``ADMIN_ONLY_VIEW_MENUS``), so
+    Alpha/Gamma were redirected to ``/superset/welcome/`` when opening
+    Settings → Info even though the menu link is shown to every
+    authenticated user. ``can_userinfo`` is already in
+    ``ACCESSIBLE_PERMS``, so stock Gamma and Alpha receive it on role sync.
+    """
+
     route_base = "/"
-    class_permission_name = "user"
+    class_permission_name = "UserInfo"
 
     @expose("/user_info/")
     @has_access
-    @permission_name("read")
+    @permission_name("userinfo")
     def list(self) -> FlaskResponse:
         return super().render_app_template()

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1701,6 +1701,9 @@ class TestRolePermission(SupersetTestCase):
         assert ("can_share_chart", "Superset") in gamma_perm_set
         assert ("can_share_dashboard", "Superset") in gamma_perm_set
         assert ("can_userinfo", "UserDBModelView") in gamma_perm_set
+        # Settings → Info SPA shell (/user_info/); must not rely on Admin-only
+        # can_read on User (see #43089).
+        assert ("can_userinfo", "UserInfo") in gamma_perm_set
         assert ("can_view_chart_as_table", "Dashboard") in gamma_perm_set
         assert ("can_view_query", "Dashboard") in gamma_perm_set
 

--- a/tests/unit_tests/views/test_user_info_permissions.py
+++ b/tests/unit_tests/views/test_user_info_permissions.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Permissions for the Settings → Info (/user_info/) page."""
+
+from unittest.mock import MagicMock
+
+from superset.security.manager import SupersetSecurityManager
+from superset.views.user_info import UserInfoView
+
+
+def test_user_info_view_uses_accessible_userinfo_permission() -> None:
+    """Settings → Info must not require Admin-only can_read on User/user."""
+    assert UserInfoView.class_permission_name == "UserInfo"
+    # FAB's @permission_name("userinfo") yields permission can_userinfo.
+    assert getattr(UserInfoView.list, "_permission_name") == "userinfo"
+
+
+def test_can_userinfo_on_user_info_is_accessible_to_all(app_context: None) -> None:
+    """can_userinfo is in ACCESSIBLE_PERMS, so Gamma/Alpha get UserInfo access."""
+    from superset.extensions import appbuilder
+
+    sm = SupersetSecurityManager(appbuilder)
+    pvm = MagicMock()
+    pvm.permission.name = "can_userinfo"
+    pvm.view_menu.name = "UserInfo"
+
+    assert "can_userinfo" in SupersetSecurityManager.ACCESSIBLE_PERMS
+    assert sm._is_accessible_to_all(pvm) is True
+    assert sm._is_gamma_pvm(pvm) is True
+    assert sm._is_alpha_pvm(pvm) is True
+
+
+def test_can_read_on_user_remains_admin_only(app_context: None) -> None:
+    """Regression: user management stays Admin-only after the UserInfo split."""
+    from superset.extensions import appbuilder
+
+    sm = SupersetSecurityManager(appbuilder)
+    pvm = MagicMock()
+    pvm.permission.name = "can_read"
+    pvm.view_menu.name = "User"
+
+    assert "User" in SupersetSecurityManager.ADMIN_ONLY_VIEW_MENUS
+    assert sm._is_admin_only(pvm) is True
+    assert sm._is_gamma_pvm(pvm) is False


### PR DESCRIPTION
### SUMMARY
Fixes #43089.

Settings → Info always links to `/user_info/`, but `UserInfoView` required `can_read on user` / `User`. That view-menu is Admin-only (`ADMIN_ONLY_VIEW_MENUS`), so Alpha/Gamma were redirected to `/superset/welcome/` while Admin worked.

This binds the SPA shell to `can_userinfo on UserInfo`. `can_userinfo` is already in `ACCESSIBLE_PERMS`, so stock Gamma and Alpha receive it on role sync without widening user-management access.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (permission / redirect behavior).

### TESTING INSTRUCTIONS
1. Log in as Alpha or Gamma (not Admin).
2. Open **Settings → Info**.
3. Confirm `/user_info/` loads the profile page instead of redirecting to `/superset/welcome/`.
4. Confirm Admin still reaches `/user_info/` and user-management (`User`) remains Admin-only.
5. After upgrade, ensure roles are synced (`superset init` / normal startup sync) so `can_userinfo on UserInfo` is granted to Gamma/Alpha.

Unit coverage: `tests/unit_tests/views/test_user_info_permissions.py`.
Integration assertion: Gamma includes `("can_userinfo", "UserInfo")` in `tests/integration_tests/security_tests.py`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #43089
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Made with [Cursor](https://cursor.com)