### PR TITLE
fix(embedded): guard guest payload check against scalar control values

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1528,6 +1528,17 @@ def _stored_param_values(params: dict[str, Any], keys: tuple[str, ...]) -> set[s
     return values
 
 
+def _ensure_list(value: Any) -> list[Any]:
+    """
+    Processing a scalar (string) for the `query_context` change check function.
+    """
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
 def _columns_metrics_modified(
     query_context: "QueryContext",
     form_data: dict[str, Any],
@@ -1557,7 +1568,7 @@ def _columns_metrics_modified(
         # ``_payload_value_identity``); metrics compare by exact frozen value.
         requested_values = {
             _payload_value_identity(value, is_metric=is_metric)
-            for value in form_data.get(key) or []
+            for value in _ensure_list(form_data.get(key))
         }
         # Stored params are read across every control name that can hold a
         # metric or column for some chart type: charts whose query is built
@@ -1576,7 +1587,7 @@ def _columns_metrics_modified(
         queries_values = {
             _payload_value_identity(value, is_metric=is_metric)
             for query in query_context.queries
-            for value in getattr(query, key, []) or []
+            for value in _ensure_list(getattr(query, key, None))
         }
         if stored_query_context:
             for query in stored_query_context.get("queries") or []:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1537,14 +1537,17 @@ def _ensure_list(value: Any) -> list[Any]:
     directly yields its individual characters, which silently breaks the
     guest payload comparison for any such chart.
 
-    ``None`` returns ``[]``; a ``list``/``tuple`` returns a list copy of
-    it; any other (scalar) value is wrapped in a single-item list.
+    ``None`` and an empty string are treated as "no value set" (mirroring
+    ``_stored_param_values``'s treatment of an unset control) and return
+    ``[]`` — an unset scalar control must not be compared as if the guest
+    had explicitly requested an empty string. A ``list``/``tuple`` is
+    filtered the same way, element by element; any other scalar is wrapped
+    in a single-item list.
     """
     if value is None:
         return []
-    if isinstance(value, (list, tuple)):
-        return list(value)
-    return [value]
+    items = value if isinstance(value, (list, tuple)) else [value]
+    return [item for item in items if item is not None and item != ""]
 
 
 def _columns_metrics_modified(

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -1530,7 +1530,15 @@ def _stored_param_values(params: dict[str, Any], keys: tuple[str, ...]) -> set[s
 
 def _ensure_list(value: Any) -> list[Any]:
     """
-    Processing a scalar (string) for the `query_context` change check function.
+    Normalize a value to a list for iteration.
+
+    Some viz types (e.g. heatmap_v2's 'groupby' control) store a single
+    value as a bare string rather than a one-item list. Iterating a string
+    directly yields its individual characters, which silently breaks the
+    guest payload comparison for any such chart.
+
+    ``None`` returns ``[]``; a ``list``/``tuple`` returns a list copy of
+    it; any other (scalar) value is wrapped in a single-item list.
     """
     if value is None:
         return []

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1473,6 +1473,59 @@ def test_query_context_modified_novel_values_still_tampered(
     assert query_context_modified(query_context)
 
 
+def test_query_context_modified_scalar_control_value_not_tampered(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Some viz types (e.g. heatmap_v2's ``groupby`` control) store a single
+    value as a bare string rather than a one-item list. A guest replaying
+    the chart's own stored value for such a control must not be treated as
+    tampering.
+
+    Regression test: the comparison iterated ``form_data.get(key)``/
+    ``getattr(query, key, [])`` directly without checking whether the value
+    was a list. Iterating a Python string yields its individual characters,
+    so the requested set never matched anything stored and every such chart
+    was permanently rejected for guest users with "Guest user cannot modify
+    chart payload", even when nothing was actually modified.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "groupby": "string_column_name",
+    }
+
+    query_context.form_data = {
+        "slice_id": 42,
+        "groupby": "string_column_name",
+    }
+    query_context.queries = [QueryObject(columns=["string_column_name"])]
+    assert not query_context_modified(query_context)
+
+
+def test_query_context_modified_scalar_control_value_tampered(
+    mocker: MockerFixture,
+) -> None:
+    """
+    The scalar-control leniency above only authorizes the chart's own
+    stored value: a different single value is still rejected.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {
+        "groupby": "string_column_name",
+    }
+
+    query_context.form_data = {
+        "slice_id": 42,
+        "groupby": "some_other_column",
+    }
+    query_context.queries = [QueryObject(columns=["some_other_column"])]
+    assert query_context_modified(query_context)
+
+
 def _native_filter_ctx(
     mocker: MockerFixture,
     queries: list[Any],

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1526,6 +1526,27 @@ def test_query_context_modified_scalar_control_value_tampered(
     assert query_context_modified(query_context)
 
 
+def test_query_context_modified_unset_scalar_control_not_tampered(
+    mocker: MockerFixture,
+) -> None:
+    """
+    An unset scalar control (empty string, or simply absent) must be
+    treated as "no value" on the requested side too — symmetric with how
+    _stored_param_values treats an unset control on the stored side.
+    """
+    query_context = mocker.MagicMock()
+    query_context.slice_.id = 42
+    query_context.slice_.query_context = None
+    query_context.slice_.params_dict = {}  # no groupby saved at all
+
+    query_context.form_data = {
+        "slice_id": 42,
+        "groupby": "",  # unset control, sent as empty string
+    }
+    query_context.queries = [QueryObject(columns=[])]
+    assert not query_context_modified(query_context)
+
+
 def _native_filter_ctx(
     mocker: MockerFixture,
     queries: list[Any],


### PR DESCRIPTION
Fixes #43576 :
Some viz types (e.g. heatmap_v2's 'groupby' control) store a single value as a bare string rather than a list. _columns_metrics_modified iterated form_data.get(key)/params_dict.get(key)/getattr(query, key) directly, so a scalar string was iterated character-by-character, causing every legitimate guest request for such a chart to be rejected as 'Guest user cannot modify chart payload'.

Wrap all four iteration sites with a small _ensure_list() helper that treats a non-list, non-None value as a single-item list.


### SUMMARY

Fixes a bug in the guest-user payload security check (`_columns_metrics_modified`
in `superset/security/manager.py`) that rejects **every** legitimate embedded
guest request for a chart whose stored `groupby`/`columns`/`metrics` control
value is a single scalar rather than a list.

`heatmap_v2` is the clearest example: its `groupby` form control stores a
single column name as a plain string (e.g. `"territory_name_2"`), not a
one-item list. `_columns_metrics_modified` iterates these values with
`for value in form_data.get(key) or []` (and the equivalent for
`stored_chart.params_dict.get(key)` and `getattr(query, key, [])`) without
checking whether the value is actually a list. Iterating a Python string
yields its individual characters, so the "requested" set ends up as e.g.
`{"t", "e", "r", "r", ...}` instead of `{"territory_name_2"}` — which is of
course never a subset of anything stored, so the guest request is always
rejected with:

```
Guest user cannot modify chart payload
```

even when the guest is requesting exactly the chart's own saved data, with no
modification whatsoever.

This was discovered while debugging why every `heatmap_v2` chart on an
embedded dashboard failed to load for guest users, while charts of other viz
types (whose equivalent controls are always lists) worked fine.

**Note on #42864:** apache/superset#42864 (merged into `6.2`) performs a much
broader rewrite of this same comparator — moving it to
`superset/security/guest_payload.py` and covering many more per-viz-type
control names and structural cases (deck.gl, Cartodiagram, MixedTimeseries
Query B, etc.) — and its description explicitly notes fixing this exact
scalar-iteration case as one of many improvements. As of this writing that
rewrite has not landed in `master` (confirmed via `git log origin/master`),
which is still on the narrower `_STORED_COLUMN_PARAMS`-based comparator this
PR patches. This PR is a minimal, `master`-targeted fix for just the
scalar-value regression, useful on its own regardless of whether/when
`6.2`'s broader rewrite is merged forward into `master`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** any embedded dashboard containing a `heatmap_v2` chart (or any
other chart type whose `groupby`/`columns`/`metrics` control happens to be a
scalar rather than a list) shows a permanent `Data error: Guest user cannot
modify chart payload` for guest users, regardless of whether the guest
actually modified anything.

**After:** the same chart loads normally for guest users.

### TESTING INSTRUCTIONS

1. Create a `heatmap_v2` chart on a dataset, using a single column for the
   "Group by" control (not multiple).
2. Add it to a dashboard and enable embedding for that dashboard.
3. Load the dashboard via the embedded SDK / guest token.
4. Before this fix: the chart fails to load with `Guest user cannot modify
   chart payload`.
5. After this fix: the chart loads normally.

Also added `tests/unit_tests/security/manager_test.py::test_query_context_modified_scalar_control_value_not_tampered`
(and a companion negative-case test,
`test_query_context_modified_scalar_control_value_tampered`) reproducing the
exact scenario at the `query_context_modified()` level, without needing a
live dashboard/guest token. Both were confirmed to fail against the
pre-patch comparator.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43576
- [ ] Required feature flags: none
- [ ] Changes UI
- [ ] Includes DB Migration (SQL)
      - [ ] Migration is atomic, supports rollback & is backwards-compatible
- [x] Confirm DB Migration upgrade and downgrade tested — N/A, no migration
- [x] Introduces new feature or API — no, bugfix only
- [x] Removes existing feature or API — no
