### PR TITLE
feat(modals): add renderExtraFields prop to chart and dashboard properties modals

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -727,11 +727,13 @@ const PropertiesModal = ({
       saveLoading={isApplying}
       contentLoading={isLoading}
       errorTooltip={
-        dashboardInfo?.isManagedExternally
-          ? t(
-              "This dashboard is managed externally, and can't be edited in Superset",
-            )
-          : errorTooltip
+        extraFields?.saveDisabled && extraFields?.saveTooltip
+          ? extraFields.saveTooltip
+          : dashboardInfo?.isManagedExternally
+            ? t(
+                "This dashboard is managed externally, and can't be edited in Superset",
+              )
+            : errorTooltip
       }
       saveText={saveLabel}
       wrapProps={{ 'data-test': 'properties-edit-modal' }}

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -79,6 +79,10 @@ type PropertiesModalProps = {
   addSuccessToast: (message: string) => void;
   addDangerToast: (message: string) => void;
   onlyApply?: boolean;
+  renderExtraFields?: (context: {
+    assetId: number;
+    assetType: 'dashboard';
+  }) => React.ReactNode;
 };
 
 type DashboardInfo = {
@@ -107,6 +111,7 @@ const PropertiesModal = ({
   onlyApply = false,
   onSubmit = () => {},
   show = false,
+  renderExtraFields,
 }: PropertiesModalProps) => {
   const dispatch = useDispatch();
   const [form] = Form.useForm();
@@ -769,6 +774,10 @@ const PropertiesModal = ({
                   onChangeViewers={handleOnChangeViewers}
                   onChangeTags={handleChangeTags}
                   onClearTags={handleClearTags}
+                  renderExtraFields={renderExtraFields?.({
+                    assetId: dashboardId,
+                    assetType: 'dashboard',
+                  })}
                 />
               ),
             },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -82,7 +82,12 @@ type PropertiesModalProps = {
   renderExtraFields?: (context: {
     assetId: number;
     assetType: 'dashboard';
-  }) => React.ReactNode;
+    accessorCount: number;
+  }) => {
+    content: React.ReactNode;
+    saveDisabled?: boolean;
+    saveTooltip?: string;
+  };
 };
 
 type DashboardInfo = {
@@ -128,6 +133,17 @@ const PropertiesModal = ({
   });
   const [editors, setEditors] = useState<Subject[]>([]);
   const [viewers, setViewers] = useState<Subject[]>([]);
+
+  const extraFields = useMemo(
+    () =>
+      renderExtraFields?.({
+        assetId: dashboardId,
+        assetType: 'dashboard',
+        accessorCount: editors.length + viewers.length,
+      }),
+    [renderExtraFields, dashboardId, editors.length, viewers.length],
+  );
+
   const saveLabel = onlyApply ? t('Apply') : t('Save');
   const [tags, setTags] = useState<TagType[]>([]);
   const [customCss, setCustomCss] = useState('');
@@ -703,7 +719,11 @@ const PropertiesModal = ({
       }}
       title={t('Dashboard properties')}
       isEditMode
-      saveDisabled={dashboardInfo?.isManagedExternally || hasErrors}
+      saveDisabled={
+        dashboardInfo?.isManagedExternally ||
+        hasErrors ||
+        extraFields?.saveDisabled
+      }
       saveLoading={isApplying}
       contentLoading={isLoading}
       errorTooltip={
@@ -774,10 +794,7 @@ const PropertiesModal = ({
                   onChangeViewers={handleOnChangeViewers}
                   onChangeTags={handleChangeTags}
                   onClearTags={handleClearTags}
-                  renderExtraFields={renderExtraFields?.({
-                    assetId: dashboardId,
-                    assetType: 'dashboard',
-                  })}
+                  renderExtraFields={extraFields}
                 />
               ),
             },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
@@ -38,6 +38,7 @@ interface AccessSectionProps {
   onChangeViewers: (viewers: SubjectPickerValue[]) => void;
   onChangeTags: (tags: { label: string; value: number }[]) => void;
   onClearTags: () => void;
+  renderExtraFields?: React.ReactNode;
 }
 
 const AccessSection = ({
@@ -49,6 +50,7 @@ const AccessSection = ({
   onChangeViewers,
   onChangeTags,
   onClearTags,
+  renderExtraFields,
 }: AccessSectionProps) => {
   const enableViewers = isFeatureEnabled(FeatureFlag.EnableViewers);
 
@@ -134,6 +136,7 @@ const AccessSection = ({
           />
         </ModalFormField>
       )}
+      {renderExtraFields}
     </>
   );
 };

--- a/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/sections/AccessSection.tsx
@@ -38,7 +38,11 @@ interface AccessSectionProps {
   onChangeViewers: (viewers: SubjectPickerValue[]) => void;
   onChangeTags: (tags: { label: string; value: number }[]) => void;
   onClearTags: () => void;
-  renderExtraFields?: React.ReactNode;
+  renderExtraFields?: {
+    content: React.ReactNode;
+    saveDisabled?: boolean;
+    saveTooltip?: string;
+  };
 }
 
 const AccessSection = ({
@@ -136,7 +140,7 @@ const AccessSection = ({
           />
         </ModalFormField>
       )}
-      {renderExtraFields}
+      {renderExtraFields?.content}
     </>
   );
 };

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -101,18 +101,19 @@ function PropertiesModal({
   >(null);
   const [tags, setTags] = useState<TagType[]>([]);
 
+  const chartId = slice.slice_id;
   const extraFields = useMemo(
     () =>
-      slice.id
+      chartId
         ? renderExtraFields?.({
-            assetId: slice.id,
+            assetId: chartId,
             assetType: 'chart',
             accessorCount:
               (selectedEditors?.length ?? 0) + (selectedViewers?.length ?? 0),
           })
         : undefined,
     [
-      slice.id,
+      chartId,
       renderExtraFields,
       selectedEditors?.length,
       selectedViewers?.length,
@@ -320,11 +321,13 @@ function PropertiesModal({
         extraFields?.saveDisabled
       }
       errorTooltip={
-        slice.is_managed_externally
-          ? t(
-              "This chart is managed externally, and can't be edited in Superset",
-            )
-          : errorTooltip
+        extraFields?.saveDisabled && extraFields?.saveTooltip
+          ? extraFields.saveTooltip
+          : slice.is_managed_externally
+            ? t(
+                "This chart is managed externally, and can't be edited in Superset",
+              )
+            : errorTooltip
       }
       wrapProps={{ 'data-test': 'properties-edit-modal' }}
     >

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -16,7 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ChangeEvent, useMemo, useState, useCallback, useEffect } from 'react';
+import {
+  type ReactNode,
+  ChangeEvent,
+  useMemo,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
 
 import {
   Input,
@@ -56,6 +63,11 @@ export type PropertiesModalProps = {
   permissionsError?: string;
   addSuccessToast: (msg: string) => void;
   addDangerToast: (msg: string) => void;
+  /** Optional render prop for injecting extra fields (e.g. folder selector). */
+  renderExtraFields?: (context: {
+    assetId: number;
+    assetType: 'chart';
+  }) => ReactNode;
 };
 
 function PropertiesModal({
@@ -65,6 +77,7 @@ function PropertiesModal({
   show,
   addSuccessToast,
   addDangerToast,
+  renderExtraFields,
 }: PropertiesModalProps) {
   const [submitting, setSubmitting] = useState(false);
   // values of form inputs
@@ -395,6 +408,7 @@ function PropertiesModal({
                     />
                   </ModalFormField>
                 )}
+                {renderExtraFields?.({ assetId: slice.id, assetType: 'chart' })}
               </>
             ),
           },

--- a/superset-frontend/src/explore/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/explore/components/PropertiesModal/index.tsx
@@ -67,7 +67,8 @@ export type PropertiesModalProps = {
   renderExtraFields?: (context: {
     assetId: number;
     assetType: 'chart';
-  }) => ReactNode;
+    accessorCount: number;
+  }) => { content: ReactNode; saveDisabled?: boolean; saveTooltip?: string };
 };
 
 function PropertiesModal({
@@ -99,6 +100,24 @@ function PropertiesModal({
     SubjectPickerValue[] | null
   >(null);
   const [tags, setTags] = useState<TagType[]>([]);
+
+  const extraFields = useMemo(
+    () =>
+      slice.id
+        ? renderExtraFields?.({
+            assetId: slice.id,
+            assetType: 'chart',
+            accessorCount:
+              (selectedEditors?.length ?? 0) + (selectedViewers?.length ?? 0),
+          })
+        : undefined,
+    [
+      slice.id,
+      renderExtraFields,
+      selectedEditors?.length,
+      selectedViewers?.length,
+    ],
+  );
 
   // Validation setup
   const modalSections = useMemo(
@@ -294,7 +313,11 @@ function PropertiesModal({
       title={t('Chart properties')}
       isEditMode
       saveDisabled={
-        submitting || !name || slice.is_managed_externally || hasErrors
+        submitting ||
+        !name ||
+        slice.is_managed_externally ||
+        hasErrors ||
+        extraFields?.saveDisabled
       }
       errorTooltip={
         slice.is_managed_externally
@@ -408,7 +431,7 @@ function PropertiesModal({
                     />
                   </ModalFormField>
                 )}
-                {renderExtraFields?.({ assetId: slice.id, assetType: 'chart' })}
+                {extraFields?.content}
               </>
             ),
           },


### PR DESCRIPTION
### SUMMARY
- Add optional `renderExtraFields` render prop to Chart and Dashboard properties modals
- Renders as the last field in the General/Access section
- No behavior change when the prop is not provided — pure extension point for downstream consumers

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
