### PR TITLE
fix(versioning): refuse version restore of externally managed entities server-side

### DIFF
--- a/superset/commands/exceptions.py
+++ b/superset/commands/exceptions.py
@@ -100,6 +100,20 @@ class ForbiddenError(CommandException):
     message = "Action is forbidden"
 
 
+class ExternallyManagedRestoreError(ForbiddenError):
+    """Version restore refused because the entity is managed externally.
+
+    Shared across charts, dashboards, and datasets: the condition and its
+    message do not vary by entity type. Deliberately a sibling of the
+    per-entity ``*ForbiddenError`` classes rather than a subclass of any of
+    them, so the restore endpoint's existing ``except`` clauses do not
+    swallow it and it can be mapped to a 403 whose body is distinguishable
+    from a permission denial.
+    """
+
+    message = _("Version restore is unavailable for externally managed entities.")
+
+
 class ImportFailedError(CommandException):
     status = 500
     message = "Import failed for an unknown reason"

--- a/superset/commands/version_restore.py
+++ b/superset/commands/version_restore.py
@@ -24,12 +24,12 @@ The three concrete commands (:mod:`superset.commands.chart.restore_version`,
 * the per-entity ``NotFoundError`` / ``ForbiddenError`` / ``UpdateFailedError``
   triplet they raise
 
-Everything else — capture gate, lookup, editorship check, version-uuid
-resolution, action-kind stamping, restore dispatch, transactional
-boundary — lives here. Subclasses are pure declarations: the base builds
-the ``@transaction`` wrapper at call time from the ``failed_exc``
-ClassVar (mirroring ``BaseRestoreCommand``), so a new entity rollout
-cannot forget the decorator.
+Everything else — capture gate, lookup, editorship check,
+external-management gate, version-uuid resolution, action-kind stamping,
+restore dispatch, transactional boundary — lives here. Subclasses are
+pure declarations: the base builds the ``@transaction`` wrapper at call
+time from the ``failed_exc`` ClassVar (mirroring ``BaseRestoreCommand``),
+so a new entity rollout cannot forget the decorator.
 """
 
 from __future__ import annotations
@@ -40,6 +40,7 @@ from uuid import UUID
 
 from superset import security_manager
 from superset.commands.base import BaseCommand
+from superset.commands.exceptions import ExternallyManagedRestoreError
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db
 from superset.utils.decorators import on_error, transaction
@@ -66,7 +67,9 @@ class BaseRestoreVersionCommand(BaseCommand):
     #: route is inert under the kill-switch); the API handler maps each
     #: to HTTP 404. ``forbidden_exc`` covers the row-level editorship
     #: denial (HTTP 403). ``failed_exc`` wraps unexpected failures inside
-    #: the transaction (HTTP 422).
+    #: the transaction (HTTP 422). The external-management refusal is the
+    #: shared :class:`ExternallyManagedRestoreError`, not a per-entity
+    #: ClassVar: the condition and its message do not vary by entity.
     not_found_exc: ClassVar[type[Exception]]
     forbidden_exc: ClassVar[type[Exception]]
     failed_exc: ClassVar[type[Exception]]
@@ -149,4 +152,13 @@ class BaseRestoreVersionCommand(BaseCommand):
             security_manager.raise_for_editorship(entity)
         except SupersetSecurityException as ex:
             raise self.forbidden_exc() from ex
+        # Policy gate, deliberately after the permission gate: a caller with
+        # no rights to the entity is never told it is externally managed.
+        # A restore would rewrite content the external owner controls — the
+        # next sync overwrites it or resurrects what the owner removed.
+        # Soft-delete *recovery* is not gated (it changes visibility, not
+        # content); that asymmetry is a recorded decision, see the
+        # per-entity integration suites.
+        if entity.is_managed_externally:
+            raise ExternallyManagedRestoreError()
         return entity

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -15210,6 +15210,9 @@ msgstr ""
 msgid "Version number"
 msgstr ""
 
+msgid "Version restore is unavailable for externally managed entities."
+msgstr ""
+
 msgid "Vertical"
 msgstr ""
 

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -42,6 +42,7 @@ import sqlalchemy as sa
 from flask import Response
 from flask_appbuilder import Model
 
+from superset.commands.exceptions import ExternallyManagedRestoreError
 from superset.daos.version import VersionDAO
 from superset.exceptions import SupersetSecurityException
 from superset.extensions import db, security_manager
@@ -293,7 +294,10 @@ def restore_version_endpoint(
 
     *command_cls* is the entity's ``BaseRestoreVersionCommand`` subclass;
     its ``not_found_exc`` / ``forbidden_exc`` / ``failed_exc`` ClassVars
-    drive the exception→HTTP mapping, so this body stays generic.
+    drive the exception→HTTP mapping, so this body stays generic. The one
+    shared exception, ``ExternallyManagedRestoreError``, maps to a 403
+    whose body names the reason — FAB's ``response_403()`` carries a fixed
+    ``"Forbidden"`` body, so it goes through ``response()`` instead.
     Authorization and the ``ENABLE_VERSIONING_CAPTURE`` kill-switch gate
     live in the command's ``validate()`` — with capture off the route is
     inert (404) because a revert without Continuum's write listeners
@@ -312,6 +316,8 @@ def restore_version_endpoint(
         result = command_cls(entity_uuid, version_uuid).run()
     except command_cls.not_found_exc:
         return api.response_404()
+    except ExternallyManagedRestoreError as ex:
+        return api.response(403, message=ex.message)
     except command_cls.forbidden_exc:
         return api.response_403()
     except command_cls.failed_exc as ex:

--- a/tests/integration_tests/charts/version_restore_tests.py
+++ b/tests/integration_tests/charts/version_restore_tests.py
@@ -33,6 +33,7 @@ from superset.extensions import db
 from superset.models.slice import Slice
 from superset.utils import json as _json
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.constants import ADMIN_USERNAME
 from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
     load_birth_names_dashboard_with_slices,
@@ -319,6 +320,137 @@ class TestChartRestoreApi(SupersetTestCase):
         chart = db.session.query(Slice).filter(Slice.id == chart_id).one()
         chart.slice_name = original_name
         db.session.commit()
+
+    def test_restore_refuses_externally_managed_chart_without_writing(self) -> None:
+        """An editor's *direct* restore of an externally managed chart is
+        refused server-side with a message-bearing 403 naming external
+        management (FR-001/FR-002/FR-004); the chart and its history are
+        untouched (FR-003); and every read path stays open (FR-008).
+
+        The unmanaged-success control is
+        ``test_restore_applies_scalar_field_from_target_version`` above,
+        which exercises the identical request on the same fixture chart
+        with the flag off.
+        """
+        _persist_fixture_state()
+        chart: Slice = (
+            db.session.query(Slice).filter(Slice.slice_name == "Girls").first()
+        )
+        assert chart is not None
+        chart_uuid = str(chart.uuid)
+        original_name = chart.slice_name
+
+        # One extra save so there is an earlier version to target.
+        chart.slice_name = "Girls managed v1"
+        db.session.commit()
+        # ``is_managed_externally`` is itself a versioned column, so this
+        # write appends a version row of its own. Everything below samples
+        # state and history only *after* it is committed.
+        chart.is_managed_externally = True
+        db.session.commit()
+
+        try:
+            self.login(ADMIN_USERNAME)
+            rv_list = self._list(chart_uuid)
+            assert rv_list.status_code == 200
+            listing = _json.loads(rv_list.data.decode("utf-8"))
+            target_uuid = listing["result"][0]["version_uuid"]
+
+            db.session.expire_all()
+            chart = db.session.query(Slice).filter(Slice.uuid == chart.uuid).one()
+            name_before = chart.slice_name
+            rows_before = len(_get_version_rows(chart))
+            count_before = listing["count"]
+
+            rv = self._restore(chart_uuid, target_uuid)
+            assert rv.status_code == 403, rv.data
+            body = _json.loads(rv.data.decode("utf-8"))
+            assert body["message"] == (
+                "Version restore is unavailable for externally managed entities."
+            )
+            # Distinguishable from FAB's permission denial by body alone.
+            assert body["message"] != "Forbidden"
+
+            # Nothing written: live state and history are exactly as before.
+            db.session.expire_all()
+            chart = db.session.query(Slice).filter(Slice.uuid == chart.uuid).one()
+            assert chart.slice_name == name_before
+            assert chart.is_managed_externally is True
+            assert len(_get_version_rows(chart)) == rows_before
+            rv_list2 = self._list(chart_uuid)
+            assert rv_list2.status_code == 200
+            assert _json.loads(rv_list2.data.decode("utf-8"))["count"] == count_before
+
+            # Read paths are indifferent to the flag.
+            rv_get = self.client.get(
+                f"/api/v1/chart/{chart_uuid}/versions/{target_uuid}/"
+            )
+            assert rv_get.status_code == 200, rv_get.data
+            rv_activity = self.client.get(f"/api/v1/chart/{chart_uuid}/activity/")
+            assert rv_activity.status_code == 200, rv_activity.data
+        finally:
+            # The birth_names fixture is shared across the module: leave the
+            # chart exactly as found.
+            db.session.expire_all()
+            chart = db.session.query(Slice).filter(Slice.uuid == chart.uuid).one()
+            chart.is_managed_externally = False
+            chart.slice_name = original_name
+            db.session.commit()
+
+    @with_feature_flags(SOFT_DELETE=True)
+    def test_recovery_succeeds_where_version_restore_is_refused(self) -> None:
+        """FR-010/FR-011 on one and the same externally managed chart:
+        soft-delete **recovery** succeeds — the restriction covers content
+        rewrites, not lifecycle changes — and a version restore attempted
+        immediately afterwards is refused. Pins the deliberate asymmetry so
+        a later change cannot quietly over-apply the guard to recovery.
+        The recovery commands are not modified by this feature.
+        """
+        _persist_fixture_state()
+        chart: Slice = (
+            db.session.query(Slice).filter(Slice.slice_name == "Girls").first()
+        )
+        assert chart is not None
+        chart_id = chart.id
+        chart_uuid = str(chart.uuid)
+        original_name = chart.slice_name
+
+        chart.slice_name = "Girls managed v1"
+        db.session.commit()
+        chart.is_managed_externally = True
+        db.session.commit()
+
+        try:
+            self.login(ADMIN_USERNAME)
+            rv_list = self._list(chart_uuid)
+            assert rv_list.status_code == 200, rv_list.data
+            target_uuid = _json.loads(rv_list.data.decode("utf-8"))["result"][0][
+                "version_uuid"
+            ]
+
+            # Archive, then recover: both succeed on an externally managed chart.
+            rv_del = self.client.delete(f"/api/v1/chart/{chart_id}")
+            assert rv_del.status_code == 200, rv_del.data
+            rv_recover = self.client.post(f"/api/v1/chart/{chart_uuid}/restore")
+            assert rv_recover.status_code == 200, rv_recover.data
+            db.session.expire_all()
+            chart = db.session.query(Slice).filter(Slice.uuid == chart.uuid).one()
+            assert chart.deleted_at is None
+            assert chart.is_managed_externally is True
+
+            # The same entity, seconds later: a content rewrite is refused.
+            rv = self._restore(chart_uuid, target_uuid)
+            assert rv.status_code == 403, rv.data
+            assert _json.loads(rv.data.decode("utf-8"))["message"] == (
+                "Version restore is unavailable for externally managed entities."
+            )
+        finally:
+            db.session.expire_all()
+            chart = db.session.query(Slice).filter(Slice.uuid == chart.uuid).one()
+            chart.deleted_at = None
+            chart.is_managed_externally = False
+            chart.slice_name = original_name
+            db.session.commit()
 
     def test_restore_denies_non_editor_with_write_permission(self) -> None:
         """A user holding can_write on Chart but who is not an editor of

--- a/tests/integration_tests/dashboards/version_restore_tests.py
+++ b/tests/integration_tests/dashboards/version_restore_tests.py
@@ -75,6 +75,87 @@ class TestDashboardRestoreApi(SupersetTestCase):
             f"/api/v1/dashboard/{dashboard_uuid}/versions/{version_uuid}/restore"
         )
 
+    def test_restore_refuses_externally_managed_dashboard_without_writing(self) -> None:
+        """Parity with the chart suite (FR-005): an editor's direct restore of
+        an externally managed dashboard is refused with the *same* 403 body,
+        the dashboard and its history are untouched, and read paths stay open.
+        """
+        _persist_fixture_state()
+        dashboard: Dashboard = (
+            db.session.query(Dashboard)
+            .filter(Dashboard.dashboard_title == "USA Births Names")
+            .first()
+        )
+        assert dashboard is not None
+        dashboard_uuid = str(dashboard.uuid)
+        original_name = dashboard.dashboard_title
+
+        # One extra save so there is an earlier version to target.
+        dashboard.dashboard_title = "USA Births Names managed v1"
+        db.session.commit()
+        # ``is_managed_externally`` is itself a versioned column; sample state
+        # and history only after this write is committed.
+        dashboard.is_managed_externally = True
+        db.session.commit()
+
+        try:
+            self.login(ADMIN_USERNAME)
+            base_url = f"/api/v1/dashboard/{dashboard_uuid}"
+            rv_list = self.client.get(f"{base_url}/versions/")
+            assert rv_list.status_code == 200, rv_list.data
+            listing = _json.loads(rv_list.data.decode("utf-8"))
+            target_uuid = listing["result"][0]["version_uuid"]
+
+            db.session.expire_all()
+            dashboard = (
+                db.session.query(Dashboard)
+                .filter(Dashboard.uuid == dashboard.uuid)
+                .one()
+            )
+            name_before = dashboard.dashboard_title
+            rows_before = len(_get_version_rows(dashboard))
+            count_before = listing["count"]
+
+            rv = self._restore(dashboard_uuid, target_uuid)
+            assert rv.status_code == 403, rv.data
+            resp = _json.loads(rv.data.decode("utf-8"))
+            assert (
+                resp["message"]
+                == "Version restore is unavailable for externally managed entities."
+            )
+            assert resp["message"] != "Forbidden"
+
+            db.session.expire_all()
+            dashboard = (
+                db.session.query(Dashboard)
+                .filter(Dashboard.uuid == dashboard.uuid)
+                .one()
+            )
+            assert dashboard.dashboard_title == name_before
+            assert dashboard.is_managed_externally is True
+            assert len(_get_version_rows(dashboard)) == rows_before
+            rv_list2 = self.client.get(f"{base_url}/versions/")
+            assert _json.loads(rv_list2.data.decode("utf-8"))["count"] == count_before
+
+            rv_get = self.client.get(
+                f"/api/v1/dashboard/{dashboard_uuid}/versions/{target_uuid}/"
+            )
+            assert rv_get.status_code == 200, rv_get.data
+            rv_activity = self.client.get(
+                f"/api/v1/dashboard/{dashboard_uuid}/activity/"
+            )
+            assert rv_activity.status_code == 200, rv_activity.data
+        finally:
+            db.session.expire_all()
+            dashboard = (
+                db.session.query(Dashboard)
+                .filter(Dashboard.uuid == dashboard.uuid)
+                .one()
+            )
+            dashboard.is_managed_externally = False
+            dashboard.dashboard_title = original_name
+            db.session.commit()
+
     def test_restore_applies_scalar_field(self) -> None:
         """Restore a dashboard title edit."""
         from superset.daos.version import derive_version_uuid

--- a/tests/integration_tests/datasets/version_restore_tests.py
+++ b/tests/integration_tests/datasets/version_restore_tests.py
@@ -96,6 +96,79 @@ class TestDatasetRestoreApi(SupersetTestCase):
             f"/api/v1/dataset/{dataset_uuid}/versions/{version_uuid}/restore"
         )
 
+    def test_restore_refuses_externally_managed_dataset_without_writing(self) -> None:
+        """Parity with the chart suite (FR-005): an editor's direct restore of
+        an externally managed dataset is refused with the *same* 403 body,
+        the dataset and its history are untouched, and read paths stay open.
+        """
+        _persist_fixture_state()
+        dataset: SqlaTable = (
+            db.session.query(SqlaTable)
+            .filter(SqlaTable.table_name == "birth_names")
+            .first()
+        )
+        assert dataset is not None
+        dataset_uuid = str(dataset.uuid)
+        original_name = dataset.table_name
+
+        # One extra save so there is an earlier version to target.
+        dataset.table_name = "birth_names managed v1"
+        db.session.commit()
+        # ``is_managed_externally`` is itself a versioned column; sample state
+        # and history only after this write is committed.
+        dataset.is_managed_externally = True
+        db.session.commit()
+
+        try:
+            self.login(ADMIN_USERNAME)
+            base_url = f"/api/v1/dataset/{dataset_uuid}"
+            rv_list = self.client.get(f"{base_url}/versions/")
+            assert rv_list.status_code == 200, rv_list.data
+            listing = _json.loads(rv_list.data.decode("utf-8"))
+            target_uuid = listing["result"][0]["version_uuid"]
+
+            db.session.expire_all()
+            dataset = (
+                db.session.query(SqlaTable).filter(SqlaTable.uuid == dataset.uuid).one()
+            )
+            name_before = dataset.table_name
+            rows_before = len(_get_table_version_rows(dataset))
+            count_before = listing["count"]
+
+            rv = self._restore(dataset_uuid, target_uuid)
+            assert rv.status_code == 403, rv.data
+            resp = _json.loads(rv.data.decode("utf-8"))
+            assert (
+                resp["message"]
+                == "Version restore is unavailable for externally managed entities."
+            )
+            assert resp["message"] != "Forbidden"
+
+            db.session.expire_all()
+            dataset = (
+                db.session.query(SqlaTable).filter(SqlaTable.uuid == dataset.uuid).one()
+            )
+            assert dataset.table_name == name_before
+            assert dataset.is_managed_externally is True
+            assert len(_get_table_version_rows(dataset)) == rows_before
+            rv_list2 = self.client.get(f"{base_url}/versions/")
+            assert _json.loads(rv_list2.data.decode("utf-8"))["count"] == count_before
+
+            rv_get = self.client.get(
+                f"/api/v1/dataset/{dataset_uuid}/versions/{target_uuid}/"
+            )
+            assert rv_get.status_code == 200, rv_get.data
+            rv_activity = self.client.get(f"{base_url}/activity/")
+            assert rv_activity.status_code == 200, rv_activity.data
+        finally:
+            db.session.expire_all()
+            dataset = (
+                db.session.query(SqlaTable).filter(SqlaTable.uuid == dataset.uuid).one()
+            )
+            dataset.is_managed_externally = False
+            dataset.table_name = original_name
+            db.session.commit()
+
     def test_restore_applies_scalar_field(self) -> None:
         """Restore a dataset's description edit."""
         from superset.daos.version import derive_version_uuid

--- a/tests/unit_tests/versioning/test_api_helpers.py
+++ b/tests/unit_tests/versioning/test_api_helpers.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit coverage for ``restore_version_endpoint``'s exception → HTTP mapping.
+
+The endpoint body is generic over the per-entity command's exception
+triplet. These tests pin that the shared externally-managed refusal is
+mapped to a 403 *with* the contracted message, that it is not swallowed
+by any of the triplet's ``except`` clauses for any entity type, and that
+the pre-existing 404 / 403 / 422 mappings are untouched.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, ClassVar
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from superset.commands.chart.exceptions import ChartUpdateFailedError
+from superset.commands.exceptions import ExternallyManagedRestoreError
+from superset.utils.decorators import on_error
+from superset.versioning.api_helpers import restore_version_endpoint
+
+_ENTITY_UUID = "00000000-0000-0000-0000-000000000001"
+_VERSION_UUID = "00000000-0000-0000-0000-000000000002"
+_CONTRACT_MESSAGE = "Version restore is unavailable for externally managed entities."
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _ForbiddenError(Exception):
+    pass
+
+
+class _FailedError(Exception):
+    pass
+
+
+def _command_raising(exc: Exception) -> type[Any]:
+    """A stand-in command class whose ``run()`` raises *exc*."""
+
+    class _Command:
+        not_found_exc: ClassVar[type[Exception]] = _NotFoundError
+        forbidden_exc: ClassVar[type[Exception]] = _ForbiddenError
+        failed_exc: ClassVar[type[Exception]] = _FailedError
+
+        def __init__(self, entity_uuid: UUID, version_uuid: UUID) -> None:
+            self.entity_uuid = entity_uuid
+            self.version_uuid = version_uuid
+
+        def run(self) -> Any:
+            raise exc
+
+    return _Command
+
+
+def _fab_like_api() -> MagicMock:
+    """Stub with Flask-AppBuilder's response-helper shapes: the fixed-body
+    helpers return their canned message, ``response`` echoes its kwargs."""
+    api = MagicMock()
+    api.response.side_effect = lambda code, **kw: ("response", code, kw)
+    api.response_403.return_value = ("response_403", 403, {"message": "Forbidden"})
+    api.response_404.return_value = ("response_404", 404, {"message": "Not found"})
+    api.response_422.side_effect = lambda message=None: ("response_422", 422, message)
+    return api
+
+
+def _call(api: MagicMock, command_cls: type[Any]) -> Any:
+    return restore_version_endpoint(
+        api, MagicMock(__name__="Slice"), command_cls, _ENTITY_UUID, _VERSION_UUID
+    )
+
+
+def test_externally_managed_maps_to_403_with_contract_message() -> None:
+    """The policy refusal goes through ``api.response(403, message=…)`` — the
+    only helper that can carry a message — never the fixed-body 403."""
+    api = _fab_like_api()
+
+    result = _call(api, _command_raising(ExternallyManagedRestoreError()))
+
+    assert result == ("response", 403, {"message": _CONTRACT_MESSAGE})
+    api.response_403.assert_not_called()
+
+
+def test_policy_and_permission_403_bodies_differ() -> None:
+    """FR-004: a caller can tell 'externally managed' from 'not permitted'
+    by the body alone. FAB's ``response_403()`` always says ``Forbidden``."""
+    api = _fab_like_api()
+
+    policy = _call(api, _command_raising(ExternallyManagedRestoreError()))
+    permission = _call(api, _command_raising(_ForbiddenError()))
+
+    assert policy[1] == permission[1] == 403
+    assert policy[2]["message"] != permission[2]["message"]
+    assert permission == ("response_403", 403, {"message": "Forbidden"})
+
+
+@pytest.mark.parametrize(
+    "command_path",
+    [
+        "superset.commands.chart.restore_version.RestoreChartVersionCommand",
+        "superset.commands.dashboard.restore_version.RestoreDashboardVersionCommand",
+        "superset.commands.dataset.restore_version.RestoreDatasetVersionCommand",
+    ],
+)
+def test_shared_exception_is_not_caught_by_any_entity_triplet(
+    command_path: str,
+) -> None:
+    """Pins the contract's inheritance constraint against the *real*
+    per-entity commands, so a future re-parenting of the exception (or of
+    a triplet class) fails here instead of silently turning the refusal
+    into a bare 403 / 404 / 422."""
+    module_path, _, name = command_path.rpartition(".")
+    command_cls = getattr(import_module(module_path), name)
+
+    triplet = (
+        command_cls.not_found_exc,
+        command_cls.forbidden_exc,
+        command_cls.failed_exc,
+    )
+    assert not issubclass(ExternallyManagedRestoreError, triplet)
+
+
+def test_transaction_on_error_passes_shared_exception_through() -> None:
+    """The command's ``@transaction(on_error=partial(on_error,
+    reraise=failed_exc))`` converts only ``SQLAlchemyError``; the policy
+    exception must be re-raised as itself, or it would surface as 422."""
+    original = ExternallyManagedRestoreError()
+
+    with pytest.raises(ExternallyManagedRestoreError) as excinfo:
+        on_error(original, reraise=ChartUpdateFailedError)
+
+    assert excinfo.value is original
+
+
+def test_existing_mappings_are_unchanged() -> None:
+    """FR-006: the 404 / 403 / 422 rows of the response matrix are exactly
+    what they were before the policy row was added."""
+    api = _fab_like_api()
+
+    assert _call(api, _command_raising(_NotFoundError())) == (
+        "response_404",
+        404,
+        {"message": "Not found"},
+    )
+    assert _call(api, _command_raising(_ForbiddenError())) == (
+        "response_403",
+        403,
+        {"message": "Forbidden"},
+    )
+    assert _call(api, _command_raising(_FailedError("boom"))) == (
+        "response_422",
+        422,
+        "boom",
+    )

--- a/tests/unit_tests/versioning/test_restore_command.py
+++ b/tests/unit_tests/versioning/test_restore_command.py
@@ -1,0 +1,201 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit coverage for ``BaseRestoreVersionCommand.validate()``'s gate chain.
+
+The engine itself is covered in ``test_restore.py`` and end-to-end in the
+per-entity integration suites. Here we pin the command's *policy* gate
+with mocks: an externally managed entity is refused after — never
+before — the editorship check, the flag is read fresh on every request,
+and the refusal fires before any version is resolved or written.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from superset.commands.exceptions import (
+    ExternallyManagedRestoreError,
+    ForbiddenError,
+)
+from superset.commands.version_restore import BaseRestoreVersionCommand
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+from superset.exceptions import SupersetSecurityException
+
+_ENTITY_UUID = UUID("00000000-0000-0000-0000-000000000001")
+_VERSION_UUID = UUID("00000000-0000-0000-0000-000000000002")
+
+_MODULE = "superset.commands.version_restore"
+
+
+class _NotFoundError(Exception):
+    pass
+
+
+class _ForbiddenError(Exception):
+    pass
+
+
+class _FailedError(Exception):
+    pass
+
+
+class _Command(BaseRestoreVersionCommand):
+    """Minimal concrete subclass — the base owns the whole workflow."""
+
+    model_cls = MagicMock(__name__="Slice")
+    not_found_exc = _NotFoundError
+    forbidden_exc = _ForbiddenError
+    failed_exc = _FailedError
+
+
+def _entity(*, managed: bool) -> MagicMock:
+    entity = MagicMock()
+    entity.is_managed_externally = managed
+    return entity
+
+
+def _not_an_editor() -> SupersetSecurityException:
+    return SupersetSecurityException(
+        SupersetError(
+            message="not an editor",
+            error_type=SupersetErrorType.DASHBOARD_SECURITY_ACCESS_ERROR,
+            level=ErrorLevel.ERROR,
+        )
+    )
+
+
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_validate_refuses_externally_managed_entity_for_editor(
+    mock_capture, mock_find, mock_security
+) -> None:
+    """An editor of an externally managed entity is refused with the
+    shared policy exception, not the permission one."""
+    mock_find.return_value = _entity(managed=True)
+    mock_security.raise_for_editorship.return_value = None
+
+    with pytest.raises(ExternallyManagedRestoreError):
+        _Command(_ENTITY_UUID, _VERSION_UUID).validate()
+
+    mock_security.raise_for_editorship.assert_called_once()
+
+
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_validate_evaluates_permission_before_policy(
+    mock_capture, mock_find, mock_security
+) -> None:
+    """A non-editor of an externally managed entity sees the permission
+    denial, so external management is never disclosed to someone with no
+    rights to the entity."""
+    mock_find.return_value = _entity(managed=True)
+    mock_security.raise_for_editorship.side_effect = _not_an_editor()
+
+    with pytest.raises(_ForbiddenError):
+        _Command(_ENTITY_UUID, _VERSION_UUID).validate()
+
+
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_validate_passes_unmanaged_entity_through(
+    mock_capture, mock_find, mock_security
+) -> None:
+    """The gate is inert for an ordinary entity: validate returns it."""
+    entity = _entity(managed=False)
+    mock_find.return_value = entity
+    mock_security.raise_for_editorship.return_value = None
+
+    assert _Command(_ENTITY_UUID, _VERSION_UUID).validate() is entity
+
+
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_validate_reads_flag_per_request(
+    mock_capture, mock_find, mock_security
+) -> None:
+    """The flag is read from the freshly loaded entity on every call, so an
+    entity that becomes externally managed between two requests is refused
+    on the second without any cached state."""
+    mock_security.raise_for_editorship.return_value = None
+    command = _Command(_ENTITY_UUID, _VERSION_UUID)
+
+    mock_find.return_value = _entity(managed=False)
+    command.validate()
+
+    mock_find.return_value = _entity(managed=True)
+    with pytest.raises(ExternallyManagedRestoreError):
+        command.validate()
+
+
+@patch(f"{_MODULE}.restore_version")
+@patch(f"{_MODULE}.resolve_version")
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_refusal_precedes_version_resolution_and_restore(
+    mock_capture, mock_find, mock_security, mock_resolve, mock_restore
+) -> None:
+    """The refusal fires before the target version is even resolved, so
+    nothing is written and a would-be no-op restore (target == current)
+    is refused exactly like any other."""
+    mock_find.return_value = _entity(managed=True)
+    mock_security.raise_for_editorship.return_value = None
+
+    with pytest.raises(ExternallyManagedRestoreError):
+        _Command(_ENTITY_UUID, _VERSION_UUID)._do_restore()
+
+    mock_resolve.assert_not_called()
+    mock_restore.assert_not_called()
+
+
+@patch(f"{_MODULE}.security_manager", new_callable=MagicMock)
+@patch(f"{_MODULE}.find_active_by_uuid")
+@patch(f"{_MODULE}.capture_enabled", return_value=True)
+def test_run_propagates_refusal_through_transaction_wrapper(
+    mock_capture, mock_find, mock_security
+) -> None:
+    """``run()`` wraps ``_do_restore`` in ``@transaction(on_error=…)``, whose
+    handler converts only ``SQLAlchemyError`` into ``failed_exc``. The policy
+    exception must come out the other side unchanged — not as a 422."""
+    mock_find.return_value = _entity(managed=True)
+    mock_security.raise_for_editorship.return_value = None
+
+    with pytest.raises(ExternallyManagedRestoreError) as excinfo:
+        _Command(_ENTITY_UUID, _VERSION_UUID).run()
+
+    assert type(excinfo.value) is ExternallyManagedRestoreError
+
+
+def test_exception_shape_matches_contract() -> None:
+    """One shared exception: a 403 ``ForbiddenError`` sibling with the
+    contracted message, and not something the transaction wrapper would
+    convert."""
+    assert issubclass(ExternallyManagedRestoreError, ForbiddenError)
+    assert not issubclass(ExternallyManagedRestoreError, SQLAlchemyError)
+    assert ExternallyManagedRestoreError.status == 403
+    assert (
+        ExternallyManagedRestoreError().message
+        == "Version restore is unavailable for externally managed entities."
+    )


### PR DESCRIPTION
### SUMMARY

`POST /api/v1/{chart,dashboard,dataset}/<uuid>/versions/<version_uuid>/restore` never checked
`is_managed_externally`. The dashboard and chart UIs hide the restore control for externally managed
entities, but any direct caller with edit rights — a script, a notebook, an integration — could restore an
older version over a dbt-synced dataset or an externally provisioned dashboard. The next sync then either
overwrites the restore or resurrects content the external owner had removed. The published documentation
(`docs/using-superset/version-history.mdx`) already states that restore "is withheld from externally managed
entities"; this PR makes that statement true.

**The change** is one gate and one mapping:

- `BaseRestoreVersionCommand.validate()` gains a fourth check, after the editorship check, raising a new
  shared `ExternallyManagedRestoreError` (a `ForbiddenError` subclass). Because the three per-entity restore
  commands are pure declarations over that base, one edit covers charts, dashboards, and datasets identically.
- `restore_version_endpoint()` maps it to `403 {"message": "Version restore is unavailable for externally
  managed entities."}` via `api.response(403, message=…)`. FAB's `response_403()` always emits
  `{"message": "Forbidden"}`, so a caller can distinguish a policy refusal from a permission denial by the body.

**Design notes reviewers will want:**

- **Ordering.** The gate runs *after* `raise_for_editorship`, so a caller with no rights to the entity still
  gets the plain permission denial and is never told the entity is externally managed. It runs *before* version
  resolution, so a refused restore writes nothing — no version row, no partial update.
- **This is the first server-side use of `is_managed_externally`.** No update or delete command enforces the
  flag today; those operations remain gated in the browser alone. After this PR a permitted editor is refused a
  version restore but can still submit an equivalent direct `PUT`. That asymmetry is accepted deliberately: the
  documentation promises the restriction for restore and for nothing else, and widening enforcement to
  update/delete is a product decision for the Versioning epic rather than this correctness fix. Follow-up:
  _to be filed before this leaves draft_.
- **Soft-delete recovery is deliberately not gated.** Recovering an archived externally managed entity changes
  visibility, not content, and is a useful escape hatch when a synced asset is archived by mistake. The
  asymmetry is pinned by a test on one and the same entity: archive → recover succeeds → version restore
  refused.
- **No `UPDATING.md` entry.** A released endpoint does change from 200 to 403 for one class of caller, but the
  change brings the API into line with already-published documentation and is a correctness fix, not a
  boundary change.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no UI change. Before/after is the API response below.

### TESTING INSTRUCTIONS

Automated (all control-first — every behavioural test was run red against the pre-fix code first):

```bash
pytest tests/unit_tests/versioning/                                    # 140 passed (14 new)
pytest tests/integration_tests/charts/version_restore_tests.py \
       tests/integration_tests/dashboards/version_restore_tests.py \
       tests/integration_tests/datasets/version_restore_tests.py     # 37 passed (4 new)
```

Manual:

1. Mark a chart externally managed (`UPDATE slices SET is_managed_externally = true WHERE uuid = '<uuid>'`).
2. As a user who can edit it, `POST /api/v1/chart/<uuid>/versions/<version_uuid>/restore`.
   - **Before:** `200 {"message": "OK"}`; the chart is rewritten and — because the flag is itself a versioned
     column — restoring an older version also silently flips `is_managed_externally` back to `false`.
   - **After:** `403 {"message": "Version restore is unavailable for externally managed entities."}`; chart and
     version history unchanged.
3. As a user who *cannot* edit it: `403 {"message": "Forbidden"}` — unchanged, and the body differs from step 2.
4. `GET …/versions/`, `GET …/versions/<v>/`, `GET …/activity/` all still `200` for the managed chart.
5. `DELETE /api/v1/chart/<id>` then `POST /api/v1/chart/<uuid>/restore` (recovery): both `200`; a version
   restore immediately after is still `403`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: sc-115616 (origin: scope note in the verification review of #41551)
- [ ] Required feature flags: none new (`VERSION_HISTORY` / `ENABLE_VERSIONING_CAPTURE`, already on by default)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
