### PR TITLE
docs(mcp): document the update_dataset_metric tool

### DIFF
--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -248,11 +248,12 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 
 ### Datasets
 
-| Tool                     | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `list_datasets`          | List datasets with filtering and search          |
-| `get_dataset_info`       | Get dataset metadata (columns, metrics, filters) |
-| `create_virtual_dataset` | Create a virtual dataset from a SQL query        |
+| Tool                     | Description                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| `list_datasets`          | List datasets with filtering and search                                                        |
+| `get_dataset_info`       | Get dataset metadata (columns, metrics, filters)                                               |
+| `create_virtual_dataset` | Create a virtual dataset from a SQL query                                                      |
+| `update_dataset_metric`  | Update a saved metric's expression, name, verbose_name, or format (requires dataset ownership) |
 
 ### Charts
 

--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -248,12 +248,12 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 
 ### Datasets
 
-| Tool                     | Description                                                                                    |
-| ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `list_datasets`          | List datasets with filtering and search                                                        |
-| `get_dataset_info`       | Get dataset metadata (columns, metrics, filters)                                               |
-| `create_virtual_dataset` | Create a virtual dataset from a SQL query                                                      |
-| `update_dataset_metric`  | Update a saved metric's expression, name, verbose_name, or format (requires dataset ownership) |
+| Tool                     | Description                                                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `list_datasets`          | List datasets with filtering and search                                                                                      |
+| `get_dataset_info`       | Get dataset metadata (columns, metrics, schema details)                                                                      |
+| `create_virtual_dataset` | Create a virtual dataset from a SQL query                                                                                    |
+| `update_dataset_metric`  | Update a saved metric's expression, name, verbose_name, or format (affects every chart using it; requires dataset ownership) |
 
 ### Charts
 


### PR DESCRIPTION
### SUMMARY
#40975 added the `update_dataset_metric` MCP tool but never got a row in the user-facing "Available Tools Reference" (Datasets section) in `docs/docs/using-superset/using-ai-with-superset.mdx`. This adds it, matching the description used elsewhere for that tool (expression/name/verbose_name/format, requires dataset ownership).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only table addition.

### TESTING INSTRUCTIONS
- Render `docs/docs/using-superset/using-ai-with-superset.mdx` (or eyeball the diff) and confirm the Datasets table lists `update_dataset_metric` alongside `list_datasets`, `get_dataset_info`, and `create_virtual_dataset`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs fix for #40975.