### PR TITLE
docs(cli): document import_directory --username option

### DIFF
--- a/docs/admin_docs/configuration/importing-exporting-datasources.mdx
+++ b/docs/admin_docs/configuration/importing-exporting-datasources.mdx
@@ -83,6 +83,25 @@ The optional username flag **-u** sets the user used for the datasource import. 
 superset import_datasources -p <path / filename> -u 'admin'
 ```
 
+## Importing a Directory of Assets
+
+The `import_directory` command imports a directory of exported assets (databases, datasets,
+dashboards, charts, etc.) in the same layout produced by the ZIP-based export:
+
+```bash
+superset import_directory <path / directory>
+```
+
+As with `import_datasources`, the optional username flag **-u** sets the user assigned as the
+owner of the imported assets. The default is 'admin'. Example:
+
+```bash
+superset import_directory <path / directory> -u 'admin'
+```
+
+If the specified user does not exist, the command fails immediately with an error rather than
+importing the assets without an owner.
+
 ## Dashboard Import Overwrite Behavior
 
 When importing a dashboard ZIP with the **overwrite** option enabled, any existing charts that are part of the dashboard are **replaced** rather than duplicated. This applies to:

--- a/docs/admin_docs/configuration/importing-exporting-datasources.mdx
+++ b/docs/admin_docs/configuration/importing-exporting-datasources.mdx
@@ -86,7 +86,8 @@ superset import_datasources -p <path / filename> -u 'admin'
 ## Importing a Directory of Assets
 
 The `import_directory` command imports a directory of exported assets (databases, datasets,
-dashboards, charts, etc.) in the same layout produced by the ZIP-based export:
+dashboards, charts) in the same layout produced by the ZIP-based export. Saved queries and tags
+included in a full export are not imported by this command:
 
 ```bash
 superset import_directory <path / directory>


### PR DESCRIPTION
### SUMMARY
#40994 added an optional `--username`/`-u` flag to the `import_directory` CLI command (mirroring `import_datasources`) so imported assets get assigned an owner instead of ending up with an empty owners list. That flag, its default value, and its fail-fast behavior for unknown users weren't documented anywhere. This adds a short section to the import/export admin doc, alongside the existing write-up of `import_datasources`'s user-resolution behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - docs only.

### TESTING INSTRUCTIONS
Docs-only change. Confirm the new "Importing a Directory of Assets" section in `docs/admin_docs/configuration/importing-exporting-datasources.mdx` renders correctly and reflects the CLI behavior added in #40994.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up to #40994.

Co-Authored-By: Claude <noreply@anthropic.com>