### PR TITLE
fix(ci): repair scheduled pre-commit drift

### DIFF
--- a/superset-core/src/superset_core/semantic_layers/layer.py
+++ b/superset-core/src/superset_core/semantic_layers/layer.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
+
 from superset_core.semantic_layers.view import SemanticView
 
 ConfigT = TypeVar("ConfigT", bound=BaseModel)

--- a/superset-frontend/src/dashboard/actions/dashboardLayout.ts
+++ b/superset-frontend/src/dashboard/actions/dashboardLayout.ts
@@ -312,7 +312,7 @@ export function handleComponentDrop(dropResult: DropResult) {
       source &&
       !(
         // ensure it has moved
-        (destination.id === source.id && destination.index === source.index)
+        destination.id === source.id && destination.index === source.index
       )
     ) {
       dispatch(moveComponent(dropResult));

--- a/superset-frontend/src/dataMask/reducer.ts
+++ b/superset-frontend/src/dataMask/reducer.ts
@@ -126,7 +126,7 @@ function fillNativeFilters(
       !(
         // Treat all-null arrays (range filters use [null, null] as their
         // canonical cleared value) and empty arrays as "no value".
-        (Array.isArray(loadedValue) && loadedValue.every(v => v === null))
+        Array.isArray(loadedValue) && loadedValue.every(v => v === null)
       );
     const loadedHasExtraFormData =
       !!loaded?.extraFormData && Object.keys(loaded.extraFormData).length > 0;

--- a/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
+++ b/superset-frontend/src/explore/components/controls/ColumnConfigControl/types.ts
@@ -29,7 +29,9 @@ import { ControlFormItemComponents } from './ControlForm';
  * Column formatting configs.
  */
 export type ColumnConfig = {
-  [key in SharedColumnConfigProp]?: (typeof SHARED_COLUMN_CONFIG_PROPS)[key]['value'];
+  [
+    key in SharedColumnConfigProp
+  ]?: (typeof SHARED_COLUMN_CONFIG_PROPS)[key]['value'];
 } & Record<string, StrictJsonValue>;
 
 /**

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -404,7 +404,7 @@ class SemanticView(AuditMixinNullable, Model):
                 for dimension in dimensions
             },
         }
-        column_formats = {
+        column_formats: dict[str, str | None] = {
             metric.name: metric.d3format for metric in metrics if metric.d3format
         }
 


### PR DESCRIPTION
### SUMMARY

Repairs the deterministic failures reported by the scheduled all-files pre-commit workflow:

- widens the inferred `column_formats` value type to match `ExplorableData`
- restores Ruff's first-party import grouping for `superset_core.semantic_layers`
- applies the pinned Oxfmt 0.64.0 output to all three files reported by the failed job

This is an automation-owned replacement for the overlapping work in #43366. That PR correctly includes the MyPy, Ruff, and `ColumnConfigControl/types.ts` changes, but omits the reported Oxfmt rewrites in `dashboardLayout.ts` and `dataMask/reducer.ts`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this changes type/lint/format output only.

### TESTING INSTRUCTIONS

- `pre-commit run mypy --all-files`
- `ruff check superset-core/src/superset_core/semantic_layers/layer.py`
- `npx oxfmt --check --no-error-on-unmatched-pattern -- src/dashboard/actions/dashboardLayout.ts src/dataMask/reducer.ts src/explore/components/controls/ColumnConfigControl/types.ts` from `superset-frontend`
- `pre-commit run --all-files` was executed before push. The repair-specific hooks pass; the local full sweep also reported unrelated baseline lint findings and missing generated frontend/docs build outputs.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
