### PR TITLE
fix(sqllab): preserve ClickHouse LIMIT BY when applying the row limit

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1386,10 +1386,33 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
                 found.add(entry)
         return found
 
+    def _has_limit_by(self) -> bool:
+        """
+        Check if the statement has a ClickHouse `LIMIT ... BY` clause.
+
+        `LIMIT n BY <cols>` keeps `n` rows *per group*, so it is a de-duplication
+        clause rather than a row cap. sqlglot models the `BY` columns as the
+        `expressions` of the root `Limit` node, or of the root `Offset` node for
+        the `LIMIT n OFFSET m BY x` and `LIMIT m, n BY x` spellings.
+
+        :return: True if the statement's limit or offset carries `BY` columns.
+        """
+        for arg in ("limit", "offset"):
+            node = self._parsed.args.get(arg)
+            if isinstance(node, exp.Expression) and node.expressions:
+                return True
+
+        return False
+
     def get_limit_value(self) -> int | None:
         """
         Parse a SQL query and return the `LIMIT` or `TOP` value, if present.
         """
+        # `LIMIT 2 BY id` bounds each group, not the result set, so reporting 2
+        # here would make `_set_query_limit()` clamp the whole query to 2 rows.
+        if self._has_limit_by():
+            return None
+
         if limit_node := self._parsed.args.get("limit"):
             literal = limit_node.args.get("expression") or getattr(
                 limit_node, "this", None
@@ -1427,11 +1450,17 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         if not isinstance(self._parsed, exp.Query):
             return
 
-        if method == LimitMethod.FORCE_LIMIT:
+        # A ClickHouse `LIMIT ... BY` occupies the very `limit`/`offset` slot that
+        # `FORCE_LIMIT` overwrites, so forcing a row cap in place would drop the
+        # `BY` grouping and silently change what the query returns. The cap can't
+        # be appended alongside it either -- sqlglot rejects ClickHouse's native
+        # `LIMIT n BY x LIMIT m` with "Found multiple 'LIMIT' clauses" -- so it
+        # goes on a wrapping query instead, exactly as `WRAP_SQL` does.
+        if method == LimitMethod.FORCE_LIMIT and not self._has_limit_by():
             self._parsed.args["limit"] = exp.Limit(
                 expression=exp.Literal(this=str(limit), is_string=False)
             )
-        elif method == LimitMethod.WRAP_SQL:
+        elif method in {LimitMethod.FORCE_LIMIT, LimitMethod.WRAP_SQL}:
             self._parsed = exp.Select(
                 expressions=[exp.Star()],
                 limit=exp.Limit(

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1461,13 +1461,29 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
                 expression=exp.Literal(this=str(limit), is_string=False)
             )
         elif method in {LimitMethod.FORCE_LIMIT, LimitMethod.WRAP_SQL}:
-            self._parsed = exp.Select(
+            inner = self._parsed.copy()
+            wrapper = exp.Select(
                 expressions=[exp.Star()],
                 limit=exp.Limit(
                     expression=exp.Literal(this=str(limit), is_string=False)
                 ),
-                from_=exp.From(this=exp.Subquery(this=self._parsed.copy())),
+                from_=exp.From(this=exp.Subquery(this=inner)),
             )
+
+            # `FORMAT` and `SETTINGS` configure the query rather than produce
+            # rows, and only mean what they say at the top level: ClickHouse
+            # rejects `FORMAT` inside a subquery outright, and a nested
+            # `SETTINGS` binds to that subquery alone, so top-level-only settings
+            # such as `extremes` would quietly stop applying. Moving them onto
+            # the wrapper keeps their original whole-query scope. Row-producing
+            # modifiers stay in the subquery, where ClickHouse keeps honoring
+            # them: a wrapped `WITH TOTALS` query still emits its totals block,
+            # and `WITH ROLLUP`/`WITH CUBE` still emit their extra rows.
+            for modifier in ("format", "settings"):
+                if value := inner.args.pop(modifier, None):
+                    wrapper.set(modifier, value)
+
+            self._parsed = wrapper
         else:  # method == LimitMethod.FETCH_MANY
             pass
 

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2473,6 +2473,21 @@ LATERAL generate_series(1, value) AS i;
         ),
         # not really valid SQL, but let's roll with it
         ("SELECT * FROM my_table LIMIT invalid", "postgresql", None),
+        # A ClickHouse `LIMIT ... BY` caps rows per group, not overall, so it is
+        # not a row limit. sqlglot hangs the `BY` columns off the `Limit` node,
+        # or off the `Offset` node for the `OFFSET` / `m, n` spellings.
+        ("SELECT * FROM t ORDER BY id, val LIMIT 2 BY id", "clickhouse", None),
+        ("SELECT * FROM t ORDER BY id, val LIMIT 2 BY id, val", "clickhouse", None),
+        (
+            "SELECT * FROM t ORDER BY id, val LIMIT 2 OFFSET 1 BY id",
+            "clickhouse",
+            None,
+        ),
+        ("SELECT * FROM t ORDER BY id, val LIMIT 1, 2 BY id", "clickhouse", None),
+        # ... while a plain ClickHouse limit, with or without an offset, is.
+        ("SELECT * FROM t ORDER BY c LIMIT 555", "clickhouse", 555),
+        ("SELECT * FROM t LIMIT 5 OFFSET 3", "clickhouse", 5),
+        ("SELECT * FROM t LIMIT 3, 5", "clickhouse", 5),
     ],
 )
 def test_get_limit_value(sql: str, engine: str, expected: str) -> None:
@@ -2688,6 +2703,107 @@ LIMIT 1000
             LimitMethod.FETCH_MANY,
             "SELECT\n  *\nFROM birth_names\nLIMIT 555",
         ),
+        # A ClickHouse `LIMIT ... BY` shares the `limit`/`offset` slot with the
+        # row limit, so `FORCE_LIMIT` wraps instead of overwriting it.
+        (
+            "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 BY id",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM limit_by
+  ORDER BY
+    id,
+    val
+  LIMIT 2 BY id
+)
+LIMIT 1001
+            """.strip(),
+        ),
+        (
+            "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 BY id, val",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM limit_by
+  ORDER BY
+    id,
+    val
+  LIMIT 2 BY id, val
+)
+LIMIT 1001
+            """.strip(),
+        ),
+        # For `LIMIT n OFFSET m BY x` sqlglot hangs the `BY` columns off the
+        # `Offset` node instead, so the `limit` arg alone doesn't reveal them.
+        (
+            "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 OFFSET 1 BY id",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM limit_by
+  ORDER BY
+    id,
+    val
+  LIMIT 2
+  OFFSET 1 BY id
+)
+LIMIT 1001
+            """.strip(),
+        ),
+        (
+            "SELECT * FROM limit_by ORDER BY id, val LIMIT 1, 2 BY id",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM limit_by
+  ORDER BY
+    id,
+    val
+  LIMIT 2
+  OFFSET 1 BY id
+)
+LIMIT 1001
+            """.strip(),
+        ),
+        # A ClickHouse limit without a `BY` still takes the in-place path.
+        (
+            "SELECT * FROM t ORDER BY c LIMIT 555",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            "SELECT\n  *\nFROM t\nORDER BY\n  c\nLIMIT 1001",
+        ),
+        (
+            "SELECT * FROM t LIMIT 5 OFFSET 3",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            "SELECT\n  *\nFROM t\nLIMIT 1001\nOFFSET 3",
+        ),
     ],
 )
 def test_set_limit_value(
@@ -2700,6 +2816,59 @@ def test_set_limit_value(
     statement = SQLStatement(sql, engine)
     statement.set_limit_value(limit, method)
     assert statement.format() == expected
+
+
+@pytest.mark.parametrize("engine", ["clickhouse", "clickhousedb"])
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 BY id",
+        "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 BY id, val",
+        "SELECT * FROM limit_by ORDER BY id, val LIMIT 2 OFFSET 1 BY id",
+        "SELECT * FROM limit_by ORDER BY id, val LIMIT 1, 2 BY id",
+    ],
+)
+def test_set_limit_value_preserves_clickhouse_limit_by(sql: str, engine: str) -> None:
+    """
+    A row limit must not cannibalize a ClickHouse ``LIMIT ... BY``.
+
+    ``LIMIT 2 BY id`` keeps 2 rows *per id*; ``FORCE_LIMIT`` used to build a
+    fresh ``Limit`` node over ``args["limit"]``, dropping the ``BY`` columns and
+    turning the query into a flat ``LIMIT 1001`` -- a different result set, with
+    no error to hint at it. ``get_limit_value()`` reported the per-group 2 as a
+    row cap on top of that, so ``_set_query_limit()`` clamped the query to 2 rows.
+
+    The cap can't simply be appended next to the ``BY`` either: sqlglot cannot
+    parse ClickHouse's own ``LIMIT n BY x LIMIT m`` ("Found multiple 'LIMIT'
+    clauses"), so the result would not survive a reparse. Wrapping the query is
+    what keeps both the grouping and the cap.
+    """
+    statement = SQLStatement(sql, engine)
+    assert statement.get_limit_value() is None
+
+    statement.set_limit_value(1001, LimitMethod.FORCE_LIMIT)
+    limited = statement.format()
+
+    assert "BY id" in limited
+    assert limited.endswith("LIMIT 1001")
+    # The rewrite has to be valid ClickHouse, not just valid-looking.
+    assert SQLStatement(limited, engine).format() == limited
+
+
+@pytest.mark.parametrize(
+    "engine", ["clickhouse", "clickhousedb", "postgresql", "mysql"]
+)
+def test_set_limit_value_without_limit_by_stays_in_place(engine: str) -> None:
+    """
+    Queries with no ``LIMIT ... BY`` keep the cheaper in-place rewrite.
+
+    The wrap is reserved for the ``LIMIT ... BY`` case; everything else -- every
+    non-ClickHouse dialect, and ClickHouse's own plain ``LIMIT`` -- must still
+    have its limit replaced without gaining a subquery.
+    """
+    statement = SQLStatement("SELECT * FROM t ORDER BY c LIMIT 555", engine)
+    statement.set_limit_value(1001, LimitMethod.FORCE_LIMIT)
+    assert statement.format() == "SELECT\n  *\nFROM t\nORDER BY\n  c\nLIMIT 1001"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2789,6 +2789,57 @@ FROM (
 LIMIT 1001
             """.strip(),
         ),
+        # `WITH TOTALS` rides into the subquery untouched: ClickHouse keeps
+        # emitting the totals block for a wrapped query, so the cap really is
+        # the only thing the rewrite adds.
+        (
+            "SELECT id, count() AS c FROM limit_by "
+            "GROUP BY id WITH TOTALS ORDER BY id LIMIT 2 BY id",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    id,
+    count() AS c
+  FROM limit_by
+  GROUP BY
+    id
+  WITH TOTALS
+  ORDER BY
+    id
+  LIMIT 2 BY id
+)
+LIMIT 1001
+            """.strip(),
+        ),
+        # `SETTINGS` and `FORMAT` do not survive a demotion into the subquery,
+        # so they move up onto the wrapper instead.
+        (
+            "SELECT * FROM limit_by ORDER BY id LIMIT 2 BY id "
+            "SETTINGS extremes = 1 FORMAT JSONCompact",
+            "clickhouse",
+            1001,
+            LimitMethod.FORCE_LIMIT,
+            """
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM limit_by
+  ORDER BY
+    id
+  LIMIT 2 BY id
+)
+LIMIT 1001
+SETTINGS extremes = 1
+FORMAT JSONCompact
+            """.strip(),
+        ),
         # A ClickHouse limit without a `BY` still takes the in-place path.
         (
             "SELECT * FROM t ORDER BY c LIMIT 555",
@@ -2853,6 +2904,35 @@ def test_set_limit_value_preserves_clickhouse_limit_by(sql: str, engine: str) ->
     assert limited.endswith("LIMIT 1001")
     # The rewrite has to be valid ClickHouse, not just valid-looking.
     assert SQLStatement(limited, engine).format() == limited
+
+
+def test_set_limit_value_keeps_clickhouse_top_level_modifiers() -> None:
+    """
+    The wrap must not demote clauses that only work at the top level.
+
+    ClickHouse rejects `FORMAT` inside a subquery outright, and a `SETTINGS`
+    attached to a subquery binds to that subquery alone -- top-level-only
+    settings such as ``extremes`` would silently stop applying. Both therefore
+    move onto the wrapper, which is where the original query had them.
+
+    The row-producing modifiers are left alone, because ClickHouse honors them
+    inside a `FROM` subquery: a wrapped `WITH TOTALS` query still emits its
+    totals block, and `WITH ROLLUP`/`WITH CUBE` still emit their extra rows.
+    Hoisting those would change the result rather than preserve it.
+    """
+    statement = SQLStatement(
+        "SELECT id, count() AS c FROM limit_by "
+        "GROUP BY id WITH TOTALS ORDER BY id LIMIT 2 BY id "
+        "SETTINGS extremes = 1 FORMAT JSONCompact",
+        "clickhouse",
+    )
+    statement.set_limit_value(1001, LimitMethod.FORCE_LIMIT)
+    limited = statement.format()
+
+    assert limited.endswith("LIMIT 1001\nSETTINGS extremes = 1\nFORMAT JSONCompact")
+    # `WITH TOTALS` stays with the aggregation it belongs to.
+    assert "WITH TOTALS\n" in limited.split("LIMIT 2 BY id")[0]
+    assert SQLStatement(limited, "clickhouse").format() == limited
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

`SQLStatement.set_limit_value()` (the `FORCE_LIMIT` path) built a fresh
`exp.Limit` node and assigned it over `self._parsed.args["limit"]`, discarding
whatever was already there.

In sqlglot's ClickHouse dialect, `LIMIT 2 BY id` parses into that *same* `Limit`
node, with the `BY` columns living in its `expressions`. So applying the SQL Lab
row limit rewrote `SELECT * FROM t ORDER BY id, val LIMIT 2 BY id` into
`SELECT * FROM t ORDER BY id, val LIMIT 1001` — 1001 rows overall instead of
2 rows per `id`. Different result set, no error, nothing in the logs.

`get_limit_value()` compounded it: it reported the per-group `2` as if it were a
row cap, so `_set_query_limit()` in `superset/commands/sql_lab/execute.py` took
`min(2, row_limit)` and clamped the query to 2 rows total.

The `LIMIT n OFFSET m BY x` and `LIMIT m, n BY x` spellings are hit too, and
worse: sqlglot hangs their `BY` columns off the **`Offset`** node rather than
`Limit`, so overwriting only `args["limit"]` produced `LIMIT 1001 OFFSET 1 BY id`
— the grouping survives but bound to the wrong number.

**Fix.** A new private `_has_limit_by()` checks the `expressions` of the root
`Limit` *and* `Offset` nodes, covering both AST shapes. Then:

- `get_limit_value()` returns `None` when a `LIMIT ... BY` is present — a
  per-group cap is not a row cap, so it must not feed `_set_query_limit()`.
- `set_limit_value()` with `FORCE_LIMIT` **wraps** instead of overwriting:
  `SELECT * FROM (<original>) LIMIT n`, reusing the existing `WRAP_SQL` rewrite
  verbatim.

**Design decision — wrap, not cap in place.** The obvious alternative is to keep
the `BY` and append the cap alongside it, which is what ClickHouse itself
supports: `LIMIT 2 BY id LIMIT 1001`. That is not available here — sqlglot
cannot parse that form at all, in either order:

    ParseError: Found multiple 'LIMIT' clauses. Line 1, Col: 47.

Emitting it would produce SQL that Superset can no longer reparse (and that
would break any later `SQLStatement` pass over the same text). Wrapping is
semantically equivalent, round-trips cleanly through sqlglot, and reuses code
that is already in this method. The same sqlglot limitation means a user query
that *already* spells both clauses fails at parse time today — that is a
pre-existing upstream gap, not something this PR changes.

Non-ClickHouse dialects leave `Limit.expressions` empty (`Fetch` and TSQL/Teradata
`TOP` too), so `_has_limit_by()` is always `False` for them and the in-place path
is bit-for-bit unchanged — as it is for plain ClickHouse `LIMIT` / `LIMIT n OFFSET m`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not a UI change. The behavioral before/after, with `row_limit = 1001` on ClickHouse:

| input | before | after |
|---|---|---|
| `SELECT * FROM t ORDER BY id, val LIMIT 2 BY id` | `... LIMIT 1001` (grouping lost) | `SELECT * FROM (SELECT * FROM t ORDER BY id, val LIMIT 2 BY id) LIMIT 1001` |
| `SELECT * FROM t ORDER BY id, val LIMIT 2 OFFSET 1 BY id` | `... LIMIT 1001 OFFSET 1 BY id` (wrong bound) | `SELECT * FROM (SELECT * FROM t ORDER BY id, val LIMIT 2 OFFSET 1 BY id) LIMIT 1001` |
| `SELECT * FROM t ORDER BY id, val LIMIT 1, 2 BY id` | `... LIMIT 1001 OFFSET 1 BY id` (wrong bound) | `SELECT * FROM (SELECT * FROM t ORDER BY id, val LIMIT 2 OFFSET 1 BY id) LIMIT 1001` |
| `SELECT * FROM t ORDER BY c LIMIT 555` | `... LIMIT 1001` | `... LIMIT 1001` (unchanged) |

`get_limit_value()` returned `2` for all three `BY` rows before; it returns
`None` now.

### TESTING INSTRUCTIONS

Unit tests:

```bash
pytest tests/unit_tests/sql/parse_tests.py -k limit
```

Or the whole file / suite: `pytest tests/unit_tests/sql/parse_tests.py`
(929 passed, 1 xfailed), `pytest tests/unit_tests` (13414 passed).

Manually, against a ClickHouse database in SQL Lab:

1. `CREATE TABLE limit_by (id Int32, val Int32) ENGINE = MergeTree ORDER BY id;`
2. `INSERT INTO limit_by VALUES (1,1),(1,2),(1,3),(2,1),(2,2),(2,3);`
3. Run `SELECT * FROM limit_by ORDER BY id, val LIMIT 2 BY id` with the SQL Lab
   row-limit dropdown at 1000.
4. Expected: 4 rows — 2 per `id`. On master you get either 6 rows (the `BY`
   is dropped and the 1000-row cap applies) or 2 rows (the per-group
   2 is read as a row cap).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
