### PR TITLE
feat(gtf): heartbeat orphan reaping + cancellable chart-data queries

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -108,6 +108,24 @@ channels (`entity-changes:*` broadcast nudges, `realtime:<channel_id>`
 per-principal messages) instead of the removed async-events streams; see
 `superset-websocket/README.md`.
 
+Orphaned GTF tasks (a worker killed mid-execution) are now detected and cleaned
+up server-side. While a worker holds a task it writes a liveness heartbeat
+(`tasks.last_heartbeat`, every `GTF_TASK_HEARTBEAT_INTERVAL` seconds, default
+`15`); the existing `prune_tasks` Celery job now reaps any active task whose
+heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default `60`) — revoking its
+Celery job and marking it `FAILURE` so waiters unblock — before its usual
+deletion of old rows. Because reaping rides on `prune_tasks`, enable that beat
+schedule (and run it on a short interval, e.g. every minute) to bound how long an
+orphaned task and its warehouse query can linger. The heartbeat write is issued
+out-of-band and deliberately does not advance `changed_on`.
+
+Async chart-data query tasks are now cancellable: a per-query timeout
+(`GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT`, default `None` = unbounded) or a user
+cancel aborts the task, and on database engines that support query cancellation
+(e.g. PostgreSQL, MySQL, Snowflake, Redshift) the abort also cancels the running
+warehouse query over a fresh connection. Engines without cancel support are
+unaffected — the task is still freed, but the query runs to completion.
+
 - `SAMPLES_ROW_LIMIT` is now the default for `/datasource/samples` requests without a valid explicit `per_page`, rather than a hard per-request ceiling; explicit limits are honored up to the existing global row-limit ceiling, matching `/chart/data` SAMPLES requests.
 
 ### MCP tool results preserve stored string values

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -417,9 +417,9 @@ See `superset/config.py` for a complete example configuration.
 A task whose worker dies mid-execution (OOM kill, crash, lost broker message) would otherwise stay `IN_PROGRESS` forever. To prevent this, a worker writes a liveness heartbeat while it holds a task, and the `prune_tasks` job reaps orphans (before the retention deletion described above):
 
 - **Heartbeat** — every `GTF_TASK_HEARTBEAT_INTERVAL` seconds (default 15) the executing worker refreshes `tasks.last_heartbeat`. This write is deliberately out-of-band and does not update `changed_on`.
-- **Reaping** — `prune_tasks` marks any active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60) as `FAILURE` and revokes its Celery job, so waiters and dependents unblock. A task stuck in `ABORTING` past the same window despite a live heartbeat is force-revoked so the worker's own cleanup finalizes it.
+- **Reaping** — `prune_tasks` marks any active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60) as `FAILURE` so waiters and dependents unblock, and revokes its Celery job so a redelivered copy (with `task_acks_late`) will not run. A task still being worked on keeps a fresh heartbeat and is never reaped, so this never interferes with a live worker's cooperative abort/cleanup.
 
-Because reaping runs inside `prune_tasks`, enable that beat schedule (and run it on a short interval) so orphaned tasks — and, on engines that support query cancellation, their warehouse queries — do not linger. Keep `GTF_ORPHAN_TASK_TIMEOUT` comfortably larger than the heartbeat interval (≥ ~3×) so a brief pause is not mistaken for a dead worker.
+Because reaping runs inside `prune_tasks`, enable that beat schedule (and run it on a short interval) so orphaned tasks do not linger. Keep `GTF_ORPHAN_TASK_TIMEOUT` comfortably larger than the heartbeat interval (≥ ~3×) so a brief pause or CPU-bound stretch is not mistaken for a dead worker.
 
 :::note Cancelling the underlying query
 For long-running work backed by an external query, register an `on_abort` handler that cancels it (this is how async chart-data query tasks cancel the warehouse query on engines that support cancellation). Without such a handler an abort/timeout frees the task but cannot stop the external work.

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -412,6 +412,19 @@ The prune job only removes tasks in terminal states (`SUCCESS`, `FAILURE`, `ABOR
 
 See `superset/config.py` for a complete example configuration.
 
+### Orphan Reaping
+
+A task whose worker dies mid-execution (OOM kill, crash, lost broker message) would otherwise stay `IN_PROGRESS` forever. To prevent this, a worker writes a liveness heartbeat while it holds a task, and the `prune_tasks` job reaps orphans (before the retention deletion described above):
+
+- **Heartbeat** — every `GTF_TASK_HEARTBEAT_INTERVAL` seconds (default 15) the executing worker refreshes `tasks.last_heartbeat`. This write is deliberately out-of-band and does not update `changed_on`.
+- **Reaping** — `prune_tasks` marks any active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60) as `FAILURE` and revokes its Celery job, so waiters and dependents unblock. A task stuck in `ABORTING` past the same window despite a live heartbeat is force-revoked so the worker's own cleanup finalizes it.
+
+Because reaping runs inside `prune_tasks`, enable that beat schedule (and run it on a short interval) so orphaned tasks — and, on engines that support query cancellation, their warehouse queries — do not linger. Keep `GTF_ORPHAN_TASK_TIMEOUT` comfortably larger than the heartbeat interval (≥ ~3×) so a brief pause is not mistaken for a dead worker.
+
+:::note Cancelling the underlying query
+For long-running work backed by an external query, register an `on_abort` handler that cancels it (this is how async chart-data query tasks cancel the warehouse query on engines that support cancellation). Without such a handler an abort/timeout frees the task but cannot stop the external work.
+:::
+
 :::tip Distributed Coordination for Faster Notifications
 By default, abort detection and sync join-and-wait poll the task row in the metadata database. Configure `DISTRIBUTED_COORDINATION_CONFIG` (Redis/Valkey) and these become event-driven: completion and abort are signalled over Redis **Streams**, so a waiter wakes when the signal lands instead of polling the database. Because stream entries are persisted, a waiter that reads slightly late, reconnects, or fails over still receives the signal. Each signal stream keeps only its latest entry and is given a TTL, so streams for tasks that are never awaited do not accumulate; set the retention window with `DISTRIBUTED_COORDINATION_SIGNAL_TTL` (default 24h). See [Distributed Coordination Backend](/admin-docs/configuration/cache#signal-cache-backend) for configuration details.
 :::

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx
@@ -332,3 +332,29 @@ test('should not apply highlight when records have no id field and highlightRowI
   const highlightedRows = container.querySelectorAll('.table-row-highlighted');
   expect(highlightedRows).toHaveLength(0);
 });
+
+test('should highlight every row for which isRowHighlighted returns true', () => {
+  const dataWithIds = [
+    { col1: 'a', col2: 'a2', id: 1, parent: { child: 'n1' } },
+    { col1: 'b', col2: 'b2', id: 2, parent: { child: 'n2' } },
+    { col1: 'c', col2: 'c2', id: 3, parent: { child: 'n3' } },
+  ];
+  const { result } = renderHook(() =>
+    useTable({ columns: tableHook.columns, data: dataWithIds }),
+  );
+  const newTableHook = result.current;
+
+  const { container } = render(
+    <TableCollection
+      {...defaultProps}
+      rows={newTableHook.rows}
+      prepareRow={newTableHook.prepareRow}
+      // Predicate matches on an arbitrary field (here: id in a set), highlighting
+      // multiple rows — this is what the Task List uses to highlight dependencies.
+      isRowHighlighted={record => [1, 3].includes(record.id as number)}
+    />,
+  );
+
+  const highlightedRows = container.querySelectorAll('.table-row-highlighted');
+  expect(highlightedRows).toHaveLength(2);
+});

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -304,6 +304,39 @@ function TableCollection<T extends object>({
     [highlightRowId, isRowHighlighted],
   );
 
+  // Memoize the custom cell/row components. A fresh `components` object (with
+  // new inner function identities) makes antd treat them as new component types
+  // and remount every row and cell on each render — which would, for example,
+  // tear down an open hover popover inside a cell whenever the table re-renders
+  // (e.g. when rowClassName changes for row highlighting).
+  const tableComponents = useMemo(
+    () => ({
+      header: {
+        cell: (props: HTMLAttributes<HTMLTableCellElement>) => {
+          const isSelectionColumn =
+            props.className?.includes('ant-table-selection-column') ?? false;
+          return (
+            <th
+              {...props}
+              data-test={
+                isSelectionColumn ? 'header-toggle-all' : 'sort-header'
+              }
+            />
+          );
+        },
+      },
+      body: {
+        row: (props: HTMLAttributes<HTMLTableRowElement>) => (
+          <tr {...props} data-test="table-row" />
+        ),
+        cell: (props: HTMLAttributes<HTMLTableCellElement>) => (
+          <td {...props} data-test="table-row-cell" />
+        ),
+      },
+    }),
+    [],
+  );
+
   return (
     <StyledTable
       loading={loading}
@@ -328,30 +361,7 @@ function TableCollection<T extends object>({
         getRowClassName as unknown as TableProps<object>['rowClassName']
       }
       expandable={expandable}
-      components={{
-        header: {
-          cell: (props: HTMLAttributes<HTMLTableCellElement>) => {
-            const isSelectionColumn =
-              props.className?.includes('ant-table-selection-column') ?? false;
-            return (
-              <th
-                {...props}
-                data-test={
-                  isSelectionColumn ? 'header-toggle-all' : 'sort-header'
-                }
-              />
-            );
-          },
-        },
-        body: {
-          row: (props: HTMLAttributes<HTMLTableRowElement>) => (
-            <tr {...props} data-test="table-row" />
-          ),
-          cell: (props: HTMLAttributes<HTMLTableCellElement>) => (
-            <td {...props} data-test="table-row-cell" />
-          ),
-        },
-      }}
+      components={tableComponents}
       onChange={handleTableChange as unknown as TableProps<object>['onChange']}
     />
   );

--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -44,6 +44,10 @@ export interface TableCollectionProps<T extends object> {
   columns: ColumnInstance<T>[];
   loading: boolean;
   highlightRowId?: number;
+  // Optional predicate to highlight arbitrary rows (in addition to
+  // highlightRowId). Receives the mapped record (which spreads row.original), so
+  // callers can match on any field, e.g. by uuid.
+  isRowHighlighted?: (record: Record<string, unknown>) => boolean;
   columnsForWrapText?: string[];
   setSortBy?: (updater: SortingRule<T>[]) => void;
   bulkSelectEnabled?: boolean;
@@ -161,6 +165,7 @@ function TableCollection<T extends object>({
   rows,
   loading,
   highlightRowId,
+  isRowHighlighted,
   setSortBy,
   headerGroups,
   columnsForWrapText,
@@ -292,10 +297,11 @@ function TableCollection<T extends object>({
 
   const getRowClassName = useCallback(
     (record: Record<string, unknown>) =>
-      highlightRowId !== undefined && record?.id === highlightRowId
+      (highlightRowId !== undefined && record?.id === highlightRowId) ||
+      isRowHighlighted?.(record)
         ? 'table-row-highlighted'
         : '',
-    [highlightRowId],
+    [highlightRowId, isRowHighlighted],
   );
 
   return (

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -341,6 +341,8 @@ export interface ListViewProps<T extends object = any> {
   defaultViewMode?: ViewModeType;
   forceViewMode?: ViewModeType;
   highlightRowId?: number;
+  /** Highlight arbitrary rows by predicate on the mapped record (e.g. by uuid). */
+  isRowHighlighted?: (record: Record<string, unknown>) => boolean;
   showThumbnails?: boolean;
   emptyState?: EmptyStateProps;
   columnsForWrapText?: string[];
@@ -384,6 +386,7 @@ export function ListView<T extends object = any>({
   defaultViewMode = 'card',
   forceViewMode,
   highlightRowId,
+  isRowHighlighted,
   emptyState,
   columnsForWrapText,
   enableBulkTag = false,
@@ -658,6 +661,7 @@ export function ListView<T extends object = any>({
                   columns={columns}
                   loading={loading && rows.length > 0}
                   highlightRowId={highlightRowId}
+                  isRowHighlighted={isRowHighlighted}
                   columnsForWrapText={columnsForWrapText}
                   expandable={expandable}
                   bulkSelectEnabled={bulkSelectEnabled}

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.test.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.test.tsx
@@ -25,23 +25,39 @@ const dependencies = [
   { uuid: 'prereq-2', task_name: null, status: TaskStatus.InProgress },
 ];
 
-test('renders the chain-link trigger icon', () => {
+const dependents = [
+  {
+    uuid: 'dep-1',
+    task_name: 'Contribution Query',
+    status: TaskStatus.Pending,
+  },
+];
+
+test('renders the branching trigger icon', () => {
   render(<TaskDependenciesPopover dependencies={dependencies} />, {
     useRedux: true,
   });
-  expect(screen.getByRole('img', { name: 'link' })).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'partition' })).toBeInTheDocument();
 });
 
-test('lists prerequisite tasks in the popover on hover', async () => {
-  render(<TaskDependenciesPopover dependencies={dependencies} />, {
-    useRedux: true,
-  });
+test('lists upstream and downstream tasks in the popover on hover', async () => {
+  render(
+    <TaskDependenciesPopover
+      dependencies={dependencies}
+      dependents={dependents}
+    />,
+    { useRedux: true },
+  );
 
-  fireEvent.mouseEnter(screen.getByRole('img', { name: 'link' }));
+  fireEvent.mouseEnter(screen.getByRole('img', { name: 'partition' }));
 
-  // Named prerequisite shows its name; the unnamed one falls back to its uuid
+  // Upstream section: named prerequisite shows its name, the unnamed one its uuid
   expect(await screen.findByText('Totals Query')).toBeInTheDocument();
   expect(screen.getByText('prereq-2')).toBeInTheDocument();
+  expect(screen.getByText('Depends on')).toBeInTheDocument();
+  // Downstream section
+  expect(screen.getByText('Contribution Query')).toBeInTheDocument();
+  expect(screen.getByText('Required by')).toBeInTheDocument();
 });
 
 test('surfaces the waiting-on state in the popover title', async () => {
@@ -50,19 +66,19 @@ test('surfaces the waiting-on state in the popover title', async () => {
     { useRedux: true },
   );
 
-  fireEvent.mouseEnter(screen.getByRole('img', { name: 'link' }));
+  fireEvent.mouseEnter(screen.getByRole('img', { name: 'partition' }));
 
   expect(
     await screen.findByText('Waiting on 1 prerequisite task(s) to finish'),
   ).toBeInTheDocument();
 });
 
-test('uses the neutral "Depends on" title when not waiting', async () => {
+test('uses the neutral "Dependencies" title when not waiting', async () => {
   render(<TaskDependenciesPopover dependencies={dependencies} />, {
     useRedux: true,
   });
 
-  fireEvent.mouseEnter(screen.getByRole('img', { name: 'link' }));
+  fireEvent.mouseEnter(screen.getByRole('img', { name: 'partition' }));
 
-  expect(await screen.findByText('Depends on')).toBeInTheDocument();
+  expect(await screen.findByText('Dependencies')).toBeInTheDocument();
 });

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.test.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.test.tsx
@@ -34,7 +34,7 @@ const dependents = [
 ];
 
 test('renders the branching trigger icon', () => {
-  render(<TaskDependenciesPopover dependencies={dependencies} />, {
+  render(<TaskDependenciesPopover dependsOn={dependencies} />, {
     useRedux: true,
   });
   expect(screen.getByRole('img', { name: 'partition' })).toBeInTheDocument();
@@ -43,8 +43,8 @@ test('renders the branching trigger icon', () => {
 test('lists upstream and downstream tasks in the popover on hover', async () => {
   render(
     <TaskDependenciesPopover
-      dependencies={dependencies}
-      dependents={dependents}
+      dependsOn={dependencies}
+      requiredBy={dependents}
     />,
     { useRedux: true },
   );
@@ -61,10 +61,9 @@ test('lists upstream and downstream tasks in the popover on hover', async () => 
 });
 
 test('surfaces the waiting-on state in the popover title', async () => {
-  render(
-    <TaskDependenciesPopover dependencies={dependencies} waitingOn={1} />,
-    { useRedux: true },
-  );
+  render(<TaskDependenciesPopover dependsOn={dependencies} waitingOn={1} />, {
+    useRedux: true,
+  });
 
   fireEvent.mouseEnter(screen.getByRole('img', { name: 'partition' }));
 
@@ -74,7 +73,7 @@ test('surfaces the waiting-on state in the popover title', async () => {
 });
 
 test('uses the neutral "Dependencies" title when not waiting', async () => {
-  render(<TaskDependenciesPopover dependencies={dependencies} />, {
+  render(<TaskDependenciesPopover dependsOn={dependencies} />, {
     useRedux: true,
   });
 

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { useState } from 'react';
 import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import { Popover } from '@superset-ui/core/components';
@@ -93,10 +94,8 @@ interface TaskDependenciesPopoverProps {
   // Unmet prerequisites while this task is still pending (blocked). When > 0 the
   // icon turns warning-colored and the popover title reflects the wait.
   waitingOn?: number;
-  // Fired on hover enter/leave of the icon so the list can highlight the related
-  // rows that are currently visible. Driven from mouse events rather than the
-  // Popover's onOpenChange: setting state inside antd's own open callback can
-  // wedge the hover popover.
+  // Fired when the popover opens/closes so the list can highlight the related
+  // rows that are currently visible.
   onHoverChange?: (hovering: boolean) => void;
 }
 
@@ -106,6 +105,11 @@ export default function TaskDependenciesPopover({
   waitingOn = 0,
   onHoverChange,
 }: TaskDependenciesPopoverProps) {
+  // Control the open state locally (like the other Task List popovers): the
+  // parent list re-renders when hovering updates the row highlight, which would
+  // reset an *uncontrolled* popover's open state and stop it from showing.
+  const [open, setOpen] = useState(false);
+
   const content = (
     <DependenciesContainer>
       <DependencySection label={t('Depends on')} tasks={dependencies} />
@@ -123,12 +127,13 @@ export default function TaskDependenciesPopover({
       content={content}
       trigger="hover"
       placement="leftTop"
+      open={open}
+      onOpenChange={next => {
+        setOpen(next);
+        onHoverChange?.(next);
+      }}
     >
-      <DagIconWrapper
-        $waiting={waitingOn > 0}
-        onMouseEnter={() => onHoverChange?.(true)}
-        onMouseLeave={() => onHoverChange?.(false)}
-      >
+      <DagIconWrapper $waiting={waitingOn > 0}>
         <Icons.PartitionOutlined iconSize="l" />
       </DagIconWrapper>
     </Popover>

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
@@ -88,9 +88,9 @@ function DependencySection({
 
 interface TaskDependenciesPopoverProps {
   // Upstream prerequisites this task depends on.
-  dependencies: TaskDependency[];
+  dependsOn: TaskDependency[];
   // Downstream tasks that depend on this task.
-  dependents?: TaskDependency[];
+  requiredBy?: TaskDependency[];
   // Unmet prerequisites while this task is still pending (blocked). When > 0 the
   // icon turns warning-colored and the popover title reflects the wait.
   waitingOn?: number;
@@ -100,8 +100,8 @@ interface TaskDependenciesPopoverProps {
 }
 
 export default function TaskDependenciesPopover({
-  dependencies,
-  dependents = [],
+  dependsOn,
+  requiredBy = [],
   waitingOn = 0,
   onHoverChange,
 }: TaskDependenciesPopoverProps) {
@@ -112,8 +112,8 @@ export default function TaskDependenciesPopover({
 
   const content = (
     <DependenciesContainer>
-      <DependencySection label={t('Depends on')} tasks={dependencies} />
-      <DependencySection label={t('Required by')} tasks={dependents} />
+      <DependencySection label={t('Depends on')} tasks={dependsOn} />
+      <DependencySection label={t('Required by')} tasks={requiredBy} />
     </DependenciesContainer>
   );
 

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
@@ -60,15 +60,17 @@ interface TaskDependenciesPopoverProps {
   // Unmet prerequisites while this task is still pending (blocked). When > 0 the
   // chain icon turns warning-colored and the popover title reflects the wait.
   waitingOn?: number;
-  // Fired when the popover opens/closes on hover, so the list can highlight the
-  // prerequisite rows that are currently visible.
-  onOpenChange?: (open: boolean) => void;
+  // Fired on hover enter/leave of the chain icon so the list can highlight the
+  // prerequisite rows that are currently visible. Driven from mouse events
+  // rather than the Popover's onOpenChange: setting state inside antd's own
+  // open callback can wedge the hover popover.
+  onHoverChange?: (hovering: boolean) => void;
 }
 
 export default function TaskDependenciesPopover({
   dependencies,
   waitingOn = 0,
-  onOpenChange,
+  onHoverChange,
 }: TaskDependenciesPopoverProps) {
   const content = (
     <DependenciesContainer>
@@ -93,9 +95,12 @@ export default function TaskDependenciesPopover({
       content={content}
       trigger="hover"
       placement="leftTop"
-      onOpenChange={onOpenChange}
     >
-      <LinkIconWrapper $waiting={waitingOn > 0}>
+      <LinkIconWrapper
+        $waiting={waitingOn > 0}
+        onMouseEnter={() => onHoverChange?.(true)}
+        onMouseLeave={() => onHoverChange?.(false)}
+      >
         <Icons.LinkOutlined iconSize="l" />
       </LinkIconWrapper>
     </Popover>

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
@@ -31,6 +31,13 @@ const DependenciesContainer = styled.div`
   padding: ${({ theme }) => theme.sizeUnit}px 0;
 `;
 
+const SectionLabel = styled.div`
+  font-weight: ${({ theme }) => theme.fontWeightStrong};
+  color: ${({ theme }) => theme.colorTextSecondary};
+  padding: ${({ theme }) => theme.sizeUnit / 2}px
+    ${({ theme }) => theme.sizeUnit * 2}px;
+`;
+
 const DependencyRow = styled.div`
   display: flex;
   align-items: center;
@@ -45,7 +52,7 @@ const DependencyName = styled.span`
   white-space: nowrap;
 `;
 
-const LinkIconWrapper = styled.span<{ $waiting?: boolean }>`
+const DagIconWrapper = styled.span<{ $waiting?: boolean }>`
   cursor: pointer;
   color: ${({ theme, $waiting }) =>
     $waiting ? theme.colorWarningText : theme.colorIcon};
@@ -55,33 +62,54 @@ const LinkIconWrapper = styled.span<{ $waiting?: boolean }>`
   }
 `;
 
+function DependencySection({
+  label,
+  tasks,
+}: {
+  label: string;
+  tasks: TaskDependency[];
+}) {
+  if (!tasks.length) {
+    return null;
+  }
+  return (
+    <>
+      <SectionLabel>{label}</SectionLabel>
+      {tasks.map(task => (
+        <DependencyRow key={task.uuid}>
+          <TaskStatusIcon status={task.status} />
+          <DependencyName>{task.task_name || task.uuid}</DependencyName>
+        </DependencyRow>
+      ))}
+    </>
+  );
+}
+
 interface TaskDependenciesPopoverProps {
+  // Upstream prerequisites this task depends on.
   dependencies: TaskDependency[];
+  // Downstream tasks that depend on this task.
+  dependents?: TaskDependency[];
   // Unmet prerequisites while this task is still pending (blocked). When > 0 the
-  // chain icon turns warning-colored and the popover title reflects the wait.
+  // icon turns warning-colored and the popover title reflects the wait.
   waitingOn?: number;
-  // Fired on hover enter/leave of the chain icon so the list can highlight the
-  // prerequisite rows that are currently visible. Driven from mouse events
-  // rather than the Popover's onOpenChange: setting state inside antd's own
-  // open callback can wedge the hover popover.
+  // Fired on hover enter/leave of the icon so the list can highlight the related
+  // rows that are currently visible. Driven from mouse events rather than the
+  // Popover's onOpenChange: setting state inside antd's own open callback can
+  // wedge the hover popover.
   onHoverChange?: (hovering: boolean) => void;
 }
 
 export default function TaskDependenciesPopover({
   dependencies,
+  dependents = [],
   waitingOn = 0,
   onHoverChange,
 }: TaskDependenciesPopoverProps) {
   const content = (
     <DependenciesContainer>
-      {dependencies.map(dependency => (
-        <DependencyRow key={dependency.uuid}>
-          <TaskStatusIcon status={dependency.status} />
-          <DependencyName>
-            {dependency.task_name || dependency.uuid}
-          </DependencyName>
-        </DependencyRow>
-      ))}
+      <DependencySection label={t('Depends on')} tasks={dependencies} />
+      <DependencySection label={t('Required by')} tasks={dependents} />
     </DependenciesContainer>
   );
 
@@ -90,19 +118,19 @@ export default function TaskDependenciesPopover({
       title={
         waitingOn > 0
           ? t('Waiting on %s prerequisite task(s) to finish', waitingOn)
-          : t('Depends on')
+          : t('Dependencies')
       }
       content={content}
       trigger="hover"
       placement="leftTop"
     >
-      <LinkIconWrapper
+      <DagIconWrapper
         $waiting={waitingOn > 0}
         onMouseEnter={() => onHoverChange?.(true)}
         onMouseLeave={() => onHoverChange?.(false)}
       >
-        <Icons.LinkOutlined iconSize="l" />
-      </LinkIconWrapper>
+        <Icons.PartitionOutlined iconSize="l" />
+      </DagIconWrapper>
     </Popover>
   );
 }

--- a/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskDependenciesPopover.tsx
@@ -60,11 +60,15 @@ interface TaskDependenciesPopoverProps {
   // Unmet prerequisites while this task is still pending (blocked). When > 0 the
   // chain icon turns warning-colored and the popover title reflects the wait.
   waitingOn?: number;
+  // Fired when the popover opens/closes on hover, so the list can highlight the
+  // prerequisite rows that are currently visible.
+  onOpenChange?: (open: boolean) => void;
 }
 
 export default function TaskDependenciesPopover({
   dependencies,
   waitingOn = 0,
+  onOpenChange,
 }: TaskDependenciesPopoverProps) {
   const content = (
     <DependenciesContainer>
@@ -89,6 +93,7 @@ export default function TaskDependenciesPopover({
       content={content}
       trigger="hover"
       placement="leftTop"
+      onOpenChange={onOpenChange}
     >
       <LinkIconWrapper $waiting={waitingOn > 0}>
         <Icons.LinkOutlined iconSize="l" />

--- a/superset-frontend/src/features/tasks/types.ts
+++ b/superset-frontend/src/features/tasks/types.ts
@@ -109,7 +109,7 @@ export interface Task {
   // Prerequisite tasks this task depends on (all_success DAG semantics).
   depends_on?: TaskDependency[];
   // Downstream tasks that depend on this task (reverse of depends_on).
-  dependents?: TaskDependency[];
+  required_by?: TaskDependency[];
 }
 
 // Derived status helpers (frontend computes these from status and properties)

--- a/superset-frontend/src/features/tasks/types.ts
+++ b/superset-frontend/src/features/tasks/types.ts
@@ -108,6 +108,8 @@ export interface Task {
   subscribers: TaskSubscriber[];
   // Prerequisite tasks this task depends on (all_success DAG semantics).
   depends_on?: TaskDependency[];
+  // Downstream tasks that depend on this task (reverse of depends_on).
+  dependents?: TaskDependency[];
 }
 
 // Derived status helpers (frontend computes these from status and properties)

--- a/superset-frontend/src/pages/TaskList/TaskList.test.tsx
+++ b/superset-frontend/src/pages/TaskList/TaskList.test.tsx
@@ -333,15 +333,15 @@ test('displays empty state when no tasks', async () => {
   });
 });
 
-test('renders the dependency chain icon in Details for tasks with prerequisites', async () => {
+test('renders the dependency icon in Details for tasks with prerequisites', async () => {
   renderTaskList();
   await screen.findByText('Shared Bulk Task');
 
-  // Dependencies live behind the chain-link icon in the Details column (antd
-  // LinkOutlined -> role "img" name "link"), no longer a standalone column. The
-  // "waiting on N" state is folded into that icon's warning color + popover
-  // title — covered by TaskDependenciesPopover.test.tsx.
-  expect(screen.getByRole('img', { name: 'link' })).toBeInTheDocument();
+  // Dependencies live behind the branching icon in the Details column (antd
+  // PartitionOutlined -> role "img" name "partition"), no longer a standalone
+  // column. The "waiting on N" state is folded into that icon's warning color +
+  // popover title — covered by TaskDependenciesPopover.test.tsx.
+  expect(screen.getByRole('img', { name: 'partition' })).toBeInTheDocument();
 });
 
 test('surfaces the dedupe count in Details for a reused task', async () => {

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -445,13 +445,13 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
       {
         Cell: ({
           row: {
-            original: { payload, properties, status, depends_on, dependents },
+            original: { payload, properties, status, depends_on, required_by },
           },
         }: TaskCellProps) => {
           const hasPayload = payload && Object.keys(payload).length > 0;
           const hasStackTrace = !!properties?.stack_trace;
-          const hasDependencies = !!depends_on && depends_on.length > 0;
-          const hasDependents = !!dependents && dependents.length > 0;
+          const hasDependsOn = !!depends_on && depends_on.length > 0;
+          const hasRequiredBy = !!required_by && required_by.length > 0;
           const dedupeCount = properties?.dedupe_count ?? 0;
 
           // Show warning if timeout is set but no abort handler during execution
@@ -465,8 +465,8 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
             !hasPayload &&
             !hasStackTrace &&
             !hasTimeoutWithoutHandler &&
-            !hasDependencies &&
-            !hasDependents &&
+            !hasDependsOn &&
+            !hasRequiredBy &&
             !dedupeCount
           ) {
             return null;
@@ -475,7 +475,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
           // "Waiting on N" surfaces the block-and-wait gate: a PENDING task
           // parked until its unmet (non-SUCCESS) prerequisites finish. Folded
           // into the dependency icon (warning color + popover title).
-          const unmet = hasDependencies
+          const unmet = hasDependsOn
             ? depends_on.filter(dep => dep.status !== TaskStatus.Success).length
             : 0;
           const waitingOn =
@@ -504,16 +504,16 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
               {hasStackTrace && properties.stack_trace && (
                 <TaskStackTracePopover stackTrace={properties.stack_trace} />
               )}
-              {(hasDependencies || hasDependents) && (
+              {(hasDependsOn || hasRequiredBy) && (
                 <TaskDependenciesPopover
-                  dependencies={depends_on ?? []}
-                  dependents={dependents ?? []}
+                  dependsOn={depends_on ?? []}
+                  requiredBy={required_by ?? []}
                   waitingOn={waitingOn}
                   onHoverChange={hovering =>
                     setHighlightedDeps(
                       hovering
                         ? new Set(
-                            [...(depends_on ?? []), ...(dependents ?? [])].map(
+                            [...(depends_on ?? []), ...(required_by ?? [])].map(
                               dep => dep.uuid,
                             ),
                           )

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -145,6 +145,12 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
   const [cancelModalTask, setCancelModalTask] = useState<Task | null>(null);
   const [forceCancel, setForceCancel] = useState(false);
 
+  // UUIDs of the prerequisite tasks to highlight while a "Depends on" popover is
+  // open, so the user can spot which visible rows this task waits on.
+  const [highlightedDeps, setHighlightedDeps] = useState<Set<string>>(
+    () => new Set(),
+  );
+
   // Determine dialog message based on task context
   const getCancelDialogMessage = useCallback((task: Task) => {
     const isSharedTask = task.scope === TaskScope.Shared;
@@ -500,10 +506,15 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                 <TaskDependenciesPopover
                   dependencies={depends_on}
                   waitingOn={waitingOn}
+                  onOpenChange={open =>
+                    setHighlightedDeps(
+                      open
+                        ? new Set(depends_on.map(dep => dep.uuid))
+                        : new Set(),
+                    )
+                  }
                 />
               )}
-              {/* Explicit > 0, not a bare truthiness check: `{dedupeCount && …}`
-                  would render a literal 0 when the count is 0. */}
               {dedupeCount > 0 && (
                 <Tooltip
                   title={tn(
@@ -707,6 +718,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
         filters={filters}
         initialSort={initialSort}
         loading={loading}
+        isRowHighlighted={record => highlightedDeps.has(record.uuid as string)}
         pageSize={PAGE_SIZE}
         refreshData={refreshData}
         addDangerToast={addDangerToast}

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -445,12 +445,13 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
       {
         Cell: ({
           row: {
-            original: { payload, properties, status, depends_on },
+            original: { payload, properties, status, depends_on, dependents },
           },
         }: TaskCellProps) => {
           const hasPayload = payload && Object.keys(payload).length > 0;
           const hasStackTrace = !!properties?.stack_trace;
           const hasDependencies = !!depends_on && depends_on.length > 0;
+          const hasDependents = !!dependents && dependents.length > 0;
           const dedupeCount = properties?.dedupe_count ?? 0;
 
           // Show warning if timeout is set but no abort handler during execution
@@ -465,6 +466,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
             !hasStackTrace &&
             !hasTimeoutWithoutHandler &&
             !hasDependencies &&
+            !hasDependents &&
             !dedupeCount
           ) {
             return null;
@@ -472,7 +474,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
 
           // "Waiting on N" surfaces the block-and-wait gate: a PENDING task
           // parked until its unmet (non-SUCCESS) prerequisites finish. Folded
-          // into the dependency chain icon (warning color + popover title).
+          // into the dependency icon (warning color + popover title).
           const unmet = hasDependencies
             ? depends_on.filter(dep => dep.status !== TaskStatus.Success).length
             : 0;
@@ -502,14 +504,19 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
               {hasStackTrace && properties.stack_trace && (
                 <TaskStackTracePopover stackTrace={properties.stack_trace} />
               )}
-              {hasDependencies && (
+              {(hasDependencies || hasDependents) && (
                 <TaskDependenciesPopover
-                  dependencies={depends_on}
+                  dependencies={depends_on ?? []}
+                  dependents={dependents ?? []}
                   waitingOn={waitingOn}
                   onHoverChange={hovering =>
                     setHighlightedDeps(
                       hovering
-                        ? new Set(depends_on.map(dep => dep.uuid))
+                        ? new Set(
+                            [...(depends_on ?? []), ...(dependents ?? [])].map(
+                              dep => dep.uuid,
+                            ),
+                          )
                         : new Set(),
                     )
                   }

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -506,9 +506,9 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                 <TaskDependenciesPopover
                   dependencies={depends_on}
                   waitingOn={waitingOn}
-                  onOpenChange={open =>
+                  onHoverChange={hovering =>
                     setHighlightedDeps(
-                      open
+                      hovering
                         ? new Set(depends_on.map(dep => dep.uuid))
                         : new Set(),
                     )

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -459,7 +459,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
             !hasStackTrace &&
             !hasTimeoutWithoutHandler &&
             !hasDependencies &&
-            dedupeCount === 0
+            !dedupeCount
           ) {
             return null;
           }
@@ -502,6 +502,8 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                   waitingOn={waitingOn}
                 />
               )}
+              {/* Explicit > 0, not a bare truthiness check: `{dedupeCount && …}`
+                  would render a literal 0 when the count is 0. */}
               {dedupeCount > 0 && (
                 <Tooltip
                   title={tn(

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -23,7 +23,7 @@ import {
   SupersetClient,
 } from '@superset-ui/core';
 import { useTheme, css } from '@apache-superset/core/theme';
-import { t } from '@apache-superset/core/translation';
+import { t, tn } from '@apache-superset/core/translation';
 import { useMemo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -446,7 +446,6 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
           const hasStackTrace = !!properties?.stack_trace;
           const hasDependencies = !!depends_on && depends_on.length > 0;
           const dedupeCount = properties?.dedupe_count ?? 0;
-          const hasDedupe = dedupeCount > 0;
 
           // Show warning if timeout is set but no abort handler during execution
           // Only show for IN_PROGRESS (abort handler registers at runtime, not during PENDING)
@@ -460,7 +459,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
             !hasStackTrace &&
             !hasTimeoutWithoutHandler &&
             !hasDependencies &&
-            !hasDedupe
+            dedupeCount === 0
           ) {
             return null;
           }
@@ -503,19 +502,25 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
                   waitingOn={waitingOn}
                 />
               )}
-              {hasDedupe && (
+              {dedupeCount > 0 && (
                 <Tooltip
-                  title={t(
-                    'Deduplicated %s time(s): other submissions reused this ' +
-                      "task's result instead of running a new query.",
+                  title={tn(
+                    'Reused by 1 other submission',
+                    'Reused by %s other submissions',
+                    dedupeCount,
                     dedupeCount,
                   )}
                   placement="top"
                 >
-                  <Flex component="span" align="center" gap={theme.sizeUnit}>
-                    <Icons.PlusOutlined iconSize="l" />
-                    {dedupeCount}
-                  </Flex>
+                  {/* Wrap in a span: Tooltip needs a ref-able DOM node, and the
+                      Flex wrapper is a function component that does not forward
+                      refs (mirrors the warning Tooltip above). */}
+                  <span>
+                    <Flex component="span" align="center" gap={theme.sizeUnit}>
+                      <Icons.PlusOutlined iconSize="l" />
+                      {dedupeCount}
+                    </Flex>
+                  </span>
                 </Tooltip>
               )}
             </Flex>

--- a/superset/commands/tasks/cancel.py
+++ b/superset/commands/tasks/cancel.py
@@ -124,7 +124,7 @@ class CancelTaskCommand(BaseCommand):
         TaskManager.publish_entity_change(self._task_uuid)
         # A cancelled prerequisite fails its dependents' all-success gate, and its
         # status shows on their rows, so refresh those too.
-        TaskManager.publish_dependents_changed(self._task_uuid)
+        TaskManager.publish_required_by_changed(self._task_uuid)
 
         return result
 

--- a/superset/commands/tasks/cancel.py
+++ b/superset/commands/tasks/cancel.py
@@ -122,6 +122,9 @@ class CancelTaskCommand(BaseCommand):
         # Abort transitions (→ABORTING/ABORTED) don't go through
         # InternalStatusTransitionCommand, so they are emitted here instead.
         TaskManager.publish_entity_change(self._task_uuid)
+        # A cancelled prerequisite fails its dependents' all-success gate, and its
+        # status shows on their rows, so refresh those too.
+        TaskManager.publish_dependents_changed(self._task_uuid)
 
         return result
 

--- a/superset/commands/tasks/internal_update.py
+++ b/superset/commands/tasks/internal_update.py
@@ -190,6 +190,9 @@ class InternalStatusTransitionCommand(BaseCommand):
         updated = self._run_in_transaction()
         if updated:
             TaskManager.publish_entity_change(self._task_uuid)
+            # A prerequisite's status is shown on its dependents' rows, so refresh
+            # them too (no-op when this task has no dependents).
+            TaskManager.publish_dependents_changed(self._task_uuid)
         return updated
 
     @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))

--- a/superset/commands/tasks/internal_update.py
+++ b/superset/commands/tasks/internal_update.py
@@ -192,7 +192,7 @@ class InternalStatusTransitionCommand(BaseCommand):
             TaskManager.publish_entity_change(self._task_uuid)
             # A prerequisite's status is shown on its dependents' rows, so refresh
             # them too (no-op when this task has no dependents).
-            TaskManager.publish_dependents_changed(self._task_uuid)
+            TaskManager.publish_required_by_changed(self._task_uuid)
         return updated
 
     @transaction(on_error=partial(on_error, reraise=TaskUpdateFailedError))

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -14,17 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Reap GTF tasks abandoned by a dead worker or wedged in ABORTING."""
+"""Reap GTF tasks abandoned by a dead worker."""
 
 import logging
 from typing import cast
+from uuid import UUID
 
 from flask import current_app
 from superset_core.tasks.types import TaskProperties, TaskStatus
 
 from superset import db
 from superset.commands.base import BaseCommand
-from superset.daos.tasks import OrphanCandidate, TaskDAO
+from superset.daos.tasks import TaskDAO
 from superset.extensions import celery_app
 from superset.models.tasks import Task
 from superset.stats_logger import BaseStatsLogger
@@ -37,82 +38,65 @@ ORPHAN_ERROR_MESSAGE = "Task orphaned: worker heartbeat timed out"
 
 
 class ReapOrphanedTasksCommand(BaseCommand):
-    """Detect and clean up tasks abandoned by a dead or wedged worker.
+    """Recover tasks abandoned by a worker that stopped refreshing its heartbeat.
 
-    Run from the prune cron before row deletion. Candidates come from
-    ``TaskDAO.find_orphaned``:
+    Run from the prune cron before row deletion. For each orphan (an active task
+    whose liveness heartbeat has gone stale — see ``TaskDAO.find_orphaned``) the
+    command transitions the row to ``FAILURE`` and publishes completion so waiters
+    (sync joiners, DAG dependents, chart-data pollers) unblock, then revokes the
+    Celery job so a redelivered copy cannot run.
 
-    - **Orphans** (dead worker, stale heartbeat): revoke any lingering Celery
-      job, then force the row to FAILURE and publish completion so waiters
-      (sync joiners, DAG dependents, chart-data pollers) unblock — the worker is
-      gone and cannot finalize itself.
-    - **Wedged aborts** (live worker still ABORTING past the grace window): only
-      escalate with a forced revoke, letting the worker's own ``finally`` block
-      finalize the status once ``SoftTimeLimitExceeded`` is raised.
-
-    All Celery/DB operations are best-effort accelerators; the atomic
-    compare-and-swap transition is authoritative, so a worker that revives and
-    commits its own terminal status simply makes the reaper's CAS a no-op.
+    It acts only on tasks with no live worker; a task still being worked on keeps
+    a fresh heartbeat and is left entirely to its own cooperative abort/cleanup.
+    The status transition is an atomic compare-and-swap, so a worker that revives
+    and commits its own terminal status simply makes the reaper's update a no-op.
     """
 
     def run(self) -> int:
         stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
-        # A single threshold governs both "no heartbeat for this long → orphaned"
-        # and "ABORTING for this long despite a live heartbeat → escalate".
         timeout = current_app.config["GTF_ORPHAN_TASK_TIMEOUT"]
 
-        candidates = TaskDAO.find_orphaned(timeout, timeout)
+        uuids = TaskDAO.find_orphaned(timeout)
         reaped = 0
-        for candidate in candidates:
-            # Isolate each candidate: a transient DB error on one must neither
-            # abort the loop nor escape as a non-CommandException (which would
-            # skip the retention prune pass that runs after this command).
+        for task_uuid in uuids:
+            # Isolate each task: a transient DB error on one must neither abort the
+            # loop nor escape as a non-CommandException (which would skip the
+            # retention prune pass that runs after this command).
             try:
-                if self._process(candidate, stats_logger):
+                if self._reap(task_uuid, stats_logger):
                     reaped += 1
             except Exception:  # noqa: BLE001 pylint: disable=broad-except
                 db.session.rollback()  # pylint: disable=consider-using-transaction
                 stats_logger.incr("gtf.task.reap_error")
-                logger.exception("Failed to reap orphaned task %s", candidate.uuid)
-        if candidates:
+                logger.exception("Failed to reap orphaned task %s", task_uuid)
+        if uuids:
             logger.info(
-                "Orphan reaper processed %d task(s), reaped %d", len(candidates), reaped
+                "Orphan reaper processed %d task(s), reaped %d", len(uuids), reaped
             )
         return reaped
 
-    def _process(
-        self, candidate: OrphanCandidate, stats_logger: BaseStatsLogger
-    ) -> bool:
-        """Handle one candidate; return True if it was reaped to FAILURE."""
-        self._revoke(
-            parse_properties(candidate.properties).get("celery_task_id"), stats_logger
+    def _reap(self, task_uuid: UUID, stats_logger: BaseStatsLogger) -> bool:
+        """Recover one orphaned task; return True if it was transitioned to FAILURE."""
+        # Read the current properties so the FAILURE write preserves existing
+        # runtime state (celery_task_id, is_abortable, ...) rather than replacing
+        # the whole column with just the error fields.
+        properties = cast(
+            TaskProperties,
+            dict(
+                parse_properties(
+                    db.session.query(Task.properties)
+                    .filter(Task.uuid == task_uuid)
+                    .scalar()
+                )
+            ),
         )
+        self._revoke(properties.get("celery_task_id"), stats_logger)
 
-        if not candidate.is_orphan:
-            # Wedged abort: the live worker finalizes its own status once the
-            # forced revoke raises SoftTimeLimitExceeded in it.
-            stats_logger.incr("gtf.task.abort_escalated")
-            logger.warning(
-                "Escalated wedged abort for task %s via forced revoke", candidate.uuid
-            )
-            return False
-
-        # Re-read the latest properties right before the CAS rather than reusing
-        # the (possibly batch-stale) find_orphaned snapshot, so we don't clobber a
-        # runtime property (progress, is_abortable, ...) a worker wrote in between.
-        # The status CAS below is still the authority: for a genuine orphan the
-        # worker is dead and cannot race it.
-        latest = (
-            db.session.query(Task.properties)
-            .filter(Task.uuid == candidate.uuid)
-            .scalar()
-        )
-        properties = cast(TaskProperties, dict(parse_properties(latest)))
         properties["error_message"] = ORPHAN_ERROR_MESSAGE
         properties["exception_type"] = "OrphanedTaskError"
 
         if not TaskDAO.conditional_status_update(
-            candidate.uuid,
+            task_uuid,
             TaskStatus.FAILURE,
             expected_status=list(ACTIVE_STATES),
             properties=properties,
@@ -125,27 +109,27 @@ class ReapOrphanedTasksCommand(BaseCommand):
 
         from superset.tasks.manager import TaskManager
 
-        TaskManager.publish_completion(candidate.uuid, TaskStatus.FAILURE.value)
-        TaskManager.publish_entity_change(candidate.uuid)
+        TaskManager.publish_completion(task_uuid, TaskStatus.FAILURE.value)
+        TaskManager.publish_entity_change(task_uuid)
         stats_logger.incr("gtf.task.orphan_reaped")
-        logger.warning(
-            "Reaped orphaned task %s (worker heartbeat stale)", candidate.uuid
-        )
+        logger.warning("Reaped orphaned task %s (worker heartbeat stale)", task_uuid)
         return True
 
     def _revoke(
         self, celery_task_id: str | None, stats_logger: BaseStatsLogger
     ) -> None:
-        """Forcibly revoke a Celery job (SIGUSR1 → SoftTimeLimitExceeded).
+        """Revoke the orphan's Celery job so a redelivered copy will not run.
 
-        ``terminate=True`` signals the worker child running the task so it raises
-        and reclaims the slot; for a not-yet-started job it prevents execution.
-        Best-effort — the DB transition is the source of truth.
+        Deliberately not ``terminate=True``: a stale heartbeat means the worker is
+        gone (nothing to signal), and force-terminating would risk killing a
+        healthy task on a false-positive detection. This only marks the job id
+        revoked, which matters when ``task_acks_late`` is enabled and the broker
+        redelivers. Best-effort; the DB transition is authoritative.
         """
         if not celery_task_id:
             return
         try:
-            celery_app.control.revoke(celery_task_id, terminate=True, signal="SIGUSR1")
+            celery_app.control.revoke(celery_task_id)
             stats_logger.incr("gtf.task.revoke")
         except Exception:  # noqa: BLE001 pylint: disable=broad-except
             stats_logger.incr("gtf.task.revoke_failure")

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Reap GTF tasks abandoned by a dead worker or wedged in ABORTING."""
+
+import logging
+from typing import cast
+
+from flask import current_app
+from superset_core.tasks.types import TaskProperties, TaskStatus
+
+from superset import db
+from superset.commands.base import BaseCommand
+from superset.daos.tasks import OrphanCandidate, TaskDAO
+from superset.extensions import celery_app
+from superset.stats_logger import BaseStatsLogger
+from superset.tasks.constants import ACTIVE_STATES
+from superset.tasks.utils import parse_properties
+
+logger = logging.getLogger(__name__)
+
+ORPHAN_ERROR_MESSAGE = "Task orphaned: worker heartbeat timed out"
+
+
+class ReapOrphanedTasksCommand(BaseCommand):
+    """Detect and clean up tasks abandoned by a dead or wedged worker.
+
+    Run from the prune cron before row deletion. Candidates come from
+    ``TaskDAO.find_orphaned``:
+
+    - **Orphans** (dead worker, stale heartbeat): revoke any lingering Celery
+      job, then force the row to FAILURE and publish completion so waiters
+      (sync joiners, DAG dependents, chart-data pollers) unblock — the worker is
+      gone and cannot finalize itself.
+    - **Wedged aborts** (live worker still ABORTING past the grace window): only
+      escalate with a forced revoke, letting the worker's own ``finally`` block
+      finalize the status once ``SoftTimeLimitExceeded`` is raised.
+
+    All Celery/DB operations are best-effort accelerators; the atomic
+    compare-and-swap transition is authoritative, so a worker that revives and
+    commits its own terminal status simply makes the reaper's CAS a no-op.
+    """
+
+    def run(self) -> int:
+        stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
+        # A single threshold governs both "no heartbeat for this long → orphaned"
+        # and "ABORTING for this long despite a live heartbeat → escalate".
+        timeout = current_app.config["GTF_ORPHAN_TASK_TIMEOUT"]
+
+        candidates = TaskDAO.find_orphaned(timeout, timeout)
+        reaped = sum(self._process(candidate, stats_logger) for candidate in candidates)
+        if candidates:
+            logger.info(
+                "Orphan reaper processed %d task(s), reaped %d", len(candidates), reaped
+            )
+        return reaped
+
+    def _process(
+        self, candidate: OrphanCandidate, stats_logger: BaseStatsLogger
+    ) -> bool:
+        """Handle one candidate; return True if it was reaped to FAILURE."""
+        # Preserve existing runtime state (is_abortable, timeout, celery_task_id,
+        # ...); conditional_status_update replaces the whole properties column.
+        properties = cast(TaskProperties, dict(parse_properties(candidate.properties)))
+        self._revoke(properties.get("celery_task_id"), stats_logger)
+
+        if not candidate.is_orphan:
+            # Wedged abort: the live worker finalizes its own status once the
+            # forced revoke raises SoftTimeLimitExceeded in it.
+            stats_logger.incr("gtf.task.abort_escalated")
+            logger.warning(
+                "Escalated wedged abort for task %s via forced revoke", candidate.uuid
+            )
+            return False
+
+        properties["error_message"] = ORPHAN_ERROR_MESSAGE
+        properties["exception_type"] = "OrphanedTaskError"
+
+        if not TaskDAO.conditional_status_update(
+            candidate.uuid,
+            TaskStatus.FAILURE,
+            expected_status=list(ACTIVE_STATES),
+            properties=properties,
+            set_ended_at=True,
+        ):
+            # The worker revived and committed a terminal status first.
+            return False
+
+        db.session.commit()
+
+        from superset.tasks.manager import TaskManager
+
+        TaskManager.publish_completion(candidate.uuid, TaskStatus.FAILURE.value)
+        TaskManager.publish_entity_change(candidate.uuid)
+        stats_logger.incr("gtf.task.orphan_reaped")
+        logger.warning(
+            "Reaped orphaned task %s (worker heartbeat stale)", candidate.uuid
+        )
+        return True
+
+    def _revoke(
+        self, celery_task_id: str | None, stats_logger: BaseStatsLogger
+    ) -> None:
+        """Forcibly revoke a Celery job (SIGUSR1 → SoftTimeLimitExceeded).
+
+        ``terminate=True`` signals the worker child running the task so it raises
+        and reclaims the slot; for a not-yet-started job it prevents execution.
+        Best-effort — the DB transition is the source of truth.
+        """
+        if not celery_task_id:
+            return
+        try:
+            celery_app.control.revoke(celery_task_id, terminate=True, signal="SIGUSR1")
+            stats_logger.incr("gtf.task.revoke")
+        except Exception:  # noqa: BLE001 pylint: disable=broad-except
+            stats_logger.incr("gtf.task.revoke_failure")
+            logger.warning(
+                "Failed to revoke Celery task %s", celery_task_id, exc_info=True
+            )
+
+    def validate(self) -> None:
+        pass

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -113,7 +113,7 @@ class ReapOrphanedTasksCommand(BaseCommand):
         TaskManager.publish_entity_change(task_uuid)
         # A reaped prerequisite fails its dependents' all-success gate, and its
         # status shows on their rows, so refresh those too.
-        TaskManager.publish_dependents_changed(task_uuid)
+        TaskManager.publish_required_by_changed(task_uuid)
         stats_logger.incr("gtf.task.orphan_reaped")
         logger.warning("Reaped orphaned task %s (worker heartbeat stale)", task_uuid)
         return True

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -111,6 +111,9 @@ class ReapOrphanedTasksCommand(BaseCommand):
 
         TaskManager.publish_completion(task_uuid, TaskStatus.FAILURE.value)
         TaskManager.publish_entity_change(task_uuid)
+        # A reaped prerequisite fails its dependents' all-success gate, and its
+        # status shows on their rows, so refresh those too.
+        TaskManager.publish_dependents_changed(task_uuid)
         stats_logger.incr("gtf.task.orphan_reaped")
         logger.warning("Reaped orphaned task %s (worker heartbeat stale)", task_uuid)
         return True

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -26,6 +26,7 @@ from superset import db
 from superset.commands.base import BaseCommand
 from superset.daos.tasks import OrphanCandidate, TaskDAO
 from superset.extensions import celery_app
+from superset.models.tasks import Task
 from superset.stats_logger import BaseStatsLogger
 from superset.tasks.constants import ACTIVE_STATES
 from superset.tasks.utils import parse_properties
@@ -61,7 +62,18 @@ class ReapOrphanedTasksCommand(BaseCommand):
         timeout = current_app.config["GTF_ORPHAN_TASK_TIMEOUT"]
 
         candidates = TaskDAO.find_orphaned(timeout, timeout)
-        reaped = sum(self._process(candidate, stats_logger) for candidate in candidates)
+        reaped = 0
+        for candidate in candidates:
+            # Isolate each candidate: a transient DB error on one must neither
+            # abort the loop nor escape as a non-CommandException (which would
+            # skip the retention prune pass that runs after this command).
+            try:
+                if self._process(candidate, stats_logger):
+                    reaped += 1
+            except Exception:  # noqa: BLE001 pylint: disable=broad-except
+                db.session.rollback()  # pylint: disable=consider-using-transaction
+                stats_logger.incr("gtf.task.reap_error")
+                logger.exception("Failed to reap orphaned task %s", candidate.uuid)
         if candidates:
             logger.info(
                 "Orphan reaper processed %d task(s), reaped %d", len(candidates), reaped
@@ -72,10 +84,9 @@ class ReapOrphanedTasksCommand(BaseCommand):
         self, candidate: OrphanCandidate, stats_logger: BaseStatsLogger
     ) -> bool:
         """Handle one candidate; return True if it was reaped to FAILURE."""
-        # Preserve existing runtime state (is_abortable, timeout, celery_task_id,
-        # ...); conditional_status_update replaces the whole properties column.
-        properties = cast(TaskProperties, dict(parse_properties(candidate.properties)))
-        self._revoke(properties.get("celery_task_id"), stats_logger)
+        self._revoke(
+            parse_properties(candidate.properties).get("celery_task_id"), stats_logger
+        )
 
         if not candidate.is_orphan:
             # Wedged abort: the live worker finalizes its own status once the
@@ -86,6 +97,17 @@ class ReapOrphanedTasksCommand(BaseCommand):
             )
             return False
 
+        # Re-read the latest properties right before the CAS rather than reusing
+        # the (possibly batch-stale) find_orphaned snapshot, so we don't clobber a
+        # runtime property (progress, is_abortable, ...) a worker wrote in between.
+        # The status CAS below is still the authority: for a genuine orphan the
+        # worker is dead and cannot race it.
+        latest = (
+            db.session.query(Task.properties)
+            .filter(Task.uuid == candidate.uuid)
+            .scalar()
+        )
+        properties = cast(TaskProperties, dict(parse_properties(latest)))
         properties["error_message"] = ORPHAN_ERROR_MESSAGE
         properties["exception_type"] = "OrphanedTaskError"
 
@@ -99,7 +121,7 @@ class ReapOrphanedTasksCommand(BaseCommand):
             # The worker revived and committed a terminal status first.
             return False
 
-        db.session.commit()
+        db.session.commit()  # pylint: disable=consider-using-transaction
 
         from superset.tasks.manager import TaskManager
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -3249,12 +3249,13 @@ TASK_PROGRESS_UPDATE_THROTTLE_INTERVAL = 2  # seconds
 # GTF worker-liveness heartbeat. While a worker holds a task it bumps
 # tasks.last_heartbeat every GTF_TASK_HEARTBEAT_INTERVAL seconds. The prune cron
 # (prune_tasks) reaps any ACTIVE task whose heartbeat is older than
-# GTF_ORPHAN_TASK_TIMEOUT — a worker that died mid-execution — by revoking its
-# Celery job and marking it FAILURE. The same threshold escalates a task stuck
-# in ABORTING (live worker ignoring a cooperative abort) with a forced revoke.
-# Keep the timeout comfortably larger than the interval (>= ~3x) so a brief GC
-# pause or stall does not look like a dead worker. Reaping only runs when the
-# prune_tasks beat schedule is enabled (see CELERY_CONFIG.beat_schedule).
+# GTF_ORPHAN_TASK_TIMEOUT — a worker that died mid-execution — by marking it
+# FAILURE (releasing waiters) and revoking its Celery job. A task still being
+# worked on keeps a fresh heartbeat and is left to its own cooperative abort, so
+# reaping never interferes with a live worker. Keep the timeout comfortably
+# larger than the interval (>= ~3x) so a brief GC pause or CPU-bound stretch does
+# not look like a dead worker. Reaping only runs when the prune_tasks beat
+# schedule is enabled (see CELERY_CONFIG.beat_schedule).
 GTF_TASK_HEARTBEAT_INTERVAL = 15  # seconds
 GTF_ORPHAN_TASK_TIMEOUT = 60  # seconds
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1844,10 +1844,13 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         #     "schedule": crontab(minute="*", hour="*"),
         #     "kwargs": {"retention_period_days": 180, "max_rows_per_run": 10000},
         # },
-        # Uncomment to enable pruning of the tasks table
+        # Uncomment to enable pruning of the tasks table. This job also reaps
+        # orphaned GTF tasks (abandoned by a dead worker) before deleting old
+        # rows, so run it on a short interval — reaping latency tracks this
+        # cadence, and an abandoned warehouse query keeps running until reaped.
         # "prune_tasks": {
         #     "task": "prune_tasks",
-        #     "schedule": crontab(minute=0, hour=0),
+        #     "schedule": crontab(minute="*", hour="*"),
         #     "kwargs": {"retention_period_days": 90, "max_rows_per_run": 10000},
         # },
         # Uncomment to enable pruning of expired entries from the key-value store
@@ -2944,6 +2947,15 @@ GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT = int(
 # ``/chart/data`` requests are unaffected even when GLOBAL_ASYNC_QUERIES is on.
 GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL = int(timedelta(minutes=5).total_seconds())
 
+# Timeout (seconds) for an async chart-data query task. When reached, the task is
+# aborted; on engines that support query cancellation the abort handler also
+# cancels the underlying warehouse query (over a fresh connection), so the task
+# ends promptly as TIMED_OUT. On engines without cancel support the query is not
+# interrupted (the task is freed once the query returns on its own). Default None
+# leaves async chart-data queries unbounded (matching prior behavior); set an int
+# to enforce a ceiling.
+GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT: int | None = None
+
 # Deployment default for whether the UI runs chart-data queries asynchronously when
 # GLOBAL_ASYNC_QUERIES is enabled. This is a FRONTEND-ONLY policy input: async is
 # opt-in per request via an ``async_mode`` flag on ``/chart/data`` (an absent flag is
@@ -3233,6 +3245,18 @@ TASK_ABORT_POLLING_DEFAULT_INTERVAL = 10
 # Minimum interval in seconds between database writes for task progress updates.
 # Set to 0 to disable throttling (write every update to DB).
 TASK_PROGRESS_UPDATE_THROTTLE_INTERVAL = 2  # seconds
+
+# GTF worker-liveness heartbeat. While a worker holds a task it bumps
+# tasks.last_heartbeat every GTF_TASK_HEARTBEAT_INTERVAL seconds. The prune cron
+# (prune_tasks) reaps any ACTIVE task whose heartbeat is older than
+# GTF_ORPHAN_TASK_TIMEOUT — a worker that died mid-execution — by revoking its
+# Celery job and marking it FAILURE. The same threshold escalates a task stuck
+# in ABORTING (live worker ignoring a cooperative abort) with a forced revoke.
+# Keep the timeout comfortably larger than the interval (>= ~3x) so a brief GC
+# pause or stall does not look like a dead worker. Reaping only runs when the
+# prune_tasks beat schedule is enabled (see CELERY_CONFIG.beat_schedule).
+GTF_TASK_HEARTBEAT_INTERVAL = 15  # seconds
+GTF_ORPHAN_TASK_TIMEOUT = 60  # seconds
 
 # ---------------------------------------------------
 # Distributed Coordination Configuration

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -636,6 +636,25 @@ class TaskDAO(BaseDAO[Task]):
         return [parse_payload(payload) for (payload,) in rows]
 
     @classmethod
+    def get_dependent_uuids(cls, task_uuid: UUID) -> list[UUID]:
+        """Return the UUIDs of the tasks that depend on ``task_uuid``.
+
+        The reverse of the dependency edge (indexed on ``depends_on_task_id``):
+        used to nudge dependents' realtime rows when a prerequisite's status
+        changes, since a dependent row displays its prerequisites' statuses.
+        """
+        prerequisite_id = (
+            db.session.query(Task.id).filter(Task.uuid == task_uuid).scalar_subquery()
+        )
+        rows = (
+            db.session.query(Task.uuid)
+            .join(TaskDependency, TaskDependency.task_id == Task.id)
+            .filter(TaskDependency.depends_on_task_id == prerequisite_id)
+            .all()
+        )
+        return [dependent_uuid for (dependent_uuid,) in rows]
+
+    @classmethod
     def set_properties_and_payload(
         cls,
         task_uuid: UUID,

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -177,13 +177,19 @@ class TaskDAO(BaseDAO[Task]):
         an idle/orphaned in-progress task is re-fetched forever.)
         """
         # Baseline: no cursor → start "from now", surfacing only later changes.
+        # Floor to whole seconds: changed_on is stored at the metastore column's
+        # precision (MySQL DATETIME truncates to seconds), so a sub-second cursor
+        # could sit *after* a same-second change and miss it under the >= bound.
+        # Flooring keeps >= inclusive on every backend; re-delivering an earlier
+        # same-second change is harmless (idempotent for the client).
         if cursor is None:
-            return {}, datetime.now()
+            return {}, datetime.now().replace(microsecond=0)
 
         # Watermark for the *next* poll, captured before the read so a change
         # landing during the query is caught next time (>= is inclusive), never
-        # skipped. Same naive-local clock as ``changed_on`` (FAB AuditMixin).
-        next_cursor = datetime.now()
+        # skipped. Same naive-local clock as ``changed_on`` (FAB AuditMixin),
+        # floored to whole seconds (see the baseline case above).
+        next_cursor = datetime.now().replace(microsecond=0)
         query = cls._apply_base_filter(db.session.query(Task)).filter(
             # Task.changed_on's type is shadowed by CoreTask's bare annotation
             # (datetime | None), so reference the real column for the comparison.

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Literal, NamedTuple, TypedDict
+from typing import Any, Literal, TypedDict
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -51,23 +51,6 @@ SubscriberPrincipalType = Literal["user", "guest"]
 class TaskSubscriberPrincipal(TypedDict):
     principal_type: SubscriberPrincipalType
     sub: str
-
-
-class OrphanCandidate(NamedTuple):
-    """A task the prune cron should reap or escalate.
-
-    ``is_orphan`` distinguishes the two cases the reaper handles differently:
-    ``True`` = a dead/orphaned worker (stale heartbeat) that must be fully reaped
-    (cancel its query, revoke, force the row terminal); ``False`` = a still-live
-    worker wedged in ABORTING past the grace window, which is only escalated with
-    a forced revoke so the worker's own ``finally`` block finalizes the status.
-    """
-
-    id: int
-    uuid: UUID
-    status: str
-    properties: str | None
-    is_orphan: bool
 
 
 class TaskDAO(BaseDAO[Task]):
@@ -139,42 +122,22 @@ class TaskDAO(BaseDAO[Task]):
         db.session.commit()  # pylint: disable=consider-using-transaction
 
     @classmethod
-    def find_orphaned(
-        cls,
-        orphan_timeout_seconds: int,
-        abort_grace_seconds: int,
-    ) -> list[OrphanCandidate]:
-        """Return active tasks the prune cron should reap or escalate.
+    def find_orphaned(cls, orphan_timeout_seconds: int) -> list[UUID]:
+        """Return UUIDs of active tasks abandoned by a dead worker.
 
-        Two disjoint sets, keyed off the worker liveness heartbeat:
-
-        - **Orphans** (``is_orphan=True``): any ACTIVE task
-          (PENDING/IN_PROGRESS/ABORTING) whose heartbeat has gone stale
-          (``last_heartbeat < now - orphan_timeout_seconds``) — no live worker is
-          holding it. A NULL heartbeat means no worker has picked the task up yet
-          (still legitimately queued), so it is excluded.
-        - **Wedged aborts** (``is_orphan=False``): a task still ABORTING with a
-          *fresh* heartbeat that entered ABORTING (``changed_on``) more than
-          ``abort_grace_seconds`` ago — a live worker not honoring the cooperative
-          abort, to be escalated with a forced Celery revoke. Requiring a fresh
-          heartbeat keeps this set disjoint from the orphan set.
+        An orphan is any active task (PENDING/IN_PROGRESS/ABORTING) whose liveness
+        heartbeat has gone stale (``last_heartbeat < now - orphan_timeout_seconds``)
+        — no worker is refreshing it. A NULL heartbeat means no worker has picked
+        the task up yet (still legitimately queued), so it is excluded. A task
+        still being worked on (fresh heartbeat) is never returned, so this never
+        interferes with a live worker's cooperative abort/cleanup.
 
         Skips the base filter: internal maintenance over all tasks, not a
         user-facing listing.
-
-        :returns: candidates to reap (dead worker) or escalate (wedged abort)
         """
-        now = naive_utcnow()
-        stale_before = now - timedelta(seconds=orphan_timeout_seconds)
-        # last_heartbeat / started_at / ended_at are stored as naive UTC, but
-        # FAB's changed_on is naive *local* (its onupdate is datetime.now). Use a
-        # matching local threshold for the changed_on comparison below.
-        abort_before = datetime.now() - timedelta(seconds=abort_grace_seconds)
-
-        columns = (Task.id, Task.uuid, Task.status, Task.properties)
-
-        orphan_rows = (
-            db.session.query(*columns)
+        stale_before = naive_utcnow() - timedelta(seconds=orphan_timeout_seconds)
+        rows = (
+            db.session.query(Task.uuid)
             .filter(
                 Task.status.in_(ACTIVE_STATES),
                 Task.last_heartbeat.isnot(None),
@@ -182,25 +145,7 @@ class TaskDAO(BaseDAO[Task]):
             )
             .all()
         )
-        wedged_rows = (
-            db.session.query(*columns)
-            .filter(
-                Task.status == TaskStatus.ABORTING.value,
-                Task.last_heartbeat.isnot(None),
-                Task.last_heartbeat >= stale_before,
-                # changed_on is shadowed by CoreTask's bare annotation; reference
-                # the real column so the comparison targets the timestamp.
-                Task.__table__.c.changed_on < abort_before,
-            )
-            .all()
-        )
-        return [
-            OrphanCandidate(id_, uuid, status, properties, is_orphan=True)
-            for id_, uuid, status, properties in orphan_rows
-        ] + [
-            OrphanCandidate(id_, uuid, status, properties, is_orphan=False)
-            for id_, uuid, status, properties in wedged_rows
-        ]
+        return [uuid for (uuid,) in rows]
 
     @classmethod
     def get_statuses_changed_since(

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -17,10 +17,11 @@
 """Task DAO for Global Task Framework (GTF)"""
 
 import logging
-from datetime import datetime
-from typing import Any, Literal, TypedDict
+from datetime import datetime, timedelta
+from typing import Any, Literal, NamedTuple, TypedDict
 from uuid import UUID
 
+import sqlalchemy as sa
 from sqlalchemy.sql.elements import ColumnElement
 from superset_core.tasks.types import TaskProperties, TaskScope, TaskStatus
 
@@ -30,7 +31,7 @@ from superset.extensions import db
 from superset.models.task_dependencies import TaskDependency
 from superset.models.task_subscribers import TaskSubscriber
 from superset.models.tasks import Task
-from superset.tasks.constants import ABORTABLE_STATES, TERMINAL_STATES
+from superset.tasks.constants import ABORTABLE_STATES, ACTIVE_STATES, TERMINAL_STATES
 from superset.tasks.filters import TaskFilter
 from superset.tasks.utils import (
     get_active_dedup_key,
@@ -50,6 +51,23 @@ SubscriberPrincipalType = Literal["user", "guest"]
 class TaskSubscriberPrincipal(TypedDict):
     principal_type: SubscriberPrincipalType
     sub: str
+
+
+class OrphanCandidate(NamedTuple):
+    """A task the prune cron should reap or escalate.
+
+    ``is_orphan`` distinguishes the two cases the reaper handles differently:
+    ``True`` = a dead/orphaned worker (stale heartbeat) that must be fully reaped
+    (cancel its query, revoke, force the row terminal); ``False`` = a still-live
+    worker wedged in ABORTING past the grace window, which is only escalated with
+    a forced revoke so the worker's own ``finally`` block finalizes the status.
+    """
+
+    id: int
+    uuid: UUID
+    status: str
+    properties: str | None
+    is_orphan: bool
 
 
 class TaskDAO(BaseDAO[Task]):
@@ -98,6 +116,91 @@ class TaskDAO(BaseDAO[Task]):
         owns, not a user-facing lookup.
         """
         return db.session.query(Task.id).filter(Task.uuid == task_uuid).scalar()
+
+    @classmethod
+    def touch_heartbeat(cls, task_id: int) -> None:
+        """Bump a task's ``last_heartbeat`` to now without touching ``changed_on``.
+
+        Called on an interval by the executing worker's heartbeat thread so the
+        prune cron can tell a live task from an orphaned one. Uses a raw textual
+        UPDATE on the single column: ``changed_on`` carries a client-side
+        ``onupdate`` default that ORM/Core updates would fire, and any bump to
+        ``changed_on`` would resurface the task in ``get_statuses_changed_since``
+        every heartbeat (resetting client polling backoff). A textual statement
+        bypasses that default processing entirely. Bound by integer ``id`` to
+        sidestep ``UUIDType`` dialect handling.
+        """
+        db.session.execute(
+            sa.text("UPDATE tasks SET last_heartbeat = :ts WHERE id = :id"),
+            {"ts": naive_utcnow(), "id": task_id},
+        )
+        # Deliberate standalone commit: this is a single out-of-band column write,
+        # not a unit of work, and must not be wrapped in the ORM transaction flow.
+        db.session.commit()  # pylint: disable=consider-using-transaction
+
+    @classmethod
+    def find_orphaned(
+        cls,
+        orphan_timeout_seconds: int,
+        abort_grace_seconds: int,
+    ) -> list[OrphanCandidate]:
+        """Return active tasks the prune cron should reap or escalate.
+
+        Two disjoint sets, keyed off the worker liveness heartbeat:
+
+        - **Orphans** (``is_orphan=True``): any ACTIVE task
+          (PENDING/IN_PROGRESS/ABORTING) whose heartbeat has gone stale
+          (``last_heartbeat < now - orphan_timeout_seconds``) — no live worker is
+          holding it. A NULL heartbeat means no worker has picked the task up yet
+          (still legitimately queued), so it is excluded.
+        - **Wedged aborts** (``is_orphan=False``): a task still ABORTING with a
+          *fresh* heartbeat that entered ABORTING (``changed_on``) more than
+          ``abort_grace_seconds`` ago — a live worker not honoring the cooperative
+          abort, to be escalated with a forced Celery revoke. Requiring a fresh
+          heartbeat keeps this set disjoint from the orphan set.
+
+        Skips the base filter: internal maintenance over all tasks, not a
+        user-facing listing.
+
+        :returns: candidates to reap (dead worker) or escalate (wedged abort)
+        """
+        now = naive_utcnow()
+        stale_before = now - timedelta(seconds=orphan_timeout_seconds)
+        # last_heartbeat / started_at / ended_at are stored as naive UTC, but
+        # FAB's changed_on is naive *local* (its onupdate is datetime.now). Use a
+        # matching local threshold for the changed_on comparison below.
+        abort_before = datetime.now() - timedelta(seconds=abort_grace_seconds)
+
+        columns = (Task.id, Task.uuid, Task.status, Task.properties)
+
+        orphan_rows = (
+            db.session.query(*columns)
+            .filter(
+                Task.status.in_(ACTIVE_STATES),
+                Task.last_heartbeat.isnot(None),
+                Task.last_heartbeat < stale_before,
+            )
+            .all()
+        )
+        wedged_rows = (
+            db.session.query(*columns)
+            .filter(
+                Task.status == TaskStatus.ABORTING.value,
+                Task.last_heartbeat.isnot(None),
+                Task.last_heartbeat >= stale_before,
+                # changed_on is shadowed by CoreTask's bare annotation; reference
+                # the real column so the comparison targets the timestamp.
+                Task.__table__.c.changed_on < abort_before,
+            )
+            .all()
+        )
+        return [
+            OrphanCandidate(id_, uuid, status, properties, is_orphan=True)
+            for id_, uuid, status, properties in orphan_rows
+        ] + [
+            OrphanCandidate(id_, uuid, status, properties, is_orphan=False)
+            for id_, uuid, status, properties in wedged_rows
+        ]
 
     @classmethod
     def get_statuses_changed_since(

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -636,12 +636,13 @@ class TaskDAO(BaseDAO[Task]):
         return [parse_payload(payload) for (payload,) in rows]
 
     @classmethod
-    def get_dependent_uuids(cls, task_uuid: UUID) -> list[UUID]:
+    def get_required_by_uuids(cls, task_uuid: UUID) -> list[UUID]:
         """Return the UUIDs of the tasks that depend on ``task_uuid``.
 
-        The reverse of the dependency edge (indexed on ``depends_on_task_id``):
-        used to nudge dependents' realtime rows when a prerequisite's status
-        changes, since a dependent row displays its prerequisites' statuses.
+        The reverse of the dependency edge (indexed on ``depends_on_task_id``) —
+        i.e. the task's ``required_by`` set. Used to nudge those tasks' realtime
+        rows when this task's status changes, since a dependent row displays its
+        prerequisites' statuses.
         """
         prerequisite_id = (
             db.session.query(Task.id).filter(Task.uuid == task_uuid).scalar_subquery()
@@ -652,7 +653,7 @@ class TaskDAO(BaseDAO[Task]):
             .filter(TaskDependency.depends_on_task_id == prerequisite_id)
             .all()
         )
-        return [dependent_uuid for (dependent_uuid,) in rows]
+        return [required_by_uuid for (required_by_uuid,) in rows]
 
     @classmethod
     def set_properties_and_payload(

--- a/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
+++ b/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
@@ -148,9 +148,22 @@ def upgrade():
             "uq_task_subscribers_task_guest", ["task_id", "guest_key"]
         )
 
+    # Liveness marker for orphan detection: the executing worker bumps
+    # ``tasks.last_heartbeat`` on a background thread, and the prune cron reaps
+    # ACTIVE tasks whose heartbeat has gone stale (a dead/orphaned worker). The
+    # index backs the reaper's ``last_heartbeat < now - timeout`` scan.
+    add_columns(
+        TASKS_TABLE,
+        Column("last_heartbeat", DateTime, nullable=True),
+    )
+    create_index(TASKS_TABLE, "ix_tasks_last_heartbeat", ["last_heartbeat"])
+
 
 def downgrade():
     """Drop task_dependencies and revert the task_subscribers.guest_key change."""
+    drop_index(TASKS_TABLE, "ix_tasks_last_heartbeat")
+    drop_columns(TASKS_TABLE, "last_heartbeat")
+
     # Guest subscriptions cannot be represented without the column; drop those
     # rows first so restoring user_id NOT NULL does not fail on NULL user_id.
     op.execute(sa.text("DELETE FROM task_subscribers WHERE user_id IS NULL"))

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -927,6 +927,13 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             rows = None
             description = None
 
+            # Give an active GTF chart-data task a chance to capture an engine
+            # cancel id off the live cursor before the (blocking) execute below,
+            # so a concurrent abort/timeout can kill the query. No-op otherwise.
+            from superset.tasks.query_cancel import notify_cursor
+
+            notify_cursor(cursor)
+
             for i, statement in enumerate(script.statements):
                 # For a single statement, execute the original SQL as-is. Re-rendering
                 # via statement.format() would round-trip through sqlglot

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -87,6 +87,13 @@ class Task(CoreTask, AuditMixinNullable, Model):
     started_at = Column(DateTime, nullable=True)
     ended_at = Column(DateTime, nullable=True)
 
+    # Liveness marker bumped by the executing worker's heartbeat thread while it
+    # holds the task. The prune cron reaps ACTIVE tasks whose heartbeat has gone
+    # stale (a dead/orphaned worker). Written out-of-band via a raw UPDATE (see
+    # TaskDAO.touch_heartbeat) so a heartbeat never advances changed_on and thus
+    # never resurfaces the task in the status-change poll.
+    last_heartbeat = Column(DateTime, nullable=True, index=True)
+
     # User context for execution
     user_id = Column(Integer, nullable=True)
 

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -120,14 +120,14 @@ class Task(CoreTask, AuditMixinNullable, Model):
         lazy="selectin",
     )
 
-    # Prerequisite tasks (self-referential many-to-many over task_dependencies).
-    # `dependencies` is the list of Task entities this task depends on, so the
-    # full prerequisite tasks load in a single selectin fetch alongside the task
-    # (no per-edge round trips). It is viewonly: edges are written through
-    # TaskDAO.add_dependency, not by mutating this collection. Cleanup on task
+    # Upstream prerequisite tasks (self-referential many-to-many over
+    # task_dependencies). `depends_on` is the list of Task entities this task
+    # depends on, loaded in a single selectin fetch alongside the task (no
+    # per-edge round trips). It is viewonly: edges are written through
+    # TaskDAO.add_dependencies, not by mutating this collection. Cleanup on task
     # deletion relies on the DB-level FK ON DELETE CASCADE (see the migration),
     # since TaskPruneCommand bulk-deletes via core DELETE, not the ORM.
-    dependencies = relationship(
+    depends_on = relationship(
         "Task",
         secondary=TaskDependency.__table__,
         primaryjoin=id == TaskDependency.task_id,
@@ -137,11 +137,11 @@ class Task(CoreTask, AuditMixinNullable, Model):
         viewonly=True,
     )
 
-    # Downstream tasks that depend on this task: the reverse of `dependencies`
+    # Downstream tasks that depend on this task: the reverse of `depends_on`
     # (same viewonly selectin pattern, joins swapped). Exposing both DAG
     # directions on the entity means callers read them directly rather than
     # issuing a separate reverse-edge query.
-    dependents = relationship(
+    required_by = relationship(
         "Task",
         secondary=TaskDependency.__table__,
         primaryjoin=id == TaskDependency.depends_on_task_id,

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -137,6 +137,20 @@ class Task(CoreTask, AuditMixinNullable, Model):
         viewonly=True,
     )
 
+    # Downstream tasks that depend on this task: the reverse of `dependencies`
+    # (same viewonly selectin pattern, joins swapped). Exposing both DAG
+    # directions on the entity means callers read them directly rather than
+    # issuing a separate reverse-edge query.
+    dependents = relationship(
+        "Task",
+        secondary=TaskDependency.__table__,
+        primaryjoin=id == TaskDependency.depends_on_task_id,
+        secondaryjoin=id == TaskDependency.task_id,
+        order_by=TaskDependency.id,
+        lazy="selectin",
+        viewonly=True,
+    )
+
     def __repr__(self) -> str:
         return f"<Task {self.task_type}:{self.task_key} [{self.status}]>"
 

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -17,10 +17,12 @@
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import Any, Iterator, TYPE_CHECKING
 from uuid import UUID
 
+from flask import current_app
 from flask_appbuilder.security.sqla.models import User
 from superset_core.tasks.types import TaskOptions, TaskScope
 
@@ -36,6 +38,7 @@ from superset.extensions import (
 )
 from superset.tasks.ambient_context import get_context
 from superset.tasks.decorators import task
+from superset.tasks.query_cancel import cancel_chart_query, capture_cancel_id
 from superset.utils.core import override_user
 
 if TYPE_CHECKING:
@@ -120,10 +123,47 @@ def _get_dependency_cache_key() -> str:
     raise SupersetException("Prerequisite task did not publish a cache key")
 
 
-# No timeout is set on these tasks yet: GTF enforces a timeout by aborting the
-# task, but chart-data queries have no abort handler to cancel the underlying
-# warehouse query, so a timeout would only mark the task failed while the query
-# kept running. Restore a timeout once query cancellation is implemented.
+@contextmanager
+def _capture_query_cancellation(query_context: "QueryContext") -> Iterator[None]:
+    """Enable engine-level cancellation of this task's warehouse query.
+
+    Captures the engine cancel id off the live cursor (for engines that expose
+    one before execution) and registers an abort handler that kills the backend
+    session over a fresh connection, unblocking the task's ``get_df``. Engines
+    without cancel support capture nothing and the task stays non-abortable, so
+    an abort/timeout simply frees the task without killing the (uncancellable)
+    query — matching the pre-cancellation behavior for those engines.
+    """
+    database = getattr(query_context.datasource, "database", None)
+    if database is None:
+        yield
+        return
+
+    ctx = get_context()
+    app = current_app._get_current_object()  # noqa: SLF001
+    captured = False
+
+    def _sink(cursor: Any) -> None:
+        nonlocal captured
+        if captured:
+            return
+        # query is unused by the explicit-id specs; the chart path has no Query.
+        cancel_id = database.db_engine_spec.get_cancel_query_id(cursor, None)
+        if cancel_id is None:
+            return
+        captured = True
+
+        # Registering the first abort handler marks the task abortable and starts
+        # the abort listener; on abort it cancels the query on a fresh connection.
+        def _cancel() -> None:
+            cancel_chart_query(database, cancel_id, app)
+
+        ctx.on_abort(_cancel)
+
+    with capture_cancel_id(_sink):
+        yield
+
+
 @task(name=CHART_QUERY_TASK, scope=TaskScope.SHARED)
 def execute_chart_query(
     serialized_query: SerializedQuery,
@@ -136,7 +176,8 @@ def execute_chart_query(
     The atomic async unit: reconstruct the one query (canonical serialization),
     optionally inject contribution totals from a prerequisite totals task, then run
     the existing per-query execution/caching path so a re-request reads the same
-    DATA-cache entry.
+    DATA-cache entry. The query runs under ``_capture_query_cancellation`` so an
+    abort/timeout can cancel it on engines that support query cancellation.
     """
     with override_user(_resolve_user(user_id, guest_token), force=False):
         query_context = load_serialized_query(serialized_query)
@@ -147,7 +188,8 @@ def execute_chart_query(
         if requires_totals:
             _inject_contribution_totals(query_obj, _get_dependency_cache_key())
         # Executes on cache miss and writes CacheRegion.DATA under query_cache_key.
-        result = query_context.get_df_payload_result(query_obj)
+        with _capture_query_cancellation(query_context):
+            result = query_context.get_df_payload_result(query_obj)
         if cache_key := result.payload.get(CACHE_KEY_PAYLOAD_KEY):
             # Write synchronously: a dependent contribution query reads this
             # cache key via get_dependency_payloads once the DAG gate releases,
@@ -253,6 +295,10 @@ def submit_chart_data_query_tasks(
                 task_key=query_cache_keys[index],
                 task_name=_task_name(index),
                 depends_on=depends_on,
+                # Abort the query after this many seconds; for cancellable
+                # engines the abort handler kills the warehouse query too.
+                # None (default) leaves it unbounded.
+                timeout=current_app.config.get("GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT"),
             ),
         )
 

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -38,7 +38,11 @@ from superset.extensions import (
 )
 from superset.tasks.ambient_context import get_context
 from superset.tasks.decorators import task
-from superset.tasks.query_cancel import cancel_chart_query, capture_cancel_id
+from superset.tasks.query_cancel import (
+    cancel_chart_query,
+    capture_cancel_id,
+    capture_cancel_query_id,
+)
 from superset.utils.core import override_user
 
 if TYPE_CHECKING:
@@ -147,8 +151,7 @@ def _capture_query_cancellation(query_context: "QueryContext") -> Iterator[None]
         nonlocal captured
         if captured:
             return
-        # query is unused by the explicit-id specs; the chart path has no Query.
-        cancel_id = database.db_engine_spec.get_cancel_query_id(cursor, None)
+        cancel_id = capture_cancel_query_id(database, cursor)
         if cancel_id is None:
             return
         captured = True

--- a/superset/tasks/heartbeat.py
+++ b/superset/tasks/heartbeat.py
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Worker liveness heartbeat for the Global Task Framework (GTF)."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Iterator, TYPE_CHECKING
+
+from superset.stats_logger import BaseStatsLogger
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def task_heartbeat(task_id: int, app: "Flask") -> Iterator[None]:
+    """Keep ``tasks.last_heartbeat`` fresh while a worker holds the task.
+
+    Stamps an initial heartbeat synchronously (so the task reads as "picked up
+    by a worker" immediately — a NULL heartbeat means still queued), then runs a
+    daemon thread that bumps it every ``GTF_TASK_HEARTBEAT_INTERVAL`` seconds
+    until the context exits. The prune cron uses this to tell a live task (fresh
+    heartbeat) from one abandoned by a dead worker (stale heartbeat).
+
+    Best-effort: a failed write is counted and logged, and the loop continues —
+    the reaper only acts after several missed intervals. The thread is a daemon
+    so it never blocks worker shutdown (matching the existing timeout/abort
+    threads) and relies on DB drivers releasing the GIL during query I/O, so a
+    task blocked in a long warehouse query still heartbeats and is not reaped.
+
+    :param task_id: integer primary key of the running task
+    :param app: Flask app for DB access from the background thread
+    """
+    interval: float = app.config["GTF_TASK_HEARTBEAT_INTERVAL"]
+    stats_logger: BaseStatsLogger = app.config.get("STATS_LOGGER", BaseStatsLogger())
+    stop = threading.Event()
+
+    def _write() -> None:
+        from superset.daos.tasks import TaskDAO
+
+        try:
+            TaskDAO.touch_heartbeat(task_id)
+            stats_logger.incr("gtf.task.heartbeat")
+        except Exception:  # noqa: BLE001 pylint: disable=broad-except
+            stats_logger.incr("gtf.task.heartbeat_failure")
+            logger.warning(
+                "Heartbeat write failed for task id=%s", task_id, exc_info=True
+            )
+
+    # Initial stamp runs in the worker's existing app context.
+    _write()
+
+    def _beat() -> None:
+        while not stop.wait(interval):
+            with app.app_context():
+                _write()
+
+    thread = threading.Thread(
+        target=_beat, name=f"gtf-heartbeat-{task_id}", daemon=True
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -148,14 +148,15 @@ class TaskManager:
             return False
 
     @classmethod
-    def publish_dependents_changed(cls, task_uuid: UUID) -> None:
+    def publish_required_by_changed(cls, task_uuid: UUID) -> None:
         """Nudge the realtime rows of the tasks that depend on ``task_uuid``.
 
         A dependent's list row shows its prerequisites' statuses (the "depends on"
         detail and the "waiting on N" indicator), so a prerequisite's status
-        change must also refresh its dependents' rows — the prerequisite's own
-        entity-change nudge only refetches the prerequisite row. Best-effort:
-        no-op without a coordination backend or when the task has no dependents.
+        change must also refresh the rows of the tasks in its ``required_by`` set
+        — the prerequisite's own entity-change nudge only refetches its own row.
+        Best-effort: no-op without a coordination backend or when nothing depends
+        on the task.
         """
         from superset.coordination.base import CoordinationService
         from superset.daos.tasks import TaskDAO
@@ -163,11 +164,13 @@ class TaskManager:
         if not CoordinationService.is_backend_defined():
             return
         try:
-            for dependent_uuid in TaskDAO.get_dependent_uuids(task_uuid):
-                cls.publish_entity_change(dependent_uuid)
+            for required_by_uuid in TaskDAO.get_required_by_uuids(task_uuid):
+                cls.publish_entity_change(required_by_uuid)
         except Exception as ex:  # noqa: BLE001 pylint: disable=broad-except
             logger.warning(
-                "Failed to publish dependent changes for task %s: %s", task_uuid, ex
+                "Failed to publish required-by changes for task %s: %s",
+                task_uuid,
+                ex,
             )
 
     # Lossy Pub/Sub channel for task status fanout. Superset publishes one

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -147,6 +147,29 @@ class TaskManager:
             )
             return False
 
+    @classmethod
+    def publish_dependents_changed(cls, task_uuid: UUID) -> None:
+        """Nudge the realtime rows of the tasks that depend on ``task_uuid``.
+
+        A dependent's list row shows its prerequisites' statuses (the "depends on"
+        detail and the "waiting on N" indicator), so a prerequisite's status
+        change must also refresh its dependents' rows — the prerequisite's own
+        entity-change nudge only refetches the prerequisite row. Best-effort:
+        no-op without a coordination backend or when the task has no dependents.
+        """
+        from superset.coordination.base import CoordinationService
+        from superset.daos.tasks import TaskDAO
+
+        if not CoordinationService.is_backend_defined():
+            return
+        try:
+            for dependent_uuid in TaskDAO.get_dependent_uuids(task_uuid):
+                cls.publish_entity_change(dependent_uuid)
+        except Exception as ex:  # noqa: BLE001 pylint: disable=broad-except
+            logger.warning(
+                "Failed to publish dependent changes for task %s: %s", task_uuid, ex
+            )
+
     # Lossy Pub/Sub channel for task status fanout. Superset publishes one
     # message per status transition with the already-authorized subscriber
     # principals. The websocket server does the local fanout and strips

--- a/superset/tasks/query_cancel.py
+++ b/superset/tasks/query_cancel.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import logging
 from contextlib import closing, contextmanager
 from contextvars import ContextVar
-from typing import Any, Callable, Iterator, TYPE_CHECKING
+from typing import Any, Callable, cast, Iterator, TYPE_CHECKING
 
 from superset.stats_logger import BaseStatsLogger
 
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
     from superset.models.core import Database
+    from superset.models.sql_lab import Query
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,40 @@ logger = logging.getLogger(__name__)
 _cancel_id_sink: ContextVar["Callable[[Any], None] | None"] = ContextVar(
     "gtf_cancel_id_sink", default=None
 )
+
+
+class _CancellationQuery:
+    """Minimal stand-in for the SQL Lab ``Query`` the engine cancel contract expects.
+
+    ``db_engine_spec.get_cancel_query_id``/``cancel_query`` take a ``Query``; the
+    common explicit-id engines (Postgres, MySQL, Snowflake, Redshift) ignore it,
+    but some (e.g. Impala reads ``query.database``, Ocient reads ``query.id``) do
+    not. Chart-data tasks have no ``Query`` row, so this exposes just those
+    attributes: the database is real, ``id`` is ``None`` (so an engine that
+    cancels by query id declines gracefully via ``validate_cancel_query_id``
+    rather than raising), and the ``extra`` accessors are no-op scratch space.
+    """
+
+    def __init__(self, database: "Database") -> None:
+        self.id = None
+        self.database = database
+        self.extra: dict[str, Any] = {}
+
+    def set_extra_json_key(self, key: str, value: Any) -> None:
+        self.extra[key] = value
+
+
+def capture_cancel_query_id(database: "Database", cursor: Any) -> "str | None":
+    """Return an engine cancel id for a live cursor, or None if unsupported.
+
+    Only engines that expose a cancel id *before* execution return non-None here
+    (the seam is invoked before the blocking execute); others yield None and the
+    task simply stays non-cancellable.
+    """
+    # The stand-in duck-types the attributes the engine specs read; cast so the
+    # call type-checks against the Query the contract nominally expects.
+    stub = cast("Query", _CancellationQuery(database))
+    return database.db_engine_spec.get_cancel_query_id(cursor, stub)
 
 
 @contextmanager
@@ -103,13 +138,12 @@ def cancel_chart_query(
         "STATS_LOGGER", BaseStatsLogger()
     )
     spec = database.db_engine_spec
+    stub = cast("Query", _CancellationQuery(database))
     try:
         with database.get_sqla_engine() as engine:
             with closing(engine.raw_connection()) as conn:
                 with closing(conn.cursor()) as cursor:
-                    # query is unused by the explicit-id specs (they cancel by
-                    # the captured id alone); the chart path has no Query model.
-                    cancelled = spec.cancel_query(cursor, None, cancel_query_id)  # type: ignore[arg-type]
+                    cancelled = spec.cancel_query(cursor, stub, cancel_query_id)
         if cancelled:
             stats_logger.incr("gtf.query.cancel")
             logger.info(

--- a/superset/tasks/query_cancel.py
+++ b/superset/tasks/query_cancel.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Engine-level cancellation for GTF chart-data query tasks.
+
+The chart-data execution path (``Database.get_df``) has none of SQL Lab's
+cancel plumbing, so a GTF abort/timeout could only mark the task terminal while
+the warehouse query kept running. This module adds the missing seam:
+
+- ``capture_cancel_id`` registers a cursor sink for the duration of a task's
+  query; ``notify_cursor`` (called from ``get_df`` before the blocking execute)
+  hands the live cursor to that sink so the task can capture an engine cancel id
+  via ``db_engine_spec.get_cancel_query_id`` — the same contract SQL Lab uses.
+- ``cancel_chart_query`` kills the backend session over a *fresh* connection
+  (``db_engine_spec.cancel_query``), which unblocks the task's blocked ``get_df``.
+
+Only engines that return a cancel id before execution participate; others
+capture nothing and are simply not cancellable (the abort still frees the task).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import closing, contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, Iterator, TYPE_CHECKING
+
+from superset.stats_logger import BaseStatsLogger
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+    from superset.models.core import Database
+
+logger = logging.getLogger(__name__)
+
+# Set by a chart-data task for the span of its query. When present,
+# Database._execute_sql_with_mutation_and_logging hands the sink the live cursor
+# before the blocking execute so the task can capture an engine cancel id.
+# Absent (None) for every other get_df caller, so this is a no-op elsewhere.
+_cancel_id_sink: ContextVar["Callable[[Any], None] | None"] = ContextVar(
+    "gtf_cancel_id_sink", default=None
+)
+
+
+@contextmanager
+def capture_cancel_id(sink: "Callable[[Any], None]") -> Iterator[None]:
+    """Register a cursor sink for the duration of a chart-data query execution."""
+    token = _cancel_id_sink.set(sink)
+    try:
+        yield
+    finally:
+        _cancel_id_sink.reset(token)
+
+
+def notify_cursor(cursor: Any) -> None:
+    """Hand the live cursor to the active sink, if any.
+
+    Called from ``get_df`` before the query executes. Best-effort: a capture
+    failure must never break query execution — it only forfeits cancellability.
+    """
+    sink = _cancel_id_sink.get()
+    if sink is None:
+        return
+    try:
+        sink(cursor)
+    except Exception:  # noqa: BLE001 pylint: disable=broad-except
+        logger.warning("Cancel-id capture failed", exc_info=True)
+
+
+def cancel_chart_query(
+    database: "Database", cancel_query_id: str, app: "Flask | None" = None
+) -> bool:
+    """Cancel a running chart-data warehouse query over a fresh connection.
+
+    Runs ``db_engine_spec.cancel_query`` against a new connection to the same
+    database, terminating the backend session that the task's blocked ``get_df``
+    is waiting on. Invoked from the task's abort handler (on the abort-listener
+    thread), so it opens its own connection rather than touching the busy one.
+    Best-effort and fully logged; the task's terminal transition is authoritative.
+
+    :param database: the database the query is running against
+    :param cancel_query_id: engine cancel handle captured at query start
+    :param app: Flask app for config/DB access from the background thread
+    :returns: True if the engine reported the query cancelled
+    """
+    from flask import current_app
+
+    stats_logger: BaseStatsLogger = (app or current_app).config.get(
+        "STATS_LOGGER", BaseStatsLogger()
+    )
+    spec = database.db_engine_spec
+    try:
+        with database.get_sqla_engine() as engine:
+            with closing(engine.raw_connection()) as conn:
+                with closing(conn.cursor()) as cursor:
+                    # query is unused by the explicit-id specs (they cancel by
+                    # the captured id alone); the chart path has no Query model.
+                    cancelled = spec.cancel_query(cursor, None, cancel_query_id)  # type: ignore[arg-type]
+        if cancelled:
+            stats_logger.incr("gtf.query.cancel")
+            logger.info(
+                "Cancelled warehouse query on database %s (id=%s)",
+                database.id,
+                cancel_query_id,
+            )
+        else:
+            stats_logger.incr("gtf.query.cancel_failed")
+        return cancelled
+    except Exception:  # noqa: BLE001 pylint: disable=broad-except
+        stats_logger.incr("gtf.query.cancel_failed")
+        logger.warning(
+            "Failed to cancel warehouse query on database %s (id=%s)",
+            database.id,
+            cancel_query_id,
+            exc_info=True,
+        )
+        return False

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -298,7 +298,7 @@ def _resolve_failed_prerequisite(task: "TaskModel") -> "TaskModel | None":
     run only if *all* of its direct prerequisites ended in ``SUCCESS``, so a
     non-``None`` return means the dependent must fail.
 
-    ``task.dependencies`` is already ``selectin``-loaded (in one query) with the
+    ``task.depends_on`` is already ``selectin``-loaded (in one query) with the
     task, so a prerequisite that is *already* terminal in that snapshot is
     evaluated with **no extra database reads** — a terminal status never changes,
     so the snapshot is authoritative for it (the common case under Model A, where
@@ -309,11 +309,11 @@ def _resolve_failed_prerequisite(task: "TaskModel") -> "TaskModel | None":
     Transitive failure propagation is emergent — a dependent that fails here is
     itself non-SUCCESS, so its own dependents fail in turn.
 
-    :param task: The dependent task about to run (with ``dependencies`` loaded)
+    :param task: The dependent task about to run (with ``depends_on`` loaded)
     :returns: The first prerequisite that did not end in ``SUCCESS``, or ``None``
         if the task has no prerequisites or all of them succeeded
     """
-    prerequisites = list(task.dependencies)
+    prerequisites = list(task.depends_on)
     if not prerequisites:
         return None
 

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -35,9 +35,10 @@ from superset.commands.report.execute import AsyncExecuteReportScheduleCommand
 from superset.commands.report.log_prune import AsyncPruneReportScheduleLogCommand
 from superset.commands.sql_lab.query import QueryPruneCommand
 from superset.commands.tasks.prune import TaskPruneCommand
+from superset.commands.tasks.reap import ReapOrphanedTasksCommand
 from superset.daos.report import ReportScheduleDAO
 from superset.daos.tasks import TaskDAO
-from superset.extensions import celery_app
+from superset.extensions import celery_app, db
 from superset.key_value.commands.prune import KeyValuePruneCommand
 from superset.reports.models import ReportScheduleType
 from superset.stats_logger import BaseStatsLogger
@@ -45,6 +46,7 @@ from superset.tasks.ambient_context import use_context
 from superset.tasks.constants import ABORT_STATES, TERMINAL_STATES
 from superset.tasks.context import TaskContext
 from superset.tasks.cron_util import cron_schedule_window
+from superset.tasks.heartbeat import task_heartbeat
 from superset.tasks.manager import TaskManager
 from superset.tasks.registry import TaskRegistry
 from superset.utils.core import LoggerLevel
@@ -259,6 +261,13 @@ def prune_tasks(
             "retention period, please use `kwargs` instead."
         )
 
+    # Reap first: revoke + fail tasks abandoned by a dead/wedged worker so they
+    # reach a terminal state, then let the retention pass below delete old rows.
+    try:
+        ReapOrphanedTasksCommand().run()
+    except CommandException as ex:
+        logger.exception("An error occurred while reaping orphaned tasks: %s", ex)
+
     try:
         TaskPruneCommand(retention_period_days, max_rows_per_run).run()
     except CommandException as ex:
@@ -324,8 +333,25 @@ def _resolve_failed_prerequisite(task: "TaskModel") -> "TaskModel | None":
     return None
 
 
+def _persist_celery_task_id(task: "TaskModel", celery_task_id: str | None) -> None:
+    """Record the Celery job id on the task so the reaper can revoke it.
+
+    Mutates the in-memory task (so the ``TaskContext`` built later carries the id
+    through its property writes) and commits. Written once at pickup, before the
+    DAG gate and the status transition, so the reaper can revoke even a task
+    still waiting on prerequisites. The id is dropped on the terminal transition
+    along with the rest of ``properties``, which is fine — only ACTIVE tasks are
+    ever reaped.
+    """
+    if not celery_task_id:
+        return
+    task.update_properties({"celery_task_id": celery_task_id})
+    # One-shot write at pickup, outside the lifecycle transaction below.
+    db.session.commit()  # pylint: disable=consider-using-transaction
+
+
 @celery_app.task(name="tasks.execute", bind=True)
-def execute_task(  # noqa: C901
+def execute_task(
     self: Any,  # Celery task instance
     task_uuid: str,
     task_type: str,
@@ -335,17 +361,10 @@ def execute_task(  # noqa: C901
     """
     Generic task executor for GTF tasks.
 
-    This executor:
-    1. Checks if task was aborted before execution starts
-    2. Fetches task from metastore
-    3. Builds context (task + user) and sets ambient context via contextvars
-    4. Executes the task function (which accesses context via get_context())
-    5. Updates task status throughout lifecycle using atomic conditional updates
-    6. Runs cleanup handlers on task end (success/failure/abortion)
-    7. Resets context after execution
-
-    Uses atomic conditional status updates to prevent race conditions with
-    concurrent abort operations.
+    Loads the task, records the Celery job id, and runs the lifecycle body under
+    a liveness heartbeat that spans the whole time this worker holds the task
+    (DAG wait, IN_PROGRESS, ABORTING) so the prune cron can revoke and reap it if
+    this worker dies. See ``_execute_task_body`` for the lifecycle itself.
 
     :param task_uuid: UUID of the task to execute
     :param task_type: Type of the task (for registry lookup)
@@ -353,8 +372,6 @@ def execute_task(  # noqa: C901
     :param kwargs: Keyword arguments for the task function
     :returns: Dict with status and task_uuid
     """
-    from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
-
     # Convert string UUID to native UUID (Celery deserializes as string)
     native_uuid = UUID(task_uuid)
 
@@ -366,6 +383,37 @@ def execute_task(  # noqa: C901
     if not task:
         logger.error("Task %s not found in metastore", task_uuid)
         return {"status": "error", "message": "Task not found"}
+
+    _persist_celery_task_id(task, self.request.id)
+    app = current_app._get_current_object()  # noqa: SLF001
+    with task_heartbeat(task.id, app):
+        return _execute_task_body(task, native_uuid, task_type, args, kwargs)
+
+
+def _execute_task_body(  # noqa: C901
+    task: "TaskModel",
+    native_uuid: UUID,
+    task_type: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Run a claimed GTF task through its lifecycle.
+
+    This body:
+    1. Checks if task was aborted before execution starts
+    2. Builds context (task + user) and sets ambient context via contextvars
+    3. Executes the task function (which accesses context via get_context())
+    4. Updates task status throughout lifecycle using atomic conditional updates
+    5. Runs cleanup handlers on task end (success/failure/abortion)
+    6. Resets context after execution
+
+    Uses atomic conditional status updates to prevent race conditions with
+    concurrent abort operations.
+    """
+    from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
+
+    task_uuid = str(native_uuid)
 
     # AUTOMATIC PRE-EXECUTION CHECK: Don't execute if already aborted/aborting
     if task.status in ABORT_STATES:
@@ -509,26 +557,38 @@ def execute_task(  # noqa: C901
         # Mark execution as completed to prevent late abort handlers
         ctx.mark_execution_completed()
 
-        # Atomic transition to FAILURE (only if still IN_PROGRESS or ABORTING)
-        InternalStatusTransitionCommand(
-            task_uuid=native_uuid,
-            new_status=TaskStatus.FAILURE,
-            expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
-            properties={"error_message": str(ex)},
-            set_ended_at=True,
-        ).run()
+        # An abort/timeout that actually cancels the work (e.g. an abort handler
+        # killing the underlying warehouse query) surfaces here as an exception.
+        # That is a successful abort, not a failure: leave the task in ABORTING
+        # so the finally block finalizes it as ABORTED/TIMED_OUT. Only a genuine
+        # error (no abort in flight) transitions to FAILURE.
+        if ctx._abort_detected or ctx.timeout_triggered:  # noqa: SLF001
+            logger.info(
+                "Task %s (uuid=%s) raised while aborting; finalizing as aborted",
+                task_type,
+                task_uuid,
+            )
+        else:
+            # Atomic transition to FAILURE (only if still IN_PROGRESS or ABORTING)
+            InternalStatusTransitionCommand(
+                task_uuid=native_uuid,
+                new_status=TaskStatus.FAILURE,
+                expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
+                properties={"error_message": str(ex)},
+                set_ended_at=True,
+            ).run()
 
-        logger.error(
-            "Task %s (uuid=%s) failed with error: %s",
-            task_type,
-            task_uuid,
-            str(ex),
-            exc_info=True,
-        )
+            logger.error(
+                "Task %s (uuid=%s) failed with error: %s",
+                task_type,
+                task_uuid,
+                str(ex),
+                exc_info=True,
+            )
 
-        # Emit stats metric for failure
-        stats_logger = current_app.config["STATS_LOGGER"]
-        stats_logger.incr("gtf.task.failure")
+            # Emit stats metric for failure
+            stats_logger = current_app.config["STATS_LOGGER"]
+            stats_logger.incr("gtf.task.failure")
 
     finally:
         # ALWAYS run cleanup handlers (also stops timeout timer)

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -67,6 +67,9 @@ depends_on_description = (
     "Prerequisite tasks this task depends on. The task only runs once all of "
     "them reach a terminal SUCCESS (all_success semantics)."
 )
+dependents_description = (
+    "Downstream tasks that depend on this task (the reverse of depends_on)."
+)
 
 
 class UserSchema(Schema):
@@ -125,6 +128,9 @@ class TaskResponseSchema(Schema):
     )
     depends_on = Method(
         "get_depends_on", metadata={"description": depends_on_description}
+    )
+    dependents = Method(
+        "get_dependents", metadata={"description": dependents_description}
     )
 
     def get_payload_dict(self, obj: object) -> dict[str, object] | None:
@@ -212,6 +218,17 @@ class TaskResponseSchema(Schema):
                 "status": prerequisite.status,
             }
             for prerequisite in obj.dependencies  # type: ignore[attr-defined]
+        ]
+
+    def get_dependents(self, obj: object) -> list[dict[str, object]]:
+        """Get downstream tasks (uuid, name, status) for DAG display."""
+        return [
+            {
+                "uuid": str(dependent.uuid),
+                "task_name": dependent.task_name,
+                "status": dependent.status,
+            }
+            for dependent in obj.dependents  # type: ignore[attr-defined]
         ]
 
 

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -67,7 +67,7 @@ depends_on_description = (
     "Prerequisite tasks this task depends on. The task only runs once all of "
     "them reach a terminal SUCCESS (all_success semantics)."
 )
-dependents_description = (
+required_by_description = (
     "Downstream tasks that depend on this task (the reverse of depends_on)."
 )
 
@@ -129,8 +129,8 @@ class TaskResponseSchema(Schema):
     depends_on = Method(
         "get_depends_on", metadata={"description": depends_on_description}
     )
-    dependents = Method(
-        "get_dependents", metadata={"description": dependents_description}
+    required_by = Method(
+        "get_required_by", metadata={"description": required_by_description}
     )
 
     def get_payload_dict(self, obj: object) -> dict[str, object] | None:
@@ -217,10 +217,10 @@ class TaskResponseSchema(Schema):
                 "task_name": prerequisite.task_name,
                 "status": prerequisite.status,
             }
-            for prerequisite in obj.dependencies  # type: ignore[attr-defined]
+            for prerequisite in obj.depends_on  # type: ignore[attr-defined]
         ]
 
-    def get_dependents(self, obj: object) -> list[dict[str, object]]:
+    def get_required_by(self, obj: object) -> list[dict[str, object]]:
         """Get downstream tasks (uuid, name, status) for DAG display."""
         return [
             {
@@ -228,7 +228,7 @@ class TaskResponseSchema(Schema):
                 "task_name": dependent.task_name,
                 "status": dependent.status,
             }
-            for dependent in obj.dependents  # type: ignore[attr-defined]
+            for dependent in obj.required_by  # type: ignore[attr-defined]
         ]
 
 

--- a/tests/integration_tests/tasks/api_tests.py
+++ b/tests/integration_tests/tasks/api_tests.py
@@ -577,6 +577,7 @@ class TestTaskApi(SupersetTestCase):
                 "subscriber_count",
                 "subscribers",
                 "depends_on",
+                "dependents",
             ]
 
             for field in expected_fields:
@@ -588,6 +589,7 @@ class TestTaskApi(SupersetTestCase):
 
             # A task with no declared prerequisites serializes an empty depends_on
             assert result["depends_on"] == []
+            assert result["dependents"] == []
 
     def test_task_depends_on_serialization(self):
         """
@@ -623,6 +625,15 @@ class TestTaskApi(SupersetTestCase):
             assert dep["uuid"] == str(prerequisite.uuid)
             assert dep["task_name"] == "Prerequisite Task"
             assert dep["status"] == prerequisite.status
+
+            # The reverse edge: the prerequisite lists the dependent under
+            # `dependents`, so the DAG is available from both directions.
+            rv = self.client.get(f"{self.TASK_API_BASE}/{prerequisite.uuid}")
+            assert rv.status_code == 200
+            prereq_result = json.loads(rv.data.decode("utf-8"))["result"]
+            assert prereq_result["depends_on"] == []
+            assert len(prereq_result["dependents"]) == 1
+            assert prereq_result["dependents"][0]["uuid"] == str(dependent.uuid)
         finally:
             if dependent is not None:
                 db.session.delete(dependent)

--- a/tests/integration_tests/tasks/api_tests.py
+++ b/tests/integration_tests/tasks/api_tests.py
@@ -577,7 +577,7 @@ class TestTaskApi(SupersetTestCase):
                 "subscriber_count",
                 "subscribers",
                 "depends_on",
-                "dependents",
+                "required_by",
             ]
 
             for field in expected_fields:
@@ -589,7 +589,7 @@ class TestTaskApi(SupersetTestCase):
 
             # A task with no declared prerequisites serializes an empty depends_on
             assert result["depends_on"] == []
-            assert result["dependents"] == []
+            assert result["required_by"] == []
 
     def test_task_depends_on_serialization(self):
         """
@@ -627,13 +627,13 @@ class TestTaskApi(SupersetTestCase):
             assert dep["status"] == prerequisite.status
 
             # The reverse edge: the prerequisite lists the dependent under
-            # `dependents`, so the DAG is available from both directions.
+            # `required_by`, so the DAG is available from both directions.
             rv = self.client.get(f"{self.TASK_API_BASE}/{prerequisite.uuid}")
             assert rv.status_code == 200
             prereq_result = json.loads(rv.data.decode("utf-8"))["result"]
             assert prereq_result["depends_on"] == []
-            assert len(prereq_result["dependents"]) == 1
-            assert prereq_result["dependents"][0]["uuid"] == str(dependent.uuid)
+            assert len(prereq_result["required_by"]) == 1
+            assert prereq_result["required_by"][0]["uuid"] == str(dependent.uuid)
         finally:
             if dependent is not None:
                 db.session.delete(dependent)

--- a/tests/integration_tests/tasks/commands/test_reap.py
+++ b/tests/integration_tests/tasks/commands/test_reap.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain
+# a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import sqlalchemy as sa
+from superset_core.tasks.types import TaskScope, TaskStatus
+
+from superset import db
+from superset.commands.tasks.reap import ORPHAN_ERROR_MESSAGE, ReapOrphanedTasksCommand
+from superset.daos.tasks import TaskDAO
+from superset.models.tasks import Task
+from superset.tasks.utils import naive_utcnow
+
+
+def _make_task(admin, key, status, *, heartbeat_offset=None, celery_task_id=None):
+    """Create a task in a given state with an optional heartbeat age (seconds)."""
+    task = TaskDAO.create_task(
+        task_type="test_type",
+        task_key=key,
+        scope=TaskScope.PRIVATE,
+        user_id=admin.id,
+    )
+    task.created_by = admin
+    task.set_status(status)
+    if heartbeat_offset is not None:
+        task.last_heartbeat = naive_utcnow() - timedelta(seconds=heartbeat_offset)
+    if celery_task_id is not None:
+        task.update_properties({"celery_task_id": celery_task_id})
+    db.session.commit()
+    return task
+
+
+def _cleanup(*tasks):
+    for task in tasks:
+        existing = db.session.get(Task, task.id)
+        if existing:
+            db.session.delete(existing)
+    db.session.commit()
+
+
+def test_touch_heartbeat_does_not_advance_changed_on(
+    app_context, get_user, login_as
+) -> None:
+    """A heartbeat write must not bump changed_on (would reset polling backoff)."""
+    login_as("admin")
+    admin = get_user("admin")
+    task = _make_task(admin, "hb_task", TaskStatus.IN_PROGRESS)
+    original_changed_on = task.changed_on
+    try:
+        TaskDAO.touch_heartbeat(task.id)
+        db.session.refresh(task)
+        assert task.last_heartbeat is not None
+        assert task.changed_on == original_changed_on
+    finally:
+        _cleanup(task)
+
+
+def test_find_orphaned_selects_only_stale_active_tasks(
+    app_context, get_user, login_as
+) -> None:
+    """Orphans = ACTIVE tasks with a stale, non-null heartbeat; nothing else."""
+    login_as("admin")
+    admin = get_user("admin")
+
+    stale = _make_task(admin, "stale", TaskStatus.IN_PROGRESS, heartbeat_offset=600)
+    fresh = _make_task(admin, "fresh", TaskStatus.IN_PROGRESS, heartbeat_offset=0)
+    never_started = _make_task(admin, "queued", TaskStatus.PENDING)  # null heartbeat
+    finished = _make_task(admin, "done", TaskStatus.SUCCESS, heartbeat_offset=600)
+    try:
+        found = {c.uuid for c in TaskDAO.find_orphaned(60, 60)}
+        assert stale.uuid in found
+        assert fresh.uuid not in found
+        assert never_started.uuid not in found
+        assert finished.uuid not in found
+    finally:
+        _cleanup(stale, fresh, never_started, finished)
+
+
+def test_find_orphaned_selects_wedged_aborting_tasks(
+    app_context, get_user, login_as
+) -> None:
+    """Wedged aborts = ABORTING + fresh heartbeat + old changed_on (live worker)."""
+    login_as("admin")
+    admin = get_user("admin")
+
+    # ABORTING with a fresh heartbeat; backdate changed_on past the grace window.
+    # changed_on is naive *local* (FAB onupdate), so use datetime.now() here.
+    wedged = _make_task(admin, "wedged", TaskStatus.ABORTING, heartbeat_offset=0)
+    db.session.execute(
+        sa.text("UPDATE tasks SET changed_on = :c WHERE id = :id"),
+        {"c": datetime.now() - timedelta(seconds=600), "id": wedged.id},
+    )
+    db.session.commit()
+    # A task that just entered ABORTING (recent changed_on) must NOT be selected.
+    recent = _make_task(admin, "recent_abort", TaskStatus.ABORTING, heartbeat_offset=0)
+    try:
+        found = {c.uuid: c.is_orphan for c in TaskDAO.find_orphaned(60, 60)}
+        assert found.get(wedged.uuid) is False  # selected, flagged wedged (not orphan)
+        assert recent.uuid not in found
+    finally:
+        _cleanup(wedged, recent)
+
+
+def test_reap_marks_orphan_failed_and_revokes(app_context, get_user, login_as) -> None:
+    """End-to-end: the reaper forces a stale in-progress task to FAILURE."""
+    login_as("admin")
+    admin = get_user("admin")
+    orphan = _make_task(
+        admin,
+        "orphan",
+        TaskStatus.IN_PROGRESS,
+        heartbeat_offset=600,
+        celery_task_id="celery-xyz",
+    )
+    try:
+        with patch("superset.commands.tasks.reap.celery_app") as celery:
+            reaped = ReapOrphanedTasksCommand().run()
+
+        assert reaped == 1
+        celery.control.revoke.assert_called_once_with(
+            "celery-xyz", terminate=True, signal="SIGUSR1"
+        )
+        db.session.refresh(orphan)
+        assert orphan.status == TaskStatus.FAILURE.value
+        assert orphan.ended_at is not None
+        assert orphan.properties_dict["error_message"] == ORPHAN_ERROR_MESSAGE
+    finally:
+        _cleanup(orphan)

--- a/tests/integration_tests/tasks/commands/test_reap.py
+++ b/tests/integration_tests/tasks/commands/test_reap.py
@@ -61,6 +61,10 @@ def test_touch_heartbeat_does_not_advance_changed_on(
     login_as("admin")
     admin = get_user("admin")
     task = _make_task(admin, "hb_task", TaskStatus.IN_PROGRESS)
+    # Read changed_on back from the DB first so the baseline is at the column's
+    # storage precision (MySQL DATETIME truncates to whole seconds), otherwise the
+    # post-refresh comparison below spuriously differs from the in-memory value.
+    db.session.refresh(task)
     original_changed_on = task.changed_on
     try:
         TaskDAO.touch_heartbeat(task.id)

--- a/tests/integration_tests/tasks/commands/test_reap.py
+++ b/tests/integration_tests/tasks/commands/test_reap.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
-import sqlalchemy as sa
 from superset_core.tasks.types import TaskScope, TaskStatus
 
 from superset import db
@@ -87,38 +86,13 @@ def test_find_orphaned_selects_only_stale_active_tasks(
     never_started = _make_task(admin, "queued", TaskStatus.PENDING)  # null heartbeat
     finished = _make_task(admin, "done", TaskStatus.SUCCESS, heartbeat_offset=600)
     try:
-        found = {c.uuid for c in TaskDAO.find_orphaned(60, 60)}
+        found = set(TaskDAO.find_orphaned(60))
         assert stale.uuid in found
         assert fresh.uuid not in found
         assert never_started.uuid not in found
         assert finished.uuid not in found
     finally:
         _cleanup(stale, fresh, never_started, finished)
-
-
-def test_find_orphaned_selects_wedged_aborting_tasks(
-    app_context, get_user, login_as
-) -> None:
-    """Wedged aborts = ABORTING + fresh heartbeat + old changed_on (live worker)."""
-    login_as("admin")
-    admin = get_user("admin")
-
-    # ABORTING with a fresh heartbeat; backdate changed_on past the grace window.
-    # changed_on is naive *local* (FAB onupdate), so use datetime.now() here.
-    wedged = _make_task(admin, "wedged", TaskStatus.ABORTING, heartbeat_offset=0)
-    db.session.execute(
-        sa.text("UPDATE tasks SET changed_on = :c WHERE id = :id"),
-        {"c": datetime.now() - timedelta(seconds=600), "id": wedged.id},
-    )
-    db.session.commit()
-    # A task that just entered ABORTING (recent changed_on) must NOT be selected.
-    recent = _make_task(admin, "recent_abort", TaskStatus.ABORTING, heartbeat_offset=0)
-    try:
-        found = {c.uuid: c.is_orphan for c in TaskDAO.find_orphaned(60, 60)}
-        assert found.get(wedged.uuid) is False  # selected, flagged wedged (not orphan)
-        assert recent.uuid not in found
-    finally:
-        _cleanup(wedged, recent)
 
 
 def test_reap_marks_orphan_failed_and_revokes(app_context, get_user, login_as) -> None:
@@ -137,9 +111,7 @@ def test_reap_marks_orphan_failed_and_revokes(app_context, get_user, login_as) -
             reaped = ReapOrphanedTasksCommand().run()
 
         assert reaped == 1
-        celery.control.revoke.assert_called_once_with(
-            "celery-xyz", terminate=True, signal="SIGUSR1"
-        )
+        celery.control.revoke.assert_called_once_with("celery-xyz")
         db.session.refresh(orphan)
         assert orphan.status == TaskStatus.FAILURE.value
         assert orphan.ended_at is not None

--- a/tests/integration_tests/tasks/commands/test_submit.py
+++ b/tests/integration_tests/tasks/commands/test_submit.py
@@ -55,7 +55,7 @@ def test_submit_task_success(app_context, login_as, get_user) -> None:
         assert result.id is not None
         assert result.uuid is not None
         # A task submitted without depends_on has no prerequisites
-        assert result.dependencies == []
+        assert result.depends_on == []
     finally:
         # Cleanup
         db.session.delete(result)
@@ -264,7 +264,7 @@ def test_submit_task_with_depends_on_persists_edges(
         db.session.refresh(dependent)
 
         # dependencies resolves to the prerequisite Task entities
-        assert [dep.uuid for dep in dependent.dependencies] == [prerequisite.uuid]
+        assert [dep.uuid for dep in dependent.depends_on] == [prerequisite.uuid]
     finally:
         # Deleting the dependent removes its edge rows via FK ON DELETE CASCADE
         if dependent is not None:

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -661,7 +661,10 @@ def test_get_statuses_changed_since_baseline_returns_no_statuses(
     statuses, cursor = TaskDAO.get_statuses_changed_since(None)
 
     assert statuses == {}
-    assert cursor >= before
+    # The cursor is floored to whole seconds (metastore datetime precision, e.g.
+    # MySQL DATETIME), so compare against a floored baseline.
+    assert cursor.microsecond == 0
+    assert cursor >= before.replace(microsecond=0)
 
 
 def test_get_statuses_changed_since_redelivers_task_on_the_cursor_boundary(

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -111,7 +111,7 @@ def test_find_by_task_key_active(session_with_task: Session) -> None:
     assert result.task_type == TEST_TASK_TYPE
     assert result.status == TaskStatus.PENDING.value
     # A task with no declared prerequisites has empty dependencies
-    assert result.dependencies == []
+    assert result.depends_on == []
 
 
 def test_find_one_or_none_refreshes_stale_task(session_with_task: Session) -> None:
@@ -620,7 +620,7 @@ def test_conditional_status_update_terminal_state_updates_dedup_key(
 
 
 def test_add_dependencies_bulk_inserts_edges(session_with_task: Session) -> None:
-    """add_dependencies bulk-inserts edges; Task.dependencies resolves them."""
+    """add_dependencies bulk-inserts edges; Task.depends_on resolves them."""
     from superset.daos.tasks import TaskDAO
 
     parent1 = create_task(session_with_task, task_key="parent1")
@@ -629,11 +629,11 @@ def test_add_dependencies_bulk_inserts_edges(session_with_task: Session) -> None
 
     TaskDAO.add_dependencies(child.id, [parent1.id, parent2.id])
 
-    # Task.dependencies resolves to the prerequisite Task entities
+    # Task.depends_on resolves to the prerequisite Task entities
     session_with_task.refresh(child)
-    assert {t.id for t in child.dependencies} == {parent1.id, parent2.id}
+    assert {t.id for t in child.depends_on} == {parent1.id, parent2.id}
     # Prerequisites themselves have no dependencies
-    assert parent1.dependencies == []
+    assert parent1.depends_on == []
 
 
 def test_add_dependencies_empty_is_noop(session_with_task: Session) -> None:
@@ -643,7 +643,7 @@ def test_add_dependencies_empty_is_noop(session_with_task: Session) -> None:
     task = create_task(session_with_task, task_key="lonely")
     TaskDAO.add_dependencies(task.id, [])
     session_with_task.refresh(task)
-    assert task.dependencies == []
+    assert task.depends_on == []
 
 
 def test_get_statuses_changed_since_baseline_returns_no_statuses(

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -103,7 +103,7 @@ class TestExecuteTaskFailedPrerequisite:
 
     @staticmethod
     def _run_with_transition(*, transitioned: bool, refreshed_status: str):
-        """Drive execute_task through the failed-prerequisite branch.
+        """Drive the task body through the failed-prerequisite branch.
 
         Returns ``(result, publish_completion_mock)`` with the status transition
         forced to ``transitioned`` and the post-transition re-read reporting
@@ -120,7 +120,7 @@ class TestExecuteTaskFailedPrerequisite:
         with (
             patch(
                 "superset.tasks.scheduler.TaskDAO.find_one_or_none",
-                side_effect=[pending, refreshed],
+                side_effect=[refreshed],
             ),
             patch(
                 "superset.tasks.scheduler._resolve_failed_prerequisite",
@@ -133,9 +133,11 @@ class TestExecuteTaskFailedPrerequisite:
                 transition,
             ),
         ):
-            from superset.tasks.scheduler import execute_task
+            from superset.tasks.scheduler import _execute_task_body
 
-            result = execute_task.run(str(native), "some.task", (), {})
+            # Call the lifecycle body directly with the already-loaded task; the
+            # heartbeat/celery-id wrapper (execute_task) is covered separately.
+            result = _execute_task_body(pending, native, "some.task", (), {})  # type: ignore[arg-type]
             return result, task_manager.publish_completion
 
     def test_failure_published_when_transition_commits(self):

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -40,13 +40,13 @@ class TestResolveFailedPrerequisite:
     def test_no_dependencies_returns_none(self):
         from superset.tasks.scheduler import _resolve_failed_prerequisite
 
-        assert _resolve_failed_prerequisite(SimpleNamespace(dependencies=[])) is None
+        assert _resolve_failed_prerequisite(SimpleNamespace(depends_on=[])) is None
 
     @patch("superset.tasks.scheduler.TaskManager.wait_for_completion")
     def test_all_success_returns_none(self, mock_wait):
         from superset.tasks.scheduler import _resolve_failed_prerequisite
 
-        task = SimpleNamespace(dependencies=[_task(), _task()])
+        task = SimpleNamespace(depends_on=[_task(), _task()])
         mock_wait.return_value = SimpleNamespace(status=TaskStatus.SUCCESS.value)
 
         assert _resolve_failed_prerequisite(task) is None
@@ -62,13 +62,13 @@ class TestResolveFailedPrerequisite:
         failed = _task(status=TaskStatus.FAILURE.value)
         assert (
             _resolve_failed_prerequisite(
-                SimpleNamespace(dependencies=[succeeded, failed])
+                SimpleNamespace(depends_on=[succeeded, failed])
             )
             is failed
         )
         # All-terminal snapshot → wait_for_completion is never called
         assert (
-            _resolve_failed_prerequisite(SimpleNamespace(dependencies=[succeeded]))
+            _resolve_failed_prerequisite(SimpleNamespace(depends_on=[succeeded]))
             is None
         )
         mock_wait.assert_not_called()
@@ -77,7 +77,7 @@ class TestResolveFailedPrerequisite:
     def test_first_non_success_is_returned(self, mock_wait):
         from superset.tasks.scheduler import _resolve_failed_prerequisite
 
-        task = SimpleNamespace(dependencies=[_task(), _task()])
+        task = SimpleNamespace(depends_on=[_task(), _task()])
         failed = SimpleNamespace(uuid=uuid4(), status=TaskStatus.FAILURE.value)
         mock_wait.side_effect = [
             SimpleNamespace(status=TaskStatus.SUCCESS.value),
@@ -91,7 +91,7 @@ class TestResolveFailedPrerequisite:
         from superset.tasks.scheduler import _resolve_failed_prerequisite
 
         prerequisite = _task()
-        task = SimpleNamespace(dependencies=[prerequisite])
+        task = SimpleNamespace(depends_on=[prerequisite])
         mock_wait.side_effect = ValueError("gone")
 
         # The (stale) prerequisite is returned rather than blocking/raising.

--- a/tests/unit_tests/tasks/test_heartbeat.py
+++ b/tests/unit_tests/tasks/test_heartbeat.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for the GTF worker-liveness heartbeat."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+from superset.tasks.heartbeat import task_heartbeat
+
+
+def _mock_app(interval: float, stats: MagicMock) -> MagicMock:
+    app = MagicMock()
+    app.config = {"GTF_TASK_HEARTBEAT_INTERVAL": interval, "STATS_LOGGER": stats}
+    app.app_context.return_value.__enter__ = MagicMock(return_value=None)
+    app.app_context.return_value.__exit__ = MagicMock(return_value=None)
+    return app
+
+
+def test_heartbeat_stamps_immediately_and_stops_on_exit() -> None:
+    """An initial heartbeat is written synchronously; none after the context ends."""
+    stats = MagicMock()
+    # Large interval so the background thread never beats within the test window;
+    # only the synchronous initial write should occur.
+    app = _mock_app(interval=100, stats=stats)
+
+    with patch("superset.daos.tasks.TaskDAO.touch_heartbeat") as touch:
+        with task_heartbeat(42, app):
+            assert touch.call_count == 1
+            touch.assert_called_once_with(42)
+        stats.incr.assert_any_call("gtf.task.heartbeat")
+
+    # No further writes after the context exits.
+    assert touch.call_count == 1
+
+
+def test_heartbeat_beats_periodically() -> None:
+    """The background thread keeps bumping the heartbeat on the interval."""
+    stats = MagicMock()
+    app = _mock_app(interval=0.02, stats=stats)
+
+    with patch("superset.daos.tasks.TaskDAO.touch_heartbeat") as touch:
+        with task_heartbeat(7, app):
+            deadline = time.time() + 2.0
+            while touch.call_count < 3 and time.time() < deadline:
+                time.sleep(0.02)
+            assert touch.call_count >= 3
+
+
+def test_heartbeat_failure_is_counted_and_swallowed() -> None:
+    """A failed write emits the failure metric and does not raise."""
+    stats = MagicMock()
+    app = _mock_app(interval=100, stats=stats)
+
+    with patch(
+        "superset.daos.tasks.TaskDAO.touch_heartbeat",
+        side_effect=RuntimeError("db down"),
+    ):
+        # Must not raise even though the initial write fails.
+        with task_heartbeat(1, app):
+            pass
+
+    stats.incr.assert_any_call("gtf.task.heartbeat_failure")

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -205,17 +205,17 @@ class TestTaskManagerEntityChange:
         assert TaskManager.publish_entity_change(uuid.uuid4()) is False
 
 
-class TestTaskManagerPublishDependentsChanged:
-    """publish_dependents_changed nudges each task that depends on the given task."""
+class TestTaskManagerPublishRequiredByChanged:
+    """publish_required_by_changed nudges each task that depends on the given task."""
 
     IS_DEFINED = "superset.coordination.base.CoordinationService.is_backend_defined"
-    GET_DEPENDENTS = "superset.daos.tasks.TaskDAO.get_dependent_uuids"
+    GET_DEPENDENTS = "superset.daos.tasks.TaskDAO.get_required_by_uuids"
     PUBLISH_ENTITY = "superset.tasks.manager.TaskManager.publish_entity_change"
 
     @patch(GET_DEPENDENTS)
     @patch(IS_DEFINED, return_value=False)
     def test_no_backend_skips_lookup(self, mock_defined, mock_get_dependents):
-        TaskManager.publish_dependents_changed(uuid.uuid4())
+        TaskManager.publish_required_by_changed(uuid.uuid4())
         mock_get_dependents.assert_not_called()
 
     @patch(PUBLISH_ENTITY)
@@ -223,7 +223,7 @@ class TestTaskManagerPublishDependentsChanged:
     def test_nudges_each_dependent(self, mock_defined, mock_publish_entity):
         dependents = [uuid.uuid4(), uuid.uuid4()]
         with patch(self.GET_DEPENDENTS, return_value=dependents):
-            TaskManager.publish_dependents_changed(uuid.uuid4())
+            TaskManager.publish_required_by_changed(uuid.uuid4())
         assert mock_publish_entity.call_count == 2
         assert {c.args[0] for c in mock_publish_entity.call_args_list} == set(
             dependents
@@ -233,7 +233,7 @@ class TestTaskManagerPublishDependentsChanged:
     @patch(IS_DEFINED, return_value=True)
     def test_no_dependents_is_noop(self, mock_defined, mock_publish_entity):
         with patch(self.GET_DEPENDENTS, return_value=[]):
-            TaskManager.publish_dependents_changed(uuid.uuid4())
+            TaskManager.publish_required_by_changed(uuid.uuid4())
         mock_publish_entity.assert_not_called()
 
 

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -205,6 +205,38 @@ class TestTaskManagerEntityChange:
         assert TaskManager.publish_entity_change(uuid.uuid4()) is False
 
 
+class TestTaskManagerPublishDependentsChanged:
+    """publish_dependents_changed nudges each task that depends on the given task."""
+
+    IS_DEFINED = "superset.coordination.base.CoordinationService.is_backend_defined"
+    GET_DEPENDENTS = "superset.daos.tasks.TaskDAO.get_dependent_uuids"
+    PUBLISH_ENTITY = "superset.tasks.manager.TaskManager.publish_entity_change"
+
+    @patch(GET_DEPENDENTS)
+    @patch(IS_DEFINED, return_value=False)
+    def test_no_backend_skips_lookup(self, mock_defined, mock_get_dependents):
+        TaskManager.publish_dependents_changed(uuid.uuid4())
+        mock_get_dependents.assert_not_called()
+
+    @patch(PUBLISH_ENTITY)
+    @patch(IS_DEFINED, return_value=True)
+    def test_nudges_each_dependent(self, mock_defined, mock_publish_entity):
+        dependents = [uuid.uuid4(), uuid.uuid4()]
+        with patch(self.GET_DEPENDENTS, return_value=dependents):
+            TaskManager.publish_dependents_changed(uuid.uuid4())
+        assert mock_publish_entity.call_count == 2
+        assert {c.args[0] for c in mock_publish_entity.call_args_list} == set(
+            dependents
+        )
+
+    @patch(PUBLISH_ENTITY)
+    @patch(IS_DEFINED, return_value=True)
+    def test_no_dependents_is_noop(self, mock_defined, mock_publish_entity):
+        with patch(self.GET_DEPENDENTS, return_value=[]):
+            TaskManager.publish_dependents_changed(uuid.uuid4())
+        mock_publish_entity.assert_not_called()
+
+
 class TestTaskManagerPublishTaskStatus:
     """publish_task_status emits one fanout message carrying subscribers."""
 

--- a/tests/unit_tests/tasks/test_query_cancel.py
+++ b/tests/unit_tests/tasks/test_query_cancel.py
@@ -1,0 +1,154 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for GTF chart-data query cancellation (Phase 2)."""
+
+from unittest.mock import MagicMock, patch
+
+from superset.tasks.query_cancel import (
+    _cancel_id_sink,
+    cancel_chart_query,
+    capture_cancel_id,
+    notify_cursor,
+)
+
+
+def _mock_database(cancel_result: bool = True):
+    database = MagicMock()
+    database.id = 5
+    cursor = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    engine = MagicMock()
+    engine.raw_connection.return_value = conn
+    database.get_sqla_engine.return_value.__enter__ = MagicMock(return_value=engine)
+    database.get_sqla_engine.return_value.__exit__ = MagicMock(return_value=None)
+    database.db_engine_spec.cancel_query.return_value = cancel_result
+    return database, cursor
+
+
+def _app_with_stats(stats: MagicMock) -> MagicMock:
+    app = MagicMock()
+    app.config = {"STATS_LOGGER": stats}
+    return app
+
+
+# --- capture seam ---------------------------------------------------------
+
+
+def test_notify_cursor_is_noop_without_a_sink() -> None:
+    # No sink registered: must not raise and must not touch the cursor.
+    assert _cancel_id_sink.get() is None
+    notify_cursor(MagicMock())
+
+
+def test_capture_cancel_id_sets_and_resets_the_sink() -> None:
+    sink = MagicMock()
+    with capture_cancel_id(sink):
+        cursor = MagicMock()
+        notify_cursor(cursor)
+        sink.assert_called_once_with(cursor)
+    assert _cancel_id_sink.get() is None
+
+
+def test_notify_cursor_swallows_sink_errors() -> None:
+    with capture_cancel_id(MagicMock(side_effect=RuntimeError("boom"))):
+        # A capture failure only forfeits cancellability; it must not raise.
+        notify_cursor(MagicMock())
+
+
+# --- cancel helper --------------------------------------------------------
+
+
+def test_cancel_chart_query_success() -> None:
+    stats = MagicMock()
+    database, cursor = _mock_database(cancel_result=True)
+
+    assert cancel_chart_query(database, "123", _app_with_stats(stats)) is True
+    database.db_engine_spec.cancel_query.assert_called_once_with(cursor, None, "123")
+    stats.incr.assert_any_call("gtf.query.cancel")
+
+
+def test_cancel_chart_query_reports_failure_when_engine_declines() -> None:
+    stats = MagicMock()
+    database, _ = _mock_database(cancel_result=False)
+
+    assert cancel_chart_query(database, "123", _app_with_stats(stats)) is False
+    stats.incr.assert_any_call("gtf.query.cancel_failed")
+
+
+def test_cancel_chart_query_swallows_exceptions() -> None:
+    stats = MagicMock()
+    database, _ = _mock_database()
+    database.get_sqla_engine.side_effect = RuntimeError("no connection")
+
+    assert cancel_chart_query(database, "123", _app_with_stats(stats)) is False
+    stats.incr.assert_any_call("gtf.query.cancel_failed")
+
+
+# --- capture wiring in execute_chart_query --------------------------------
+
+
+def _query_context(cancel_id):
+    qc = MagicMock()
+    qc.datasource.database.db_engine_spec.get_cancel_query_id.return_value = cancel_id
+    return qc
+
+
+def test_capture_registers_abort_handler_once_when_id_available() -> None:
+    from superset.tasks.async_queries import _capture_query_cancellation
+
+    ctx = MagicMock()
+    qc = _query_context("42")
+    with (
+        patch("superset.tasks.async_queries.get_context", return_value=ctx),
+        patch("superset.tasks.async_queries.current_app"),
+    ):
+        with _capture_query_cancellation(qc):
+            sink = _cancel_id_sink.get()
+            assert sink is not None
+            sink(MagicMock())  # first cursor -> registers handler
+            sink(MagicMock())  # second cursor -> no double registration
+
+    ctx.on_abort.assert_called_once()
+
+
+def test_capture_skips_abort_handler_when_engine_has_no_cancel_id() -> None:
+    from superset.tasks.async_queries import _capture_query_cancellation
+
+    ctx = MagicMock()
+    qc = _query_context(None)
+    with (
+        patch("superset.tasks.async_queries.get_context", return_value=ctx),
+        patch("superset.tasks.async_queries.current_app"),
+    ):
+        with _capture_query_cancellation(qc):
+            sink = _cancel_id_sink.get()
+            assert sink is not None
+            sink(MagicMock())
+
+    ctx.on_abort.assert_not_called()
+
+
+def test_capture_is_noop_without_a_database() -> None:
+    from superset.tasks.async_queries import _capture_query_cancellation
+
+    qc = MagicMock()
+    qc.datasource.database = None
+    with patch("superset.tasks.async_queries.get_context") as get_context:
+        with _capture_query_cancellation(qc):
+            assert _cancel_id_sink.get() is None
+    get_context.assert_not_called()

--- a/tests/unit_tests/tasks/test_query_cancel.py
+++ b/tests/unit_tests/tasks/test_query_cancel.py
@@ -20,8 +20,10 @@ from unittest.mock import MagicMock, patch
 
 from superset.tasks.query_cancel import (
     _cancel_id_sink,
+    _CancellationQuery,
     cancel_chart_query,
     capture_cancel_id,
+    capture_cancel_query_id,
     notify_cursor,
 )
 
@@ -78,8 +80,34 @@ def test_cancel_chart_query_success() -> None:
     database, cursor = _mock_database(cancel_result=True)
 
     assert cancel_chart_query(database, "123", _app_with_stats(stats)) is True
-    database.db_engine_spec.cancel_query.assert_called_once_with(cursor, None, "123")
+    # Called with the live cursor, a Query stand-in bound to this database, and id.
+    call = database.db_engine_spec.cancel_query.call_args
+    assert call.args[0] is cursor
+    assert isinstance(call.args[1], _CancellationQuery)
+    assert call.args[1].database is database
+    assert call.args[2] == "123"
     stats.incr.assert_any_call("gtf.query.cancel")
+
+
+def test_cancellation_query_stub_exposes_expected_attributes() -> None:
+    database = MagicMock()
+    query = _CancellationQuery(database)
+    # id is None so an engine that cancels by query id declines rather than raises.
+    assert query.id is None
+    assert query.database is database
+    query.set_extra_json_key("early_cancel_query", True)
+    assert query.extra["early_cancel_query"] is True
+
+
+def test_capture_cancel_query_id_passes_a_query_stub() -> None:
+    database = MagicMock()
+    database.db_engine_spec.get_cancel_query_id.return_value = "42"
+    cursor = MagicMock()
+
+    assert capture_cancel_query_id(database, cursor) == "42"
+    call = database.db_engine_spec.get_cancel_query_id.call_args
+    assert call.args[0] is cursor
+    assert isinstance(call.args[1], _CancellationQuery)
 
 
 def test_cancel_chart_query_reports_failure_when_engine_declines() -> None:

--- a/tests/unit_tests/tasks/test_reap.py
+++ b/tests/unit_tests/tasks/test_reap.py
@@ -23,37 +23,24 @@ from uuid import UUID
 from superset_core.tasks.types import TaskStatus
 
 from superset.commands.tasks.reap import ORPHAN_ERROR_MESSAGE, ReapOrphanedTasksCommand
-from superset.daos.tasks import OrphanCandidate
 from superset.utils import json
 
 TEST_UUID = UUID("b8b61b7b-1cd3-4a31-a74a-0a95341afc06")
 
 
-def _candidate(
-    *, is_orphan: bool, celery_task_id: str | None = "celery-1"
-) -> OrphanCandidate:
-    properties = json.dumps(
-        {"celery_task_id": celery_task_id} if celery_task_id else {}
-    )
-    return OrphanCandidate(
-        id=1,
-        uuid=TEST_UUID,
-        status=TaskStatus.IN_PROGRESS.value,
-        properties=properties,
-        is_orphan=is_orphan,
-    )
-
-
 @contextmanager
-def _patched(candidates, cas_result=True):
-    """Patch the reaper's collaborators and yield the mocks it interacts with."""
+def _patched(*, celery_task_id="celery-1", cas_result=True):
+    """Patch the reaper's collaborators; yield the mocks it interacts with."""
     stats = MagicMock()
     app = MagicMock()
     app.config = {"STATS_LOGGER": stats, "GTF_ORPHAN_TASK_TIMEOUT": 60}
+    properties = json.dumps(
+        {"celery_task_id": celery_task_id} if celery_task_id else {}
+    )
     with (
         patch("superset.commands.tasks.reap.current_app", app),
         patch("superset.commands.tasks.reap.db") as db,
-        patch("superset.daos.tasks.TaskDAO.find_orphaned", return_value=candidates),
+        patch("superset.daos.tasks.TaskDAO.find_orphaned", return_value=[TEST_UUID]),
         patch(
             "superset.daos.tasks.TaskDAO.conditional_status_update",
             return_value=cas_result,
@@ -62,24 +49,21 @@ def _patched(candidates, cas_result=True):
         patch("superset.tasks.manager.TaskManager.publish_completion") as publish,
         patch("superset.tasks.manager.TaskManager.publish_entity_change"),
     ):
-        # The fresh pre-CAS properties re-read returns the candidate's properties.
-        properties = candidates[0].properties if candidates else "{}"
+        # The pre-CAS properties re-read returns the orphan's current properties.
         db.session.query.return_value.filter.return_value.scalar.return_value = (
             properties
         )
         yield stats, cas, celery, publish
 
 
-def test_orphan_is_revoked_failed_and_published() -> None:
-    """A dead-worker orphan is revoked, forced to FAILURE, and completion published."""
-    with _patched([_candidate(is_orphan=True)]) as (stats, cas, celery, publish):
+def test_orphan_is_failed_published_and_revoked() -> None:
+    """A dead-worker orphan is forced to FAILURE, published, and its job revoked."""
+    with _patched() as (stats, cas, celery, publish):
         reaped = ReapOrphanedTasksCommand().run()
 
     assert reaped == 1
-    celery.control.revoke.assert_called_once_with(
-        "celery-1", terminate=True, signal="SIGUSR1"
-    )
-    # Forced to FAILURE, preserving the orphan error in properties.
+    # Revoke is non-terminating: no forced signal into a (possibly healthy) process.
+    celery.control.revoke.assert_called_once_with("celery-1")
     _args, kwargs = cas.call_args
     assert kwargs["properties"]["error_message"] == ORPHAN_ERROR_MESSAGE
     publish.assert_called_once_with(TEST_UUID, TaskStatus.FAILURE.value)
@@ -87,26 +71,9 @@ def test_orphan_is_revoked_failed_and_published() -> None:
     stats.incr.assert_any_call("gtf.task.revoke")
 
 
-def test_wedged_abort_is_only_escalated() -> None:
-    """A live wedged-ABORTING worker is force-revoked but not marked itself."""
-    with _patched([_candidate(is_orphan=False)]) as (stats, cas, celery, publish):
-        reaped = ReapOrphanedTasksCommand().run()
-
-    assert reaped == 0
-    celery.control.revoke.assert_called_once()
-    cas.assert_not_called()  # the worker finalizes its own status
-    publish.assert_not_called()
-    stats.incr.assert_any_call("gtf.task.abort_escalated")
-
-
 def test_cas_noop_does_not_publish() -> None:
     """A revived worker that already committed a terminal status wins the CAS race."""
-    with _patched([_candidate(is_orphan=True)], cas_result=False) as (
-        _stats,
-        _cas,
-        celery,
-        publish,
-    ):
+    with _patched(cas_result=False) as (_stats, _cas, celery, publish):
         reaped = ReapOrphanedTasksCommand().run()
 
     assert reaped == 0
@@ -116,12 +83,7 @@ def test_cas_noop_does_not_publish() -> None:
 
 def test_missing_celery_id_skips_revoke_but_still_reaps() -> None:
     """A task with no stored Celery id is still reaped; revoke is simply skipped."""
-    with _patched([_candidate(is_orphan=True, celery_task_id=None)]) as (
-        _stats,
-        _cas,
-        celery,
-        publish,
-    ):
+    with _patched(celery_task_id=None) as (_stats, _cas, celery, publish):
         reaped = ReapOrphanedTasksCommand().run()
 
     assert reaped == 1

--- a/tests/unit_tests/tasks/test_reap.py
+++ b/tests/unit_tests/tasks/test_reap.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for ReapOrphanedTasksCommand."""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from superset_core.tasks.types import TaskStatus
+
+from superset.commands.tasks.reap import ORPHAN_ERROR_MESSAGE, ReapOrphanedTasksCommand
+from superset.daos.tasks import OrphanCandidate
+from superset.utils import json
+
+TEST_UUID = UUID("b8b61b7b-1cd3-4a31-a74a-0a95341afc06")
+
+
+def _candidate(
+    *, is_orphan: bool, celery_task_id: str | None = "celery-1"
+) -> OrphanCandidate:
+    properties = json.dumps(
+        {"celery_task_id": celery_task_id} if celery_task_id else {}
+    )
+    return OrphanCandidate(
+        id=1,
+        uuid=TEST_UUID,
+        status=TaskStatus.IN_PROGRESS.value,
+        properties=properties,
+        is_orphan=is_orphan,
+    )
+
+
+@contextmanager
+def _patched(candidates, cas_result=True):
+    """Patch the reaper's collaborators and yield the mocks it interacts with."""
+    stats = MagicMock()
+    app = MagicMock()
+    app.config = {"STATS_LOGGER": stats, "GTF_ORPHAN_TASK_TIMEOUT": 60}
+    with (
+        patch("superset.commands.tasks.reap.current_app", app),
+        patch("superset.commands.tasks.reap.db"),
+        patch("superset.daos.tasks.TaskDAO.find_orphaned", return_value=candidates),
+        patch(
+            "superset.daos.tasks.TaskDAO.conditional_status_update",
+            return_value=cas_result,
+        ) as cas,
+        patch("superset.commands.tasks.reap.celery_app") as celery,
+        patch("superset.tasks.manager.TaskManager.publish_completion") as publish,
+        patch("superset.tasks.manager.TaskManager.publish_entity_change"),
+    ):
+        yield stats, cas, celery, publish
+
+
+def test_orphan_is_revoked_failed_and_published() -> None:
+    """A dead-worker orphan is revoked, forced to FAILURE, and completion published."""
+    with _patched([_candidate(is_orphan=True)]) as (stats, cas, celery, publish):
+        reaped = ReapOrphanedTasksCommand().run()
+
+    assert reaped == 1
+    celery.control.revoke.assert_called_once_with(
+        "celery-1", terminate=True, signal="SIGUSR1"
+    )
+    # Forced to FAILURE, preserving the orphan error in properties.
+    _args, kwargs = cas.call_args
+    assert kwargs["properties"]["error_message"] == ORPHAN_ERROR_MESSAGE
+    publish.assert_called_once_with(TEST_UUID, TaskStatus.FAILURE.value)
+    stats.incr.assert_any_call("gtf.task.orphan_reaped")
+    stats.incr.assert_any_call("gtf.task.revoke")
+
+
+def test_wedged_abort_is_only_escalated() -> None:
+    """A live wedged-ABORTING worker is force-revoked but not marked itself."""
+    with _patched([_candidate(is_orphan=False)]) as (stats, cas, celery, publish):
+        reaped = ReapOrphanedTasksCommand().run()
+
+    assert reaped == 0
+    celery.control.revoke.assert_called_once()
+    cas.assert_not_called()  # the worker finalizes its own status
+    publish.assert_not_called()
+    stats.incr.assert_any_call("gtf.task.abort_escalated")
+
+
+def test_cas_noop_does_not_publish() -> None:
+    """A revived worker that already committed a terminal status wins the CAS race."""
+    with _patched([_candidate(is_orphan=True)], cas_result=False) as (
+        _stats,
+        _cas,
+        celery,
+        publish,
+    ):
+        reaped = ReapOrphanedTasksCommand().run()
+
+    assert reaped == 0
+    celery.control.revoke.assert_called_once()
+    publish.assert_not_called()
+
+
+def test_missing_celery_id_skips_revoke_but_still_reaps() -> None:
+    """A task with no stored Celery id is still reaped; revoke is simply skipped."""
+    with _patched([_candidate(is_orphan=True, celery_task_id=None)]) as (
+        _stats,
+        _cas,
+        celery,
+        publish,
+    ):
+        reaped = ReapOrphanedTasksCommand().run()
+
+    assert reaped == 1
+    celery.control.revoke.assert_not_called()
+    publish.assert_called_once_with(TEST_UUID, TaskStatus.FAILURE.value)

--- a/tests/unit_tests/tasks/test_reap.py
+++ b/tests/unit_tests/tasks/test_reap.py
@@ -52,7 +52,7 @@ def _patched(candidates, cas_result=True):
     app.config = {"STATS_LOGGER": stats, "GTF_ORPHAN_TASK_TIMEOUT": 60}
     with (
         patch("superset.commands.tasks.reap.current_app", app),
-        patch("superset.commands.tasks.reap.db"),
+        patch("superset.commands.tasks.reap.db") as db,
         patch("superset.daos.tasks.TaskDAO.find_orphaned", return_value=candidates),
         patch(
             "superset.daos.tasks.TaskDAO.conditional_status_update",
@@ -62,6 +62,11 @@ def _patched(candidates, cas_result=True):
         patch("superset.tasks.manager.TaskManager.publish_completion") as publish,
         patch("superset.tasks.manager.TaskManager.publish_entity_change"),
     ):
+        # The fresh pre-CAS properties re-read returns the candidate's properties.
+        properties = candidates[0].properties if candidates else "{}"
+        db.session.query.return_value.filter.return_value.scalar.return_value = (
+            properties
+        )
         yield stats, cas, celery, publish
 
 

--- a/tests/unit_tests/tasks/test_scheduler_executor.py
+++ b/tests/unit_tests/tasks/test_scheduler_executor.py
@@ -90,6 +90,17 @@ def _requested_statuses(transition: MagicMock):
     return [call.kwargs.get("new_status") for call in transition.call_args_list]
 
 
+def _find_call(transition: MagicMock, new_status):
+    return next(
+        (
+            c
+            for c in transition.call_args_list
+            if c.kwargs.get("new_status") == new_status
+        ),
+        None,
+    )
+
+
 def test_exception_during_timeout_finalizes_timed_out_not_failure() -> None:
     """A body that raises while timing out must end TIMED_OUT, never FAILURE."""
     result, transition, task_manager, stats_logger = _run_body_with_raising_executor(
@@ -97,6 +108,10 @@ def test_exception_during_timeout_finalizes_timed_out_not_failure() -> None:
     )
 
     assert TaskStatus.FAILURE not in _requested_statuses(transition)
+    # The finally block must actually issue the ABORTING -> TIMED_OUT transition.
+    timed_out = _find_call(transition, TaskStatus.TIMED_OUT)
+    assert timed_out is not None
+    assert timed_out.kwargs.get("expected_status") == TaskStatus.ABORTING
     assert result["status"] == TaskStatus.TIMED_OUT.value
     task_manager.publish_completion.assert_called_once()
     # The failure metric must not fire for a successful cancellation.
@@ -112,6 +127,9 @@ def test_exception_during_abort_finalizes_aborted_not_failure() -> None:
     )
 
     assert TaskStatus.FAILURE not in _requested_statuses(transition)
+    aborted = _find_call(transition, TaskStatus.ABORTED)
+    assert aborted is not None
+    assert aborted.kwargs.get("expected_status") == TaskStatus.ABORTING
     assert result["status"] == TaskStatus.ABORTED.value
 
 

--- a/tests/unit_tests/tasks/test_scheduler_executor.py
+++ b/tests/unit_tests/tasks/test_scheduler_executor.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for the GTF executor body (scheduler._execute_task_body)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from superset_core.tasks.types import TaskStatus
+
+
+def _run_body_with_raising_executor(*, timeout_triggered: bool, abort_detected: bool):
+    """Drive _execute_task_body where the task body raises mid-abort/timeout.
+
+    Returns ``(result, transition_mock, task_manager_mock, stats_logger_mock)`` for
+    the caller to assert on the terminal handling.
+    """
+    native = uuid4()
+    task = SimpleNamespace(
+        uuid=native,
+        status=TaskStatus.PENDING.value,
+        properties_dict={},  # no "timeout" key -> no timeout timer started
+    )
+    # What the finally block's terminal transition commits, read back at the end.
+    refreshed = SimpleNamespace(
+        status=(
+            TaskStatus.TIMED_OUT.value
+            if timeout_triggered
+            else TaskStatus.ABORTED.value
+        )
+    )
+
+    ctx = MagicMock()
+    ctx._abort_detected = abort_detected
+    ctx.timeout_triggered = timeout_triggered
+    ctx.abort_handlers_completed = True
+
+    transition = MagicMock()
+    transition.return_value.run.return_value = True  # PENDING->IN_PROGRESS succeeds
+
+    def _raise(*_args, **_kwargs):
+        # Simulates the abort handler cancelling the warehouse query, which makes
+        # the blocked get_df raise inside the task body.
+        raise RuntimeError("query cancelled")
+
+    stats_logger = MagicMock()
+    app = MagicMock()
+    app.config = {"STATS_LOGGER": stats_logger}
+
+    with (
+        patch(
+            "superset.tasks.scheduler.TaskDAO.find_one_or_none", return_value=refreshed
+        ),
+        patch(
+            "superset.tasks.scheduler._resolve_failed_prerequisite", return_value=None
+        ),
+        patch("superset.tasks.scheduler.TaskContext", return_value=ctx),
+        patch(
+            "superset.tasks.scheduler.TaskRegistry.get_executor", return_value=_raise
+        ),
+        patch("superset.tasks.scheduler.TaskManager") as task_manager,
+        patch("superset.tasks.scheduler.current_app", app),
+        patch(
+            "superset.commands.tasks.internal_update.InternalStatusTransitionCommand",
+            transition,
+        ),
+    ):
+        from superset.tasks.scheduler import _execute_task_body
+
+        # SimpleNamespace stands in for the Task ORM row the body only reads from.
+        result = _execute_task_body(task, native, "some.task", (), {})  # type: ignore[arg-type]
+    return result, transition, task_manager, stats_logger
+
+
+def _requested_statuses(transition: MagicMock):
+    return [call.kwargs.get("new_status") for call in transition.call_args_list]
+
+
+def test_exception_during_timeout_finalizes_timed_out_not_failure() -> None:
+    """A body that raises while timing out must end TIMED_OUT, never FAILURE."""
+    result, transition, task_manager, stats_logger = _run_body_with_raising_executor(
+        timeout_triggered=True, abort_detected=False
+    )
+
+    assert TaskStatus.FAILURE not in _requested_statuses(transition)
+    assert result["status"] == TaskStatus.TIMED_OUT.value
+    task_manager.publish_completion.assert_called_once()
+    # The failure metric must not fire for a successful cancellation.
+    assert ("gtf.task.failure",) not in [
+        c.args for c in stats_logger.incr.call_args_list
+    ]
+
+
+def test_exception_during_abort_finalizes_aborted_not_failure() -> None:
+    """A body that raises while aborting must end ABORTED, never FAILURE."""
+    result, transition, _task_manager, _stats = _run_body_with_raising_executor(
+        timeout_triggered=False, abort_detected=True
+    )
+
+    assert TaskStatus.FAILURE not in _requested_statuses(transition)
+    assert result["status"] == TaskStatus.ABORTED.value
+
+
+def test_persist_celery_task_id_writes_and_commits() -> None:
+    from superset.tasks.scheduler import _persist_celery_task_id
+
+    task = MagicMock()
+    with patch("superset.tasks.scheduler.db") as db:
+        _persist_celery_task_id(task, "celery-9")
+
+    task.update_properties.assert_called_once_with({"celery_task_id": "celery-9"})
+    db.session.commit.assert_called_once()
+
+
+def test_persist_celery_task_id_is_noop_without_an_id() -> None:
+    from superset.tasks.scheduler import _persist_celery_task_id
+
+    task = MagicMock()
+    with patch("superset.tasks.scheduler.db") as db:
+        _persist_celery_task_id(task, None)
+
+    task.update_properties.assert_not_called()
+    db.session.commit.assert_not_called()


### PR DESCRIPTION
### SUMMARY

Part of the GAQ→GTF epic (targets `gaq-to-gtf`, not `master`). It closes two resilience gaps in the Global Task Framework once async chart data runs on it:

1. **A worker that stops running a task leaves the task unresolved.** If a worker process ends mid-execution (crash, OOM kill, `SIGKILL`, or a lost broker message), the `Task` row stays in an active state (`IN_PROGRESS`/`ABORTING`) and is never transitioned to a terminal state. Anything waiting on it — sync join-and-wait callers, DAG dependents, and the chart-data status poll — waits indefinitely. `prune_tasks` only deletes *old terminal* rows, so it does not help; the only existing signal is the client-side `GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT`, which stops the browser from waiting but leaves the server-side row and any warehouse query in place.
2. **Async chart-data query tasks are not cancellable.** `execute_chart_query` sets no timeout and registers no abort handler, because the chart-data execution path (`Database.get_df` → `db_engine_spec.execute`) captures no engine cancel id, unlike SQL Lab. A cancel/timeout therefore only changes the task row; the warehouse query continues to run.

This PR adds a worker liveness **heartbeat** and folds **orphan recovery** into the existing `prune_tasks` cron, and makes chart-data query tasks **cancellable** via the framework's existing `on_abort` mechanism, with an opt-in per-query timeout.

#### GAQ vs. GTF vs. this PR

| Capability | Legacy GAQ | GTF (before this PR) | After this PR |
|---|---|---|---|
| Recover a task whose worker stopped running it | No | No | Heartbeat + reaper transitions the row to `FAILURE` and releases waiters |
| Prevent a redelivered Celery job from re-running | `revoke(terminate=True)` | No | `revoke` (no `terminate`) |
| Cooperative user/timeout cancellation | Redis flag polled by the worker | `on_abort` handlers | `on_abort` handlers (unchanged) |
| Cancel the underlying warehouse query | SQL Lab path only | Not for chart data | `on_abort` handler calls the engine's `cancel_query` (engines that support it) |
| Per-query timeout for async chart data | No | No (removed pending cancellation) | Opt-in `GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT` |

#### How it works

- **Heartbeat** (`superset/tasks/heartbeat.py`): while a worker holds a task it refreshes `tasks.last_heartbeat` on a daemon thread every `GTF_TASK_HEARTBEAT_INTERVAL` (default 15s). The write is a raw `UPDATE` of that one column so it does not touch `changed_on` — otherwise every heartbeat would resurface the task in the `status_changes` poll and reset client backoff. `execute_task` is split into a thin wrapper (records the Celery job id, runs the body under the heartbeat) and `_execute_task_body`; the heartbeat starts before the DAG gate so a task blocked on prerequisites is still covered.
- **Reaper** (`ReapOrphanedTasksCommand`, run from `prune_tasks` before deletion): for each active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60s), it transitions the row to `FAILURE` (an atomic compare-and-swap, so a worker that revives and commits its own terminal status simply makes it a no-op), publishes completion so waiters unblock, and revokes the Celery job. Each task is handled independently so one failure neither aborts the pass nor skips the subsequent retention prune.
- **Deliberately no forced termination.** The reaper revokes **without** `terminate=True`, and there is no path that force-terminates a live worker. Orphan detection is heartbeat-based, and a healthy but CPU-bound task can briefly starve its own heartbeat thread; forcing `SoftTimeLimitExceeded` into it on a false positive would kill good work. The reaper acts only on tasks that already have no live worker; a task still being worked on keeps a fresh heartbeat and is left entirely to its own cooperative abort/cleanup. `revoke` without `terminate` only marks the job id revoked, which matters when `task_acks_late` is enabled and the broker redelivers.
- **Query cancellation** (`superset/tasks/query_cancel.py`) reuses the framework's existing cooperation model rather than adding a parallel one: a contextvar seam (invoked from `get_df` before the blocking execute) lets the task capture an engine cancel id via `db_engine_spec.get_cancel_query_id`, and `execute_chart_query` registers an `on_abort` handler that runs `db_engine_spec.cancel_query` over a fresh connection. Cancellation auto-enables per engine — Postgres/MySQL/Snowflake/Redshift are cancellable; engines that expose no cancel id register no handler and behave exactly as before. A cancel/timeout that makes the running query raise is finalized as `ABORTED`/`TIMED_OUT` (not `FAILURE`).
- **Metrics**: `gtf.task.heartbeat`, `gtf.task.heartbeat_failure`, `gtf.task.orphan_reaped`, `gtf.task.revoke`, `gtf.task.revoke_failure`, `gtf.task.reap_error`, `gtf.query.cancel`, `gtf.query.cancel_failed`.

#### Also included

A few Task List / realtime improvements surfaced while building and demoing the above:

- **Dedupe-count tooltip fix.** It wrapped its content directly in `Flex`, which is not a `forwardRef` component, so the antd `Tooltip` had no DOM node to anchor to and never showed on hover (the sibling tooltips wrap a `span`). Wrapped it in a `span`, and tightened/pluralized the copy via `tn`.
- **Bidirectional dependency hover.** The Task entity/API exposes both DAG directions as a self-documenting pair — `depends_on` (upstream) and a symmetric `required_by` (downstream) relationship (`A depends_on B` ⟺ `B required_by A`). In the list, the dependency detail uses a branching icon whose popover shows both "Depends on" and "Required by" sections; hovering highlights the related rows (both directions) visible on the current page — via an additive `isRowHighlighted` predicate on `ListView`/`TableCollection`, reusing the existing `table-row-highlighted` background.
- **Keep dependents' rows fresh.** A dependent's row shows its prerequisites' statuses, so a task's status change now also nudges the tasks that depend on it — otherwise those rows showed stale prerequisite state.

#### Out of scope

Cancelling the *warehouse query* of an already-orphaned task (from the reaper) is not included: it would require persisting the engine cancel handle on the row, which can race the task's own property writes. The reaper still transitions the row and releases waiters; an abandoned query is bounded by the warehouse's own timeouts. Live user-abort/timeout cancellation is fully implemented.

### TESTING INSTRUCTIONS

- Unit + integration: `pytest tests/unit_tests/tasks/ tests/integration_tests/tasks/commands/test_reap.py`. Coverage includes the heartbeat lifecycle/failure, `find_orphaned` selection (stale vs. fresh vs. null-heartbeat vs. terminal), the reaper (revoke + `FAILURE` CAS + publish, CAS no-op race, missing-id skip, per-task error isolation), `touch_heartbeat` leaving `changed_on` unchanged, the executor finalizing a cancel-induced exception as `TIMED_OUT`/`ABORTED`, and the cancel seam (capture/notify/cancel success/decline/exception). Frontend: `npm run test -- src/pages/TaskList`.
- Manual (needs `DISTRIBUTED_COORDINATION_CONFIG` + a Celery worker + `celery beat` running `prune_tasks` on a short interval): submit an async chart query, `kill -9` the worker mid-query → within `GTF_ORPHAN_TASK_TIMEOUT` the row becomes `FAILURE` and waiters unblock. On a supported engine, set `GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT` or cancel a long query from the UI and confirm the warehouse query is cancelled (e.g. `pg_stat_activity`) and the task ends `ABORTED`/`TIMED_OUT`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_TASK_FRAMEWORK` (async chart data also needs `GLOBAL_ASYNC_QUERIES`)
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

<sub>The `tasks.last_heartbeat` column (nullable, indexed, reversible) is folded into the branch's existing task-schema migration `7e2c9a4f1b83` rather than a new revision, matching how `guest_key` was folded — so there is no new migration file.</sub>



