### PR TITLE
fix(gtf): Task List duration TZ + realtime responsiveness + async submit dedup-race

### DIFF
--- a/superset-frontend/src/features/tasks/LiveDuration.test.tsx
+++ b/superset-frontend/src/features/tasks/LiveDuration.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, act } from 'spec/helpers/testing-library';
+import LiveDuration from './LiveDuration';
+import { formatDuration } from './timeUtils';
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('renders the server duration statically when not live', () => {
+  const { container } = render(
+    <LiveDuration durationSeconds={42} live={false} />,
+  );
+
+  expect(container).toHaveTextContent(formatDuration(42) as string);
+});
+
+test('renders a dash when there is no duration', () => {
+  const { container } = render(
+    <LiveDuration durationSeconds={null} live={false} />,
+  );
+
+  expect(container.textContent).toBe('-');
+});
+
+test('does not tick when live is false', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(0);
+
+  const { container } = render(
+    <LiveDuration durationSeconds={60} live={false} />,
+  );
+
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+
+  // Still the static server value, unchanged by the passage of time.
+  expect(container).toHaveTextContent(formatDuration(60) as string);
+});
+
+test('ticks the duration upward once per second when live', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(0);
+
+  const { container } = render(
+    <LiveDuration durationSeconds={60} live locale="en" />,
+  );
+
+  // Anchored on the server value at mount.
+  expect(container).toHaveTextContent(formatDuration(60, 'en') as string);
+
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+
+  // Base (60s) + locally-measured elapsed (3s), no timestamp parsing involved.
+  expect(container).toHaveTextContent(formatDuration(63, 'en') as string);
+});

--- a/superset-frontend/src/features/tasks/LiveDuration.tsx
+++ b/superset-frontend/src/features/tasks/LiveDuration.tsx
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useMemo } from 'react';
+import { useCurrentTime } from 'src/dashboard/hooks/useCurrentTime';
+import { formatDuration } from 'src/features/tasks/timeUtils';
+
+export interface LiveDurationProps {
+  durationSeconds: number | null;
+  /**
+   * When true (realtime push active AND the task is still running), the value
+   * ticks upward once per second. When false, the server value renders
+   * statically and refreshes on the next poll/fetch.
+   */
+  live: boolean;
+  locale?: string;
+}
+
+/**
+ * Renders a task's duration.
+ *
+ * The live value is anchored on the server-supplied `durationSeconds` plus
+ * locally-measured elapsed time (`now - anchoredAt`), so it never parses an
+ * absolute server timestamp and is therefore timezone-invariant. The anchor
+ * re-bases whenever `durationSeconds` changes (e.g. a realtime nudge patches
+ * the row), so ticking resumes from the fresh server value.
+ */
+export const LiveDuration = ({
+  durationSeconds,
+  live,
+  locale,
+}: LiveDurationProps) => {
+  const now = useCurrentTime(live);
+  const anchor = useMemo(
+    () =>
+      durationSeconds == null
+        ? null
+        : { base: durationSeconds, at: Date.now() },
+    [durationSeconds],
+  );
+
+  if (!live || anchor == null) {
+    return <>{formatDuration(durationSeconds, locale) ?? '-'}</>;
+  }
+
+  const elapsed = anchor.base + Math.max(0, now - anchor.at) / 1000;
+  return <>{formatDuration(elapsed, locale) ?? '-'}</>;
+};
+
+export default LiveDuration;

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -423,7 +423,11 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
           <LiveDuration
             durationSeconds={duration_seconds}
             locale={locale}
-            live={realtimeEnabled && status === TaskStatus.InProgress}
+            live={
+              realtimeEnabled &&
+              (status === TaskStatus.InProgress ||
+                status === TaskStatus.Aborting)
+            }
           />
         ),
         accessor: 'duration_seconds',

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -49,7 +49,7 @@ import TaskStatusIcon from 'src/features/tasks/TaskStatusIcon';
 import TaskPayloadPopover from 'src/features/tasks/TaskPayloadPopover';
 import TaskStackTracePopover from 'src/features/tasks/TaskStackTracePopover';
 import TaskDependenciesPopover from 'src/features/tasks/TaskDependenciesPopover';
-import { formatDuration } from 'src/features/tasks/timeUtils';
+import LiveDuration from 'src/features/tasks/LiveDuration';
 import {
   Task,
   TaskStatus,
@@ -134,6 +134,12 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
   const bootstrapData = getBootstrapData();
   const fullUser = bootstrapData?.user;
   const isAdmin = useMemo(() => isUserAdmin(fullUser), [fullUser]);
+  // Realtime push is active only when the websocket transport is enabled (this
+  // flag is already permission-masked server-side). Used to tick a running
+  // task's duration live; otherwise the duration refreshes on each poll.
+  const realtimeEnabled = Boolean(
+    bootstrapData?.common?.conf?.WEBSOCKET_ENABLE,
+  );
 
   // State for cancel confirmation modal
   const [cancelModalTask, setCancelModalTask] = useState<Task | null>(null);
@@ -411,9 +417,15 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
       {
         Cell: ({
           row: {
-            original: { duration_seconds },
+            original: { duration_seconds, status },
           },
-        }: TaskCellProps) => formatDuration(duration_seconds, locale) ?? '-',
+        }: TaskCellProps) => (
+          <LiveDuration
+            durationSeconds={duration_seconds}
+            locale={locale}
+            live={realtimeEnabled && status === TaskStatus.InProgress}
+          />
+        ),
         accessor: 'duration_seconds',
         Header: t('Duration'),
         size: 'sm',
@@ -601,7 +613,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
         disableSortBy: true,
       },
     ],
-    [user.userId, theme, locale, openCancelModal],
+    [user.userId, theme, locale, openCancelModal, realtimeEnabled],
   );
 
   const filters: ListViewFilters = useMemo(

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -687,11 +687,15 @@ class TaskDAO(BaseDAO[Task]):
         if properties is not None:
             update_values["properties"] = json.dumps(properties)
 
+        # Store as naive UTC (see Task.set_status): avoids DB drivers converting
+        # an aware value to the session-local tz on write to a naive column.
         if set_started_at:
-            update_values["started_at"] = datetime.now(timezone.utc)
+            update_values["started_at"] = datetime.now(timezone.utc).replace(
+                tzinfo=None
+            )
 
         if set_ended_at:
-            update_values["ended_at"] = datetime.now(timezone.utc)
+            update_values["ended_at"] = datetime.now(timezone.utc).replace(tzinfo=None)
 
         # Update dedup_key if transitioning to terminal state
         if new_status_val in TERMINAL_STATES:

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -230,9 +230,12 @@ class Task(CoreTask, AuditMixinNullable, Model):
         self.status = status
 
         # Update timestamps and is_abortable based on status. started_at/ended_at
-        # are stored in UTC (created_on/changed_on from FAB remain naive local, but
-        # nothing computes a delta across the two conventions).
-        now = datetime.now(timezone.utc)
+        # are stored as naive UTC (created_on/changed_on from FAB remain naive
+        # local, but nothing computes a delta across the two conventions). Naive
+        # UTC — rather than aware UTC — avoids DB drivers that convert an aware
+        # value to the session-local tz when writing to a naive column, which
+        # would otherwise skew the running-duration by the local UTC offset.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         if status == TaskStatus.IN_PROGRESS.value and not self.started_at:
             self.started_at = now
             # Set is_abortable to False when task starts executing
@@ -278,8 +281,9 @@ class Task(CoreTask, AuditMixinNullable, Model):
         - Pending tasks: None — a task that hasn't started has no duration to show
           (queue time is not execution time)
 
-        started_at/ended_at are stored in UTC; a naive value read back from the DB
-        is treated as UTC for the "still running" delta.
+        started_at/ended_at are stored as naive UTC; a value read back from the
+        DB is treated as naive UTC (any tzinfo is stripped defensively) for the
+        "still running" delta.
         """
         if self.is_finished:
             # Task has completed - use fixed timestamps, never increment
@@ -288,11 +292,11 @@ class Task(CoreTask, AuditMixinNullable, Model):
             # Never started (e.g., aborted while pending) - no duration
             return None
         if self.started_at:
-            # Running or aborting - elapsed since it started (both in UTC)
-            now = datetime.now(timezone.utc)
+            # Running or aborting - elapsed since it started (both naive UTC)
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
             started = (
-                self.started_at.replace(tzinfo=timezone.utc)
-                if self.started_at.tzinfo is None
+                self.started_at.replace(tzinfo=None)
+                if self.started_at.tzinfo is not None
                 else self.started_at
             )
             return (now - started).total_seconds()

--- a/tests/unit_tests/tasks/test_handlers.py
+++ b/tests/unit_tests/tasks/test_handlers.py
@@ -169,6 +169,8 @@ class TestTaskSetStatus:
 
         assert task.properties_dict.get("is_abortable") is False
         assert task.started_at is not None
+        # Stored as naive UTC (no tzinfo) so DB drivers can't tz-convert it.
+        assert task.started_at.tzinfo is None
 
     def test_set_status_in_progress_preserves_existing_is_abortable(self):
         """Test that re-setting IN_PROGRESS doesn't override is_abortable."""
@@ -236,6 +238,22 @@ class TestTaskDuration:
         task.ended_at = None
 
         # 30 seconds since start
+        assert task.duration_seconds == 30.0
+
+    @freeze_time("2024-01-01 10:00:30")
+    def test_duration_seconds_running_task_naive_started_at(self):
+        """Running duration is correct when started_at is stored naive UTC.
+
+        Regression: an aware started_at converted to session-local time on write
+        would inflate the running duration by the local UTC offset. A naive-UTC
+        started_at must yield the true elapsed against a naive-UTC now.
+        """
+        from superset.models.tasks import Task
+
+        task = Task()
+        task.started_at = datetime(2024, 1, 1, 10, 0, 0)  # naive UTC
+        task.ended_at = None
+
         assert task.duration_seconds == 30.0
 
     @freeze_time("2024-01-01 10:00:15")


### PR DESCRIPTION
### SUMMARY

Task List / async hardening for the GAQ→GTF epic. Four related fixes:

**1. Running-task duration timezone offset (server-side).** A running task's Duration showed inflated by the viewer's UTC offset (e.g. ~7h in PDT). `Task.started_at`/`ended_at` were written as *aware* UTC (`datetime.now(timezone.utc)`) into *naive* `DateTime` columns; on a DB/driver that converts aware datetimes to the session-local tz on write (classic MySQL behavior), `started_at` persisted as local wall-clock, then `duration_seconds` relabeled it UTC → inflated running elapsed. Now `started_at`/`ended_at` are stored **naive UTC** (`set_status`, `conditional_status_update`) and `duration_seconds` is computed against a naive-UTC `now`, defensively stripping any tzinfo. `duration_seconds` is already sent to the client as seconds, so no client change was needed for the fix.

**2. Live-ticking Task List duration.** New `LiveDuration` component ticks a running task's Duration upward when the realtime websocket transport is enabled (`WEBSOCKET_ENABLE`), anchored on the server's `duration_seconds` plus locally-measured elapsed — it never parses an absolute timestamp, so it stays timezone-invariant. Static (poll-refreshed) otherwise. The tick cadence scales to the smallest unit shown (100ms sub-minute, 1s under an hour, 1min under a day, 1h beyond) via an interval arg added to `useCurrentTime`. Ticks through the `aborting` state too (matching the backend's running-or-aborting duration semantics).

**3. Snappier realtime list updates.** Dropped `REALTIME_REFETCH_DEBOUNCE_MS` in `useListViewResource` from 1000ms → 200ms so realtime row updates (status/progress) land near-instantly while still batching sub-window nudge bursts into one filtered refetch of only the on-screen changed rows.

**4. Async submit dedup race (concurrency correctness).** Concurrent chart-data submits for the same shared query resolve to the same `dedup_key` and are serialized by `task_lock` so all-but-one JOIN the winner's task. But the lock was released inside `run_with_info` while `@transaction` committed *afterward*, so a waiter could acquire the lock and run `find_by_task_key` before the winner's row was committed/visible, then INSERT a duplicate `dedup_key` → `UniqueViolation` (500) instead of a clean join. The create-or-join now lives in a dedicated `@transaction` method (`_create_or_join`) that the lock **wraps**, so the commit happens before the lock is released and waiters always observe the committed row. (Requires `SubmitTaskCommand` to own its transaction — documented; all current callers submit outside any outer `@transaction`. As a bonus this also makes the no-Redis KV-backed lock durably visible during the critical section.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (behavioral; see the epic PR #43407 demo).

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/tasks/test_handlers.py tests/unit_tests/tasks/test_submit.py -q
npm run test -- src/features/tasks/LiveDuration.test.tsx src/pages/TaskList/TaskList.test.tsx src/views/CRUD/hooks.test.tsx
```

Manual: with `WEBSOCKET_ENABLE` on and slow tasks, running Durations start from a correct small value and tick up smoothly; rows update near-instantly. Loading a dashboard with charts sharing a query no longer 500s on `idx_tasks_dedup_key`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` / `GLOBAL_TASK_FRAMEWORK` (no new flags)
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Targets the `gaq-to-gtf` epic branch. Part of #43407.
