### PR TITLE
docs(embedding): document EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE

### DIFF
--- a/docs/docs/using-superset/embedding.mdx
+++ b/docs/docs/using-superset/embedding.mdx
@@ -88,6 +88,19 @@ embedDashboard({
 
 If the callback returns `null` or is not provided, Superset uses its own permalink URL as a fallback.
 
+### Permalink origin rewriting
+
+Separately from `resolvePermalinkUrl`, Superset itself rewrites the origin of any permalink URL it generates to `window.location.origin` before showing it to the user. This keeps a proxied or subdirectory-deployed Superset from handing out a permalink that points at an internal hostname the user's browser can't reach.
+
+If your reverse proxy correctly forwards `X-Forwarded-Host` and you'd rather permalinks carry the backend's literal origin, opt out of the rewrite with `EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE`:
+
+```python
+# superset_config.py
+EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE = True
+```
+
+This defaults to `False` (rewrite enabled). Flipping the default would regress the common proxied/subdirectory deployment by exposing an unreachable internal host in copied permalinks.
+
 ---
 
 ## Feature Flags for Embedded Mode

--- a/docs/docs/using-superset/embedding.mdx
+++ b/docs/docs/using-superset/embedding.mdx
@@ -90,16 +90,18 @@ If the callback returns `null` or is not provided, Superset uses its own permali
 
 ### Permalink origin rewriting
 
-Separately from `resolvePermalinkUrl`, Superset itself rewrites the origin of any permalink URL it generates to `window.location.origin` before showing it to the user. This keeps a proxied or subdirectory-deployed Superset from handing out a permalink that points at an internal hostname the user's browser can't reach.
+This rewrite only applies to the non-embedded permalink path — it has no effect on embedded dashboards. When Superset is not embedded, it rewrites the origin of any permalink URL it generates to `window.location.origin` before showing it to the user, which keeps a proxied or subdirectory-deployed Superset from handing out a permalink that points at an internal hostname the user's browser can't reach.
 
-If your reverse proxy correctly forwards `X-Forwarded-Host` and you'd rather permalinks carry the backend's literal origin, opt out of the rewrite with `EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE`:
+When Superset **is** embedded, this rewrite is skipped entirely regardless of the flag below: a `resolvePermalinkUrl` callback's return value is used as-is, and if no callback is provided (or it fails), the backend-supplied URL is also returned as-is.
+
+If your reverse proxy correctly forwards `X-Forwarded-Host` and you'd rather non-embedded permalinks carry the backend's literal origin, opt out of the rewrite with `EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE`:
 
 ```python
 # superset_config.py
 EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE = True
 ```
 
-This defaults to `False` (rewrite enabled). Flipping the default would regress the common proxied/subdirectory deployment by exposing an unreachable internal host in copied permalinks.
+This defaults to `False` (rewrite enabled) and only affects non-embedded permalinks. Flipping the default would regress the common proxied/subdirectory deployment by exposing an unreachable internal host in copied permalinks.
 
 ---
 


### PR DESCRIPTION
### SUMMARY
#39925 added the `EMBEDDED_DISABLE_PERMALINK_ORIGIN_REWRITE` config flag (opt-out for the frontend's permalink origin rewrite, used to avoid handing out unreachable internal-host permalinks on proxied/subdirectory deployments) but never documented it. This adds a short section to the embedding docs, next to the existing `resolvePermalinkUrl` callback docs since both deal with permalink URLs in embedded contexts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs only.

### TESTING INSTRUCTIONS
- Read `docs/docs/using-superset/embedding.mdx` and confirm the new "Permalink origin rewriting" section accurately describes the flag added in #39925 (`superset/config.py`, `superset/views/base.py`, `superset-frontend/src/utils/urlUtils.ts`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API