### PR TITLE
fix(mcp): surface rejected filter columns in get_chart_data

### DIFF
--- a/superset/mcp_service/chart/tool/get_chart_data.py
+++ b/superset/mcp_service/chart/tool/get_chart_data.py
@@ -82,6 +82,31 @@ def _requested_filter_columns(extra_form_data: dict[str, Any] | None) -> set[str
     return columns
 
 
+def _rejected_columns_in_query(query: Any) -> set[str]:
+    """Return the rejected filter column names reported by one query payload.
+
+    ``_materialize_full_payload`` converts the datasource's raw
+    ``rejected_filter_columns`` list into the ``rejected_filters`` entries
+    (``{"reason": ..., "column": ...}``) that every consumer of a chart-data
+    payload sees, so that is the primary shape to read. The raw key is still
+    accepted for payloads captured before that conversion.
+    """
+    if not isinstance(query, dict):
+        return set()
+
+    columns = {
+        column
+        for entry in query.get("rejected_filters", [])
+        if isinstance(entry, dict) and isinstance(column := entry.get("column"), str)
+    }
+    columns.update(
+        column
+        for column in query.get("rejected_filter_columns", [])
+        if isinstance(column, str)
+    )
+    return columns
+
+
 def _rejected_requested_filter_columns(
     result: Any, extra_form_data: dict[str, Any] | None
 ) -> list[str]:
@@ -92,8 +117,7 @@ def _rejected_requested_filter_columns(
     rejected = {
         column
         for query in result.get("queries", [])
-        for column in query.get("rejected_filter_columns", [])
-        if isinstance(column, str)
+        for column in _rejected_columns_in_query(query)
     }
     return sorted(requested & rejected)
 

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py
@@ -45,7 +45,7 @@ from superset.mcp_service.chart.tool.get_chart_data import (
     _requested_filter_columns,
 )
 from superset.utils import json
-from superset.utils.core import GenericDataType
+from superset.utils.core import ExtraFiltersReasonType, GenericDataType
 
 
 def test_requested_filter_columns_supports_both_payload_shapes() -> None:
@@ -85,6 +85,56 @@ def test_rejected_requested_filter_columns_ignores_saved_chart_filters() -> None
             ]
         },
     ) == ["missing_request"]
+
+
+def test_rejected_requested_filter_columns_reads_materialized_payload() -> None:
+    """A chart-data payload reports rejections as ``rejected_filters`` entries.
+
+    ``_materialize_full_payload`` deletes the raw ``rejected_filter_columns``
+    key and emits ``rejected_filters`` instead, so this is the only shape the
+    tool ever sees in practice. Reading just the raw key made the check a
+    no-op and let unknown columns return unfiltered data as a success.
+    """
+    result = {
+        "queries": [
+            {
+                "data": [{"country": "USA"}],
+                "rejected_filters": [
+                    {
+                        "reason": "COL_NOT_IN_DATASOURCE",
+                        "column": "does_not_exist",
+                    }
+                ],
+            }
+        ]
+    }
+
+    assert _rejected_requested_filter_columns(
+        result,
+        {"filters": [{"col": "does_not_exist", "op": "==", "val": "x"}]},
+    ) == ["does_not_exist"]
+
+
+def test_rejected_requested_filter_columns_ignores_rejected_time_filters() -> None:
+    """``rejected_filters`` also carries time-extra rejections, which are not
+    request filter columns and must not be attributed to the caller."""
+    result = {
+        "queries": [
+            {
+                "rejected_filters": [
+                    {"reason": "NO_TEMPORAL_COLUMN", "column": "__time_range"}
+                ]
+            }
+        ]
+    }
+
+    assert (
+        _rejected_requested_filter_columns(
+            result,
+            {"filters": [{"col": "country", "op": "==", "val": "USA"}]},
+        )
+        == []
+    )
 
 
 def _collect_groupby_extras(
@@ -1462,13 +1512,22 @@ class TestSavedChartExtraFormDataFilters:
             def __init__(self, query_context: Any) -> None: ...
             def validate(self) -> None: ...
             def run(self) -> dict[str, Any]:
+                # Mirror the payload ChartDataCommand actually returns:
+                # _materialize_full_payload has already converted
+                # rejected_filter_columns into rejected_filters entries.
                 return {
                     "queries": [
                         {
                             "data": [{"country": "USA"}],
                             "colnames": ["country"],
                             "rowcount": 1,
-                            "rejected_filter_columns": rejected_filter_columns or [],
+                            "rejected_filters": [
+                                {
+                                    "reason": ExtraFiltersReasonType.COL_NOT_IN_DATASOURCE,  # noqa: E501
+                                    "column": column,
+                                }
+                                for column in rejected_filter_columns or []
+                            ],
                         }
                     ]
                 }


### PR DESCRIPTION
## Why

`get_chart_data` accepts filters through `extra_form_data`. When a filter names a column
that does not exist on the dataset, the datasource drops that predicate and runs the query
unfiltered. A guard was added to catch this and return a `ValidationError`, but it reads
`rejected_filter_columns` off the `ChartDataCommand` result, and that key never reaches the
tool: `_materialize_full_payload` deletes it and emits `rejected_filters` entries
(`{"reason": ..., "column": ...}`) in its place before the payload is returned.

The guard therefore intersected the requested columns against an empty set and never fired,
so the original failure mode was still live: a filter on an unknown column returns **every**
row with a success response. On an agent-facing API this is worse than an error, because the
caller has no signal that the filter was dropped and will present unfiltered data as filtered.

The existing regression test did not catch this because it mocked `ChartDataCommand.run()`
with the pre-materialization shape, so it exercised a payload production never produces.

## What

Read the rejected columns from `rejected_filters`, which is the shape every consumer of a
chart-data payload sees, and keep `rejected_filter_columns` as a fallback for payloads
captured before that conversion. Only entries carrying a string `column` are considered, which
guards against malformed entries rather than against time extras: `get_time_filter_status`
rejections do carry a string `column` such as `__time_range`. What keeps those from being
attributed to the caller is the intersection with the columns the request actually named, and
`test_rejected_requested_filter_columns_ignores_rejected_time_filters` pins that behavior.

## Blast radius

Limited to the `get_chart_data` MCP tool. No change to query construction, execution, or the
chart-data REST API: this only reads a field that was already present on the payload. Filters
supplied by the request are the only ones validated, so a stale filter saved on an older chart
config still cannot fail the call.

## How to test

`tests/unit_tests/mcp_service/chart/tool/test_get_chart_data.py`

- `test_rejected_requested_filter_columns_reads_materialized_payload` — fails on master.
- `test_rejected_requested_filter_columns_ignores_rejected_time_filters` — pins that a
  rejected time extra is not reported as a rejected request filter.
- `TestSavedChartExtraFormDataFilters::test_unknown_adhoc_filter_column_returns_validation_error`
  now drives the tool with the materialized payload shape; it fails on master, where it
  previously passed against the mocked shape.

Verified by reverting the source change with the tests in place: the two cases above fail,
the remaining 105 pass.

## Risk & rollback

Low. The behavior change is that a request naming an unknown filter column now returns a
`ValidationError` instead of unfiltered rows — the intended behavior, and the reason the
guard exists. A caller relying on the silent-unfiltered response would see an error instead;
that response was incorrect. Straight revert if needed.

## Review guidance

Start with `_rejected_columns_in_query` in `get_chart_data.py`, then the updated `_Command.run()`
mock in the test file — the mock shape is the crux of why this went unnoticed.

