### PR TITLE
docs(mcp): document chart type plugin filtering config

### DIFF
--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -910,7 +910,7 @@ Set `MCP_DISABLED_CHART_PLUGINS` in your `superset_config.py` to a set of chart 
 MCP_DISABLED_CHART_PLUGINS = {"handlebars"}
 ```
 
-Disabled chart types are removed from the registry at startup and are never listed in `generate_chart`'s supported chart types. `get_chart_type_schema` consults its own static schema/example map rather than the registry filter, so a disabled chart type's schema remains queryable through that tool even though `generate_chart` will reject it.
+Disabled chart types stay registered but are filtered out at lookup time: they're never listed in `generate_chart`'s supported chart types, and `generate_chart` calls for them are rejected. `get_chart_type_schema` consults its own static schema/example map rather than the registry filter, so a disabled chart type's schema remains queryable through that tool even though `generate_chart` will reject it.
 
 ### Dynamic predicate
 

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -505,6 +505,8 @@ All MCP settings go in `superset_config.py`. Defaults are defined in `superset/m
 | `MCP_DEV_USERNAME`   | --            | Superset username for development mode (no auth)                                                                                                                                                                                                                             |
 | `MCP_RBAC_ENABLED`   | `True`        | Enforce Superset's role-based access control on MCP tool calls. When `True`, each tool checks that the authenticated user has the required FAB permission before executing. Disable only for testing or trusted-network deployments.                                         |
 | `MCP_DISABLED_TOOLS` | `set()`       | Set of tool names to remove from the MCP server at startup. Disabled tools are never advertised to AI clients during tool discovery. Useful when a custom extension tool should replace a built-in Superset tool. See [Disabling built-in tools](#disabling-built-in-tools). |
+| `MCP_DISABLED_CHART_PLUGINS` | `frozenset()` | Set of chart type plugin names (e.g. `"handlebars"`) to hide from `generate_chart` and related chart tools. See [Disabling chart type plugins](#disabling-chart-type-plugins). |
+| `MCP_CHART_PLUGIN_ENABLED_FUNC` | `None`        | Callable `(chart_type: str) -> bool` evaluated per registry lookup for dynamic enable/disable decisions. Takes precedence over `MCP_DISABLED_CHART_PLUGINS` when set. See [Disabling chart type plugins](#disabling-chart-type-plugins). |
 
 ### Authentication
 
@@ -892,6 +894,39 @@ MCP_DISABLED_TOOLS = {"extensions.myorg.myextension.some_tool"}
 :::note
 Specifying a tool name that does not exist logs a warning at startup and is otherwise ignored — it will not prevent the server from starting.
 :::
+
+## Disabling chart type plugins
+
+The `generate_chart` tool dispatches per chart type (`xy`, `table`, `pie`, `pivot_table`, `mixed_timeseries`, `handlebars`, `big_number`) to a registered chart type plugin. Two settings let operators enable or disable individual chart type plugins at runtime, without a code deploy.
+
+### Static deny-list
+
+Set `MCP_DISABLED_CHART_PLUGINS` in your `superset_config.py` to a set of chart type names:
+
+```python
+# superset_config.py
+
+# Emergency kill switch: hide "handlebars" from all callers
+MCP_DISABLED_CHART_PLUGINS = {"handlebars"}
+```
+
+Disabled chart types are removed from the registry at startup and are never listed in `generate_chart`'s supported chart types.
+
+### Dynamic predicate
+
+For per-request control (A/B tests, gradual rollout, entitlement checks), set `MCP_CHART_PLUGIN_ENABLED_FUNC` to a callable. It's evaluated as `enabled_func(chart_type: str) -> bool` on every registry lookup, and it takes precedence over `MCP_DISABLED_CHART_PLUGINS` when set:
+
+```python
+# superset_config.py
+from flask import g
+
+
+def MCP_CHART_PLUGIN_ENABLED_FUNC(chart_type: str) -> bool:
+    flags = getattr(g, "feature_flags", {})
+    return flags.get(f"mcp_chart_{chart_type}", True)
+```
+
+The callable must be cheap and in-process (consult already-loaded feature flags or request-local context) -- do not perform network I/O per call. If it raises, the registry fails closed (the plugin is hidden) and logs a warning.
 
 ## Security Best Practices
 

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -505,7 +505,7 @@ All MCP settings go in `superset_config.py`. Defaults are defined in `superset/m
 | `MCP_DEV_USERNAME`   | --            | Superset username for development mode (no auth)                                                                                                                                                                                                                             |
 | `MCP_RBAC_ENABLED`   | `True`        | Enforce Superset's role-based access control on MCP tool calls. When `True`, each tool checks that the authenticated user has the required FAB permission before executing. Disable only for testing or trusted-network deployments.                                         |
 | `MCP_DISABLED_TOOLS` | `set()`       | Set of tool names to remove from the MCP server at startup. Disabled tools are never advertised to AI clients during tool discovery. Useful when a custom extension tool should replace a built-in Superset tool. See [Disabling built-in tools](#disabling-built-in-tools). |
-| `MCP_DISABLED_CHART_PLUGINS` | `frozenset()` | Set of chart type plugin names (e.g. `"handlebars"`) to hide from `generate_chart` and related chart tools. See [Disabling chart type plugins](#disabling-chart-type-plugins). |
+| `MCP_DISABLED_CHART_PLUGINS` | `frozenset()` | Set of chart type plugin names (e.g. `"handlebars"`) to hide from `generate_chart`. Does not affect `get_chart_type_schema`. See [Disabling chart type plugins](#disabling-chart-type-plugins). |
 | `MCP_CHART_PLUGIN_ENABLED_FUNC` | `None`        | Callable `(chart_type: str) -> bool` evaluated per registry lookup for dynamic enable/disable decisions. Takes precedence over `MCP_DISABLED_CHART_PLUGINS` when set. See [Disabling chart type plugins](#disabling-chart-type-plugins). |
 
 ### Authentication
@@ -897,7 +897,7 @@ Specifying a tool name that does not exist logs a warning at startup and is othe
 
 ## Disabling chart type plugins
 
-The `generate_chart` tool dispatches per chart type (`xy`, `table`, `pie`, `pivot_table`, `mixed_timeseries`, `handlebars`, `big_number`) to a registered chart type plugin. Two settings let operators enable or disable individual chart type plugins at runtime, without a code deploy.
+The `generate_chart` tool dispatches per chart type (`xy`, `table`, `pie`, `pivot_table`, `mixed_timeseries`, `handlebars`, `big_number`, `histogram`, `box_plot`, `waterfall`) to a registered chart type plugin. Two settings let operators enable or disable individual chart type plugins at runtime, without a code deploy.
 
 ### Static deny-list
 
@@ -910,7 +910,7 @@ Set `MCP_DISABLED_CHART_PLUGINS` in your `superset_config.py` to a set of chart 
 MCP_DISABLED_CHART_PLUGINS = {"handlebars"}
 ```
 
-Disabled chart types are removed from the registry at startup and are never listed in `generate_chart`'s supported chart types.
+Disabled chart types are removed from the registry at startup and are never listed in `generate_chart`'s supported chart types. `get_chart_type_schema` consults its own static schema/example map rather than the registry filter, so a disabled chart type's schema remains queryable through that tool even though `generate_chart` will reject it.
 
 ### Dynamic predicate
 


### PR DESCRIPTION
### SUMMARY
#39922 added two operator-facing MCP config knobs, `MCP_DISABLED_CHART_PLUGINS` (deny-list) and `MCP_CHART_PLUGIN_ENABLED_FUNC` (dynamic predicate), for filtering which chart type plugins `generate_chart` exposes. They weren't covered in the MCP server config docs. This adds them to the Configuration Reference table and a new "Disabling chart type plugins" section, following the existing "Disabling built-in tools" pattern.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs only.

### TESTING INSTRUCTIONS
- Read `docs/admin_docs/configuration/mcp-server.mdx` and confirm the new rows/section render correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs for #39922.