### PR TITLE
docs(alerts-reports): document report/alert content format options

### DIFF
--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -14,6 +14,18 @@ Users can configure automated alerts and reports to send dashboards or charts to
 
 Alerts and reports are disabled by default. To turn them on, you'll need to change configuration settings and install a suitable headless browser in your environment.
 
+## Content Format Options
+
+When scheduling an alert or report, you can choose the format used to deliver the dashboard or chart:
+
+- **PDF** – a full-page screenshot rendered as a PDF attachment. Available for both dashboards and charts.
+- **PNG** – a screenshot embedded directly in the email or Slack message. Available for both dashboards and charts.
+- **CSV** – chart data attached as a `.csv` file. Available for charts only.
+- **XLSX (Excel)** – chart data attached as a `.xlsx` file. Available for charts only. If the chart's data spans multiple server-paginated files, the attachment is delivered instead as a `.zip` archive containing the individual `.xlsx` files.
+- **Text** – chart data embedded directly in the email or Slack message body. Available only for charts using a text-based visualization type (e.g. Table, Pivot Table, Paired t-test).
+
+Dashboard reports and alerts are limited to the PDF and PNG formats; the CSV, XLSX, and Text options are only available when scheduling a report or alert for an individual chart.
+
 ## Requirements
 
 ### Commons

--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -19,12 +19,14 @@ Alerts and reports are disabled by default. To turn them on, you'll need to chan
 When scheduling an alert or report, you can choose the format used to deliver the dashboard or chart:
 
 - **PDF** – a full-page screenshot rendered as a PDF attachment. Available for both dashboards and charts.
-- **PNG** – a screenshot embedded directly in the email or Slack message. Available for both dashboards and charts.
+- **PNG** – a screenshot delivered as an attachment. Emails embed the image inline in the message body; Slack and webhook recipients receive it as an uploaded file. Available for both dashboards and charts.
 - **CSV** – chart data attached as a `.csv` file. Available for charts only.
-- **XLSX (Excel)** – chart data attached as a `.xlsx` file. Available for charts only. If the chart's data spans multiple server-paginated files, the attachment is delivered instead as a `.zip` archive containing the individual `.xlsx` files.
+- **XLSX (Excel)** – chart data attached as a `.xlsx` file. Available for charts only. If the chart's data spans multiple server-paginated files, email delivery detects the bundle and renames the attachment to `.zip`; Slack and webhook deliveries always name the file with an `.xlsx` extension even when the contents are a multi-file ZIP archive.
 - **Text** – chart data embedded directly in the email or Slack message body. Available only for charts using a text-based visualization type (e.g. Table, Pivot Table, Paired t-test).
 
 Dashboard reports and alerts are limited to the PDF and PNG formats; the CSV, XLSX, and Text options are only available when scheduling a report or alert for an individual chart.
+
+For alerts (not scheduled reports), PNG/PDF screenshots and chart CSV/XLSX data are only generated when the `ALERTS_ATTACH_REPORTS` [feature flag](/admin-docs/configuration/configuring-superset#feature-flags) is enabled (the default); with it disabled, an alert notification is still sent, but without the attachment.
 
 ## Requirements
 


### PR DESCRIPTION
### SUMMARY

#40885 added XLSX as an email attachment format for chart reports, but `docs/admin_docs/configuration/alerts-reports.mdx` never documented the set of content format options at all (PDF, PNG, CSV, XLSX, Text), or which ones apply to dashboards vs. charts. That PR only touched a single troubleshooting sentence in passing. This adds a dedicated section listing all formats and their availability.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, docs-only change.

### TESTING INSTRUCTIONS

Render `docs/admin_docs/configuration/alerts-reports.mdx` and confirm the new "Content Format Options" section appears near the top of the page with correct formatting.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up to #40885.