### PR TITLE
docs: update frontend Node/npm prerequisites to match engines

### DIFF
--- a/docs/developer_docs/contributing/development-setup.md
+++ b/docs/developer_docs/contributing/development-setup.md
@@ -493,8 +493,8 @@ Frontend assets (TypeScript, JavaScript, CSS, and images) must be compiled in or
 
 First, be sure you are using the following versions of Node.js and npm:
 
-- `Node.js`: Version 22 (LTS)
-- `npm`: Version 10
+- `Node.js`: Version 24 (see `superset-frontend/.nvmrc` for the exact version)
+- `npm`: Version 11
 
 We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage your node environment:
 
@@ -507,8 +507,8 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 cd superset-frontend
-nvm install --lts
-nvm use --lts
+nvm install
+nvm use
 ```
 
 Or if you use the default macOS starting with Catalina shell `zsh`, try:


### PR DESCRIPTION
### SUMMARY
The development setup guide tells contributors to install Node.js 22 (LTS) and npm 10, and to run `nvm install --lts`. The frontend's `package.json` engines field requires `node ^24.16.0` / `npm ^11.13.0`, and `superset-frontend/.nvmrc` pins `v24.16.0`, so following the guide as written fails the engines check on install. This updates the stated versions to Node 24 / npm 11, points at `.nvmrc` for the exact version, and switches the snippet to bare `nvm install` / `nvm use` so nvm picks up the `.nvmrc` pin instead of whatever LTS happens to be.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (docs only)

### TESTING INSTRUCTIONS
Compare the guide against `superset-frontend/package.json` (`engines`) and `superset-frontend/.nvmrc`. From `superset-frontend/`, `nvm install && nvm use` now lands on the pinned v24.16.0.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
