### PR TITLE
fix(explore): catch TemplateError when validating access for permalinked query datasources

### DIFF
--- a/superset/commands/explore/permalink/create.py
+++ b/superset/commands/explore/permalink/create.py
@@ -18,11 +18,13 @@ import logging
 from functools import partial
 from typing import Any, Optional
 
+from jinja2.exceptions import TemplateError
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset import db
 from superset.commands.explore.permalink.base import BaseExplorePermalinkCommand
 from superset.daos.key_value import KeyValueDAO
+from superset.exceptions import SupersetTemplateException
 from superset.explore.permalink.exceptions import ExplorePermalinkCreateFailedError
 from superset.explore.utils import check_access as check_chart_access
 from superset.key_value.exceptions import (
@@ -58,7 +60,10 @@ class CreateExplorePermalinkCommand(BaseExplorePermalinkCommand):
         d_id, d_type = self.datasource.split("__")
         datasource_id = int(d_id)
         datasource_type = DatasourceType(d_type)
-        check_chart_access(datasource_id, self.chart_id, datasource_type)
+        try:
+            check_chart_access(datasource_id, self.chart_id, datasource_type)
+        except TemplateError as ex:
+            raise SupersetTemplateException(str(ex)) from ex
         value = {
             "chartId": self.chart_id,
             "datasourceId": datasource_id,

--- a/superset/commands/explore/permalink/get.py
+++ b/superset/commands/explore/permalink/get.py
@@ -17,11 +17,13 @@
 import logging
 from typing import Optional
 
+from jinja2.exceptions import TemplateError
 from sqlalchemy.exc import SQLAlchemyError
 
 from superset.commands.dataset.exceptions import DatasetNotFoundError
 from superset.commands.explore.permalink.base import BaseExplorePermalinkCommand
 from superset.daos.key_value import KeyValueDAO
+from superset.exceptions import SupersetTemplateException
 from superset.explore.permalink.exceptions import ExplorePermalinkGetFailedError
 from superset.explore.permalink.types import ExplorePermalinkValue
 from superset.explore.utils import check_access as check_chart_access
@@ -54,7 +56,10 @@ class GetExplorePermalinkCommand(BaseExplorePermalinkCommand):
                 datasource_type = DatasourceType(
                     value.get("datasourceType", DatasourceType.TABLE)
                 )
-                check_chart_access(datasource_id, chart_id, datasource_type)
+                try:
+                    check_chart_access(datasource_id, chart_id, datasource_type)
+                except TemplateError as ex:
+                    raise SupersetTemplateException(str(ex)) from ex
                 return value
             return None
         except (

--- a/superset/explore/permalink/api.py
+++ b/superset/explore/permalink/api.py
@@ -31,6 +31,7 @@ from superset.commands.dataset.exceptions import (
 from superset.commands.explore.permalink.create import CreateExplorePermalinkCommand
 from superset.commands.explore.permalink.get import GetExplorePermalinkCommand
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP
+from superset.exceptions import SupersetTemplateException
 from superset.explore.permalink.exceptions import ExplorePermalinkInvalidStateError
 from superset.explore.permalink.schemas import ExplorePermalinkStateSchema
 from superset.extensions import event_logger
@@ -107,6 +108,8 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except (ChartNotFoundError, DatasetNotFoundError) as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))
 
     @expose("/permalink/<string:key>", methods=("GET",))
     @protect()
@@ -162,3 +165,5 @@ class ExplorePermalinkRestApi(BaseSupersetApi):
             return self.response(403, message=str(ex))
         except (ChartNotFoundError, DatasetNotFoundError) as ex:
             return self.response(404, message=str(ex))
+        except SupersetTemplateException as ex:
+            return self.response(ex.status, message=str(ex))

--- a/tests/unit_tests/commands/explore/permalink/__init__.py
+++ b/tests/unit_tests/commands/explore/permalink/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/commands/explore/permalink/test_create.py
+++ b/tests/unit_tests/commands/explore/permalink/test_create.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import patch
+
+import pytest
+from jinja2.exceptions import TemplateError, TemplateSyntaxError
+
+from superset.commands.explore.permalink.create import CreateExplorePermalinkCommand
+from superset.exceptions import SupersetTemplateException
+
+check_chart_access = "superset.commands.explore.permalink.create.check_chart_access"
+
+
+def test_create_permalink_malformed_jinja_template() -> None:
+    # ``check_chart_access`` funnels into ``raise_for_access`` which re-parses the
+    # query's unrendered Jinja via ``process_jinja_sql`` and can raise a raw
+    # ``TemplateError`` (e.g. an unclosed ``{% if %}``). ``TemplateSyntaxError`` is
+    # a subclass of ``TemplateError``. It must surface as a
+    # ``SupersetTemplateException`` (422), not propagate as an opaque 500.
+    assert issubclass(TemplateSyntaxError, TemplateError)
+
+    command = CreateExplorePermalinkCommand(
+        {"formData": {"datasource": "1__table", "slice_id": 1}}
+    )
+
+    with patch(
+        check_chart_access,
+        side_effect=TemplateSyntaxError("unexpected end of template", lineno=1),
+    ):
+        with pytest.raises(SupersetTemplateException):
+            command.run()

--- a/tests/unit_tests/commands/explore/permalink/test_get.py
+++ b/tests/unit_tests/commands/explore/permalink/test_get.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import patch
+
+import pytest
+from jinja2.exceptions import TemplateError, TemplateSyntaxError
+
+from superset.commands.explore.permalink.get import GetExplorePermalinkCommand
+from superset.exceptions import SupersetTemplateException
+from superset.utils.core import DatasourceType
+
+check_chart_access = "superset.commands.explore.permalink.get.check_chart_access"
+decode_permalink_id = "superset.commands.explore.permalink.get.decode_permalink_id"
+get_value = "superset.daos.key_value.KeyValueDAO.get_value"
+
+
+def test_get_permalink_malformed_jinja_template() -> None:
+    # ``check_chart_access`` funnels into ``raise_for_access`` which re-parses the
+    # query's unrendered Jinja via ``process_jinja_sql`` and can raise a raw
+    # ``TemplateError`` (e.g. an unclosed ``{% if %}``). ``TemplateSyntaxError`` is
+    # a subclass of ``TemplateError``. It must surface as a
+    # ``SupersetTemplateException`` (422), not propagate as an opaque 500.
+    assert issubclass(TemplateSyntaxError, TemplateError)
+
+    command = GetExplorePermalinkCommand("thisisallmocked")
+
+    with (
+        patch(decode_permalink_id, return_value="123456"),
+        patch(
+            get_value,
+            return_value={
+                "chartId": 1,
+                "datasourceId": 1,
+                "datasourceType": DatasourceType.TABLE.value,
+            },
+        ),
+        patch(
+            check_chart_access,
+            side_effect=TemplateSyntaxError("unexpected end of template", lineno=1),
+        ),
+    ):
+        with pytest.raises(SupersetTemplateException):
+            command.run()


### PR DESCRIPTION
### SUMMARY

A malformed Jinja SQL template on a query-backed datasource can make `security_manager.raise_for_access(query=...)` raise a raw `jinja2.exceptions.TemplateError`, which propagates uncaught out of the explore-permalink API as an opaque HTTP 500 instead of a proper 4xx.

**PROBLEM**

When a query-backed datasource carries malformed Jinja (e.g. an unclosed `{% if %}`), `security_manager.raise_for_access(query=...)` re-parses the unrendered SQL via `process_jinja_sql` and raises a raw `jinja2.exceptions.TemplateError`. That exception propagates uncaught through:

`superset/explore/utils.py::check_query_access` → `check_datasource_access` → `check_access` (imported as `check_chart_access`) → `CreateExplorePermalinkCommand.run()` / `GetExplorePermalinkCommand.run()` → `ExplorePermalinkRestApi.post()` / `.get()`

None of the command or API `except` chains cover `TemplateError`, so flask-appbuilder's `@safe` decorator turns it into an opaque **500** rather than a meaningful **4xx**.

**FIX**

- Catch `jinja2.exceptions.TemplateError` around the `check_chart_access(...)` call in both `superset/commands/explore/permalink/create.py` and `get.py`, re-raising it as the existing `SupersetTemplateException` (HTTP **422**).
- Add an `except SupersetTemplateException as ex: return self.response(ex.status, message=str(ex))` clause to both the `post()` and `get()` handlers in `superset/explore/permalink/api.py`. flask-appbuilder's `@safe` decorator intercepts the exception before Superset's global `SupersetException` error handler can, so the API layer needs its own explicit catch — the same reason the sibling `form_data` API fix needs it in #43470.

This is a strict additive-catch: no behavior changes on any non-error path.

This is the same bug class as #42366, #42401, #43423, #43433, and #43470. The closest sibling is **#43470**, which fixes the identical root call for the `form_data` API family — same root call, different consumer (form_data vs permalink). #43470 is **not yet merged**; this PR does **not** depend on or touch it (`superset/explore/utils.py` is untouched here) — they are independent files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API error-handling change (500 → 422).

### TESTING INSTRUCTIONS

Two new regression unit tests were added:

- `tests/unit_tests/commands/explore/permalink/test_create.py::test_create_permalink_malformed_jinja_template`
- `tests/unit_tests/commands/explore/permalink/test_get.py::test_get_permalink_malformed_jinja_template`

Each mocks `check_chart_access` with a `jinja2.exceptions.TemplateSyntaxError` side-effect (a `TemplateError` subclass) and asserts the command raises `SupersetTemplateException` instead of leaking the raw `TemplateError`.

```
pytest tests/unit_tests/commands/explore/permalink/
```

Verified they fail on pre-fix code: `git stash` the three source-file changes (keeping the tests), re-run — both fail with the raw `TemplateSyntaxError` propagating; restore the fix — both pass.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
