### PR TITLE
fix(dashboard): remove @has_access_api from filter state REST API

### DIFF
--- a/superset/dashboards/filter_state/api.py
+++ b/superset/dashboards/filter_state/api.py
@@ -18,7 +18,6 @@ import logging
 
 from flask import Response
 from flask_appbuilder.api import expose, protect, safe
-from flask_appbuilder.security.decorators import has_access_api
 
 from superset.commands.dashboard.filter_state.create import CreateFilterStateCommand
 from superset.commands.dashboard.filter_state.delete import DeleteFilterStateCommand
@@ -26,7 +25,6 @@ from superset.commands.dashboard.filter_state.get import GetFilterStateCommand
 from superset.commands.dashboard.filter_state.update import UpdateFilterStateCommand
 from superset.extensions import event_logger
 from superset.temporary_cache.api import TemporaryCacheRestApi
-from superset.views.base import api
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +46,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
     def get_delete_command(self) -> type[DeleteFilterStateCommand]:
         return DeleteFilterStateCommand
 
-    @api
-    @has_access_api
     @expose("/<int:pk>/filter_state", methods=("POST",))
     @protect()
     @safe
@@ -173,8 +169,6 @@ class DashboardFilterStateRestApi(TemporaryCacheRestApi):
         """
         return super().post(pk)
 
-    @api
-    @has_access_api
     @expose("/<int:pk>/filter_state/<string:key>", methods=("PUT",))
     @protect()
     @safe

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -296,6 +296,7 @@ def test_put_authenticated_user_with_access(
         f"api/v1/dashboard/{dashboard_id}/filter_state/{key}", json=put_payload
     )
     assert resp.status_code == 200
+    mock_create_check_access.assert_called_once_with(dashboard_id)
     mock_update_check_access.assert_called_once_with(dashboard_id)
 
 

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -255,7 +255,10 @@ def test_put_access_denied(test_client, login_as, dashboard_id: int):
     assert resp.status_code == 404
 
 
-def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
+@patch("superset.commands.dashboard.filter_state.create.check_access")
+def test_post_authenticated_user_with_access(
+    mock_check_access, test_client, login_as, dashboard_id: int
+):
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,
@@ -264,9 +267,18 @@ def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id
         f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload
     )
     assert resp.status_code == 201
+    mock_check_access.assert_called_once_with(dashboard_id)
 
 
-def test_put_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
+@patch("superset.commands.dashboard.filter_state.create.check_access")
+@patch("superset.commands.dashboard.filter_state.update.check_access")
+def test_put_authenticated_user_with_access(
+    mock_update_check_access,
+    mock_create_check_access,
+    test_client,
+    login_as,
+    dashboard_id: int,
+):
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,
@@ -284,6 +296,7 @@ def test_put_authenticated_user_with_access(test_client, login_as, dashboard_id:
         f"api/v1/dashboard/{dashboard_id}/filter_state/{key}", json=put_payload
     )
     assert resp.status_code == 200
+    mock_update_check_access.assert_called_once_with(dashboard_id)
 
 
 def test_get_key_not_found(test_client, login_as_admin, dashboard_id: int):

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -256,6 +256,12 @@ def test_put_access_denied(test_client, login_as, dashboard_id: int):
 
 
 def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
+    dashboard = db.session.query(Dashboard).get(dashboard_id)
+    alpha = db.session.query(User).filter_by(username="alpha").one()
+    if alpha not in dashboard.owners:
+        dashboard.owners.append(alpha)
+        db.session.commit()
+
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,
@@ -267,12 +273,27 @@ def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id
 
 
 def test_put_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
+    dashboard = db.session.query(Dashboard).get(dashboard_id)
+    alpha = db.session.query(User).filter_by(username="alpha").one()
+    if alpha not in dashboard.owners:
+        dashboard.owners.append(alpha)
+        db.session.commit()
+
     login_as("alpha")
     payload = {
+        "value": INITIAL_VALUE,
+    }
+    post_resp = test_client.post(
+        f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload
+    )
+    assert post_resp.status_code == 201
+    key = json.loads(post_resp.data.decode("utf-8"))["key"]
+
+    put_payload = {
         "value": UPDATED_VALUE,
     }
     resp = test_client.put(
-        f"api/v1/dashboard/{dashboard_id}/filter_state/{KEY}", json=payload
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{key}", json=put_payload
     )
     assert resp.status_code == 200
 

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -256,12 +256,6 @@ def test_put_access_denied(test_client, login_as, dashboard_id: int):
 
 
 def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
-    dashboard = db.session.query(Dashboard).get(dashboard_id)
-    alpha = db.session.query(User).filter_by(username="alpha").one()
-    if alpha not in dashboard.owners:
-        dashboard.owners.append(alpha)
-        db.session.commit()
-
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,
@@ -273,12 +267,6 @@ def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id
 
 
 def test_put_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
-    dashboard = db.session.query(Dashboard).get(dashboard_id)
-    alpha = db.session.query(User).filter_by(username="alpha").one()
-    if alpha not in dashboard.owners:
-        dashboard.owners.append(alpha)
-        db.session.commit()
-
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -255,9 +255,7 @@ def test_put_access_denied(test_client, login_as, dashboard_id: int):
     assert resp.status_code == 404
 
 
-def test_post_authenticated_user_with_access(
-    test_client, login_as, dashboard_id: int
-):
+def test_post_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
     login_as("alpha")
     payload = {
         "value": INITIAL_VALUE,
@@ -268,9 +266,7 @@ def test_post_authenticated_user_with_access(
     assert resp.status_code == 201
 
 
-def test_put_authenticated_user_with_access(
-    test_client, login_as, dashboard_id: int
-):
+def test_put_authenticated_user_with_access(test_client, login_as, dashboard_id: int):
     login_as("alpha")
     payload = {
         "value": UPDATED_VALUE,

--- a/tests/integration_tests/dashboards/filter_state/api_tests.py
+++ b/tests/integration_tests/dashboards/filter_state/api_tests.py
@@ -255,6 +255,32 @@ def test_put_access_denied(test_client, login_as, dashboard_id: int):
     assert resp.status_code == 404
 
 
+def test_post_authenticated_user_with_access(
+    test_client, login_as, dashboard_id: int
+):
+    login_as("alpha")
+    payload = {
+        "value": INITIAL_VALUE,
+    }
+    resp = test_client.post(
+        f"api/v1/dashboard/{dashboard_id}/filter_state", json=payload
+    )
+    assert resp.status_code == 201
+
+
+def test_put_authenticated_user_with_access(
+    test_client, login_as, dashboard_id: int
+):
+    login_as("alpha")
+    payload = {
+        "value": UPDATED_VALUE,
+    }
+    resp = test_client.put(
+        f"api/v1/dashboard/{dashboard_id}/filter_state/{KEY}", json=payload
+    )
+    assert resp.status_code == 200
+
+
 def test_get_key_not_found(test_client, login_as_admin, dashboard_id: int):
     resp = test_client.get(f"api/v1/dashboard/{dashboard_id}/filter_state/unknown-key/")
     assert resp.status_code == 404

--- a/tests/unit_tests/dashboards/filter_state_api_test.py
+++ b/tests/unit_tests/dashboards/filter_state_api_test.py
@@ -46,17 +46,25 @@ def test_dashboard_filter_state_command_factories():
     assert api.get_delete_command() is DeleteFilterStateCommand
 
 
-def test_post_put_methods_have_no_has_access_api_decorator():
+def test_post_put_methods_have_no_has_access_api_or_api_decorator():
     """
-    Ensure post and put methods are not decorated with @has_access_api.
+    Ensure post and put methods are not decorated with @has_access_api or @api.
 
     Because DashboardFilterStateRestApi is a temporary cache API, permission
     verification is handled dynamically at the command level via
     CheckAccessDataCommand. @has_access_api causes 401 Unauthorized for regular
-    users due to missing FAB permissions.
+    users due to missing FAB permissions. The @api wrapper would catch and convert
+    uncaught auth errors into 500s.
     """
     source_post = inspect.getsource(DashboardFilterStateRestApi.post)
     source_put = inspect.getsource(DashboardFilterStateRestApi.put)
 
     assert "has_access_api" not in source_post
     assert "has_access_api" not in source_put
+
+    assert not any(
+        line.strip().startswith("@api") for line in source_post.splitlines()
+    )
+    assert not any(
+        line.strip().startswith("@api") for line in source_put.splitlines()
+    )

--- a/tests/unit_tests/dashboards/filter_state_api_test.py
+++ b/tests/unit_tests/dashboards/filter_state_api_test.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for DashboardFilterStateRestApi."""
+
+import inspect
+
+from superset.commands.dashboard.filter_state.create import CreateFilterStateCommand
+from superset.commands.dashboard.filter_state.delete import DeleteFilterStateCommand
+from superset.commands.dashboard.filter_state.get import GetFilterStateCommand
+from superset.commands.dashboard.filter_state.update import UpdateFilterStateCommand
+from superset.dashboards.filter_state.api import DashboardFilterStateRestApi
+from superset.temporary_cache.api import TemporaryCacheRestApi
+
+
+def test_dashboard_filter_state_rest_api_inheritance():
+    """Ensure DashboardFilterStateRestApi correctly subclasses TemporaryCacheRestApi."""
+    assert issubclass(DashboardFilterStateRestApi, TemporaryCacheRestApi)
+    assert DashboardFilterStateRestApi.class_permission_name == "DashboardFilterStateRestApi"
+    assert DashboardFilterStateRestApi.resource_name == "dashboard"
+    assert DashboardFilterStateRestApi.openapi_spec_tag == "Dashboard Filter State"
+
+
+def test_dashboard_filter_state_command_factories():
+    """Ensure factory methods return the expected command classes."""
+    api = DashboardFilterStateRestApi()
+    assert api.get_create_command() is CreateFilterStateCommand
+    assert api.get_update_command() is UpdateFilterStateCommand
+    assert api.get_get_command() is GetFilterStateCommand
+    assert api.get_delete_command() is DeleteFilterStateCommand
+
+
+def test_post_put_methods_have_no_has_access_api_decorator():
+    """
+    Ensure post and put methods are not decorated with @has_access_api.
+
+    Because DashboardFilterStateRestApi is a temporary cache API, permission
+    verification is handled dynamically at the command level via CheckAccessDataCommand.
+    @has_access_api causes 401 Unauthorized for regular users due to missing FAB permissions.
+    """
+    source_post = inspect.getsource(DashboardFilterStateRestApi.post)
+    source_put = inspect.getsource(DashboardFilterStateRestApi.put)
+
+    assert "has_access_api" not in source_post
+    assert "has_access_api" not in source_put

--- a/tests/unit_tests/dashboards/filter_state_api_test.py
+++ b/tests/unit_tests/dashboards/filter_state_api_test.py
@@ -29,7 +29,10 @@ from superset.temporary_cache.api import TemporaryCacheRestApi
 def test_dashboard_filter_state_rest_api_inheritance():
     """Ensure DashboardFilterStateRestApi correctly subclasses TemporaryCacheRestApi."""
     assert issubclass(DashboardFilterStateRestApi, TemporaryCacheRestApi)
-    assert DashboardFilterStateRestApi.class_permission_name == "DashboardFilterStateRestApi"
+    assert (
+        DashboardFilterStateRestApi.class_permission_name
+        == "DashboardFilterStateRestApi"
+    )
     assert DashboardFilterStateRestApi.resource_name == "dashboard"
     assert DashboardFilterStateRestApi.openapi_spec_tag == "Dashboard Filter State"
 
@@ -48,8 +51,9 @@ def test_post_put_methods_have_no_has_access_api_decorator():
     Ensure post and put methods are not decorated with @has_access_api.
 
     Because DashboardFilterStateRestApi is a temporary cache API, permission
-    verification is handled dynamically at the command level via CheckAccessDataCommand.
-    @has_access_api causes 401 Unauthorized for regular users due to missing FAB permissions.
+    verification is handled dynamically at the command level via
+    CheckAccessDataCommand. @has_access_api causes 401 Unauthorized for regular
+    users due to missing FAB permissions.
     """
     source_post = inspect.getsource(DashboardFilterStateRestApi.post)
     source_put = inspect.getsource(DashboardFilterStateRestApi.put)

--- a/tests/unit_tests/dashboards/filter_state_api_test.py
+++ b/tests/unit_tests/dashboards/filter_state_api_test.py
@@ -62,9 +62,5 @@ def test_post_put_methods_have_no_has_access_api_or_api_decorator():
     assert "has_access_api" not in source_post
     assert "has_access_api" not in source_put
 
-    assert not any(
-        line.strip().startswith("@api") for line in source_post.splitlines()
-    )
-    assert not any(
-        line.strip().startswith("@api") for line in source_put.splitlines()
-    )
+    assert not any(line.strip().startswith("@api") for line in source_post.splitlines())
+    assert not any(line.strip().startswith("@api") for line in source_put.splitlines())


### PR DESCRIPTION
### SUMMARY
Fixes #43257

In `DashboardFilterStateRestApi`, `@has_access_api` and `@api` decorators were erroneously present on `post()` and `put()` endpoints. Because `DashboardFilterStateRestApi` inherits from `TemporaryCacheRestApi`, endpoint access control and permissions are managed at the command level (verifying access to the underlying dashboard resource via `CheckAccessDataCommand`).

The presence of `@has_access_api` caused standard users and API clients to receive `401 Unauthorized` on `POST` and `PUT` requests when creating or updating filter state in dashboards, as `can_post` / `can_put` permissions for `DashboardFilterStateRestApi` are not registered in FAB's role manager.

This PR removes `@has_access_api` and `@api` from `post()` and `put()`, aligning them with `get()` and `delete()` in the same API as well as `FormDataRestApi`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (Backend REST API fix)

### TESTING INSTRUCTIONS
1. Open a dashboard with native filters as an authenticated user.
2. Apply or update a filter state (`POST /api/v1/dashboard/<pk>/filter_state` or `PUT /api/v1/dashboard/<pk>/filter_state/<key>`).
3. Verify that the request succeeds (returns HTTP 200/201) without returning 401 Unauthorized.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #43257
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SUGGESTED LABELS
`#bug:regression`, `api`, `api:dashboards`, `dashboard:native-filters`, `validation:validated`, `P2`
