### PR TITLE
fix(sql): preserve optimizer hints when formatting semicolon-terminated statements with trailing comments

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -732,6 +732,40 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         return self.format()
 
 
+_SELECT_TRAILING_CLAUSES: tuple[str, ...] = (
+    "options",
+    "settings",
+    "format",
+    "locks",
+    "offset",
+    "limit",
+    "sort",
+    "cluster",
+    "distribute",
+    "order",
+    "windows",
+    "qualify",
+    "having",
+    "group",
+    "where",
+    "joins",
+    "laterals",
+    "from",
+    "into",
+    "expressions",
+)
+
+
+def _get_select_trailing_child(node: exp.Select) -> exp.Expression | None:
+    for clause_name in _SELECT_TRAILING_CLAUSES:
+        val = node.args.get(clause_name)
+        if isinstance(val, list) and val:
+            return _find_last_token_node(val[-1])
+        if isinstance(val, exp.Expression):
+            return _find_last_token_node(val)
+    return None
+
+
 def _find_last_token_node(node: exp.Expression) -> exp.Expression:
     """
     Find the last token/leaf node in SQL generation order to attach trailing comments.
@@ -740,34 +774,8 @@ def _find_last_token_node(node: exp.Expression) -> exp.Expression:
     trailing comments inside optimizer hint blocks (e.g. /*+ SET_VAR(...) */).
     """
     if isinstance(node, exp.Select):
-        for clause_name in (
-            "options",
-            "settings",
-            "format",
-            "locks",
-            "offset",
-            "limit",
-            "sort",
-            "cluster",
-            "distribute",
-            "order",
-            "windows",
-            "qualify",
-            "having",
-            "group",
-            "where",
-            "joins",
-            "laterals",
-            "from",
-            "into",
-            "expressions",
-        ):
-            val = node.args.get(clause_name)
-            if val is not None:
-                if isinstance(val, list) and val:
-                    return _find_last_token_node(val[-1])
-                if isinstance(val, exp.Expression):
-                    return _find_last_token_node(val)
+        if trailing := _get_select_trailing_child(node):
+            return trailing
 
     children: list[exp.Expression] = []
     for k, v in node.args.items():
@@ -776,9 +784,7 @@ def _find_last_token_node(node: exp.Expression) -> exp.Expression:
         if isinstance(v, exp.Expression):
             children.append(v)
         elif isinstance(v, list):
-            for item in v:
-                if isinstance(item, exp.Expression):
-                    children.append(item)
+            children.extend(item for item in v if isinstance(item, exp.Expression))
 
     if children:
         return _find_last_token_node(children[-1])

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -751,7 +751,7 @@ def _find_last_token_node(node: exp.Expression) -> exp.Expression:
             "cluster",
             "distribute",
             "order",
-            "window",
+            "windows",
             "qualify",
             "having",
             "group",

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -732,6 +732,60 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         return self.format()
 
 
+def _find_last_token_node(node: exp.Expression) -> exp.Expression:
+    """
+    Find the last token/leaf node in SQL generation order to attach trailing comments.
+
+    Avoids optimizer hints (exp.Hint) and non-trailing subtrees to prevent injecting
+    trailing comments inside optimizer hint blocks (e.g. /*+ SET_VAR(...) */).
+    """
+    if isinstance(node, exp.Select):
+        for clause_name in (
+            "options",
+            "settings",
+            "format",
+            "locks",
+            "offset",
+            "limit",
+            "sort",
+            "cluster",
+            "distribute",
+            "order",
+            "window",
+            "qualify",
+            "having",
+            "group",
+            "where",
+            "joins",
+            "laterals",
+            "from",
+            "into",
+            "expressions",
+        ):
+            val = node.args.get(clause_name)
+            if val is not None:
+                if isinstance(val, list) and val:
+                    return _find_last_token_node(val[-1])
+                if isinstance(val, exp.Expression):
+                    return _find_last_token_node(val)
+
+    children: list[exp.Expression] = []
+    for k, v in node.args.items():
+        if k in ("hint", "comments"):
+            continue
+        if isinstance(v, exp.Expression):
+            children.append(v)
+        elif isinstance(v, list):
+            for item in v:
+                if isinstance(item, exp.Expression):
+                    children.append(item)
+
+    if children:
+        return _find_last_token_node(children[-1])
+
+    return node
+
+
 class SQLStatement(BaseSQLStatement[exp.Expression]):
     """
     A SQL statement.
@@ -896,11 +950,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         # statement; move them back to the last token in the last real statement
         if len(statements) > 1 and isinstance(statements[-1], exp.Semicolon):
             last_statement = statements.pop()
-            target = statements[-1]
-            for node in statements[-1].walk():
-                if hasattr(node, "comments"):  # pragma: no cover
-                    target = node
-
+            target = _find_last_token_node(statements[-1])
             target.comments = target.comments or []
             target.comments.extend(last_statement.comments)
 

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1333,8 +1333,8 @@ def test_sqlscript_format_preserves_optimizer_hint_block_with_semicolon() -> Non
     """
     Same as `test_sqlscript_format_preserves_optimizer_hint_block`, but with
     a terminating `;` on the statement -- verifies #38189 fix so that trailing
-    `--` comments land after the statement rather than injected into the `/*+ SET_VAR(...) */`
-    hint block for StarRocks/MySQL-style engines.
+    `--` comments land after the statement rather than injected into the
+    `/*+ SET_VAR(...) */` hint block for StarRocks/MySQL-style engines.
     """
     sql = """SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
 FROM my_table

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1329,20 +1329,12 @@ LIMIT 100
     assert "increase timeout for large scans" in formatted[hint_end:]
 
 
-@pytest.mark.xfail(
-    reason=(
-        "#38189 is not fully fixed: a `;`-terminated statement still hits "
-        "the comment-relocation branch and corrupts the hint block. Only "
-        "the no-semicolon form from the original repro was fixed."
-    ),
-    strict=True,
-)
 def test_sqlscript_format_preserves_optimizer_hint_block_with_semicolon() -> None:
     """
     Same as `test_sqlscript_format_preserves_optimizer_hint_block`, but with
-    a terminating `;` on the statement -- this still reproduces #38189: the
-    trailing `--` comment gets injected inside the `/*+ SET_VAR(...) */`
-    hint block, corrupting it for StarRocks/MySQL-style engines.
+    a terminating `;` on the statement -- verifies #38189 fix so that trailing
+    `--` comments land after the statement rather than injected into the `/*+ SET_VAR(...) */`
+    hint block for StarRocks/MySQL-style engines.
     """
     sql = """SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
 FROM my_table
@@ -1357,6 +1349,26 @@ LIMIT 100;
     assert "SET_VAR(query_timeout /*" not in formatted
     hint_end = formatted.index(hint) + len(hint)
     assert "increase timeout for large scans" in formatted[hint_end:]
+
+
+def test_sqlscript_format_preserves_optimizer_hint_with_cte_and_semicolon() -> None:
+    """
+    Ensure optimizer hints with CTEs and trailing comments survive formatting intact.
+    """
+    sql = """WITH cte AS (SELECT 1 AS id)
+SELECT /*+ SET_VAR(query_timeout = 3000) */ id
+FROM cte
+WHERE id = 1;
+
+-- trailing explanation comment"""
+    statement = SQLScript(sql, "mysql").statements[0]
+    formatted = statement.format()
+
+    hint = "/*+ SET_VAR(query_timeout = 3000) */"
+    assert hint in formatted
+    assert "SET_VAR(query_timeout /*" not in formatted
+    hint_end = formatted.index(hint) + len(hint)
+    assert "trailing explanation comment" in formatted[hint_end:]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1377,7 +1377,8 @@ def test_find_last_token_node_branches() -> None:
     """
     Directly test all branches of _find_last_token_node and _get_select_trailing_child.
     """
-    # 1. Empty select returns None from _get_select_trailing_child and falls back to node
+    # 1. Empty select returns None from _get_select_trailing_child
+    # and falls back to node
     empty_select = exp.Select()
     assert _get_select_trailing_child(empty_select) is None
     assert _find_last_token_node(empty_select) is empty_select

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -29,6 +29,8 @@ from superset.jinja_context import JinjaTemplateProcessor
 from superset.sql.parse import (
     _check_script_length,
     _count_weighted_table_references,
+    _find_last_token_node,
+    _get_select_trailing_child,
     BaseSQLStatement,
     count_referenced_tables,
     CTASMethod,
@@ -1369,6 +1371,40 @@ WHERE id = 1;
     assert "SET_VAR(query_timeout /*" not in formatted
     hint_end = formatted.index(hint) + len(hint)
     assert "trailing explanation comment" in formatted[hint_end:]
+
+
+def test_find_last_token_node_branches() -> None:
+    """
+    Directly test all branches of _find_last_token_node and _get_select_trailing_child.
+    """
+    # 1. Empty select returns None from _get_select_trailing_child and falls back to node
+    empty_select = exp.Select()
+    assert _get_select_trailing_child(empty_select) is None
+    assert _find_last_token_node(empty_select) is empty_select
+
+    # 2. Select with list clause vs single Expression clause
+    select_with_exprs = exp.Select(expressions=[exp.Literal.number(1)])
+    assert _get_select_trailing_child(select_with_exprs) == exp.Literal.number(1)
+
+    select_with_where = exp.Select(where=exp.Where(this=exp.Literal.number(2)))
+    assert _get_select_trailing_child(select_with_where) == exp.Literal.number(2)
+
+    # 3. Node with hint or comments in args is skipped during child traversal
+    col_with_comment = exp.Column(this="foo", comments=["my comment"])
+    assert _find_last_token_node(col_with_comment) is not None
+
+    table_with_hint = exp.Table(
+        this="bar", hint=exp.Hint(expressions=[exp.var("HINT")])
+    )
+    assert _find_last_token_node(table_with_hint) is not None
+
+    # 4. Non-select node with list of expressions
+    tup = exp.Tuple(expressions=[exp.Literal.number(1), exp.Literal.number(2)])
+    assert _find_last_token_node(tup) == exp.Literal.number(2)
+
+    # 5. Leaf node with no children returns itself
+    lit = exp.Literal.number(42)
+    assert _find_last_token_node(lit) is lit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY
Fixes #38189

In `SQLStatement._parse`, when a SQL script contained statements terminated by a semicolon followed by trailing `--` comments (which `sqlglot` parses as a trailing `exp.Semicolon` statement), the comment relocation logic iterated over all AST nodes using `.walk()`. 

Because `.walk()` traverses AST subtrees in internal dictionary order rather than reverse SQL document rendering order, `target` was erroneously set to leaf nodes inside optimizer hint blocks (e.g. `exp.Hint` -> `Identifier("query_timeout")`), causing trailing comments to be injected directly inside optimizer hints (e.g. `/*+ SET_VAR(query_timeout /* comment */ = 3000) */`).

This PR fixes this by introducing `_find_last_token_node(node)`, which:
1. Traverses SQL clauses in true reverse generation order (`offset`, `limit`, `order`, `window`, `where`, `from`, `expressions`, etc.).
2. Explicitly skips `exp.Hint` / non-trailing nodes so that comments are safely attached to the final token/clause of the statement.
3. Removes the `@pytest.mark.xfail` marker from `test_sqlscript_format_preserves_optimizer_hint_block_with_semicolon` in `tests/unit_tests/sql/parse_tests.py` and adds tests covering CTEs and optimizer hints.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (SQL Parsing & formatting fix)

### TESTING INSTRUCTIONS
1. Execute formatting on a query containing an optimizer hint and trailing comments with a terminating semicolon (e.g., in SQL Lab with StarRocks/MySQL):
   ```sql
   SELECT /*+ SET_VAR(query_timeout = 3000) */ col1, col2
   FROM my_table
   LIMIT 100;

   -- increase timeout for large scans
   ```
2. Verify that the query formats cleanly without inserting comments inside the `/*+ ... */` hint block.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #38189
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SUGGESTED LABELS
`#bug:regression`, `data:sqllab`, `sql`, `validation:validated`, `P2`
