### PR TITLE
chore(deps): group Dependabot security-update PRs per directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
     cooldown:
       default-days: 7
 
@@ -61,6 +65,9 @@ updates:
       - npm
       - dependabot
     groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
       rjsf:
         patterns:
           - "@rjsf/*"
@@ -98,6 +105,10 @@ updates:
     labels:
       - pip
       - dependabot
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
     cooldown:
       default-days: 7
 
@@ -105,6 +116,10 @@ updates:
     directory: ".github/actions"
     schedule:
       interval: "daily"
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
     open-pull-requests-limit: 10
     versioning-strategy: increase
     cooldown:
@@ -115,6 +130,9 @@ updates:
     schedule:
       interval: "daily"
     groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
       storybook:
         patterns:
           - "@storybook/*"
@@ -142,6 +160,10 @@ updates:
     labels:
       - npm
       - dependabot
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
     versioning-strategy: increase
     cooldown:
       default-days: 7
@@ -153,6 +175,10 @@ updates:
     labels:
       - npm
       - dependabot
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns: ["*"]
     open-pull-requests-limit: 10
     versioning-strategy: increase
     cooldown:


### PR DESCRIPTION
### SUMMARY

Groups Dependabot pull requests that resolve a Dependabot alert (security updates) into one PR per package manager and directory, the same behavior as the org-level "Grouped security updates" toggle, achieved instead through `dependabot.yml` itself.

Each of the 7 existing `updates` blocks in `.github/dependabot.yml` gets a `security` group:

```yaml
groups:
  security:
    applies-to: "security-updates"
    patterns: ["*"]
```

Per GitHub's docs, a directory/ecosystem with its own explicit `groups` config in `dependabot.yml` is governed by that config independent of the repo/org-level toggle, so this achieves full coverage without needing repo Settings access or an ASF INFRA ticket. Existing version-update groups (rjsf, babel, storybook, etc.) are untouched; this only adds the security-update grouping alongside them.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, config-only change to `dependabot.yml`.

### TESTING INSTRUCTIONS

- `.github/dependabot.yml` parses as valid YAML (checked with `yaml.safe_load`).
- `pre-commit run --files .github/dependabot.yml` passes (check-yaml, zizmor).
- Next time Dependabot opens security-update PRs for a given directory, they should land as one grouped PR instead of one per vulnerable dependency.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
