### PR TITLE
docs(security): document the RLS indicator badge on dataset list/Explore

### DIFF
--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -583,6 +583,24 @@ SELECT * FROM (
   queries run against tables that have associated datasets with RLS filters will then have
   the appropriate predicates injected automatically.
 
+#### RLS Indicator in the Dataset List and Explore
+
+When a dataset has one or more RLS filters that apply to it, Superset shows a lock
+icon badge next to the dataset name in the **Datasets** list and next to the dataset
+selector in **Explore**. Hovering over the badge shows a tooltip listing each
+applicable filter's name, filter type (Regular or Base), group key (if any), assigned
+roles, and clause.
+
+This badge also surfaces filters that are inherited from the physical tables
+referenced by a virtual (SQL-based) dataset, as described above. Inherited filters
+are marked "from underlying table" in the tooltip, and a summary note is shown
+whenever any of the listed filters are inherited rather than assigned directly to
+the dataset.
+
+The badge is a visibility aid only — it does not change which filters are applied to
+a query. Use the RLS REST API described below if you need to confirm exactly which
+filters affect a dataset.
+
 #### Checking RLS Filters via the API
 
 You can use the RLS REST API to audit which filters are configured and which datasets

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -589,13 +589,17 @@ When a dataset has one or more RLS filters that apply to it, Superset shows a lo
 icon badge next to the dataset name in the **Datasets** list and next to the dataset
 selector in **Explore**. Hovering over the badge shows a tooltip listing each
 applicable filter's name, filter type (Regular or Base), group key (if any), assigned
-roles, and clause.
+subjects (labeled "Roles" in the tooltip, but may include users and groups too), and
+clause.
 
 This badge also surfaces filters that are inherited from the physical tables
 referenced by a virtual (SQL-based) dataset, as described above. Inherited filters
 are marked "from underlying table" in the tooltip, and a summary note is shown
 whenever any of the listed filters are inherited rather than assigned directly to
-the dataset.
+the dataset. Inherited-filter detection depends on Superset's SQL parser being able
+to identify the referenced tables and match them to a physical dataset by name,
+schema, and database, so it's best-effort: unparseable or unmatched references won't
+surface a filter on the badge even if one would apply at query time.
 
 The badge is a visibility aid only — it does not change which filters are applied to
 a query. Use the RLS REST API described below if you need to confirm exactly which


### PR DESCRIPTION
### SUMMARY
#38807 adds a lock-icon badge (`RlsBadge`) that surfaces row-level-security filters — including ones inherited from a virtual dataset's underlying physical tables — on the dataset list and in Explore's dataset selector. That UI addition wasn't reflected anywhere in the docs, so this adds a short subsection to the existing Row Level Security documentation covering what the badge shows and where it appears.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs only.

### TESTING INSTRUCTIONS
Docs-only change. Render `docs/admin_docs/security/security.mdx` (e.g. `npm run start` in `docs/`) and check the new "RLS Indicator in the Dataset List and Explore" subsection under Row Level Security.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #38807.