### PR TITLE
docs(cache): document NATIVE_FILTER_OPTIONS_CACHE_TIMEOUT

### DIFF
--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -76,6 +76,27 @@ value defined in `DATA_CACHE_CONFIG`.
 Note, that by setting the cache timeout to `-1`, caching for charting data can be disabled, either
 per chart, dataset or database, or by default if set in `DATA_CACHE_CONFIG`.
 
+Native filter option queries (the dropdown values for native filters) go through this same
+chart-data cache, but their freshness needs often differ from regular chart queries, especially for
+datasets whose visible values change frequently, including RLS-constrained datasets. Set
+`NATIVE_FILTER_OPTIONS_CACHE_TIMEOUT` in `superset_config.py` to give these queries a dedicated
+timeout, checked before the chart/dataset/database chain and the `DATA_CACHE_CONFIG` default above:
+
+```python
+NATIVE_FILTER_OPTIONS_CACHE_TIMEOUT = 60  # seconds
+```
+
+- `None` (default): native filter option queries fall through to the normal
+  chart/dataset/database/`DATA_CACHE_CONFIG` resolution chain.
+- `-1`: disables caching for native filter option queries entirely.
+- `0`: passed directly to the cache backend; behavior is backend-specific, so use `-1` if the intent
+  is to disable caching.
+- A positive integer: cache native filter option queries for that many seconds.
+
+This setting only applies to requests detected as native filter option queries. It takes precedence
+over the per-chart/dataset/database timeouts, but not over an explicit per-request
+`custom_cache_timeout` override (e.g. "Force refresh").
+
 ## Limiting Cached Result Size
 
 Very large chart or SQL query results can flood the cache backend (Redis/Memcached), evicting many


### PR DESCRIPTION
### SUMMARY
#38910 added `NATIVE_FILTER_OPTIONS_CACHE_TIMEOUT` to `superset/config.py` so native filter dropdown queries can use their own cache TTL instead of `DATA_CACHE_CONFIG`, but `docs/admin_docs/configuration/cache.mdx` never documented this setting in the main "Chart Cache Timeout" section (it's only mentioned in passing under the later cache warm-up section). This adds a short paragraph next to `DATA_CACHE_CONFIG` explaining the setting, its valid values (`None`/`-1`/`0`/positive int), and where it sits in the timeout precedence chain.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (docs only)

### TESTING INSTRUCTIONS
Render `docs/admin_docs/configuration/cache.mdx` and confirm the new "Chart Cache Timeout" section content is accurate and matches `QueryContextProcessor.get_cache_timeout()`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs fix identified while triaging #38910.