### PR TITLE
fix(number-format): handle sub-byte values and unit rollover in memory formatter

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/number-format/factories/createMemoryFormatter.ts
+++ b/superset-frontend/packages/superset-ui-core/src/number-format/factories/createMemoryFormatter.ts
@@ -38,11 +38,21 @@ function formatMemory(
         : ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
       const base = binary ? 1024 : 1000;
 
-      const i = Math.min(
-        suffixes.length - 1,
-        Math.floor(Math.log(absValue) / Math.log(base)),
+      let i = Math.max(
+        0,
+        Math.min(
+          suffixes.length - 1,
+          Math.floor(Math.log(absValue) / Math.log(base)),
+        ),
       );
-      formatted = `${sign}${parseFloat((absValue / Math.pow(base, i)).toFixed(decimals))}${suffixes[i]}`;
+      let scaled = parseFloat((absValue / Math.pow(base, i)).toFixed(decimals));
+
+      if (scaled >= base && i < suffixes.length - 1) {
+        i += 1;
+        scaled = parseFloat((absValue / Math.pow(base, i)).toFixed(decimals));
+      }
+
+      formatted = `${sign}${scaled}${suffixes[i]}`;
     }
 
     if (transfer) {

--- a/superset-frontend/packages/superset-ui-core/test/number-format/factories/createMemoryFormatter.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/number-format/factories/createMemoryFormatter.test.ts
@@ -60,6 +60,31 @@ test('formats float bytes in human readable format with default options', () => 
   expect(formatter(1200.666)).toBe('1.2kB');
 });
 
+test('formats values below one byte without dropping the unit', () => {
+  const formatter = createMemoryFormatter();
+  expect(formatter(0.5)).toBe('0.5B');
+  expect(formatter(0.004)).toBe('0B');
+  expect(formatter(-0.25)).toBe('-0.25B');
+
+  const binaryFormatter = createMemoryFormatter({ binary: true });
+  expect(binaryFormatter(0.5)).toBe('0.5B');
+});
+
+test('rolls over to the next unit when rounding reaches the base', () => {
+  const formatter = createMemoryFormatter();
+  expect(formatter(999999)).toBe('1MB');
+  expect(formatter(999995)).toBe('1MB');
+  expect(formatter(999994)).toBe('999.99kB');
+  expect(formatter(-999999)).toBe('-1MB');
+
+  const binaryFormatter = createMemoryFormatter({ binary: true });
+  expect(binaryFormatter(1024 * 1024 - 1)).toBe('1MiB');
+
+  // the largest unit has nothing to roll over into
+  const largest = createMemoryFormatter();
+  expect(largest(Math.pow(1000, 11))).toBe('1000QB');
+});
+
 test('formats bytes in human readable format with additional binary option', () => {
   const formatter = createMemoryFormatter({ binary: true });
   expect(formatter(0)).toBe('0B');


### PR DESCRIPTION
### SUMMARY
The memory formatter (`createMemoryFormatter` in `@superset-ui/core`) breaks on two edge ranges:

- For values between 0 and 1 byte, the suffix index `Math.floor(Math.log(absValue) / Math.log(base))` goes negative, so `suffixes[i]` is `undefined`. `formatter(0.5)` returns `500undefined` instead of `0.5B` (negative fractions too: `-0.25` -> `-250undefined`).
- For values that round up to the base, e.g. `999999` with the default 2 decimals, the scaled value `999.999` rounds to `1000.00` and the output is `1000kB` instead of `1MB`. Binary mode has the same problem near 1024.

This PR clamps the suffix index at 0 (sub-byte values stay in bytes) and, when the rounded value reaches the base, bumps to the next unit and rescales. The largest unit is left as-is since there is nothing to roll over into. Added unit tests for both cases.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (formatter output only). Before/after:

| input | before | after |
|---|---|---|
| `0.5` | `500undefined` | `0.5B` |
| `-0.25` | `-250undefined` | `-0.25B` |
| `999999` | `1000kB` | `1MB` |
| `1024 * 1024 - 1` (binary) | `1024KiB` | `1MiB` |

### TESTING INSTRUCTIONS
From `superset-frontend/`:

```
npm run test -- packages/superset-ui-core/test/number-format/factories/createMemoryFormatter.test.ts
```

All 10 tests pass (8 existing + 2 new). You can also reproduce the old behavior on master with `createMemoryFormatter()(0.5)`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
