### PR TITLE
fix(excel): handle duplicate column labels in xlsx export

### DIFF
--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -46,7 +46,13 @@ def quote_formulas(df: pd.DataFrame) -> pd.DataFrame:
     # individual cells, silently leaving formulas unquoted.
     for idx in range(len(df.columns)):
         series = df.iloc[:, idx]
-        if series.dtype == object:
+        # ``is_string_dtype`` rather than an ``object`` comparison: pandas 3
+        # gives string columns a dedicated ``str`` dtype, which an object-only
+        # check (as the ``select_dtypes(include="object")`` this replaced) would
+        # skip, silently leaving formulas unquoted.
+        if pd.api.types.is_object_dtype(series.dtype) or pd.api.types.is_string_dtype(
+            series.dtype
+        ):
             df.isetitem(idx, series.map(_quote_formula))
 
     return df

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -21,21 +21,33 @@ import pandas as pd
 
 from superset.utils.core import GenericDataType
 
+# Leading characters that turn a cell into a formula in spreadsheet apps.
+FORMULA_PREFIXES = {"=", "+", "-", "@"}
+
+
+def _quote_formula(value: Any) -> Any:
+    """Prefix a string with a quote when it would parse as a formula."""
+    return (
+        f"'{value}"
+        if isinstance(value, str) and len(value) and value[0] in FORMULA_PREFIXES
+        else value
+    )
+
 
 def quote_formulas(df: pd.DataFrame) -> pd.DataFrame:
     """
     Make sure to quote any formulas for security reasons.
     """
-    formula_prefixes = {"=", "+", "-", "@"}
-
-    for col in df.select_dtypes(include="object").columns:
-        df[col] = df[col].apply(
-            lambda x: (
-                f"'{x}"
-                if isinstance(x, str) and len(x) and x[0] in formula_prefixes
-                else x
-            )
-        )
+    # Columns are addressed by position rather than by label: a dataframe can
+    # carry duplicate column labels (the verbose_map rename in
+    # QueryContextProcessor.get_data can collapse two columns onto the same
+    # name), and ``df[label]`` then yields a DataFrame instead of a Series.
+    # ``DataFrame.apply`` would hand whole columns to the mapper rather than
+    # individual cells, silently leaving formulas unquoted.
+    for idx in range(len(df.columns)):
+        series = df.iloc[:, idx]
+        if series.dtype == object:
+            df.isetitem(idx, series.map(_quote_formula))
 
     return df
 
@@ -63,20 +75,31 @@ def apply_column_types(
     :param column_types: The types of the columns
     :return: The dataframe with the column types applied
     """
-    for column, column_type in zip(df.columns, column_types, strict=False):
+    # Columns are addressed by position for the same reason as in
+    # ``quote_formulas``: duplicate column labels make ``df[label]`` return a
+    # DataFrame, and ``DataFrame`` has no ``dtype``. Slicing column_types keeps
+    # the lenient pairing the previous ``zip(..., strict=False)`` provided.
+    for idx, column_type in enumerate(column_types[: len(df.columns)]):
+        series = df.iloc[:, idx]
         if column_type == GenericDataType.NUMERIC:
             try:
-                df[column] = pd.to_numeric(df[column])
+                series = pd.to_numeric(series)
                 # if the number is too large, convert it to a string
                 # Excel does not support numbers larger than 10^15
-                df[column] = df[column].apply(
+                series = series.apply(
                     lambda x: str(x)
                     if isinstance(x, (int, float)) and abs(x) > 10**15
                     else x
                 )
             except ValueError:
-                df[column] = df[column].astype(str)
-        elif isinstance(df[column].dtype, pd.DatetimeTZDtype):
+                series = series.astype(str)
+        elif isinstance(series.dtype, pd.DatetimeTZDtype):
             # timezones are not supported
-            df[column] = df[column].astype(str)
+            series = series.astype(str)
+        else:
+            continue
+        # ``isetitem`` replaces the column at that position, which is both
+        # unambiguous under duplicate labels and free of the in-place dtype
+        # casting that ``iloc`` assignment attempts.
+        df.isetitem(idx, series)
     return df

--- a/tests/unit_tests/utils/excel_tests.py
+++ b/tests/unit_tests/utils/excel_tests.py
@@ -156,6 +156,20 @@ def test_quote_formulas_with_duplicate_column_labels() -> None:
     assert df.iloc[0].tolist() == ["'=SUM(A1:A2)", "'@SUM(A1:A2)", "normal"]
 
 
+def test_quote_formulas_with_dedicated_string_dtype() -> None:
+    """
+    Test that formulas are quoted in columns using the dedicated string dtype.
+
+    pandas 3 gives string columns a ``str`` dtype rather than ``object``, so an
+    object-only dtype check would skip them and leave formulas unquoted.
+    """
+    df = pd.DataFrame({"formula": pd.array(["=SUM(A1:A2)", "normal"], dtype="string")})
+
+    result = quote_formulas(df)
+
+    assert result["formula"].tolist() == ["'=SUM(A1:A2)", "normal"]
+
+
 def test_column_data_types_with_large_numeric_values():
     df = pd.DataFrame(
         {

--- a/tests/unit_tests/utils/excel_tests.py
+++ b/tests/unit_tests/utils/excel_tests.py
@@ -21,7 +21,7 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
 from superset.utils.core import GenericDataType
-from superset.utils.excel import apply_column_types, df_to_excel
+from superset.utils.excel import apply_column_types, df_to_excel, quote_formulas
 
 
 def test_timezone_conversion() -> None:
@@ -105,6 +105,55 @@ def test_column_data_types_with_failing_conversion():
     assert not is_numeric_dtype(df["col1"])
     assert not is_numeric_dtype(df["col2"])
     assert not is_numeric_dtype(df["col3"])
+
+
+def test_apply_column_types_with_duplicate_column_labels() -> None:
+    """
+    Test that duplicate column labels do not break the export.
+
+    The verbose_map rename in QueryContextProcessor.get_data can collapse two
+    columns onto the same label, which used to raise
+    "'DataFrame' object has no attribute 'dtype'".
+    """
+    df = pd.DataFrame(
+        [
+            ["1", datetime(2023, 1, 1, 0, 0, tzinfo=timezone.utc), "2"],
+            ["3", datetime(2023, 1, 2, 0, 0, tzinfo=timezone.utc), "4"],
+        ],
+        columns=["dupe", "dupe", "other"],
+    )
+    coltypes: list[GenericDataType] = [
+        GenericDataType.STRING,
+        GenericDataType.TEMPORAL,
+        GenericDataType.NUMERIC,
+    ]
+
+    apply_column_types(df, coltypes)
+
+    # each position is typed independently, despite sharing a label
+    assert not is_numeric_dtype(df.iloc[:, 0])
+    assert df.iloc[:, 1].tolist() == [
+        "2023-01-01 00:00:00+00:00",
+        "2023-01-02 00:00:00+00:00",
+    ]
+    assert is_numeric_dtype(df.iloc[:, 2])
+
+    contents = df_to_excel(df, index=False)
+    assert pd.read_excel(contents).shape == (2, 3)
+
+
+def test_quote_formulas_with_duplicate_column_labels() -> None:
+    """
+    Test that formulas are quoted even when column labels are duplicated.
+    """
+    df = pd.DataFrame(
+        [["=SUM(A1:A2)", "@SUM(A1:A2)", "normal"]],
+        columns=["dupe", "dupe", "other"],
+    )
+
+    quote_formulas(df)
+
+    assert df.iloc[0].tolist() == ["'=SUM(A1:A2)", "'@SUM(A1:A2)", "normal"]
 
 
 def test_column_data_types_with_large_numeric_values():


### PR DESCRIPTION
### SUMMARY

Exporting to Excel fails with a 500 and `'DataFrame' object has no attribute 'dtype'` whenever the result set contains duplicate column labels. CSV export of the same data works.

`apply_column_types` and `quote_formulas` in `superset/utils/excel.py` addressed columns by label. Under duplicate labels `df[label]` returns a DataFrame rather than a Series, so:

- `apply_column_types` called `.dtype` on a DataFrame and raised.
- `quote_formulas` passed whole columns to its mapper instead of individual cells, so `isinstance(x, str)` was `False` and formula escaping was silently skipped — no crash, just unquoted formulas.

Duplicates arise because the `verbose_map` rename in `QueryContextProcessor.get_data` is not injective: two columns can share a verbose name. Drill to detail hits this readily because `_get_drill_detail` selects every column on the dataset, so one collision among them is enough. Only the XLSX branch calls `apply_column_types`, hence CSV being unaffected.

Both functions now address columns by position via `df.iloc[:, idx]` and write back with `df.isetitem`, which is unambiguous under duplicate labels and avoids the in-place dtype casting that `iloc` assignment attempts. Duplicate headers are preserved in the output, matching what CSV export already does, so the two formats stay consistent.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

Two unit tests in `tests/unit_tests/utils/excel_tests.py` cover a frame with duplicate labels — one per bug. Both fail without this change (the first with the exact production error) and pass with it:

```
pytest tests/unit_tests/utils/excel_tests.py
```

Manually:

1. Pick a dataset where two columns share a `verbose_name`, or add one via **Edit dataset → Columns → Label**.
2. Build a chart on it, open the context menu → **Drill to detail**.
3. **Export to Excel.** Without this change the download fails with a 500; with it the file downloads, both columns present under the shared header.
4. **Export to CSV** as well, to confirm it is unchanged.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
