### PR TITLE
feat(reports): gate retry functionality behind ALERT_REPORTS_RETRY flag

### DIFF
--- a/docs/static/feature-flags.json
+++ b/docs/static/feature-flags.json
@@ -121,6 +121,12 @@
         "description": "Enables filter functionality in Alerts and Reports"
       },
       {
+        "name": "ALERT_REPORTS_RETRY",
+        "default": false,
+        "lifecycle": "testing",
+        "description": "Enables automatic retry functionality for failed report executions"
+      },
+      {
         "name": "ALERT_REPORT_SLACK_V2",
         "default": true,
         "lifecycle": "testing",

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -28,6 +28,7 @@ export enum FeatureFlag {
   AlertReportSlackV2 = 'ALERT_REPORT_SLACK_V2',
   AlertReportWebhook = 'ALERT_REPORT_WEBHOOK',
   AlertReportsFilter = 'ALERT_REPORTS_FILTER',
+  AlertReportsRetry = 'ALERT_REPORTS_RETRY',
   AllowFullCsvExport = 'ALLOW_FULL_CSV_EXPORT',
   ChartPluginsExperimental = 'CHART_PLUGINS_EXPERIMENTAL',
   ConfirmDashboardDiff = 'CONFIRM_DASHBOARD_DIFF',

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -723,11 +723,13 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     force_screenshot: false,
     include_cta: true,
     grace_period: undefined,
-    retry_on_failure: false,
-    retry_max_attempts: 3,
-    send_failed_reports: false,
-    retry_notify_owners: true,
-    retry_notify_recipients: false,
+    ...(isFeatureEnabled(FeatureFlag.AlertReportsRetry) && {
+      retry_on_failure: false,
+      retry_max_attempts: 3,
+      send_failed_reports: false,
+      retry_notify_owners: true,
+      retry_notify_recipients: false,
+    }),
   };
 
   const fetchDashboardFilterValues = async (
@@ -2762,7 +2764,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 </>
               ),
             },
-            ...(isReport
+            ...(isReport && isFeatureEnabled(FeatureFlag.AlertReportsRetry)
               ? [
                   {
                     key: 'error-handling',

--- a/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/ReportModal.test.tsx
@@ -452,7 +452,23 @@ test('submit failure dispatches danger toast and keeps modal open', async () => 
 // Error Handling section tests
 // ---------------------------------------------------------------------------
 
-test('Error Handling section is visible and Enable Retries checkbox is unchecked by default', () => {
+const enableRetryFlag = () => {
+  mockedIsFeatureEnabled.mockImplementation(
+    (featureFlag: string) =>
+      featureFlag === FeatureFlag.AlertReports ||
+      featureFlag === FeatureFlag.AlertReportsRetry,
+  );
+};
+
+test('Error Handling section is hidden when ALERT_REPORTS_RETRY flag is off', () => {
+  const store = createStore({}, reducerIndex);
+  render(<ReportModal {...defaultProps} />, { useRedux: true, store });
+
+  expect(screen.queryByText('Error Handling')).not.toBeInTheDocument();
+});
+
+test('Error Handling section is visible when ALERT_REPORTS_RETRY flag is on', () => {
+  enableRetryFlag();
   const store = createStore({}, reducerIndex);
   render(<ReportModal {...defaultProps} />, { useRedux: true, store });
 
@@ -464,6 +480,7 @@ test('Error Handling section is visible and Enable Retries checkbox is unchecked
 });
 
 test('conditional retry fields are hidden when Enable Retries is unchecked', () => {
+  enableRetryFlag();
   const store = createStore({}, reducerIndex);
   render(<ReportModal {...defaultProps} />, { useRedux: true, store });
 
@@ -473,6 +490,7 @@ test('conditional retry fields are hidden when Enable Retries is unchecked', () 
 });
 
 test('conditional retry fields appear when Enable Retries is checked', async () => {
+  enableRetryFlag();
   const store = createStore({}, reducerIndex);
   render(<ReportModal {...defaultProps} />, { useRedux: true, store });
 
@@ -489,6 +507,7 @@ test('conditional retry fields appear when Enable Retries is checked', async () 
 });
 
 test('retry fields are included in the POST body when Enable Retries is enabled', async () => {
+  enableRetryFlag();
   fetchMock.post(REPORT_ENDPOINT, { result: {} }, { name: 'post-retry' });
   const store = createStore({}, reducerIndex);
   render(

--- a/superset-frontend/src/features/reports/ReportModal/index.tsx
+++ b/superset-frontend/src/features/reports/ReportModal/index.tsx
@@ -26,7 +26,12 @@ import {
 } from 'react';
 
 import { t } from '@apache-superset/core/translation';
-import { getClientErrorObject, VizType } from '@superset-ui/core';
+import {
+  getClientErrorObject,
+  isFeatureEnabled,
+  FeatureFlag,
+  VizType,
+} from '@superset-ui/core';
 import { Alert } from '@apache-superset/core/components';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { useDispatch, useSelector } from 'react-redux';
@@ -196,11 +201,13 @@ function ReportModal({
       crontab: currentReport.crontab,
       report_format: currentReport.report_format || defaultNotificationFormat,
       timezone: currentReport.timezone,
-      retry_on_failure: currentReport.retry_on_failure ?? false,
-      retry_max_attempts: currentReport.retry_max_attempts ?? 3,
-      send_failed_reports: currentReport.send_failed_reports ?? false,
-      retry_notify_owners: currentReport.retry_notify_owners ?? true,
-      retry_notify_recipients: currentReport.retry_notify_recipients ?? false,
+      ...(isFeatureEnabled(FeatureFlag.AlertReportsRetry) && {
+        retry_on_failure: currentReport.retry_on_failure ?? false,
+        retry_max_attempts: currentReport.retry_max_attempts ?? 3,
+        send_failed_reports: currentReport.send_failed_reports ?? false,
+        retry_notify_owners: currentReport.retry_notify_owners ?? true,
+        retry_notify_recipients: currentReport.retry_notify_recipients ?? false,
+      }),
     };
 
     setCurrentReport({ isSubmitting: true, error: undefined });
@@ -478,7 +485,8 @@ function ReportModal({
         />
         {isChart && renderMessageContentSection}
         {(!isChart || !isTextBasedChart) && renderCustomWidthSection}
-        {renderErrorHandlingSection}
+        {isFeatureEnabled(FeatureFlag.AlertReportsRetry) &&
+          renderErrorHandlingSection}
       </StyledBottomSection>
       {currentReport.error && (
         <Alert

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -1771,8 +1771,9 @@ class ReportNotTriggeredErrorState(BaseReportState):
                     return
             self.send()
             # Clear any retry state from previous failed attempts in this window.
-            if feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY"):
-                self._reset_retry_counter()
+            # Always reset on success regardless of feature flag — prevents
+            # stale counters from being reused if the flag is later re-enabled.
+            self._reset_retry_counter()
             warning_message = (
                 ";".join(self._execution_warnings) if self._execution_warnings else None
             )
@@ -2061,9 +2062,9 @@ class ReportSuccessState(BaseReportState):
             raise
 
         # send() succeeded — clear retry state and log success. Any execution
-        # warnings are incorporated by create_log().
-        if feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY"):
-            self._reset_retry_counter()
+        # warnings are incorporated by create_log(). Always reset regardless
+        # of feature flag to prevent stale counters.
+        self._reset_retry_counter()
         self.update_report_schedule_and_log(ReportState.SUCCESS, error_message=None)
 
 

--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -1620,6 +1620,9 @@ class BaseReportState:
         (caller should ``return`` without re-raising), or False if the caller
         should fall through to its own error handling path.
         """
+        if not feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY"):
+            return False
+
         retry_on_failure: bool = self._report_schedule.retry_on_failure
         if not retry_on_failure:
             return False
@@ -1735,7 +1738,8 @@ class ReportNotTriggeredErrorState(BaseReportState):
         # retry delay, consider the retry chain dead and let the new window
         # proceed (e.g., apply_async failed after committing RETRYING).
         if (
-            self._report_schedule.last_state == ReportState.RETRYING
+            feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY")
+            and self._report_schedule.last_state == ReportState.RETRYING
             and self._is_retry_window_stale()
         ):
             max_delay: int = app.config.get(
@@ -1767,7 +1771,8 @@ class ReportNotTriggeredErrorState(BaseReportState):
                     return
             self.send()
             # Clear any retry state from previous failed attempts in this window.
-            self._reset_retry_counter()
+            if feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY"):
+                self._reset_retry_counter()
             warning_message = (
                 ";".join(self._execution_warnings) if self._execution_warnings else None
             )
@@ -2057,7 +2062,8 @@ class ReportSuccessState(BaseReportState):
 
         # send() succeeded — clear retry state and log success. Any execution
         # warnings are incorporated by create_log().
-        self._reset_retry_counter()
+        if feature_flag_manager.is_feature_enabled("ALERT_REPORTS_RETRY"):
+            self._reset_retry_counter()
         self.update_report_schedule_and_log(ReportState.SUCCESS, error_message=None)
 
 

--- a/superset/commands/report/update.py
+++ b/superset/commands/report/update.py
@@ -22,7 +22,7 @@ from flask_appbuilder.models.sqla import Model
 from flask_babel import gettext as _
 from marshmallow import ValidationError
 
-from superset import security_manager
+from superset import is_feature_enabled, security_manager
 from superset.commands.base import UpdateMixin
 from superset.commands.report.base import BaseReportScheduleCommand
 from superset.commands.report.exceptions import (
@@ -193,23 +193,24 @@ class UpdateReportScheduleCommand(UpdateMixin, BaseReportScheduleCommand):
             include_viewers=False,
         )
 
-        # Validate retry config: send_failed_reports requires retry_on_failure.
-        # Fall back to the existing DB value for fields not in the payload.
-        send_failed = self._properties.get(
-            "send_failed_reports", self._model.send_failed_reports
-        )
-        retry_enabled = self._properties.get(
-            "retry_on_failure", self._model.retry_on_failure
-        )
-        if send_failed and not retry_enabled:
-            msg = _("send_failed_reports requires retry_on_failure to be enabled")
-            exceptions.append(ValidationError({"send_failed_reports": [msg]}))
+        # Validate retry config when the feature is enabled.
+        if is_feature_enabled("ALERT_REPORTS_RETRY"):
+            # Fall back to the existing DB value for fields not in the payload.
+            send_failed = self._properties.get(
+                "send_failed_reports", self._model.send_failed_reports
+            )
+            retry_enabled = self._properties.get(
+                "retry_on_failure", self._model.retry_on_failure
+            )
+            if send_failed and not retry_enabled:
+                msg = _("send_failed_reports requires retry_on_failure to be enabled")
+                exceptions.append(ValidationError({"send_failed_reports": [msg]}))
 
-        # Retries are only supported for reports, not alerts.
-        report_type = self._properties.get("type", self._model.type)
-        if report_type == ReportScheduleType.ALERT and retry_enabled:
-            msg = _("Retries are not supported for alerts")
-            exceptions.append(ValidationError({"retry_on_failure": [msg]}))
+            # Retries are only supported for reports, not alerts.
+            report_type = self._properties.get("type", self._model.type)
+            if report_type == ReportScheduleType.ALERT and retry_enabled:
+                msg = _("Retries are not supported for alerts")
+                exceptions.append(ValidationError({"retry_on_failure": [msg]}))
 
         if exceptions:
             raise ReportScheduleInvalidError(exceptions=exceptions)

--- a/superset/config.py
+++ b/superset/config.py
@@ -759,6 +759,9 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # @lifecycle: testing
     # @docs: https://superset.apache.org/docs/configuration/alerts-reports
     "ALERT_REPORTS": False,
+    # Enables automatic retry functionality for failed report executions
+    # @lifecycle: testing
+    "ALERT_REPORTS_RETRY": False,
     # Enables Slack V2 integration for Alerts and Reports.
     # Defaults to True; the legacy Slack v1 path is deprecated and will be removed
     # in the next major release. Operators must grant the Slack bot both the

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -20,10 +20,19 @@ from typing import Any, Optional, Union
 from croniter import croniter
 from flask import current_app
 from flask_babel import gettext as _
-from marshmallow import EXCLUDE, fields, Schema, validate, validates, validates_schema
+from marshmallow import (
+    EXCLUDE,
+    fields,
+    post_load,
+    Schema,
+    validate,
+    validates,
+    validates_schema,
+)
 from marshmallow.validate import Length, Range, ValidationError
 from pytz import all_timezones
 
+from superset import is_feature_enabled
 from superset.reports.models import (
     ReportCreationMethod,
     ReportDataFormat,
@@ -355,6 +364,8 @@ class ReportSchedulePostSchema(Schema):
         data: dict[str, Any],
         **kwargs: Any,
     ) -> None:
+        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
+            return
         if data.get("send_failed_reports") and not data.get("retry_on_failure"):
             raise ValidationError(
                 {
@@ -370,6 +381,23 @@ class ReportSchedulePostSchema(Schema):
             raise ValidationError(
                 {"retry_on_failure": [_("Retries are not supported for alerts")]}
             )
+
+    @post_load
+    def strip_retry_fields_if_disabled(  # pylint: disable=unused-argument
+        self,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
+            for key in (
+                "retry_on_failure",
+                "retry_max_attempts",
+                "send_failed_reports",
+                "retry_notify_owners",
+                "retry_notify_recipients",
+            ):
+                data.pop(key, None)
+        return data
 
 
 class ReportScheduleSubscribeSchema(ReportSchedulePostSchema):
@@ -554,6 +582,23 @@ class ReportSchedulePutSchema(Schema):
                     max=max_width,
                 )
             )
+
+    @post_load
+    def strip_retry_fields_if_disabled(  # pylint: disable=unused-argument
+        self,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
+            for key in (
+                "retry_on_failure",
+                "retry_max_attempts",
+                "send_failed_reports",
+                "retry_notify_owners",
+                "retry_notify_recipients",
+            ):
+                data.pop(key, None)
+        return data
 
 
 class SlackChannelSchema(Schema):

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -189,7 +189,31 @@ class ReportRecipientSchema(Schema):
         validate_addresses("bccTarget", config.get("bccTarget"), required=False)
 
 
-class ReportSchedulePostSchema(Schema):
+_RETRY_FIELD_KEYS = (
+    "retry_on_failure",
+    "retry_max_attempts",
+    "send_failed_reports",
+    "retry_notify_owners",
+    "retry_notify_recipients",
+)
+
+
+class RetryFieldStripMixin:
+    """Strip retry fields from the deserialized payload when the feature is off."""
+
+    @post_load
+    def strip_retry_fields_if_disabled(
+        self,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
+            for key in _RETRY_FIELD_KEYS:
+                data.pop(key, None)
+        return data
+
+
+class ReportSchedulePostSchema(RetryFieldStripMixin, Schema):
     type = fields.String(
         metadata={"description": type_description},
         allow_none=False,
@@ -382,23 +406,6 @@ class ReportSchedulePostSchema(Schema):
                 {"retry_on_failure": [_("Retries are not supported for alerts")]}
             )
 
-    @post_load
-    def strip_retry_fields_if_disabled(  # pylint: disable=unused-argument
-        self,
-        data: dict[str, Any],
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
-            for key in (
-                "retry_on_failure",
-                "retry_max_attempts",
-                "send_failed_reports",
-                "retry_notify_owners",
-                "retry_notify_recipients",
-            ):
-                data.pop(key, None)
-        return data
-
 
 class ReportScheduleSubscribeSchema(ReportSchedulePostSchema):
     """Schema for creating a chart/dashboard subscription.
@@ -424,7 +431,7 @@ class ReportScheduleSubscribeSchema(ReportSchedulePostSchema):
         unknown = EXCLUDE
 
 
-class ReportSchedulePutSchema(Schema):
+class ReportSchedulePutSchema(RetryFieldStripMixin, Schema):
     type = fields.String(
         metadata={"description": type_description},
         required=False,
@@ -582,23 +589,6 @@ class ReportSchedulePutSchema(Schema):
                     max=max_width,
                 )
             )
-
-    @post_load
-    def strip_retry_fields_if_disabled(  # pylint: disable=unused-argument
-        self,
-        data: dict[str, Any],
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        if not is_feature_enabled("ALERT_REPORTS_RETRY"):
-            for key in (
-                "retry_on_failure",
-                "retry_max_attempts",
-                "send_failed_reports",
-                "retry_notify_owners",
-                "retry_notify_recipients",
-            ):
-                data.pop(key, None)
-        return data
 
 
 class SlackChannelSchema(Schema):

--- a/superset/reports/schemas.py
+++ b/superset/reports/schemas.py
@@ -23,7 +23,7 @@ from flask_babel import gettext as _
 from marshmallow import (
     EXCLUDE,
     fields,
-    post_load,
+    pre_load,
     Schema,
     validate,
     validates,
@@ -199,9 +199,12 @@ _RETRY_FIELD_KEYS = (
 
 
 class RetryFieldStripMixin:
-    """Strip retry fields from the deserialized payload when the feature is off."""
+    """Strip retry fields from the raw payload before validation when the
+    feature is off.  Using ``@pre_load`` ensures that field-level validators
+    (e.g. ``Range`` on ``retry_max_attempts``) are never reached for values
+    that will be discarded anyway."""
 
-    @post_load
+    @pre_load
     def strip_retry_fields_if_disabled(
         self,
         data: dict[str, Any],

--- a/tests/integration_tests/reports/commands_tests.py
+++ b/tests/integration_tests/reports/commands_tests.py
@@ -3147,6 +3147,7 @@ def test__send_with_server_errors(notification_mock, logger_mock):
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -3191,6 +3192,7 @@ def test_retry_on_failure_schedules_retry(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.commands.report.execute.BaseReportState.send_retry_notification")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -3247,6 +3249,7 @@ def test_retry_exhausted_transitions_to_error(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.commands.report.execute.BaseReportState.send_final_failure_report")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -3291,6 +3294,7 @@ def test_send_failed_reports_sends_to_recipients(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_retrying_state_schedules_another_retry(
@@ -3336,6 +3340,7 @@ def test_retrying_state_schedules_another_retry(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -3372,6 +3377,7 @@ def test_retry_disabled_preserves_default_error_path(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.commands.report.execute.BaseReportState.send_retry_notification")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
@@ -3414,6 +3420,7 @@ def test_retry_notify_owners_sends_notification(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")
 def test_new_crontab_window_skipped_while_retrying(
@@ -3462,6 +3469,7 @@ def test_new_crontab_window_skipped_while_retrying(
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+@with_feature_flags(ALERT_REPORTS_RETRY=True)
 @patch("superset.commands.report.execute.ReportNotTriggeredErrorState._schedule_retry")
 @patch("superset.reports.notifications.email.send_email_smtp")
 @patch("superset.utils.screenshots.ChartScreenshot.get_screenshot")

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -3663,6 +3663,10 @@ def test_not_triggered_error_state_success_clears_retry_state(
     mocker: MockerFixture,
 ) -> None:
     """A successful retry clears its persisted retry-window state."""
+    mocker.patch(
+        "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
+        return_value=True,
+    )
     state = _make_state_instance(
         mocker,
         ReportNotTriggeredErrorState,
@@ -4160,6 +4164,10 @@ def test_success_state_report_sends_and_logs_success(
     mocker: MockerFixture,
 ) -> None:
     """REPORT type success path: send() + update state to SUCCESS."""
+    mocker.patch(
+        "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
+        return_value=True,
+    )
     state = _make_state_instance(
         mocker,
         ReportSuccessState,

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -3665,7 +3665,7 @@ def test_not_triggered_error_state_success_clears_retry_state(
     """A successful retry clears its persisted retry-window state."""
     mocker.patch(
         "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
-        return_value=True,
+        side_effect=lambda flag: flag == "ALERT_REPORTS_RETRY",
     )
     state = _make_state_instance(
         mocker,
@@ -4166,7 +4166,7 @@ def test_success_state_report_sends_and_logs_success(
     """REPORT type success path: send() + update state to SUCCESS."""
     mocker.patch(
         "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
-        return_value=True,
+        side_effect=lambda flag: flag == "ALERT_REPORTS_RETRY",
     )
     state = _make_state_instance(
         mocker,

--- a/tests/unit_tests/commands/report/execute_test.py
+++ b/tests/unit_tests/commands/report/execute_test.py
@@ -3663,10 +3663,6 @@ def test_not_triggered_error_state_success_clears_retry_state(
     mocker: MockerFixture,
 ) -> None:
     """A successful retry clears its persisted retry-window state."""
-    mocker.patch(
-        "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
-        side_effect=lambda flag: flag == "ALERT_REPORTS_RETRY",
-    )
     state = _make_state_instance(
         mocker,
         ReportNotTriggeredErrorState,
@@ -4164,10 +4160,6 @@ def test_success_state_report_sends_and_logs_success(
     mocker: MockerFixture,
 ) -> None:
     """REPORT type success path: send() + update state to SUCCESS."""
-    mocker.patch(
-        "superset.commands.report.execute.feature_flag_manager.is_feature_enabled",
-        side_effect=lambda flag: flag == "ALERT_REPORTS_RETRY",
-    )
     state = _make_state_instance(
         mocker,
         ReportSuccessState,

--- a/tests/unit_tests/commands/report/update_test.py
+++ b/tests/unit_tests/commands/report/update_test.py
@@ -513,10 +513,14 @@ def test_alert_with_nonexistent_database_rejected(mocker: MockerFixture) -> None
 # --- Retry config validation on update ---
 
 
+_PATCH_RETRY_FLAG = "superset.commands.report.update.is_feature_enabled"
+
+
 def test_update_rejects_retry_on_alert(mocker: MockerFixture) -> None:
     """Enabling retries on an alert schedule is rejected."""
     model = _make_model(mocker, model_type=ReportScheduleType.ALERT, database_id=5)
     _setup_mocks(mocker, model)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
 
     cmd = UpdateReportScheduleCommand(model_id=1, data={"retry_on_failure": True})
     with pytest.raises(ReportScheduleInvalidError) as exc_info:
@@ -529,6 +533,7 @@ def test_update_rejects_send_failed_without_retry(mocker: MockerFixture) -> None
     """send_failed_reports=True requires retry_on_failure=True."""
     model = _make_model(mocker, model_type=ReportScheduleType.REPORT, database_id=None)
     _setup_mocks(mocker, model)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
 
     cmd = UpdateReportScheduleCommand(model_id=1, data={"send_failed_reports": True})
     with pytest.raises(ReportScheduleInvalidError) as exc_info:
@@ -541,6 +546,7 @@ def test_update_accepts_retry_on_report(mocker: MockerFixture) -> None:
     """Enabling retries on a report schedule is accepted."""
     model = _make_model(mocker, model_type=ReportScheduleType.REPORT, database_id=None)
     _setup_mocks(mocker, model)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
 
     cmd = UpdateReportScheduleCommand(
         model_id=1, data={"retry_on_failure": True, "retry_max_attempts": 5}

--- a/tests/unit_tests/reports/schemas_test.py
+++ b/tests/unit_tests/reports/schemas_test.py
@@ -419,9 +419,13 @@ def test_put_schema_allows_database_on_report_type(mocker: MockerFixture) -> Non
 # ---------------------------------------------------------------------------
 
 
+_PATCH_RETRY_FLAG = "superset.reports.schemas.is_feature_enabled"
+
+
 def test_retry_fields_defaults(mocker: MockerFixture) -> None:
     """POST schema: retry fields have correct defaults when omitted."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePostSchema()
     result = schema.load(MINIMAL_POST_PAYLOAD)
     assert result["retry_on_failure"] is False
@@ -434,6 +438,7 @@ def test_retry_fields_defaults(mocker: MockerFixture) -> None:
 def test_retry_fields_accepted(mocker: MockerFixture) -> None:
     """POST schema: retry fields are accepted with valid values."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePostSchema()
     result = schema.load(
         {
@@ -460,6 +465,7 @@ def test_retry_fields_accepted(mocker: MockerFixture) -> None:
 def test_retry_max_attempts_out_of_range(mocker: MockerFixture, value: int) -> None:
     """POST schema: retry_max_attempts outside 1–10 is rejected."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePostSchema()
     with pytest.raises(ValidationError) as exc:
         schema.load(
@@ -480,6 +486,7 @@ def test_retry_max_attempts_out_of_range(mocker: MockerFixture, value: int) -> N
 def test_retry_max_attempts_boundary_values(mocker: MockerFixture, value: int) -> None:
     """POST schema: retry_max_attempts at boundaries (1 and 10) is accepted."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePostSchema()
     result = schema.load(
         {**MINIMAL_POST_PAYLOAD, "retry_on_failure": True, "retry_max_attempts": value}
@@ -492,6 +499,7 @@ def test_send_failed_reports_requires_retry_on_failure(
 ) -> None:
     """POST schema: send_failed_reports=True with retry_on_failure=False is rejected."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePostSchema()
     with pytest.raises(ValidationError) as exc:
         schema.load(
@@ -507,6 +515,7 @@ def test_send_failed_reports_requires_retry_on_failure(
 def test_put_schema_accepts_retry_fields(mocker: MockerFixture) -> None:
     """PUT schema: retry fields are accepted as optional partial updates."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePutSchema()
     result = schema.load({"retry_on_failure": True, "retry_max_attempts": 7})
     assert result["retry_on_failure"] is True
@@ -518,6 +527,7 @@ def test_put_schema_retry_max_attempts_out_of_range(
 ) -> None:
     """PUT schema: retry_max_attempts outside 1–10 is rejected."""
     mocker.patch("flask.current_app.config", CUSTOM_WIDTH_CONFIG)
+    mocker.patch(_PATCH_RETRY_FLAG, return_value=True)
     schema = ReportSchedulePutSchema()
     with pytest.raises(ValidationError) as exc:
         schema.load({"retry_max_attempts": 11})


### PR DESCRIPTION
### SUMMARY

- Places the report retry feature behind a new ALERT_REPORTS_RETRY feature flag, defaulting to False
- When the flag is off: retry UI is hidden, retry fields are stripped from API writes, and _handle_retry_or_error is a no-op
- When the flag is on: full retry functionality works as implemented

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
