### PR TITLE
fix(gtf): hold task submit lock across commit to close dedup race

### DIFF
--- a/superset/commands/tasks/submit.py
+++ b/superset/commands/tasks/submit.py
@@ -60,7 +60,6 @@ class SubmitTaskCommand(BaseCommand):
     def __init__(self, data: dict[str, Any]):
         self._properties = data.copy()
 
-    @transaction(on_error=partial(on_error, reraise=TaskCreateFailedError))
     def run(self) -> "Task":
         """
         Execute the command with distributed locking.
@@ -73,7 +72,6 @@ class SubmitTaskCommand(BaseCommand):
         task, _ = self.run_with_info()
         return task
 
-    @transaction(on_error=partial(on_error, reraise=TaskCreateFailedError))
     def run_with_info(self) -> tuple["Task", bool]:
         """
         Execute the command and return (task, is_new) tuple.
@@ -82,16 +80,29 @@ class SubmitTaskCommand(BaseCommand):
         and joining an existing one. Useful for sync execution where the caller
         needs to wait for an existing task to complete rather than executing again.
 
+        The task lock is held across the **entire** create-or-join transaction —
+        including the commit performed by ``_create_or_join``'s ``@transaction`` —
+        so a concurrent submitter for the same ``dedup_key`` always observes the
+        winner's committed row and joins it. Releasing the lock before the commit
+        would let a waiter read-before-commit and insert a duplicate ``dedup_key``,
+        surfacing as a unique-constraint 500 instead of a clean join.
+
+        NOTE: ``SubmitTaskCommand`` must own its transaction for this guarantee to
+        hold. It must not be called within an outer ``@transaction`` — the
+        reentrancy guard would defer the real commit until after the lock is
+        released (see ``superset.utils.decorators.transaction``).
+
         :returns: Tuple of (Task, is_new) where is_new is True if task was created
         """
-        from superset.daos.tasks import TaskDAO
-
         self.validate()
 
-        # Extract and normalize parameters
+        # Extract and normalize parameters (no DB access — validate() has run and
+        # normalized ``scope``). Done before acquiring the lock so invalid input
+        # fails fast without taking a lock.
         task_type = self._properties["task_type"]
         task_key = self._properties.get("task_key") or str(uuid.uuid4())
-        scope = self._properties.get("scope", TaskScope.PRIVATE.value)
+        self._properties["task_key"] = task_key  # reuse the generated key downstream
+        scope = self._properties["scope"]
         user_id = get_user_id()
         # Embedded guests have no ab_user id; they subscribe by a token-derived
         # key so TaskFilter can grant them visibility of their own tasks.
@@ -105,67 +116,81 @@ class SubmitTaskCommand(BaseCommand):
             user_id=user_id,
         )
 
-        # Acquire lock to prevent race conditions during create/join
+        # Acquire the lock around the whole transaction (see docstring): it is
+        # released only after _create_or_join commits.
         with task_lock(dedup_key):
-            # Check for existing task (safe under lock)
-            existing = TaskDAO.find_by_task_key(task_type, task_key, scope, user_id)
+            return self._create_or_join(task_type, task_key, scope, user_id, guest_key)
 
-            # Get stats logger
-            stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
+    @transaction(on_error=partial(on_error, reraise=TaskCreateFailedError))
+    def _create_or_join(
+        self,
+        task_type: str,
+        task_key: str,
+        scope: str,
+        user_id: int | None,
+        guest_key: str | None,
+    ) -> tuple["Task", bool]:
+        """Find an existing task for ``dedup_key`` and join it, or create a new one.
 
-            if existing:
-                # Finding an existing task is itself a dedupe (work reused, not
-                # re-created), whether the caller becomes a new subscriber or
-                # resubmits as an existing one. Count it on the task's properties.
-                existing.update_properties(
-                    {
-                        "dedupe_count": existing.properties_dict.get("dedupe_count", 0)
-                        + 1
-                    }
+        Runs as a single transaction (committed by ``@transaction`` on return)
+        while the caller holds the task lock, so the create-vs-join decision and
+        its commit are atomic with respect to other submitters.
+        """
+        from superset.daos.tasks import TaskDAO
+
+        stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
+
+        # Check for an existing task under the lock; join it if present.
+        if existing := TaskDAO.find_by_task_key(task_type, task_key, scope, user_id):
+            # Finding an existing task is itself a dedupe (work reused, not
+            # re-created), whether the caller becomes a new subscriber or
+            # resubmits as an existing one. Count it on the task's properties.
+            existing.update_properties(
+                {"dedupe_count": existing.properties_dict.get("dedupe_count", 0) + 1}
+            )
+            # Join existing task - add subscriber if not already subscribed
+            if user_id and not existing.has_subscriber(user_id):
+                TaskDAO.add_subscriber(existing.id, user_id)
+                stats_logger.incr("gtf.task.subscribe")
+                logger.info(
+                    "User %s joined existing task: %s",
+                    user_id,
+                    task_key,
                 )
-                # Join existing task - add subscriber if not already subscribed
-                if user_id and not existing.has_subscriber(user_id):
-                    TaskDAO.add_subscriber(existing.id, user_id)
-                    stats_logger.incr("gtf.task.subscribe")
-                    logger.info(
-                        "User %s joined existing task: %s",
-                        user_id,
-                        task_key,
-                    )
-                elif guest_key and not existing.has_guest_subscriber(guest_key):
-                    # Embedded guest joining a SHARED task an equivalent guest
-                    # created; subscribe so this guest can also poll it.
-                    TaskDAO.add_guest_subscriber(existing.id, guest_key)
-                    stats_logger.incr("gtf.task.subscribe")
-                else:
-                    # Same subscriber resubmitted the same task - deduplication hit
-                    stats_logger.incr("gtf.task.dedupe")
-                    logger.debug(
-                        "Deduplication hit for task: %s (user_id=%s)",
-                        task_key,
-                        user_id,
-                    )
-                return existing, False  # is_new=False: joined existing task
-
-            # Create new task (DAO is now a pure data operation)
-            try:
-                task = TaskDAO.create_task(
-                    task_type=task_type,
-                    task_key=task_key,
-                    scope=scope,
-                    task_name=self._properties.get("task_name"),
-                    user_id=user_id,
-                    guest_key=guest_key,
-                    payload=self._properties.get("payload", {}),
-                    properties=self._properties.get("properties", {}),
+            elif guest_key and not existing.has_guest_subscriber(guest_key):
+                # Embedded guest joining a SHARED task an equivalent guest
+                # created; subscribe so this guest can also poll it.
+                TaskDAO.add_guest_subscriber(existing.id, guest_key)
+                stats_logger.incr("gtf.task.subscribe")
+            else:
+                # Same subscriber resubmitted the same task - deduplication hit
+                stats_logger.incr("gtf.task.dedupe")
+                logger.debug(
+                    "Deduplication hit for task: %s (user_id=%s)",
+                    task_key,
+                    user_id,
                 )
-                # Persist dependency edges (with cycle guard) for the new task.
-                # Joined/deduplicated tasks keep their original dependencies.
-                self._persist_dependencies(task, TaskDAO)
-                stats_logger.incr("gtf.task.create")
-                return task, True  # is_new=True: created new task
-            except DAOCreateFailedError as ex:
-                raise TaskCreateFailedError() from ex
+            return existing, False  # is_new=False: joined existing task
+
+        # Create new task (DAO is now a pure data operation)
+        try:
+            task = TaskDAO.create_task(
+                task_type=task_type,
+                task_key=task_key,
+                scope=scope,
+                task_name=self._properties.get("task_name"),
+                user_id=user_id,
+                guest_key=guest_key,
+                payload=self._properties.get("payload", {}),
+                properties=self._properties.get("properties", {}),
+            )
+            # Persist dependency edges (with cycle guard) for the new task.
+            # Joined/deduplicated tasks keep their original dependencies.
+            self._persist_dependencies(task, TaskDAO)
+            stats_logger.incr("gtf.task.create")
+            return task, True  # is_new=True: created new task
+        except DAOCreateFailedError as ex:
+            raise TaskCreateFailedError() from ex
 
     def _persist_dependencies(self, task: "Task", dao: type["TaskDAO"]) -> None:
         """

--- a/superset/commands/tasks/submit.py
+++ b/superset/commands/tasks/submit.py
@@ -22,7 +22,7 @@ from functools import partial
 from typing import Any, TYPE_CHECKING
 from uuid import UUID
 
-from flask import current_app
+from flask import current_app, g
 from marshmallow import ValidationError
 from superset_core.tasks.types import TaskScope
 
@@ -94,6 +94,21 @@ class SubmitTaskCommand(BaseCommand):
 
         :returns: Tuple of (Task, is_new) where is_new is True if task was created
         """
+        # Enforce the "must own its transaction" contract (see docstring). If a
+        # caller has already opened a transaction, ``_create_or_join``'s
+        # ``@transaction`` would be reentrant and defer its commit past the lock
+        # release (``transaction`` keys reentrancy off ``g.in_transaction``),
+        # silently reopening the dedup race. Fail loudly so the caller is forced
+        # to submit outside its transaction rather than reintroduce the bug.
+        if getattr(g, "in_transaction", False):
+            raise RuntimeError(
+                "SubmitTaskCommand must own its transaction: the task lock is "
+                "held across commit to serialize concurrent dedup submits, which "
+                "requires the commit to happen before the lock is released. It "
+                "cannot run inside an outer @transaction. Submit outside the "
+                "surrounding transaction instead."
+            )
+
         self.validate()
 
         # Extract and normalize parameters (no DB access — validate() has run and

--- a/superset/commands/tasks/submit.py
+++ b/superset/commands/tasks/submit.py
@@ -24,8 +24,10 @@ from uuid import UUID
 
 from flask import current_app, g
 from marshmallow import ValidationError
+from sqlalchemy.exc import IntegrityError
 from superset_core.tasks.types import TaskScope
 
+from superset import db
 from superset.commands.base import BaseCommand
 from superset.commands.tasks.exceptions import (
     TaskCreateFailedError,
@@ -149,63 +151,93 @@ class SubmitTaskCommand(BaseCommand):
 
         Runs as a single transaction (committed by ``@transaction`` on return)
         while the caller holds the task lock, so the create-vs-join decision and
-        its commit are atomic with respect to other submitters.
+        its commit are atomic with respect to other submitters. The create is
+        additionally guarded by a SAVEPOINT that joins the winner on a dedup_key
+        unique violation, so correctness holds even if the lock expires or fails
+        to serialize (see the create block below).
+        """
+        from superset.daos.tasks import TaskDAO
+
+        # Check for an existing task under the lock; join it if present.
+        if existing := TaskDAO.find_by_task_key(task_type, task_key, scope, user_id):
+            return self._join_existing(existing, user_id, guest_key, task_key), False
+
+        # Create the new task. The task lock serializes concurrent submits for
+        # this dedup_key, but as a backstop — the lock has a fixed TTL and could
+        # expire mid-transaction, and a misconfigured backend could fail to
+        # serialize at all — the create runs inside a SAVEPOINT. On the dedup_key
+        # unique violation (a concurrent submitter won the create), roll the
+        # SAVEPOINT back and join the winner instead of surfacing a 500. The DB
+        # unique constraint, not the lock, is the ultimate arbiter.
+        try:
+            with db.session.begin_nested():
+                task = TaskDAO.create_task(
+                    task_type=task_type,
+                    task_key=task_key,
+                    scope=scope,
+                    task_name=self._properties.get("task_name"),
+                    user_id=user_id,
+                    guest_key=guest_key,
+                    payload=self._properties.get("payload", {}),
+                    properties=self._properties.get("properties", {}),
+                )
+                # Persist dependency edges (with cycle guard) for the new task.
+                # Joined/deduplicated tasks keep their original dependencies.
+                self._persist_dependencies(task, TaskDAO)
+        except IntegrityError:
+            # SAVEPOINT rolled back (session still usable). Re-read: the winner's
+            # row is committed by now, so join it. If nothing is found the
+            # violation was not the expected dedup race — re-raise.
+            existing = TaskDAO.find_by_task_key(task_type, task_key, scope, user_id)
+            if existing is None:
+                raise
+            current_app.config["STATS_LOGGER"].incr("gtf.task.create_race_joined")
+            return self._join_existing(existing, user_id, guest_key, task_key), False
+        except DAOCreateFailedError as ex:
+            raise TaskCreateFailedError() from ex
+
+        current_app.config["STATS_LOGGER"].incr("gtf.task.create")
+        return task, True  # is_new=True: created new task
+
+    def _join_existing(
+        self,
+        existing: "Task",
+        user_id: int | None,
+        guest_key: str | None,
+        task_key: str,
+    ) -> "Task":
+        """Join an existing task: bump its dedupe count and subscribe the caller.
+
+        Shared by the fast path (found before creating) and the create-race
+        backstop (found after a unique-constraint rollback).
         """
         from superset.daos.tasks import TaskDAO
 
         stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
 
-        # Check for an existing task under the lock; join it if present.
-        if existing := TaskDAO.find_by_task_key(task_type, task_key, scope, user_id):
-            # Finding an existing task is itself a dedupe (work reused, not
-            # re-created), whether the caller becomes a new subscriber or
-            # resubmits as an existing one. Count it on the task's properties.
-            existing.update_properties(
-                {"dedupe_count": existing.properties_dict.get("dedupe_count", 0) + 1}
+        # Finding an existing task is itself a dedupe (work reused, not
+        # re-created), whether the caller becomes a new subscriber or resubmits
+        # as an existing one. Count it on the task's properties.
+        existing.update_properties(
+            {"dedupe_count": existing.properties_dict.get("dedupe_count", 0) + 1}
+        )
+        # Add subscriber if not already subscribed
+        if user_id and not existing.has_subscriber(user_id):
+            TaskDAO.add_subscriber(existing.id, user_id)
+            stats_logger.incr("gtf.task.subscribe")
+            logger.info("User %s joined existing task: %s", user_id, task_key)
+        elif guest_key and not existing.has_guest_subscriber(guest_key):
+            # Embedded guest joining a SHARED task an equivalent guest created;
+            # subscribe so this guest can also poll it.
+            TaskDAO.add_guest_subscriber(existing.id, guest_key)
+            stats_logger.incr("gtf.task.subscribe")
+        else:
+            # Same subscriber resubmitted the same task - deduplication hit
+            stats_logger.incr("gtf.task.dedupe")
+            logger.debug(
+                "Deduplication hit for task: %s (user_id=%s)", task_key, user_id
             )
-            # Join existing task - add subscriber if not already subscribed
-            if user_id and not existing.has_subscriber(user_id):
-                TaskDAO.add_subscriber(existing.id, user_id)
-                stats_logger.incr("gtf.task.subscribe")
-                logger.info(
-                    "User %s joined existing task: %s",
-                    user_id,
-                    task_key,
-                )
-            elif guest_key and not existing.has_guest_subscriber(guest_key):
-                # Embedded guest joining a SHARED task an equivalent guest
-                # created; subscribe so this guest can also poll it.
-                TaskDAO.add_guest_subscriber(existing.id, guest_key)
-                stats_logger.incr("gtf.task.subscribe")
-            else:
-                # Same subscriber resubmitted the same task - deduplication hit
-                stats_logger.incr("gtf.task.dedupe")
-                logger.debug(
-                    "Deduplication hit for task: %s (user_id=%s)",
-                    task_key,
-                    user_id,
-                )
-            return existing, False  # is_new=False: joined existing task
-
-        # Create new task (DAO is now a pure data operation)
-        try:
-            task = TaskDAO.create_task(
-                task_type=task_type,
-                task_key=task_key,
-                scope=scope,
-                task_name=self._properties.get("task_name"),
-                user_id=user_id,
-                guest_key=guest_key,
-                payload=self._properties.get("payload", {}),
-                properties=self._properties.get("properties", {}),
-            )
-            # Persist dependency edges (with cycle guard) for the new task.
-            # Joined/deduplicated tasks keep their original dependencies.
-            self._persist_dependencies(task, TaskDAO)
-            stats_logger.incr("gtf.task.create")
-            return task, True  # is_new=True: created new task
-        except DAOCreateFailedError as ex:
-            raise TaskCreateFailedError() from ex
+        return existing
 
     def _persist_dependencies(self, task: "Task", dao: type["TaskDAO"]) -> None:
         """

--- a/tests/unit_tests/tasks/test_submit.py
+++ b/tests/unit_tests/tasks/test_submit.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for SubmitTaskCommand lock/transaction ordering."""
+
+from contextlib import contextmanager
+from unittest import mock
+
+from pytest_mock import MockerFixture
+
+from superset.commands.tasks.submit import SubmitTaskCommand
+
+
+def test_lock_encloses_create_or_join(mocker: MockerFixture) -> None:
+    """The task lock must be held across the whole create-or-join transaction.
+
+    Regression: the lock previously wrapped only the find/create inside
+    ``run_with_info`` while ``@transaction`` committed *after* the lock was
+    released, letting a concurrent submitter read-before-commit and insert a
+    duplicate ``dedup_key``. The lock must now enclose ``_create_or_join``
+    (which commits on return), so the observable order is
+    enter-lock -> create/join(+commit) -> exit-lock.
+    """
+    order: list[str] = []
+
+    @contextmanager
+    def fake_lock(dedup_key: str):
+        order.append("lock-enter")
+        try:
+            yield
+        finally:
+            order.append("lock-exit")
+
+    mocker.patch("superset.commands.tasks.submit.task_lock", fake_lock)
+    mocker.patch("superset.commands.tasks.submit.get_user_id", return_value=1)
+
+    def fake_create_or_join(*args, **kwargs):
+        order.append("create-or-join")
+        return mock.MagicMock(), True
+
+    mocker.patch.object(
+        SubmitTaskCommand, "_create_or_join", side_effect=fake_create_or_join
+    )
+
+    task, is_new = SubmitTaskCommand(
+        {"task_type": "superset.query_object_v1", "scope": "shared"}
+    ).run_with_info()
+
+    assert is_new is True
+    assert order == ["lock-enter", "create-or-join", "lock-exit"]

--- a/tests/unit_tests/tasks/test_submit.py
+++ b/tests/unit_tests/tasks/test_submit.py
@@ -19,6 +19,8 @@
 from contextlib import contextmanager
 from unittest import mock
 
+import pytest
+from flask import g
 from pytest_mock import MockerFixture
 
 from superset.commands.tasks.submit import SubmitTaskCommand
@@ -61,3 +63,27 @@ def test_lock_encloses_create_or_join(mocker: MockerFixture) -> None:
 
     assert is_new is True
     assert order == ["lock-enter", "create-or-join", "lock-exit"]
+
+
+def test_refuses_to_run_inside_an_outer_transaction(mocker: MockerFixture) -> None:
+    """Submitting inside an outer @transaction must fail loudly.
+
+    The lock-across-commit guarantee requires SubmitTaskCommand to own its
+    transaction; an outer @transaction (signalled by ``g.in_transaction``) would
+    make the inner commit reentrant and defer it past the lock release, silently
+    reopening the dedup race. Guard against that.
+    """
+    entered = mocker.patch(
+        "superset.commands.tasks.submit.task_lock",
+    )
+    g.in_transaction = True
+    try:
+        with pytest.raises(RuntimeError, match="must own its transaction"):
+            SubmitTaskCommand(
+                {"task_type": "superset.query_object_v1", "scope": "shared"}
+            ).run_with_info()
+    finally:
+        g.in_transaction = False
+
+    # We must bail before taking the lock.
+    entered.assert_not_called()

--- a/tests/unit_tests/tasks/test_submit.py
+++ b/tests/unit_tests/tasks/test_submit.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 from flask import g
 from pytest_mock import MockerFixture
+from sqlalchemy.exc import IntegrityError
 
 from superset.commands.tasks.submit import SubmitTaskCommand
 
@@ -87,3 +88,39 @@ def test_refuses_to_run_inside_an_outer_transaction(mocker: MockerFixture) -> No
 
     # We must bail before taking the lock.
     entered.assert_not_called()
+
+
+def test_create_race_joins_winner_on_unique_violation(
+    mocker: MockerFixture,
+) -> None:
+    """A dedup_key unique violation during create must join the winner, not 500.
+
+    Backstop for the lock expiring mid-transaction (fixed TTL) or otherwise
+    failing to serialize: the SAVEPOINT rolls back and the command re-reads and
+    joins the concurrently-created task instead of surfacing the IntegrityError.
+    """
+    winner = mock.MagicMock()
+    winner.properties_dict = {}
+    winner.has_subscriber.return_value = False
+
+    dao = mocker.patch("superset.daos.tasks.TaskDAO")
+    # No task on the first look (before create), the winner on the post-rollback
+    # re-read.
+    dao.find_by_task_key.side_effect = [None, winner]
+    dao.create_task.side_effect = IntegrityError("dup", None, Exception())
+    # begin_nested() is only a no-op savepoint here; let the IntegrityError from
+    # create_task propagate out to the except clause.
+    mocker.patch("superset.db.session.begin_nested", return_value=_null_cm())
+
+    task, is_new = SubmitTaskCommand({})._create_or_join(
+        "superset.query_object_v1", "k", "shared", 1, None
+    )
+
+    assert is_new is False
+    assert task is winner
+    dao.add_subscriber.assert_called_once_with(winner.id, 1)
+
+
+@contextmanager
+def _null_cm():
+    yield


### PR DESCRIPTION
### SUMMARY

Fixes a concurrency bug in GTF async task submission (surfaced on the epic branch after #43557 merged).

**The race.** Concurrent chart-data submits for the same shared query resolve to the same `dedup_key` and are serialized by `task_lock` so all-but-one JOIN the winner's task. But the lock was released *inside* `run_with_info` while `@transaction` committed *afterward*. A waiter could acquire the lock and run `find_by_task_key` in the window between the winner's lock release and its commit — not yet seeing the winner's row (READ COMMITTED) — then INSERT a duplicate `dedup_key`, blocking until the winner committed and then failing with `UniqueViolation` on `idx_tasks_dedup_key` (a 500) instead of a clean join. Reproduces by loading a dashboard with charts that share a query (e.g. the deck.gl demo); it clears on reload once the row/cache is warm.

**The fix.** Move the create-or-join into a dedicated `@transaction` method (`_create_or_join`) that the lock now **wraps**, so the commit happens before the lock is released and a waiter always observes the committed row. Validation runs before the lock so invalid input still fails fast (as `TaskInvalidError`). As a bonus, with `run_with_info` no longer decorated, the no-Redis KV-backed lock's own `@transaction` now commits and is durably visible during the critical section, so the metastore-fallback lock serializes properly too.

**Contract guard.** This guarantee requires `SubmitTaskCommand` to own its transaction — if it runs inside an outer `@transaction`, the reentrancy guard would defer the commit past the lock release and silently reopen the race. All current callers submit outside any transaction; to keep it that way, `run_with_info` now raises if `g.in_transaction` is already set, so a future caller that wraps submit in a transaction fails loudly and reconsiders.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (backend concurrency fix).

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/tasks/test_submit.py -q
```

Manual: load a dashboard whose charts share a query with `GLOBAL_ASYNC_QUERIES` on; it no longer 500s on `idx_tasks_dedup_key`, and duplicate submits join the shared task.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` / `GLOBAL_TASK_FRAMEWORK` (no new flags)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Targets the `gaq-to-gtf` epic branch. Part of #43407.
