### PR TITLE
chore(superset-core): drop unused `__all__` lists

### DIFF
--- a/superset-core/src/superset_core/common/models.py
+++ b/superset-core/src/superset_core/common/models.py
@@ -390,19 +390,3 @@ def get_session() -> scoped_session:
     :returns: The SQLAlchemy scoped session instance.
     """
     raise NotImplementedError("Function will be replaced during initialization")
-
-
-__all__ = [
-    "Dataset",
-    "Database",
-    "Chart",
-    "Dashboard",
-    "User",
-    "Role",
-    "Group",
-    "Tag",
-    "KeyValue",
-    "Subject",
-    "CoreModel",
-    "get_session",
-]

--- a/superset-core/src/superset_core/mcp/decorators.py
+++ b/superset-core/src/superset_core/mcp/decorators.py
@@ -183,10 +183,3 @@ def prompt(
         "MCP prompt decorator not initialized. "
         "This decorator should be replaced during Superset startup."
     )
-
-
-__all__ = [
-    "tool",
-    "prompt",
-    "ToolAnnotations",
-]

--- a/superset-core/src/superset_core/queries/daos.py
+++ b/superset-core/src/superset_core/queries/daos.py
@@ -55,9 +55,3 @@ class SavedQueryDAO(BaseDAO[SavedQuery]):
     model_cls = None
     base_filter = None
     id_column_name = "id"
-
-
-__all__ = [
-    "QueryDAO",
-    "SavedQueryDAO",
-]

--- a/superset-core/src/superset_core/queries/models.py
+++ b/superset-core/src/superset_core/queries/models.py
@@ -71,9 +71,3 @@ class SavedQuery(CoreModel):
     database_id: int | None
     description: str | None
     user_id: int | None
-
-
-__all__ = [
-    "Query",
-    "SavedQuery",
-]

--- a/superset-core/src/superset_core/queries/query.py
+++ b/superset-core/src/superset_core/queries/query.py
@@ -46,6 +46,3 @@ def get_sqlglot_dialect(database: "Database") -> Dialects:
     :returns: The SQLGlot dialect enum corresponding to the database.
     """
     raise NotImplementedError("Function will be replaced during initialization")
-
-
-__all__ = ["get_sqlglot_dialect"]

--- a/superset-core/src/superset_core/queries/types.py
+++ b/superset-core/src/superset_core/queries/types.py
@@ -165,13 +165,3 @@ class AsyncQueryHandle:
         :returns: True if cancellation was successful
         """
         raise NotImplementedError("Method will be replaced during initialization")
-
-
-__all__ = [
-    "QueryStatus",
-    "QueryOptions",
-    "QueryResult",
-    "StatementResult",
-    "AsyncQueryHandle",
-    "CacheOptions",
-]

--- a/superset-core/src/superset_core/rest_api/api.py
+++ b/superset-core/src/superset_core/rest_api/api.py
@@ -27,6 +27,3 @@ class RestApi(BaseApi):
     """
 
     allow_browser_login = True
-
-
-__all__ = ["RestApi"]

--- a/superset-core/src/superset_core/rest_api/decorators.py
+++ b/superset-core/src/superset_core/rest_api/decorators.py
@@ -98,6 +98,3 @@ def api(
         "API decorator not initialized. "
         "This decorator should be replaced during Superset startup."
     )
-
-
-__all__ = ["api"]

--- a/superset-core/src/superset_core/semantic_layers/daos.py
+++ b/superset-core/src/superset_core/semantic_layers/daos.py
@@ -164,6 +164,3 @@ class AbstractSemanticViewDAO(BaseDAO[SemanticViewModel]):
         :return: SemanticViewModel instance or None
         """
         ...
-
-
-__all__ = ["AbstractSemanticLayerDAO", "AbstractSemanticViewDAO"]

--- a/superset-core/src/superset_core/semantic_layers/decorators.py
+++ b/superset-core/src/superset_core/semantic_layers/decorators.py
@@ -97,6 +97,3 @@ def semantic_layer(
         "Semantic layer decorator not initialized. "
         "This decorator should be replaced during Superset startup."
     )
-
-
-__all__ = ["semantic_layer"]

--- a/superset-core/src/superset_core/semantic_layers/models.py
+++ b/superset-core/src/superset_core/semantic_layers/models.py
@@ -80,6 +80,3 @@ class SemanticViewModel(CoreModel):
     semantic_layer_uuid: UUID
     created_on: datetime | None
     changed_on: datetime | None
-
-
-__all__ = ["SemanticLayerModel", "SemanticViewModel"]

--- a/superset-core/src/superset_core/tasks/daos.py
+++ b/superset-core/src/superset_core/tasks/daos.py
@@ -71,6 +71,3 @@ class TaskDAO(BaseDAO[Task]):
         :returns: Task instance or None if not found or not active
         """
         ...
-
-
-__all__ = ["TaskDAO"]

--- a/superset-core/src/superset_core/tasks/decorators.py
+++ b/superset-core/src/superset_core/tasks/decorators.py
@@ -144,9 +144,3 @@ def get_context() -> TaskContext:
             )
     """
     raise NotImplementedError("Function will be replaced during initialization")
-
-
-__all__ = [
-    "task",
-    "get_context",
-]

--- a/superset-core/src/superset_core/tasks/models.py
+++ b/superset-core/src/superset_core/tasks/models.py
@@ -161,9 +161,3 @@ class TaskSubscriber(CoreModel):
     changed_on: datetime | None
     created_by_fk: int | None
     changed_by_fk: int | None
-
-
-__all__ = [
-    "Task",
-    "TaskSubscriber",
-]

--- a/superset-core/src/superset_core/tasks/types.py
+++ b/superset-core/src/superset_core/tasks/types.py
@@ -226,12 +226,3 @@ class TaskContext(ABC):
                 cleanup_partial_work()
         """
         ...
-
-
-__all__ = [
-    "TaskStatus",
-    "TaskScope",
-    "TaskProperties",
-    "TaskContext",
-    "TaskOptions",
-]


### PR DESCRIPTION
### SUMMARY

`superset_core` carried `__all__` lists in 15 modules, but nothing relies on the convention — there are no star-imports (`from superset_core... import *`) of these modules anywhere in the codebase (verified). The lists are therefore dead maintenance overhead that silently drifts out of sync as symbols are added (e.g. a recently-added model wasn't in its module's list). This removes `__all__` from all 15 modules.

No public API change: without `__all__`, `import *` (which nothing uses here) would export the same non-underscore names; normal `from x import Name` imports are unaffected.

### TESTING INSTRUCTIONS

`ruff check` / `ruff format --check` clean on the changed files; `grep -rn 'import \*' ` confirms no star-imports of these modules. Import surface is unchanged for explicit imports.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API