### PR TITLE
fix(ci): unblock lint-frontend after the oxlint 1.79.0 bump

### DIFF
--- a/superset-frontend/oxlint.json
+++ b/superset-frontend/oxlint.json
@@ -113,7 +113,7 @@
     // === Import plugin rules ===
     "import/named": "error",
     "import/export": "error",
-    "import/no-named-as-default": "error",
+    "import/no-named-as-default": "warn",
     "import/no-named-as-default-member": "error",
     "import/no-mutable-exports": "error",
     "import/no-amd": "error",


### PR DESCRIPTION
### SUMMARY

`lint-frontend` has failed on every master commit since #43553, and on every open PR, with 94 `import(no-named-as-default)` errors in files nobody touched.

Cause: oxlint **1.79.0** (bumped in #43543) *implemented* `import/no-named-as-default`, which `oxlint.json` has set to `"error"` all along. The rule was a no-op before, so 94 pre-existing hits surfaced at once. Bisected against clean master:

| oxlint | exit | `no-named-as-default` hits |
|---|---|---|
| 1.78.0 | 0 | 0 |
| 1.79.0 | 1 | 94 |

The 94 are not real defects. They're modules that intentionally export a symbol both as default and by name (`export const Foo` + `export default Foo`), plus upstream packages whose documented usage is a default import — 39 of the 94 are `import configureStore from 'redux-mock-store'`, and others are `import $ from 'jquery'`, `import Chart from 'src/types/Chart'`. The rule exists to catch an *accidental* default import of a named-only export, which is not what it found here. Renaming 94 correct call sites to satisfy it would be churn, so the rule is downgraded to `"warn"`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI-only change, no UI.

### TESTING INSTRUCTIONS

From `superset-frontend/`, against this branch:

```
npx oxlint@1.79.0 --config oxlint.json --quiet ; echo $?   # 0 (was 1 on master)
```

The 94 findings still appear as warnings without `--quiet`, so they stay visible.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [ ] Changes UI: No — lint config only
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No — the rule still reports, at warning level