### PR TITLE
docs(theming): document THEME_DEFAULT_MODE config setting

### DIFF
--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -92,7 +92,7 @@ THEME_DARK = {
 
 By default, Superset mimics the visitor's OS/browser preference (light or dark) for
 sessions that don't have a saved user preference. Use `THEME_DEFAULT_MODE` to override
-that starting point instance-wide:
+that starting point instance-wide for the standard application:
 
 ```python
 # Default theme mode for sessions without a saved user preference.
@@ -100,9 +100,14 @@ that starting point instance-wide:
 THEME_DEFAULT_MODE = "dark"
 ```
 
-- `"system"` (the default) preserves the existing behavior of following the OS/browser preference.
+- `"system"` (the default) preserves the existing behavior of following the OS/browser
+  preference, provided a dark theme is configured (`THEME_DARK` is not `None`). If no dark
+  theme is available, Superset always starts in light mode regardless of this setting.
 - `"default"` or `"dark"` forces that starting mode for first-time visitors; users can still switch themes manually afterward if both `THEME_DEFAULT` and `THEME_DARK` are available.
 - A user's own saved preference, once they toggle the theme switcher, always takes precedence over `THEME_DEFAULT_MODE`.
+- `THEME_DEFAULT_MODE` has no effect on embedded dashboards: the embed SDK sets the
+  starting mode via its own `themeMode` URL parameter, which takes precedence and falls
+  back to light mode when the parameter is absent.
 
 ### App Branding
 

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -88,6 +88,22 @@ THEME_DARK = {
 # - OS preference detection is automatically enabled
 ```
 
+### Default Theme Mode
+
+By default, Superset mimics the visitor's OS/browser preference (light or dark) for
+sessions that don't have a saved user preference. Use `THEME_DEFAULT_MODE` to override
+that starting point instance-wide:
+
+```python
+# Default theme mode for sessions without a saved user preference.
+# One of "default" (always light), "dark" (always dark), or "system" (mimic OS preference).
+THEME_DEFAULT_MODE = "dark"
+```
+
+- `"system"` (the default) preserves the existing behavior of following the OS/browser preference.
+- `"default"` or `"dark"` forces that starting mode for first-time visitors; users can still switch themes manually afterward if both `THEME_DEFAULT` and `THEME_DARK` are available.
+- A user's own saved preference, once they toggle the theme switcher, always takes precedence over `THEME_DEFAULT_MODE`.
+
 ### App Branding
 
 The application name shown in the browser title bar and navigation can be


### PR DESCRIPTION
### SUMMARY
#41007 added `THEME_DEFAULT_MODE` (config.py), letting operators default the app to `dark`, `default` (light), or `system` instead of always following the OS/browser preference. The theming docs never got updated for it, so `docs/admin_docs/configuration/theming.mdx` only documented `THEME_DEFAULT`/`THEME_DARK` and the Theme Management UI. This adds a short "Default Theme Mode" subsection covering the new setting, its allowed values, and how it interacts with a user's own saved theme preference.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - docs only.

### TESTING INSTRUCTIONS
Read the new "Default Theme Mode" section under Configuration Options in `docs/admin_docs/configuration/theming.mdx`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs gap from #41007.