### PR TITLE
fix(dashboard): don't 500 on inconsistent position_json

### DIFF
--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -173,14 +173,13 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
     def process_tab_diff(self) -> None:
         def find_deleted_tabs() -> list[str]:
             position_json = self._properties.get("position_json", "")
+            if not position_json:
+                return []
             current_tabs = self._model.tabs  # type: ignore
-            if position_json and current_tabs:
-                position = json.loads(position_json)
-                deleted_tabs = [
-                    tab for tab in current_tabs["all_tabs"] if tab not in position
-                ]
-                return deleted_tabs
-            return []
+            if not current_tabs:
+                return []
+            position = json.loads(position_json)
+            return [tab for tab in current_tabs["all_tabs"] if tab not in position]
 
         def find_reports_containing_tabs(tabs: list[str]) -> list[ReportSchedule]:
             alert_reports_list = []

--- a/superset/commands/dashboard/update.py
+++ b/superset/commands/dashboard/update.py
@@ -175,9 +175,10 @@ class UpdateDashboardCommand(UpdateMixin, BaseCommand):
             position_json = self._properties.get("position_json", "")
             if not position_json:
                 return []
+            # ``tabs`` always answers with both keys, even for a layout it
+            # could not walk, so an empty ``all_tabs`` needs no guard of its
+            # own: nothing is diffed against the new layout.
             current_tabs = self._model.tabs  # type: ignore
-            if not current_tabs:
-                return []
             position = json.loads(position_json)
             return [tab for tab in current_tabs["all_tabs"] if tab not in position]
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import defaultdict, deque
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import sqlalchemy as sqla
 from flask import current_app as app, has_request_context, url_for
@@ -378,15 +378,42 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
         return {}
 
     @property
-    def tabs(self) -> dict[str, Any]:
+    def tabs(self) -> dict[str, Any]:  # noqa: C901
+        if not isinstance(self.position, dict):
+            logger.warning("Dashboard %s: layout is not a mapping", self.id)
+            return {}
         if self.position == {}:
             return {}
 
-        def get_node(node_id: str) -> dict[str, Any]:
+        def get_node(node_id: str) -> Optional[dict[str, Any]]:
             """
             Helper function for getting a node from the position_data
             """
-            return self.position[node_id]
+            return self.position.get(node_id)
+
+        def register_tab(node: dict[str, Any]) -> None:
+            """
+            Helper function for titling a TAB node and adding it to all_tabs
+            """
+            meta = node.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+            if "text" not in meta:
+                logger.warning(
+                    "Dashboard %s: tab node %s has no title in the layout",
+                    self.id,
+                    node.get("id"),
+                )
+            node["title"] = meta.get("text", "")
+            node_id = node.get("id")
+            if node_id is None:
+                logger.warning(
+                    "Dashboard %s: skipping tab node with no id in the layout",
+                    self.id,
+                )
+                return
+            node["value"] = node_id
+            all_tabs[node_id] = node["title"]
 
         def build_tab_tree(
             node: dict[str, Any], children: list[dict[str, Any]]
@@ -394,27 +421,47 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
             """
             Function for building the tab tree structure and list of all tabs
             """
+            if "type" not in node:
+                logger.warning(
+                    "Dashboard %s: skipping untyped layout node %s",
+                    self.id,
+                    node.get("id"),
+                )
+                return
 
+            # A node whose type is not one of the four below is walked through
+            # without contributing to the tree, exactly as an untabbed layout
+            # element always has been.
+            node_type = node["type"]
             new_children: list[dict[str, Any]] = []
             # new children to overwrite parent's children
             for child_id in node.get("children", []):
                 child = get_node(child_id)
-                if node["type"] == "TABS":
+                if not isinstance(child, dict):
+                    logger.warning(
+                        "Dashboard %s: skipping layout node %s, missing or malformed",
+                        self.id,
+                        child_id,
+                    )
+                    continue
+                if node_type == "TABS":
                     # if TABS add create a new list and append children to it
                     # new_children.append(child)
                     children.append(child)
                     queue.append((child, new_children))
-                elif node["type"] in ["GRID", "ROOT"]:
+                elif node_type in ["GRID", "ROOT"]:
                     queue.append((child, children))
-                elif node["type"] == "TAB":
+                elif node_type == "TAB":
                     queue.append((child, new_children))
-            if node["type"] == "TAB":
+            if node_type == "TAB":
                 node["children"] = new_children
-                node["title"] = node["meta"]["text"]
-                node["value"] = node["id"]
-                all_tabs[node["id"]] = node["title"]
+                register_tab(node)
 
         root = get_node("ROOT_ID")
+        if not isinstance(root, dict):
+            logger.warning("Dashboard %s: layout has no usable ROOT_ID node", self.id)
+            return {}
+
         tab_tree: list[dict[str, Any]] = []
         all_tabs: dict[str, str] = {}
         queue: deque[tuple[dict[str, Any], list[dict[str, Any]]]] = deque()

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -453,6 +453,19 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
                     )
                     continue
                 if node_type == "TABS":
+                    # A tab that cannot be keyed by a string is unusable: it
+                    # could not be selected, and it would reach the API as a
+                    # tree entry with no ``value``. Keep it out of the tree as
+                    # well as out of ``all_tabs``.
+                    if child.get("type") == "TAB" and not isinstance(
+                        child.get("id"), str
+                    ):
+                        logger.warning(
+                            "Dashboard %s: skipping tab node with no usable id "
+                            "in the layout",
+                            self.id,
+                        )
+                        continue
                     # if TABS add create a new list and append children to it
                     # new_children.append(child)
                     children.append(child)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -463,8 +463,6 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
                     # left in the tree with no ``value`` and no ``title``. It is
                     # still walked, so tabs stored below it are not lost.
                     if child.get("type") == "TAB" and isinstance(child.get("id"), str):
-                        # if TABS add create a new list and append children to it
-                        # new_children.append(child)
                         children.append(child)
                     else:
                         logger.warning(

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -379,11 +379,15 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
 
     @property
     def tabs(self) -> dict[str, Any]:  # noqa: C901
+        # Callers index ``all_tabs`` and iterate ``tab_tree``, so every exit
+        # returns that shape. A bare ``{}`` reaches the API as a payload with
+        # neither key, which a caller cannot iterate.
+        no_tabs: dict[str, Any] = {"all_tabs": {}, "tab_tree": []}
         if not isinstance(self.position, dict):
             logger.warning("Dashboard %s: layout is not a mapping", self.id)
-            return {}
+            return no_tabs
         if self.position == {}:
-            return {}
+            return no_tabs
 
         def get_node(node_id: str) -> Optional[dict[str, Any]]:
             """
@@ -453,22 +457,22 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
                     )
                     continue
                 if node_type == "TABS":
-                    # A tab that cannot be keyed by a string is unusable: it
-                    # could not be selected, and it would reach the API as a
-                    # tree entry with no ``value``. Keep it out of the tree as
-                    # well as out of ``all_tabs``.
-                    if child.get("type") == "TAB" and not isinstance(
-                        child.get("id"), str
-                    ):
+                    # Only a node that will register as a tab belongs in the
+                    # tree. Anything else -- an untyped node, or a tab whose id
+                    # cannot key ``all_tabs`` -- is rejected later and would be
+                    # left in the tree with no ``value`` and no ``title``. It is
+                    # still walked, so tabs stored below it are not lost.
+                    if child.get("type") == "TAB" and isinstance(child.get("id"), str):
+                        # if TABS add create a new list and append children to it
+                        # new_children.append(child)
+                        children.append(child)
+                    else:
                         logger.warning(
-                            "Dashboard %s: skipping tab node with no usable id "
-                            "in the layout",
+                            "Dashboard %s: keeping layout node %s out of the "
+                            "tab tree, it is not a usable tab",
                             self.id,
+                            child_id,
                         )
-                        continue
-                    # if TABS add create a new list and append children to it
-                    # new_children.append(child)
-                    children.append(child)
                     queue.append((child, new_children))
                 elif node_type in ["GRID", "ROOT"]:
                     queue.append((child, children))
@@ -481,7 +485,7 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
         root = get_node("ROOT_ID")
         if not isinstance(root, dict):
             logger.warning("Dashboard %s: layout has no usable ROOT_ID node", self.id)
-            return {}
+            return no_tabs
 
         tab_tree: list[dict[str, Any]] = []
         all_tabs: dict[str, str] = {}

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -396,24 +396,24 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
             Helper function for titling a TAB node and adding it to all_tabs
             """
             meta = node.get("meta")
-            if not isinstance(meta, dict):
-                meta = {}
-            if "text" not in meta:
+            title = meta.get("text") if isinstance(meta, dict) else None
+            if not isinstance(title, str):
                 logger.warning(
                     "Dashboard %s: tab node %s has no title in the layout",
                     self.id,
                     node.get("id"),
                 )
-            node["title"] = meta.get("text", "")
+                title = ""
+            node["title"] = title
             node_id = node.get("id")
-            if node_id is None:
+            if not isinstance(node_id, str):
                 logger.warning(
-                    "Dashboard %s: skipping tab node with no id in the layout",
+                    "Dashboard %s: skipping tab node with no usable id in the layout",
                     self.id,
                 )
                 return
             node["value"] = node_id
-            all_tabs[node_id] = node["title"]
+            all_tabs[node_id] = title
 
         def build_tab_tree(
             node: dict[str, Any], children: list[dict[str, Any]]
@@ -433,10 +433,18 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
             # without contributing to the tree, exactly as an untabbed layout
             # element always has been.
             node_type = node["type"]
+            child_ids = node.get("children", [])
+            if not isinstance(child_ids, list):
+                logger.warning(
+                    "Dashboard %s: layout node %s has malformed children",
+                    self.id,
+                    node.get("id"),
+                )
+                child_ids = []
             new_children: list[dict[str, Any]] = []
             # new children to overwrite parent's children
-            for child_id in node.get("children", []):
-                child = get_node(child_id)
+            for child_id in child_ids:
+                child = get_node(child_id) if isinstance(child_id, str) else None
                 if not isinstance(child, dict):
                     logger.warning(
                         "Dashboard %s: skipping layout node %s, missing or malformed",

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -395,6 +395,29 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
             """
             return self.position.get(node_id)
 
+        def resolve_child(child_id: Any) -> Optional[dict[str, Any]]:
+            """
+            Helper function for reading a child id, or None if it cannot be walked
+            """
+            child = get_node(child_id) if isinstance(child_id, str) else None
+            if not isinstance(child, dict):
+                logger.warning(
+                    "Dashboard %s: skipping layout node %s, missing or malformed",
+                    self.id,
+                    child_id,
+                )
+                return None
+            if child_id in visited:
+                logger.warning(
+                    "Dashboard %s: skipping layout node %s, the layout reaches "
+                    "it more than once",
+                    self.id,
+                    child_id,
+                )
+                return None
+            visited.add(child_id)
+            return child
+
         def register_tab(node: dict[str, Any]) -> None:
             """
             Helper function for titling a TAB node and adding it to all_tabs
@@ -448,13 +471,8 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
             new_children: list[dict[str, Any]] = []
             # new children to overwrite parent's children
             for child_id in child_ids:
-                child = get_node(child_id) if isinstance(child_id, str) else None
-                if not isinstance(child, dict):
-                    logger.warning(
-                        "Dashboard %s: skipping layout node %s, missing or malformed",
-                        self.id,
-                        child_id,
-                    )
+                child = resolve_child(child_id)
+                if child is None:
                     continue
                 if node_type == "TABS":
                     # Only a node that will register as a tab belongs in the
@@ -487,6 +505,10 @@ class Dashboard(CoreDashboard, SoftDeleteMixin, AuditMixinNullable, ImportExport
 
         tab_tree: list[dict[str, Any]] = []
         all_tabs: dict[str, str] = {}
+        # A layout is a tree, so every node is reached once. A stored layout
+        # that reaches one twice would walk it twice, and a cycle would never
+        # stop, so the walk keeps track of what it has already reached.
+        visited: set[str] = {"ROOT_ID"}
         queue: deque[tuple[dict[str, Any], list[dict[str, Any]]]] = deque()
         queue.append((root, tab_tree))
         while queue:

--- a/tests/unit_tests/commands/dashboard/update_test.py
+++ b/tests/unit_tests/commands/dashboard/update_test.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from superset.commands.dashboard.update import UpdateDashboardCommand
+from superset.utils import json
+
+
+def test_process_tab_diff_ignores_the_layout_without_position_json(
+    app_context: None,
+) -> None:
+    """An update that does not carry a layout must not walk the stored one.
+
+    A tab can only be deleted by an update that supplies `position_json`, so
+    for any other payload — publishing a dashboard, renaming it — there is
+    nothing to diff and the stored layout must be left alone.
+    """
+    command = UpdateDashboardCommand(1, {"published": True})
+    tabs = PropertyMock(side_effect=AssertionError("the layout must not be read"))
+    model = MagicMock()
+    type(model).tabs = tabs
+    command._model = model  # noqa: SLF001
+
+    command.process_tab_diff()
+
+    tabs.assert_not_called()
+
+
+def test_process_tab_diff_deactivates_reports_on_deleted_tabs(
+    app_context: None,
+) -> None:
+    """An update that drops a tab still deactivates the reports using it."""
+    command = UpdateDashboardCommand(
+        1,
+        {
+            "position_json": json.dumps(
+                {
+                    "ROOT_ID": {
+                        "id": "ROOT_ID",
+                        "type": "ROOT",
+                        "children": ["TAB-1"],
+                    },
+                    "TAB-1": {
+                        "id": "TAB-1",
+                        "type": "TAB",
+                        "meta": {"text": "First"},
+                        "children": [],
+                    },
+                }
+            )
+        },
+    )
+    model = MagicMock()
+    type(model).tabs = PropertyMock(
+        return_value={"all_tabs": {"TAB-1": "First", "TAB-2": "Second"}}
+    )
+    command._model = model  # noqa: SLF001
+
+    report = MagicMock()
+    report.editors = []
+    with patch("superset.commands.dashboard.update.ReportScheduleDAO") as report_dao:
+        report_dao.find_by_extra_metadata.return_value = [report]
+        command.process_tab_diff()
+
+    # TAB-2 is gone from the new layout, TAB-1 is not.
+    report_dao.find_by_extra_metadata.assert_called_once_with("TAB-2")
+    report_dao.update.assert_called_once_with(report, {"active": False})

--- a/tests/unit_tests/dashboards/api_test.py
+++ b/tests/unit_tests/dashboards/api_test.py
@@ -15,11 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy.orm.session import Session
 
+from superset import db, security_manager
 from superset.dashboards.schemas import DashboardGetResponseSchema
+from superset.utils import json
 
 
 @pytest.fixture
@@ -136,3 +141,77 @@ def test_schema_includes_all_fields_for_regular_user(
     assert "viewers" in result
     assert "changed_by_name" in result
     assert "changed_by" in result
+
+
+ROOT = {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]}
+GRID = {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]}
+TAB_1 = {"id": "TAB-1", "type": "TAB", "meta": {"text": "Kept"}, "children": []}
+
+
+def _layout(tabs_children: list[str]) -> dict[str, Any]:
+    return {
+        "ROOT_ID": ROOT,
+        "GRID_ID": GRID,
+        "TABS-1": {"id": "TABS-1", "type": "TABS", "children": tabs_children},
+        "TAB-1": TAB_1,
+    }
+
+
+def _store_dashboard(position_json: str) -> int:
+    from superset.models.dashboard import Dashboard
+
+    Dashboard.metadata.create_all(db.session.get_bind())
+    dashboard = Dashboard(
+        dashboard_title="broken layout",
+        position_json=position_json,
+        json_metadata="{}",
+    )
+    db.session.add(dashboard)
+    db.session.flush()
+    return dashboard.id
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        # A tab bar pointing at a tab the layout does not hold. Walking it is
+        # what used to raise, so the dashboard could not be written again.
+        pytest.param(_layout(["TAB-1", "TAB-2"]), id="dangling child"),
+        # A layout that reaches a node it has already reached. Walking it used
+        # to never finish, so the request hung instead of failing.
+        pytest.param({"ROOT_ID": {**ROOT, "children": ["ROOT_ID"]}}, id="cycle"),
+    ],
+)
+def test_put_repairs_a_stored_layout_that_cannot_be_walked(
+    stored: dict[str, Any],
+    session: Session,
+    client: Any,
+    full_api_access: None,
+    mocker: MockerFixture,
+) -> None:
+    """A dashboard stored with an unwalkable layout can still be repaired.
+
+    The layouts here are JSON-parseable, so they pass validation and reach the
+    metadata database. Reading the tabs off them is what fails, and an update
+    reads the stored tabs to find the deleted ones, so before this change the
+    repair request itself failed and the dashboard stayed unwritable.
+    """
+    from superset.models.dashboard import Dashboard
+
+    # ``full_api_access`` stops at the route decorators, so the row filter and
+    # the editorship check still need a user the request does not have.
+    mocker.patch.object(security_manager, "is_admin", return_value=True)
+    mocker.patch.object(security_manager, "raise_for_editorship")
+
+    dashboard_id = _store_dashboard(json.dumps(stored))
+    repaired = json.dumps(_layout(["TAB-1"]))
+
+    response = client.put(
+        f"/api/v1/dashboard/{dashboard_id}",
+        json={"position_json": repaired},
+    )
+
+    assert response.status_code == 200
+    assert json.loads(
+        db.session.query(Dashboard).get(dashboard_id).position_json
+    ) == json.loads(repaired)

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -15,11 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
 from unittest.mock import patch, PropertyMock
 
+import pytest
 from flask import current_app
 
 from superset.models.dashboard import Dashboard
+from superset.utils import json
 
 
 def test_dashboard_link_escapes_slug(app_context: None) -> None:
@@ -127,3 +130,328 @@ def test_thumbnail_url_works_outside_request_context(app_context: None) -> None:
         url = dash.thumbnail_url
 
     assert url == "/api/v1/dashboard/7/thumbnail/abc123/"
+
+
+LOGGER = "superset.models.dashboard"
+
+
+def test_tabs_returns_all_tabs_and_tree_for_a_valid_layout(
+    app_context: None,
+) -> None:
+    """A well-formed layout is walked exactly as before.
+
+    This is the regression guard for the defensive lookups in `tabs`: when
+    every id referenced by a `children` array resolves and every TAB node
+    carries `meta.text`, the property must return the same `all_tabs` mapping
+    and the same `tab_tree` shape it always has. Only TAB nodes surface in the
+    tree — ROOT/GRID/TABS are traversed through, not emitted — and a tab
+    nested inside another tab is emitted under its parent, not at top level.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "children": ["TAB-1", "TAB-2"],
+            },
+            # TAB-1 holds a nested tab bar of its own.
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": ["TABS-2"],
+            },
+            "TABS-2": {
+                "id": "TABS-2",
+                "type": "TABS",
+                "children": ["TAB-1-1"],
+            },
+            "TAB-1-1": {
+                "id": "TAB-1-1",
+                "type": "TAB",
+                "meta": {"text": "Nested"},
+                "children": [],
+            },
+            "TAB-2": {
+                "id": "TAB-2",
+                "type": "TAB",
+                "meta": {"text": "Second"},
+                "children": [],
+            },
+        }
+    )
+
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {
+        "TAB-1": "First",
+        "TAB-1-1": "Nested",
+        "TAB-2": "Second",
+    }
+
+    tab_tree = tabs["tab_tree"]
+    assert [node["id"] for node in tab_tree] == ["TAB-1", "TAB-2"]
+    assert [node["type"] for node in tab_tree] == ["TAB", "TAB"]
+    assert [node["title"] for node in tab_tree] == ["First", "Second"]
+    assert [node["value"] for node in tab_tree] == ["TAB-1", "TAB-2"]
+
+    # The nested tab replaces its parent's original children, and the TABS
+    # container that held it is walked through rather than emitted.
+    nested = tab_tree[0]["children"]
+    assert [node["id"] for node in nested] == ["TAB-1-1"]
+    assert [node["title"] for node in nested] == ["Nested"]
+    assert [node["value"] for node in nested] == ["TAB-1-1"]
+    assert nested[0]["children"] == []
+    # Leaf tabs get an empty child list.
+    assert tab_tree[1]["children"] == []
+
+
+def test_tabs_skips_children_missing_from_the_layout(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A `children` entry naming an id that is not a key in the layout is
+    skipped, with a warning, rather than raising.
+
+    `position_json` is only validated for JSON parseability, so a stored
+    layout can reference a node that no longer exists. The tabs that do
+    resolve must still be returned.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                # TAB-2 is referenced but never defined below.
+                "children": ["TAB-1", "TAB-2"],
+            },
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "First"}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1"]
+    assert "skipping layout node TAB-2, missing or malformed" in caplog.text
+
+
+def test_tabs_skips_layout_nodes_that_are_not_mappings(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A `children` entry resolving to something that is not an object is
+    skipped, with a warning, rather than raising."""
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "children": ["TAB-1", "TAB-2"],
+            },
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": [],
+            },
+            # Present, but not an object.
+            "TAB-2": "not a node",
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "First"}
+    assert "skipping layout node TAB-2, missing or malformed" in caplog.text
+
+
+def test_tabs_skips_layout_nodes_without_a_type(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A node with no `type` is skipped, with a warning, rather than raising.
+
+    Its subtree is dropped, so the warning is what tells an operator why a
+    dashboard that visibly has tabs reports fewer of them.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            # No `type` key, so the tab bar underneath is never reached.
+            "GRID_ID": {"id": "GRID_ID", "children": ["TABS-1"]},
+            "TABS-1": {"id": "TABS-1", "type": "TABS", "children": ["TAB-1"]},
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs == {"all_tabs": {}, "tab_tree": []}
+    assert "skipping untyped layout node GRID_ID" in caplog.text
+
+
+def test_tabs_handles_tab_nodes_without_a_title(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A TAB node whose title cannot be read does not raise.
+
+    Every shape that `meta` can take without carrying a `text` is covered: no
+    `meta` at all, an empty `meta`, and a `meta` that is not an object. All
+    three keep the node, with an empty title, so a single untitled tab cannot
+    take down the whole layout walk.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "children": ["TAB-1", "TAB-2", "TAB-3"],
+            },
+            # No `meta` key at all.
+            "TAB-1": {"id": "TAB-1", "type": "TAB", "children": []},
+            # `meta` present but carrying no `text`.
+            "TAB-2": {
+                "id": "TAB-2",
+                "type": "TAB",
+                "meta": {},
+                "children": [],
+            },
+            # `meta` present but not an object.
+            "TAB-3": {
+                "id": "TAB-3",
+                "type": "TAB",
+                "meta": "First",
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "", "TAB-2": "", "TAB-3": ""}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1", "TAB-2", "TAB-3"]
+    assert [node["title"] for node in tabs["tab_tree"]] == ["", "", ""]
+    for tab_id in ("TAB-1", "TAB-2", "TAB-3"):
+        assert f"tab node {tab_id} has no title in the layout" in caplog.text
+
+
+def test_tabs_skips_tab_nodes_without_an_id(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A TAB node with no `id` cannot be addressed, so it is left out of
+    `all_tabs` with a warning rather than raising."""
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "children": ["TAB-1", "TAB-2"],
+            },
+            # No `id` key.
+            "TAB-1": {"type": "TAB", "meta": {"text": "First"}, "children": []},
+            "TAB-2": {
+                "id": "TAB-2",
+                "type": "TAB",
+                "meta": {"text": "Second"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-2": "Second"}
+    assert "skipping tab node with no id in the layout" in caplog.text
+
+
+def test_tabs_returns_empty_dict_when_layout_has_no_root(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-empty layout with no ROOT_ID node yields no tabs.
+
+    The empty-layout early return does not cover this case, because the parsed
+    layout is a non-empty mapping — it simply has nothing to start the walk
+    from.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {"GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": []}}
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+
+    assert dash.tabs == {}
+    assert "layout has no usable ROOT_ID node" in caplog.text
+
+
+def test_tabs_returns_empty_dict_for_an_empty_layout(app_context: None) -> None:
+    """No layout at all — unset, blank or an empty object — yields no tabs."""
+    dash = Dashboard()
+    dash.id = 1
+
+    dash.position_json = None
+    assert dash.tabs == {}
+
+    dash.position_json = ""
+    assert dash.tabs == {}
+
+    dash.position_json = json.dumps({})
+    assert dash.tabs == {}
+
+
+def test_tabs_returns_empty_dict_when_layout_is_not_a_mapping(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Valid JSON that is not an object yields no tabs instead of raising.
+
+    `null` and `[]` parse successfully but are not mappings, so they slip past
+    the empty-layout early return.
+    """
+    dash = Dashboard()
+    dash.id = 1
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+
+    dash.position_json = json.dumps(None)
+    assert dash.tabs == {}
+
+    dash.position_json = json.dumps([])
+    assert dash.tabs == {}
+
+    assert caplog.text.count("layout is not a mapping") == 2

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -374,8 +374,12 @@ def test_tabs_handles_tab_nodes_without_a_title(
 def test_tabs_skips_tab_nodes_without_an_id(
     app_context: None, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """A TAB node with no `id` cannot be addressed, so it is left out of
-    `all_tabs` with a warning rather than raising."""
+    """A TAB node without a usable `id` is left out of the result entirely.
+
+    Such a tab cannot be keyed in `all_tabs`, and it cannot carry a `value`,
+    so a tree entry for it would not satisfy `TabSchema` and could never be
+    selected in the tab picker. It is dropped from both, with a warning.
+    """
     dash = Dashboard()
     dash.id = 1
     dash.position_json = json.dumps(
@@ -409,6 +413,10 @@ def test_tabs_skips_tab_nodes_without_an_id(
     tabs = dash.tabs
 
     assert tabs["all_tabs"] == {"TAB-2": "Second"}
+    # The unusable tabs are absent from the tree too, so it cannot carry an
+    # entry that has no `value` for the API to serialise.
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-2"]
+    assert all("value" in node for node in tabs["tab_tree"])
     assert caplog.text.count("skipping tab node with no usable id in the layout") == 2
 
 

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -425,14 +425,15 @@ def test_tabs_skips_tab_nodes_without_an_id(
     assert caplog.text.count("skipping tab node with no usable id in the layout") == 2
 
 
-def test_tabs_returns_empty_dict_when_layout_has_no_root(
+def test_tabs_returns_no_tabs_when_layout_has_no_root(
     app_context: None, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A non-empty layout with no ROOT_ID node yields no tabs.
 
     The empty-layout early return does not cover this case, because the parsed
     layout is a non-empty mapping — it simply has nothing to start the walk
-    from.
+    from. Like every other exit it returns the normal payload shape, since
+    callers index `all_tabs` and iterate `tab_tree`.
     """
     dash = Dashboard()
     dash.id = 1
@@ -442,26 +443,26 @@ def test_tabs_returns_empty_dict_when_layout_has_no_root(
 
     caplog.set_level(logging.WARNING, logger=LOGGER)
 
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
     assert "layout has no usable ROOT_ID node" in caplog.text
 
 
-def test_tabs_returns_empty_dict_for_an_empty_layout(app_context: None) -> None:
+def test_tabs_returns_no_tabs_for_an_empty_layout(app_context: None) -> None:
     """No layout at all — unset, blank or an empty object — yields no tabs."""
     dash = Dashboard()
     dash.id = 1
 
     dash.position_json = None
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
 
     dash.position_json = ""
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
 
     dash.position_json = json.dumps({})
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
 
 
-def test_tabs_returns_empty_dict_when_layout_is_not_a_mapping(
+def test_tabs_returns_no_tabs_when_layout_is_not_a_mapping(
     app_context: None, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Valid JSON that is not an object yields no tabs instead of raising.
@@ -475,10 +476,10 @@ def test_tabs_returns_empty_dict_when_layout_is_not_a_mapping(
     caplog.set_level(logging.WARNING, logger=LOGGER)
 
     dash.position_json = json.dumps(None)
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
 
     dash.position_json = json.dumps([])
-    assert dash.tabs == {}
+    assert dash.tabs == {"all_tabs": {}, "tab_tree": []}
 
     assert caplog.text.count("layout is not a mapping") == 2
 
@@ -555,3 +556,49 @@ def test_tabs_skips_an_unusable_tab_outside_a_tab_bar(
 
     assert tabs == {"all_tabs": {}, "tab_tree": []}
     assert "skipping tab node with no usable id in the layout" in caplog.text
+
+
+def test_tabs_keeps_nodes_that_are_not_usable_tabs_out_of_the_tree(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Only a node that registers as a tab is added to the tree.
+
+    A TABS node contributes its children to `tab_tree`, but a child that is
+    untyped, or is not a TAB, never reaches `register_tab` and so never gets a
+    `value` or a `title`. Such an entry would not satisfy `TabSchema`, so it is
+    kept out of the tree, while still being walked in case tabs are stored
+    below it.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                "children": ["TAB-1", "ROW-1", "TAB-2"],
+            },
+            # No `type`, so the walk rejects it before it can be registered.
+            "TAB-1": {"id": "TAB-1", "meta": {"text": "Untyped"}, "children": []},
+            # Typed, but not a tab.
+            "ROW-1": {"id": "ROW-1", "type": "ROW", "children": []},
+            "TAB-2": {
+                "id": "TAB-2",
+                "type": "TAB",
+                "meta": {"text": "Second"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-2": "Second"}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-2"]
+    # Nothing in the tree may be missing the fields the API serialises.
+    assert all("value" in node and "title" in node for node in tabs["tab_tree"])
+    for node_id in ("TAB-1", "ROW-1"):
+        assert f"keeping layout node {node_id} out of the tab tree" in caplog.text

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -158,13 +158,18 @@ def test_tabs_returns_all_tabs_and_tree_for_a_valid_layout(
                 "type": "TABS",
                 "children": ["TAB-1", "TAB-2"],
             },
-            # TAB-1 holds a nested tab bar of its own.
+            # TAB-1 holds a nested tab bar of its own, alongside a row, so a
+            # tab with more than one child is covered.
             "TAB-1": {
                 "id": "TAB-1",
                 "type": "TAB",
                 "meta": {"text": "First"},
-                "children": ["TABS-2"],
+                "children": ["TABS-2", "ROW-1"],
             },
+            # A non-tab sibling holding a chart: walked through, and neither
+            # it nor its child is ever part of the tree.
+            "ROW-1": {"id": "ROW-1", "type": "ROW", "children": ["CHART-1"]},
+            "CHART-1": {"id": "CHART-1", "type": "CHART", "children": []},
             "TABS-2": {
                 "id": "TABS-2",
                 "type": "TABS",
@@ -517,3 +522,36 @@ def test_tabs_handles_malformed_children(
     assert tabs["tab_tree"][0]["children"] == []
     assert "layout node TAB-1 has malformed children" in caplog.text
     assert "missing or malformed" in caplog.text
+
+
+def test_tabs_skips_an_unusable_tab_outside_a_tab_bar(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A TAB reached without a TABS parent is validated when it is registered.
+
+    Only a TABS node contributes its children to the tree, so that is where an
+    unusable tab is normally caught. A TAB stored directly under GRID or ROOT
+    never passes that check, and is rejected when its title and id are read
+    instead.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            # The tab hangs straight off the grid, with no tab bar in between.
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TAB-1"]},
+            "TAB-1": {
+                "id": ["TAB-1"],
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs == {"all_tabs": {}, "tab_tree": []}
+    assert "skipping tab node with no usable id in the layout" in caplog.text

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -602,3 +602,99 @@ def test_tabs_keeps_nodes_that_are_not_usable_tabs_out_of_the_tree(
     assert all("value" in node and "title" in node for node in tabs["tab_tree"])
     for node_id in ("TAB-1", "ROW-1"):
         assert f"keeping layout node {node_id} out of the tab tree" in caplog.text
+
+
+def test_tabs_stops_at_a_layout_that_reaches_itself(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A self-referencing layout must not queue the same node forever.
+
+    The walk is a queue, so a node listed among its own descendants is
+    re-enqueued on every pass and the walk never ends. A dashboard stored with
+    such a layout could not be read or written again, because an update reads
+    the stored tabs to find the deleted ones.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {"ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["ROOT_ID"]}}
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs == {"all_tabs": {}, "tab_tree": []}
+    assert "skipping layout node ROOT_ID, the layout reaches it more than once" in (
+        caplog.text
+    )
+
+
+def test_tabs_keeps_the_tabs_above_a_cycle(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A cycle deeper in the layout costs only the nodes below it."""
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {"id": "TABS-1", "type": "TABS", "children": ["TAB-1"]},
+            # Points back at its own tab bar.
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": ["TABS-1"],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "First"}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1"]
+    assert "skipping layout node TABS-1, the layout reaches it more than once" in (
+        caplog.text
+    )
+
+
+def test_tabs_places_a_node_the_layout_reaches_twice_only_once(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A node reached from two parents is placed where it is reached first.
+
+    This is not a cycle, but it is not a tree either — a node cannot render in
+    two places — and the walk writes `title`, `value` and `children` onto each
+    node it visits, so a second visit would overwrite the first.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {
+                "id": "GRID_ID",
+                "type": "GRID",
+                "children": ["TABS-1", "TABS-2"],
+            },
+            "TABS-1": {"id": "TABS-1", "type": "TABS", "children": ["TAB-1"]},
+            "TABS-2": {"id": "TABS-2", "type": "TABS", "children": ["TAB-1"]},
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "Shared"},
+                "children": [],
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "Shared"}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1"]
+    assert "skipping layout node TAB-1, the layout reaches it more than once" in (
+        caplog.text
+    )

--- a/tests/unit_tests/models/dashboard_test.py
+++ b/tests/unit_tests/models/dashboard_test.py
@@ -334,7 +334,7 @@ def test_tabs_handles_tab_nodes_without_a_title(
             "TABS-1": {
                 "id": "TABS-1",
                 "type": "TABS",
-                "children": ["TAB-1", "TAB-2", "TAB-3"],
+                "children": ["TAB-1", "TAB-2", "TAB-3", "TAB-4"],
             },
             # No `meta` key at all.
             "TAB-1": {"id": "TAB-1", "type": "TAB", "children": []},
@@ -352,16 +352,22 @@ def test_tabs_handles_tab_nodes_without_a_title(
                 "meta": "First",
                 "children": [],
             },
+            # `text` present but not a string.
+            "TAB-4": {
+                "id": "TAB-4",
+                "type": "TAB",
+                "meta": {"text": None},
+                "children": [],
+            },
         }
     )
 
     caplog.set_level(logging.WARNING, logger=LOGGER)
     tabs = dash.tabs
 
-    assert tabs["all_tabs"] == {"TAB-1": "", "TAB-2": "", "TAB-3": ""}
-    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1", "TAB-2", "TAB-3"]
-    assert [node["title"] for node in tabs["tab_tree"]] == ["", "", ""]
-    for tab_id in ("TAB-1", "TAB-2", "TAB-3"):
+    assert tabs["all_tabs"] == {"TAB-1": "", "TAB-2": "", "TAB-3": "", "TAB-4": ""}
+    assert [node["title"] for node in tabs["tab_tree"]] == ["", "", "", ""]
+    for tab_id in ("TAB-1", "TAB-2", "TAB-3", "TAB-4"):
         assert f"tab node {tab_id} has no title in the layout" in caplog.text
 
 
@@ -379,7 +385,7 @@ def test_tabs_skips_tab_nodes_without_an_id(
             "TABS-1": {
                 "id": "TABS-1",
                 "type": "TABS",
-                "children": ["TAB-1", "TAB-2"],
+                "children": ["TAB-1", "TAB-2", "TAB-3"],
             },
             # No `id` key.
             "TAB-1": {"type": "TAB", "meta": {"text": "First"}, "children": []},
@@ -389,6 +395,13 @@ def test_tabs_skips_tab_nodes_without_an_id(
                 "meta": {"text": "Second"},
                 "children": [],
             },
+            # `id` present but not a string, so it cannot key `all_tabs`.
+            "TAB-3": {
+                "id": ["TAB-3"],
+                "type": "TAB",
+                "meta": {"text": "Third"},
+                "children": [],
+            },
         }
     )
 
@@ -396,7 +409,7 @@ def test_tabs_skips_tab_nodes_without_an_id(
     tabs = dash.tabs
 
     assert tabs["all_tabs"] == {"TAB-2": "Second"}
-    assert "skipping tab node with no id in the layout" in caplog.text
+    assert caplog.text.count("skipping tab node with no usable id in the layout") == 2
 
 
 def test_tabs_returns_empty_dict_when_layout_has_no_root(
@@ -455,3 +468,44 @@ def test_tabs_returns_empty_dict_when_layout_is_not_a_mapping(
     assert dash.tabs == {}
 
     assert caplog.text.count("layout is not a mapping") == 2
+
+
+def test_tabs_handles_malformed_children(
+    app_context: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A `children` value that cannot be walked is treated as empty.
+
+    `children` is only meaningful as a list of node ids. A layout may store
+    `null`, a scalar, or a list holding something that is not an id, none of
+    which can be dereferenced.
+    """
+    dash = Dashboard()
+    dash.id = 1
+    dash.position_json = json.dumps(
+        {
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["TABS-1"]},
+            "TABS-1": {
+                "id": "TABS-1",
+                "type": "TABS",
+                # TAB-2 is named by an entry that is not an id.
+                "children": ["TAB-1", ["TAB-2"]],
+            },
+            # `children` is not a list at all.
+            "TAB-1": {
+                "id": "TAB-1",
+                "type": "TAB",
+                "meta": {"text": "First"},
+                "children": None,
+            },
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger=LOGGER)
+    tabs = dash.tabs
+
+    assert tabs["all_tabs"] == {"TAB-1": "First"}
+    assert [node["id"] for node in tabs["tab_tree"]] == ["TAB-1"]
+    assert tabs["tab_tree"][0]["children"] == []
+    assert "layout node TAB-1 has malformed children" in caplog.text
+    assert "missing or malformed" in caplog.text


### PR DESCRIPTION
### SUMMARY

`position_json` is validated for JSON parseability only, so a layout whose `children` array names an id that is not a key in that layout is accepted by `PUT /api/v1/dashboard/{id}` and stored. `Dashboard.tabs` then raises `KeyError` walking it, and since `UpdateDashboardCommand.process_tab_diff` reads the layout from the database rather than from the request body, every subsequent update to that dashboard returns 500 — including the update that would repair the layout. The dashboard is left unwritable through the API, recoverable only by export → edit YAML → import with overwrite.

The write that causes it returns 200 and the failure surfaces on the *next* request, so nothing points back at the request responsible.

Two changes:

**`superset/commands/dashboard/update.py`** — `find_deleted_tabs` computed `self._model.tabs` before checking whether the payload carried a `position_json`, so every `PUT` walked the whole stored layout, `{"published": true}` included. It now returns early when there is no incoming layout. A tab can only be deleted by an update that supplies one, so behaviour is unchanged for every input that could produce a non-empty result.

**`superset/models/dashboard.py`** — `Dashboard.tabs` no longer raises on stored layout data:

- `get_node` uses `.get()`; a `children` entry that is missing or is not an object is skipped rather than dereferenced. Skipping is required, not just tolerating: a `None` pushed onto the queue would fail on `node.get("children", [])` in the next iteration with `AttributeError`, which is still a 500.
- A node with no `type` is skipped. A node whose `type` is present but not one of `ROOT`/`GRID`/`TABS`/`TAB` is walked through without contributing to the tree, exactly as before — that is how ordinary rows and charts have always been handled, so it stays silent.
- A `TAB` whose title cannot be read gets an empty title. `meta` is checked with `isinstance`, not just `.get("meta", {})`: a `meta` that is present but is a string or a list would otherwise raise `AttributeError`, which is *not* caught in `superset/dashboards/api.py`, turning a 400 into a 500.
- A layout with no usable `ROOT_ID`, or one that parses to something other than an object (`null`, `[]`), returns `{}`.

The patch does not hide the problem: every node that is skipped or degraded is logged at WARNING with the dashboard id and the node id, so a broken layout stays visible to operators instead of quietly producing fewer tabs. Well-formed layouts produce identical output.

No structural validation was added to `DashboardPutSchema`, on purpose. It would turn payloads that are accepted today into 400s — a breaking change for any client scripting dashboards — and doing it properly means formally specifying the `position_json` invariants, which Superset has never specified. That belongs in its own discussion.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — backend-only change, no UI surface.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/models/dashboard_test.py \
       tests/unit_tests/commands/dashboard/update_test.py
```

The pre-existing integration coverage for the function reworked in `update.py` should also still pass:

```bash
pytest tests/integration_tests/dashboards/update_tabs_test.py
pytest tests/integration_tests/dashboards/api_tests.py -k test_get_dashboard_tabs
```

Cases covered by the new tests:

`tests/unit_tests/models/dashboard_test.py` — `Dashboard.tabs`
- a well-formed layout, including a tab nested inside another tab, returns the same `all_tabs` mapping and `tab_tree` shape as before (the regression guard)
- a `children` entry naming an id that is not in the layout is skipped, and a WARNING is logged
- a `children` entry resolving to something that is not an object is skipped, and a WARNING is logged
- a node with no `type` is skipped, and a WARNING is logged
- a `TAB` with no `meta`, an empty `meta`, or a non-object `meta` gets an empty title, and a WARNING is logged
- a `TAB` with no `id` is left out of `all_tabs`, and a WARNING is logged
- a layout with no `ROOT_ID`, an empty layout, and a layout that is not a mapping all return `{}`

`tests/unit_tests/commands/dashboard/update_test.py` — `process_tab_diff`
- a payload with no `position_json` does not read `self._model.tabs` at all
- a payload that drops a tab still deactivates the reports using it

Verified as real regression guards: reverting only the two source files fails 8 of the 17 new tests, and downgrading the `logger.warning` calls to `debug` fails 7 of them.

Manual check, against an affected dashboard: `GET /api/v1/dashboard/{id}/tabs` returns 200 with the tabs that resolve instead of 500, and `PUT /api/v1/dashboard/{id}` with a corrected `position_json` now succeeds and repairs the dashboard.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #43574
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Not a breaking change: no request that succeeds today starts failing, and no response shape changes for a well-formed layout.
