### PR TITLE
feat(dashboard): add dashboard.slice.header.menu extension slot

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/ui-overrides/types.ts
@@ -30,6 +30,7 @@ import type {
   QueryFormData,
 } from '../query';
 import type { JsonResponse } from '../connection';
+import type { MenuItem } from '../components/Menu';
 
 /**
  * A function which returns text (or marked-up text)
@@ -165,6 +166,13 @@ export interface SliceHeaderExtension {
 }
 
 /**
+ * Interface for extensions to the Slice Header more-options menu
+ */
+export interface SliceHeaderMenuExtension extends SliceHeaderExtension {
+  sliceName: string;
+}
+
+/**
  * Interface for extensions to Embed Modal
  */
 export interface DashboardEmbedModalExtensions {
@@ -262,6 +270,9 @@ export type Extensions = Partial<{
   'sqleditor.extension.form': ComponentType<SQLFormExtensionProps>;
   'sqleditor.extension.resultTable': ComponentType<SQLResultTableExtensionProps>;
   'dashboard.slice.header': ComponentType<SliceHeaderExtension>;
+  'dashboard.slice.header.menu': (
+    context: SliceHeaderMenuExtension,
+  ) => MenuItem[];
   'sqleditor.extension.customAutocomplete': (
     args: CustomAutoCompleteArgs,
   ) => CustomAutocomplete[] | undefined;

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -23,7 +23,7 @@ import {
   userEvent,
   waitFor,
 } from 'spec/helpers/testing-library';
-import { FeatureFlag, VizType } from '@superset-ui/core';
+import { FeatureFlag, VizType, getExtensionsRegistry } from '@superset-ui/core';
 import mockState from 'spec/fixtures/mockState';
 import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import downloadAsImage from 'src/utils/downloadAsImage';
@@ -165,12 +165,43 @@ beforeEach(() => {
 
 afterEach(() => {
   Reflect.deleteProperty(document, 'fullscreenElement');
+  // TypedRegistry has no remove(); reset to a no-op so a registered slot does
+  // not leak into other tests (the empty array is guarded, so nothing injects).
+  getExtensionsRegistry().set('dashboard.slice.header.menu', () => []);
 });
 
 test('Should render', () => {
   renderWrapper();
   openMenu();
   expect(screen.getByTestId(`slice_${SLICE_ID}-menu`)).toBeInTheDocument();
+});
+
+test('Injects dashboard.slice.header.menu items at the top of the menu', () => {
+  getExtensionsRegistry().set('dashboard.slice.header.menu', () => [
+    { key: 'custom-ext', label: 'Custom Menu Extension' },
+  ]);
+  renderWrapper();
+  openMenu();
+
+  const injected = screen.getByText('Custom Menu Extension');
+  expect(injected).toBeInTheDocument();
+  // Sits above the built-in entries.
+  const forceRefresh = screen.getByText('Force refresh');
+  expect(
+    injected.compareDocumentPosition(forceRefresh) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+});
+
+test('Injects nothing when dashboard.slice.header.menu returns no items', () => {
+  getExtensionsRegistry().set('dashboard.slice.header.menu', () => []);
+  renderWrapper();
+  openMenu();
+
+  expect(screen.queryByText('Custom Menu Extension')).not.toBeInTheDocument();
+  // The menu still renders its built-in entries unchanged (no dangling divider
+  // is added since the empty array is guarded).
+  expect(screen.getByText('Force refresh')).toBeInTheDocument();
 });
 
 test('Should render default props', () => {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -204,6 +204,30 @@ test('Injects nothing when dashboard.slice.header.menu returns no items', () => 
   expect(screen.getByText('Force refresh')).toBeInTheDocument();
 });
 
+test('Menu survives a dashboard.slice.header.menu extension that throws', () => {
+  getExtensionsRegistry().set('dashboard.slice.header.menu', () => {
+    throw new Error('boom');
+  });
+  renderWrapper();
+  openMenu();
+
+  // The throw is isolated: the built-in menu still renders.
+  expect(screen.getByText('Force refresh')).toBeInTheDocument();
+  expect(screen.getByText('Enter fullscreen')).toBeInTheDocument();
+});
+
+test('Injects nothing when the extension returns a non-array', () => {
+  getExtensionsRegistry().set(
+    'dashboard.slice.header.menu',
+    // JS registrations bypass the MenuItem[] type; a bad return must not crash.
+    (() => undefined) as never,
+  );
+  renderWrapper();
+  openMenu();
+
+  expect(screen.getByText('Force refresh')).toBeInTheDocument();
+});
+
 test('Should render default props', () => {
   const props = createProps();
 

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -34,6 +34,7 @@ import {
   isFeatureEnabled,
   FeatureFlag,
   getChartMetadataRegistry,
+  getExtensionsRegistry,
   VizType,
   BinaryQueryObjectFilterClause,
   JsonObject,
@@ -164,6 +165,8 @@ const queueChartResize = () => {
     window.dispatchEvent(new Event('resize'));
   }, 300);
 };
+
+const extensionsRegistry = getExtensionsRegistry();
 
 const SliceHeaderControls = (
   props: SliceHeaderControlsPropsWithRouter | SliceHeaderControlsProps,
@@ -513,6 +516,20 @@ const SliceHeaderControls = (
       type: 'divider',
     },
   ];
+
+  const sliceHeaderMenuExtension = extensionsRegistry.get(
+    'dashboard.slice.header.menu',
+  );
+  if (sliceHeaderMenuExtension) {
+    const extensionItems = sliceHeaderMenuExtension({
+      sliceId: slice.slice_id,
+      sliceName: slice.slice_name,
+      dashboardId,
+    });
+    if (extensionItems.length) {
+      newMenuItems.unshift(...extensionItems, { type: 'divider' });
+    }
+  }
 
   if (slice.description) {
     newMenuItems.push({

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -40,6 +40,7 @@ import {
   JsonObject,
   QueryFormData,
 } from '@superset-ui/core';
+import { logging } from '@apache-superset/core/utils';
 import { css, useTheme, styled } from '@apache-superset/core/theme';
 import { useSelector } from 'react-redux';
 import { Menu, MenuItem } from '@superset-ui/core/components/Menu';
@@ -521,13 +522,19 @@ const SliceHeaderControls = (
     'dashboard.slice.header.menu',
   );
   if (sliceHeaderMenuExtension) {
-    const extensionItems = sliceHeaderMenuExtension({
-      sliceId: slice.slice_id,
-      sliceName: slice.slice_name,
-      dashboardId,
-    });
-    if (extensionItems.length) {
-      newMenuItems.unshift(...extensionItems, { type: 'divider' });
+    // Isolate the extension: a bad registration (throwing, or returning a
+    // non-array) must not take down the whole dashboard render.
+    try {
+      const extensionItems = sliceHeaderMenuExtension({
+        sliceId: slice.slice_id,
+        sliceName: slice.slice_name,
+        dashboardId,
+      });
+      if (Array.isArray(extensionItems) && extensionItems.length) {
+        newMenuItems.unshift(...extensionItems, { type: 'divider' });
+      }
+    } catch (error) {
+      logging.error('dashboard.slice.header.menu extension failed', error);
     }
   }
 


### PR DESCRIPTION
### SUMMARY

Adds a new UI extension slot, `dashboard.slice.header.menu`, that lets a deployment inject custom items into a chart's more-options ("…") menu on a dashboard.

The slot is a function that receives the chart context (`sliceId`, `sliceName`, `dashboardId`) and returns an array of `MenuItem`.
Returned items are prepended to the top of the menu, above the built-in entries, followed by a divider.
An empty array injects nothing, so no dangling divider is added.

This mirrors the existing `dashboard.slice.header` component slot, but returns menu data instead of a rendered component, since the host owns the menu structure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.
This adds an extension point with no built-in UI of its own; the visible result depends on what a deployment registers against the slot.

### TESTING INSTRUCTIONS

Register the slot and confirm the item renders at the top of a chart's "…" menu on a dashboard:

```ts
import { getExtensionsRegistry } from '@superset-ui/core';

getExtensionsRegistry().set('dashboard.slice.header.menu', ({ sliceName }) => [
  { key: 'demo', label: `Ask about ${sliceName}`, onClick: () => {} },
]);
```

Run the unit tests:

```bash
cd superset-frontend
npm run test -- src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
```

The suite covers two behaviors: registered items render at the top of the menu, and an empty array injects nothing.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
