### PR TITLE
docs(security): document EXTRA_EDITORS_RESOLVER

### DIFF
--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -263,15 +263,21 @@ The resolver's result is unioned with the resource's own `editors` for editorshi
 feeds `is_editor`, `raise_for_editorship`, save-as, and soft-delete restore. When
 `EXTRA_EDITORS_RESOLVER` is configured, the usual lockout-prevention behavior — automatically
 re-adding a non-admin who removes themselves from a resource's editors — is skipped, since the
-deployment has its own way of keeping the resource editable.
+deployment has its own way of keeping the resource editable. This skip is global to the setting,
+not per-resource: it still applies on a resource where the resolver currently returns no
+subjects, so a resolver that can't guarantee an alternate editor for every resource can let the
+last editor remove themselves and leave it uneditable by non-admins.
 
 Resolved subject ids are also surfaced as `extra_editors` in the chart and dashboard `GET`
 responses, so API clients can distinguish resolver-granted editorship from the resource's own
-`editors` list.
+`editors` list. This field is attached after serialization and isn't part of the OpenAPI response
+schema, so generated API clients won't see it as a typed field.
 
 Because the resolver is arbitrary per-deployment Python rather than a SQL-expressible condition,
 editorship it grants cannot be reflected in list-view filtering (for example, the soft-deleted
-archive is scoped to editors via a SQL query) — it only takes effect on direct, per-object checks.
+archive is scoped to editors via a SQL query). It does still run once per row on chart and
+dashboard list responses to populate `extra_editors`, so a slow or unavailable external resolver
+affects ordinary list requests, not just direct per-object checks.
 
 ### Dashboard Access Control
 

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -243,6 +243,36 @@ Each subject in the response includes flat scalar ids (`user_id`, `role_id`, `gr
 than a nested object, so callers can match directly on whichever id they already have — only the
 id field matching the subject's `type` is populated; the others are `null`.
 
+#### Extending Editorship with EXTRA_EDITORS_RESOLVER
+
+Deployments that grant edit access to a dashboard or chart through a mechanism outside
+Superset's own Subject-based `editors` list — for example, a folder-permission system or an
+internal directory service — can plug that logic in with `EXTRA_EDITORS_RESOLVER`:
+
+```python
+def extra_editors_resolver(resource):
+    # `resource` is the Dashboard or Slice instance being checked.
+    # Return Subject instances, raw subject ids, or dicts with an `id` key.
+    return [...]
+
+
+EXTRA_EDITORS_RESOLVER = extra_editors_resolver
+```
+
+The resolver's result is unioned with the resource's own `editors` for editorship checks: it
+feeds `is_editor`, `raise_for_editorship`, save-as, and soft-delete restore. When
+`EXTRA_EDITORS_RESOLVER` is configured, the usual lockout-prevention behavior — automatically
+re-adding a non-admin who removes themselves from a resource's editors — is skipped, since the
+deployment has its own way of keeping the resource editable.
+
+Resolved subject ids are also surfaced as `extra_editors` in the chart and dashboard `GET`
+responses, so API clients can distinguish resolver-granted editorship from the resource's own
+`editors` list.
+
+Because the resolver is arbitrary per-deployment Python rather than a SQL-expressible condition,
+editorship it grants cannot be reflected in list-view filtering (for example, the soft-deleted
+archive is scoped to editors via a SQL query) — it only takes effect on direct, per-object checks.
+
 ### Dashboard Access Control
 
 Access to dashboards is managed via editors (subjects that have edit permissions to the dashboard).


### PR DESCRIPTION
### SUMMARY
Follow-up doc gap from #38831. That PR added the Subject/editor/viewer access model (`ENABLE_VIEWERS`, `SUBJECTS_RELATED_TYPES`, `VIEWER_PROMISCUOUS_MODE`, the owner→editor terminology shift), and most of it has since been documented in `docs/admin_docs/security/security.mdx` via follow-up PRs (#39440, #38829, #42951, #42472). The one config hook that never got written up is `EXTRA_EDITORS_RESOLVER`, which lets a deployment plug in externally-resolved editor subjects (e.g. a folder-permission system) that feed into `is_editor`/`raise_for_editorship`, save-as, and restore checks.

This adds a subsection documenting what it does, how the resolver's return value is used, its interaction with the self-protection lockout-prevention logic, and its `extra_editors` surfacing in the chart/dashboard `GET` responses.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — docs-only change.

### TESTING INSTRUCTIONS
- Read the new "Extending Editorship with EXTRA_EDITORS_RESOLVER" subsection in `docs/admin_docs/security/security.mdx` and confirm it matches the behavior in `superset/security/manager.py` (`get_extra_editor_subject_ids`, `is_editor`) and `superset/commands/utils.py` (`_has_extra_editors_resolver`).
- `pre-commit run --files docs/admin_docs/security/security.mdx` passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>