### PR TITLE
feat(chart): list semantic views in the Create Chart datasource picker

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
@@ -752,6 +752,25 @@ test('displays an error message when an exception is thrown while fetching', asy
   expect(screen.getByText(error)).toBeInTheDocument();
 });
 
+test('clears a previous fetch error once a later fetch succeeds', async () => {
+  const error = 'Fetch error';
+  const loadOptions = jest.fn(async (search: string) => {
+    if (search === 'fail') {
+      throw new Error(error);
+    }
+    // Report more results than are loaded so every new search hits the server.
+    return { data: [{ label: search, value: search }], totalCount: 100 };
+  });
+  render(<AsyncSelect {...defaultProps} options={loadOptions} />);
+  await open();
+  await type('fail');
+  expect(await screen.findByText(error)).toBeInTheDocument();
+
+  await type('retry');
+  expect(await findSelectOption('retry')).toBeInTheDocument();
+  expect(screen.queryByText(error)).not.toBeInTheDocument();
+});
+
 test('does not fire a new request for the same search input', async () => {
   const loadOptions = jest.fn(async () => ({ data: [], totalCount: 0 }));
   render(

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
@@ -771,6 +771,55 @@ test('clears a previous fetch error once a later fetch succeeds', async () => {
   expect(screen.queryByText(error)).not.toBeInTheDocument();
 });
 
+test('clears a previous fetch error when the next page comes from cache', async () => {
+  const error = 'Fetch error';
+  const loadOptions = jest.fn(
+    async (search: string, page: number, pageSize: number) => {
+      if (search === 'fail') {
+        throw new Error(error);
+      }
+      return defaultProps.options(search, page, pageSize);
+    },
+  );
+  render(<AsyncSelect {...defaultProps} options={loadOptions} />);
+  await open();
+  await findSelectOption(OPTIONS[0].label);
+
+  await type('fail');
+  expect(await screen.findByText(error)).toBeInTheDocument();
+
+  // Clearing the input re-requests the first page, which is already cached
+  // and therefore never reaches the network.
+  await userEvent.clear(getSelect());
+  expect(await findSelectOption(OPTIONS[0].label)).toBeInTheDocument();
+  expect(screen.queryByText(error)).not.toBeInTheDocument();
+});
+
+test('ignores a late failure from a search the user has moved on from', async () => {
+  const error = 'Fetch error';
+  let rejectSlow: (reason: Error) => void = () => {};
+  const loadOptions = jest.fn(async (search: string) => {
+    if (search === 'slow') {
+      return new Promise<never>((_, reject) => {
+        rejectSlow = reject;
+      });
+    }
+    return { data: [{ label: search, value: search }], totalCount: 100 };
+  });
+  render(<AsyncSelect {...defaultProps} options={loadOptions} />);
+  await open();
+  await type('slow');
+  await waitFor(() => expect(loadOptions).toHaveBeenCalledWith('slow', 0, 10));
+
+  await type('fast');
+  expect(await findSelectOption('fast')).toBeInTheDocument();
+
+  rejectSlow(new Error(error));
+  await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(3));
+  expect(screen.queryByText(error)).not.toBeInTheDocument();
+  expect(await findSelectOption('fast')).toBeInTheDocument();
+});
+
 test('does not fire a new request for the same search input', async () => {
   const loadOptions = jest.fn(async () => ({ data: [], totalCount: 0 }));
   render(

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.test.tsx
@@ -820,6 +820,29 @@ test('ignores a late failure from a search the user has moved on from', async ()
   expect(await findSelectOption('fast')).toBeInTheDocument();
 });
 
+test('still surfaces a base-fetch failure that lands mid-search', async () => {
+  const error = 'Fetch error';
+  let rejectBase: (reason: Error) => void = () => {};
+  const loadOptions = jest.fn(async (search: string) => {
+    if (search === '') {
+      // Defer the base page so it can fail after the user starts searching.
+      return new Promise<never>((_, reject) => {
+        rejectBase = reject;
+      });
+    }
+    return { data: [{ label: search, value: search }], totalCount: 100 };
+  });
+  render(<AsyncSelect {...defaultProps} options={loadOptions} />);
+  await open();
+  await type('abc');
+  expect(await findSelectOption('abc')).toBeInTheDocument();
+
+  // Base fetches keep the accumulator and allValuesLoaded up to date even
+  // mid-search, so their failures must surface too.
+  rejectBase(new Error(error));
+  expect(await screen.findByText(error)).toBeInTheDocument();
+});
+
 test('does not fire a new request for the same search input', async () => {
   const loadOptions = jest.fn(async () => ({ data: [], totalCount: 0 }));
   render(

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -491,13 +491,17 @@ const AsyncSelect = forwardRef(
             }
           })
           .catch((response: Response) => {
-            // Same rule as for results: a failure belonging to a search the
-            // user has since moved on from must not replace the outcome of
-            // the fetch that superseded it.
-            if (inputValueRef.current === search) {
-              return internalOnError(response);
+            // Mirror the results guard above: a failure belonging to a search
+            // the user has since moved on from must not replace the outcome
+            // of the fetch that superseded it. Base fetches (search === '')
+            // are exempt exactly as their results are — they maintain the
+            // accumulator and allValuesLoaded, so their failures must stay
+            // visible even when they land mid-search. The consumer's onError
+            // is skipped along with the banner for superseded searches.
+            if (search && inputValueRef.current !== search) {
+              return undefined;
             }
-            return undefined;
+            return internalOnError(response);
           })
           .finally(() => {
             inFlightFetchesRef.current = Math.max(

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -412,6 +412,9 @@ const AsyncSelect = forwardRef(
           setIsLoading(false);
           return;
         }
+        // A previous fetch may have left an error on screen; clear it so the
+        // dropdown renders this fetch's outcome instead of the stale error.
+        setError('');
         setIsLoading(true);
 
         const fetchOptions = options as SelectOptionsPagePromise;

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/AsyncSelect.tsx
@@ -401,6 +401,10 @@ const AsyncSelect = forwardRef(
     const fetchPage = useMemo(
       () => (search: string, page: number) => {
         setPage(page);
+        // A previous fetch may have left an error on screen. Clear it before
+        // any early return so a page served from cache, or from an already
+        // complete option set, is not shown next to a stale error.
+        setError('');
         if (allValuesLoaded) {
           setIsLoading(false);
           return;
@@ -412,9 +416,6 @@ const AsyncSelect = forwardRef(
           setIsLoading(false);
           return;
         }
-        // A previous fetch may have left an error on screen; clear it so the
-        // dropdown renders this fetch's outcome instead of the stale error.
-        setError('');
         setIsLoading(true);
 
         const fetchOptions = options as SelectOptionsPagePromise;
@@ -489,7 +490,15 @@ const AsyncSelect = forwardRef(
               setTotalCount(totalCount);
             }
           })
-          .catch(internalOnError)
+          .catch((response: Response) => {
+            // Same rule as for results: a failure belonging to a search the
+            // user has since moved on from must not replace the outcome of
+            // the fetch that superseded it.
+            if (inputValueRef.current === search) {
+              return internalOnError(response);
+            }
+            return undefined;
+          })
           .finally(() => {
             inFlightFetchesRef.current = Math.max(
               0,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/DatasetSelect.tsx
@@ -17,12 +17,10 @@
  * under the License.
  */
 import { useCallback, useMemo, ReactNode } from 'react';
-import rison from 'rison';
 import { t } from '@apache-superset/core/translation';
 import {
   isFeatureEnabled,
   FeatureFlag,
-  JsonResponse,
   ClientErrorObject,
   getClientErrorObject,
 } from '@superset-ui/core';
@@ -32,6 +30,7 @@ import {
   Dataset,
   DatasetSelectLabel,
 } from 'src/features/datasets/DatasetSelectLabel';
+import { fetchDatasourceList } from 'src/features/datasets/fetchDatasourceList';
 import {
   datasetLabel,
   datasetLabelLower,
@@ -95,27 +94,10 @@ export const loadDatasetOptions = async (
   excludeDatasetIds: number[] = [],
 ) => {
   const useSemanticLayers = isFeatureEnabled(FeatureFlag.SemanticLayers);
-  const query = rison.encode({
-    ...(useSemanticLayers
-      ? {}
-      : {
-          columns: ['id', 'table_name', 'database.database_name', 'schema'],
-        }),
-    filters: [{ col: 'table_name', opr: 'ct', value: search }],
-    page,
-    page_size: pageSize,
-    order_column: 'table_name',
-    order_direction: 'asc',
-  });
-  const endpoint = useSemanticLayers
-    ? `/api/v1/datasource/?q=${query}`
-    : `/api/v1/dataset/?q=${query}`;
-  return cachedSupersetGet({
-    endpoint,
-  })
-    .then((response: JsonResponse) => {
-      const filteredResult = response.json.result.filter(
-        (item: Dataset) => !isExcludedDatasource(item, excludeDatasetIds),
+  return fetchDatasourceList(search, page, pageSize, { get: cachedSupersetGet })
+    .then(({ result, count }) => {
+      const filteredResult = result.filter(
+        item => !isExcludedDatasource(item, excludeDatasetIds),
       );
 
       const list: {
@@ -123,7 +105,7 @@ export const loadDatasetOptions = async (
         value: string | number;
         table_name: string;
         kind?: string;
-      }[] = filteredResult.map((item: Dataset) => ({
+      }[] = filteredResult.map(item => ({
         ...item,
         label: DatasetSelectLabel(item),
         value: useSemanticLayers
@@ -134,7 +116,7 @@ export const loadDatasetOptions = async (
       }));
       return {
         data: list,
-        totalCount: response.json.count ?? 0,
+        totalCount: count,
       };
     })
     .catch(async error => {

--- a/superset-frontend/src/features/datasets/DatasetSelectLabel/index.tsx
+++ b/superset-frontend/src/features/datasets/DatasetSelectLabel/index.tsx
@@ -25,13 +25,18 @@ type Database = {
   database_name: string;
 };
 
+/**
+ * One row of a dataset or combined datasource listing. Semantic views report
+ * ``kind: 'semantic_view'`` and carry no schema; their ``database`` names the
+ * owning semantic layer.
+ */
 export type Dataset = {
   id: number;
   table_name: string;
   datasource_type?: string;
   kind?: string;
-  schema: string;
-  database?: Database;
+  schema?: string | null;
+  database?: Database | null;
 };
 
 const TooltipContent = styled.div`

--- a/superset-frontend/src/features/datasets/fetchDatasourceList.test.ts
+++ b/superset-frontend/src/features/datasets/fetchDatasourceList.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import { isFeatureEnabled } from '@superset-ui/core';
+import { fetchDatasourceList } from './fetchDatasourceList';
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(() => false),
+}));
+
+const mockIsFeatureEnabled = jest.mocked(isFeatureEnabled);
+
+const emptyPage = { result: [], count: 0 };
+
+beforeEach(() => {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+  fetchMock.get('glob:*/api/v1/dataset/*', emptyPage);
+  fetchMock.get('glob:*/api/v1/datasource/*', emptyPage);
+  mockIsFeatureEnabled.mockReturnValue(false);
+});
+
+const requestedUrls = () =>
+  fetchMock.callHistory.calls().map(call => decodeURIComponent(call.url));
+
+test('uses the combined endpoint when the flag is on and the dataset endpoint when off', async () => {
+  mockIsFeatureEnabled.mockReturnValue(true);
+  await fetchDatasourceList('orders', 0, 25);
+  mockIsFeatureEnabled.mockReturnValue(false);
+  await fetchDatasourceList('orders', 0, 25);
+
+  const urls = requestedUrls();
+  expect(urls[0]).toContain('/api/v1/datasource/');
+  expect(urls[1]).toContain('/api/v1/dataset/');
+});
+
+test('exactMatch with datasetsOnly stays on the dataset endpoint with an eq filter', async () => {
+  mockIsFeatureEnabled.mockReturnValue(true);
+  await fetchDatasourceList('orders', 0, 1, {
+    exactMatch: true,
+    datasetsOnly: true,
+  });
+
+  const urls = requestedUrls();
+  expect(urls[0]).toContain('/api/v1/dataset/');
+  expect(urls[0]).toContain('opr:eq');
+});
+
+test('exactMatch without datasetsOnly is refused, not silently unfiltered', async () => {
+  // The combined endpoint's filter parser honours only substring (ct) name
+  // filters; an eq filter is dropped and the page comes back unfiltered.
+  mockIsFeatureEnabled.mockReturnValue(true);
+  expect(() =>
+    // @ts-expect-error deliberately violating the option coupling
+    fetchDatasourceList('orders', 0, 1, { exactMatch: true }),
+  ).toThrow(/exactMatch requires datasetsOnly/);
+  expect(requestedUrls()).toHaveLength(0);
+});

--- a/superset-frontend/src/features/datasets/fetchDatasourceList.ts
+++ b/superset-frontend/src/features/datasets/fetchDatasourceList.ts
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import rison from 'rison';
+import {
+  FeatureFlag,
+  isFeatureEnabled,
+  JsonResponse,
+  SupersetClient,
+} from '@superset-ui/core';
+import { Dataset } from './DatasetSelectLabel';
+
+/** Columns requested from the dataset-only endpoint. */
+const DATASET_LIST_COLUMNS = [
+  'id',
+  'table_name',
+  'datasource_type',
+  'database.database_name',
+  'schema',
+];
+
+export type DatasourceListPage = {
+  result: Dataset[];
+  count: number;
+};
+
+export type FetchDatasourceListOptions = {
+  /** Match `search` against the name exactly rather than as a substring. */
+  exactMatch?: boolean;
+  /**
+   * Query the dataset-only endpoint even when semantic layers are enabled.
+   * Used by callers that resolve a dataset by name and must not be answered
+   * with a same-named semantic view.
+   */
+  datasetsOnly?: boolean;
+  /** Transport to use; pass a cached variant to share responses. */
+  get?: typeof SupersetClient.get;
+};
+
+/**
+ * Fetches one page of datasources by name, ordered by name.
+ *
+ * When the SEMANTIC_LAYERS feature flag is enabled the combined datasource
+ * endpoint is queried and the page mixes datasets with semantic views
+ * (distinguished by `kind`); otherwise only datasets are listed. Every picker
+ * that offers datasources should load through here so the two endpoints stay
+ * behind one contract.
+ */
+export const fetchDatasourceList = (
+  search: string,
+  page: number,
+  pageSize: number,
+  {
+    exactMatch = false,
+    datasetsOnly = false,
+    get = SupersetClient.get,
+  }: FetchDatasourceListOptions = {},
+): Promise<DatasourceListPage> => {
+  const useCombinedList =
+    !datasetsOnly && isFeatureEnabled(FeatureFlag.SemanticLayers);
+  const query = rison.encode({
+    ...(useCombinedList ? {} : { columns: DATASET_LIST_COLUMNS }),
+    filters: [
+      { col: 'table_name', opr: exactMatch ? 'eq' : 'ct', value: search },
+    ],
+    page,
+    page_size: pageSize,
+    order_column: 'table_name',
+    order_direction: 'asc',
+  });
+  const endpoint = useCombinedList
+    ? `/api/v1/datasource/?q=${query}`
+    : `/api/v1/dataset/?q=${query}`;
+  return get({ endpoint }).then((response: JsonResponse) => ({
+    result: response.json.result as Dataset[],
+    count: response.json.count ?? 0,
+  }));
+};

--- a/superset-frontend/src/features/datasets/fetchDatasourceList.ts
+++ b/superset-frontend/src/features/datasets/fetchDatasourceList.ts
@@ -40,17 +40,30 @@ export type DatasourceListPage = {
 };
 
 export type FetchDatasourceListOptions = {
-  /** Match `search` against the name exactly rather than as a substring. */
-  exactMatch?: boolean;
-  /**
-   * Query the dataset-only endpoint even when semantic layers are enabled.
-   * Used by callers that resolve a dataset by name and must not be answered
-   * with a same-named semantic view.
-   */
-  datasetsOnly?: boolean;
   /** Transport to use; pass a cached variant to share responses. */
   get?: typeof SupersetClient.get;
-};
+} & (
+  | {
+      /**
+       * Match `search` against the name exactly rather than as a substring.
+       * Only supported together with `datasetsOnly`: the combined datasource
+       * endpoint's filter parser honours only substring (`ct`) name filters
+       * and silently drops an `eq` filter, so an exact-match preload against
+       * it would resolve to an arbitrary unfiltered page.
+       */
+      exactMatch: true;
+      datasetsOnly: true;
+    }
+  | {
+      exactMatch?: false;
+      /**
+       * Query the dataset-only endpoint even when semantic layers are
+       * enabled. Used by callers that resolve a dataset by name and must not
+       * be answered with a same-named semantic view.
+       */
+      datasetsOnly?: boolean;
+    }
+);
 
 /**
  * Fetches one page of datasources by name, ordered by name.
@@ -71,6 +84,13 @@ export const fetchDatasourceList = (
     get = SupersetClient.get,
   }: FetchDatasourceListOptions = {},
 ): Promise<DatasourceListPage> => {
+  if (exactMatch && !datasetsOnly) {
+    // Enforced at the type level too; this guards plain-JS callers.
+    throw new Error(
+      'fetchDatasourceList: exactMatch requires datasetsOnly — the combined ' +
+        'datasource endpoint only supports substring name filters.',
+    );
+  }
   const useCombinedList =
     !datasetsOnly && isFeatureEnabled(FeatureFlag.SemanticLayers);
   const query = rison.encode({

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -18,7 +18,6 @@
  */
 
 import {
-  fireEvent,
   render,
   screen,
   userEvent,
@@ -41,6 +40,11 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 const mockIsFeatureEnabled = jest.mocked(isFeatureEnabled);
+
+const enableSemanticLayers = () =>
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
 
 const mockDatasourceResponse = {
   result: [
@@ -491,85 +495,39 @@ test('shows only exact match when loading dataset from URL, not partial matches'
   locationSpy.mockRestore();
 });
 
-test('loads and labels mixed datasource results across pages', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
-  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, ({ url }) => {
-    const isSecondPage = url.includes('page:1');
-    return {
-      body: {
-        result: isSecondPage
-          ? [
-              {
-                id: 43,
-                table_name: 'second_page_view',
-                kind: 'semantic_view',
-                source_type: 'semantic_layer',
-                database: { database_name: 'Sales semantics' },
-                schema: null,
-              },
-            ]
-          : combinedDatasourceFixtures,
-        count: 101,
-      },
-      status: 200,
-    };
+test('lists a same-named dataset and semantic view as distinct, typed options', async () => {
+  enableSemanticLayers();
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
+    body: { result: combinedDatasourceFixtures, count: 2 },
+    status: 200,
   });
 
   await renderComponent();
-  const datasourceSelect = screen.getByRole('combobox', {
-    name: 'Datasource',
-  });
-  userEvent.click(datasourceSelect);
+  userEvent.click(screen.getByRole('combobox', { name: 'Datasource' }));
 
   expect(await screen.findAllByText('shared_source')).toHaveLength(2);
-  const datasetTypeLabel = screen.getByText('Dataset');
-  const semanticViewTypeLabel = screen.getByText('Semantic View');
-  expect(datasetTypeLabel).toBeInTheDocument();
-  expect(datasetTypeLabel).not.toHaveAttribute('aria-hidden', 'true');
-  expect(semanticViewTypeLabel).toBeInTheDocument();
-  expect(semanticViewTypeLabel).not.toHaveAttribute('aria-hidden', 'true');
-  await waitFor(() =>
-    expect(document.querySelector('.ant-select-suffix .ant-spin')).toBeNull(),
+  // The type label is plain text inside each option rather than colour or an
+  // icon, so it is read out along with the name.
+  const optionTexts = Array.from(
+    document.querySelectorAll('.ant-select-item-option-content'),
+    option => option.textContent,
   );
-
-  const scrollContainer = document.querySelector(
-    '.ant-select-dropdown-list-holder',
+  expect(optionTexts).toEqual([
+    expect.stringMatching(/^shared_source.*Dataset$/),
+    expect.stringMatching(/^shared_source.*Semantic View$/),
+  ]);
+  expect(screen.getByText('Dataset')).not.toHaveAttribute(
+    'aria-hidden',
+    'true',
   );
-  expect(scrollContainer).not.toBeNull();
-  if (!scrollContainer) {
-    throw new Error('Expected datasource options to have a scroll container');
-  }
-  Object.defineProperty(scrollContainer, 'scrollHeight', {
-    configurable: true,
-    get: () => 1000,
-  });
-  Object.defineProperty(scrollContainer, 'offsetHeight', {
-    configurable: true,
-    get: () => 100,
-  });
-  Object.defineProperty(scrollContainer, 'clientHeight', {
-    configurable: true,
-    get: () => 100,
-  });
-  Object.defineProperty(scrollContainer, 'scrollTop', {
-    configurable: true,
-    get: () => 900,
-    set: () => {},
-  });
-  fireEvent.scroll(scrollContainer);
-
-  expect(await screen.findByText('second_page_view')).toBeInTheDocument();
-  expect(
-    fetchMock.callHistory.calls().some(call => call.url.includes('page:1')),
-  ).toBe(true);
+  expect(screen.getByText('Semantic View')).not.toHaveAttribute(
+    'aria-hidden',
+    'true',
+  );
 });
 
-test('preserves unified server ordering without datasource type priority', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
+test('requests unified server ordering by table name', async () => {
+  enableSemanticLayers();
   fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
     body: {
       result: [
@@ -598,12 +556,7 @@ test('preserves unified server ordering without datasource type priority', async
   await renderComponent();
   userEvent.click(screen.getByRole('combobox', { name: 'Datasource' }));
 
-  const semanticView = await screen.findByText('alpha_semantic_view');
-  const dataset = screen.getByText('beta_dataset');
-  expect(
-    semanticView.compareDocumentPosition(dataset) &
-      Node.DOCUMENT_POSITION_FOLLOWING,
-  ).toBeTruthy();
+  await screen.findByText('alpha_semantic_view');
   expect(
     fetchMock.callHistory.calls().some(call => {
       const decodedUrl = decodeURIComponent(call.url);
@@ -615,25 +568,11 @@ test('preserves unified server ordering without datasource type priority', async
   ).toBe(true);
 });
 
-test('searches semantic views and rejects unknown datasource kinds', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
+test('searches semantic views through the combined datasource endpoint', async () => {
+  enableSemanticLayers();
   fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
-    body: {
-      result: [
-        combinedDatasourceFixtures[1],
-        {
-          id: 99,
-          table_name: 'unsupported_source',
-          kind: 'future_kind',
-          source_type: 'future_source',
-          database: null,
-          schema: null,
-        },
-      ],
-      count: 2,
-    },
+    // More results than are loaded, so searching goes back to the server.
+    body: { result: [combinedDatasourceFixtures[1]], count: 26 },
     status: 200,
   });
 
@@ -645,7 +584,6 @@ test('searches semantic views and rejects unknown datasource kinds', async () =>
   userEvent.type(datasourceSelect, 'shared');
 
   expect(await screen.findByText('shared_source')).toBeInTheDocument();
-  expect(screen.queryByText('unsupported_source')).not.toBeInTheDocument();
   await waitFor(() =>
     expect(
       fetchMock.callHistory.calls().some(call => {
@@ -662,9 +600,7 @@ test('searches semantic views and rejects unknown datasource kinds', async () =>
 });
 
 test('navigates to Explore with the semantic view composite identity', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
+  enableSemanticLayers();
   fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
     body: { result: [combinedDatasourceFixtures[1]], count: 1 },
     status: 200,
@@ -681,18 +617,30 @@ test('navigates to Explore with the semantic view composite identity', async () 
   );
 });
 
-test('recovers from a failed mixed datasource load without replacing selection', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
-  let requestCount = 0;
-  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, () => {
-    requestCount += 1;
-    if (requestCount === 2) {
-      return { throws: new Error('datasource load failed') };
+test('shows a failed datasource load as an error, then recovers on the next search', async () => {
+  enableSemanticLayers();
+  const retryView = {
+    id: 43,
+    table_name: 'retry_view',
+    kind: 'semantic_view',
+    source_type: 'semantic_layer',
+    database: { database_name: 'Sales semantics' },
+    schema: null,
+  };
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, ({ url }) => {
+    const request = decodeURIComponent(url);
+    if (request.includes('value:fail')) {
+      // An HTTP failure rather than a thrown error: the client retries
+      // network errors, which would only slow the test down.
+      return { status: 500, body: { message: 'datasource load failed' } };
     }
     return {
-      body: { result: [combinedDatasourceFixtures[1]], count: 26 },
+      body: {
+        result: request.includes('value:retry')
+          ? [retryView]
+          : [combinedDatasourceFixtures[1]],
+        count: 26,
+      },
       status: 200,
     };
   });
@@ -706,19 +654,32 @@ test('recovers from a failed mixed datasource load without replacing selection',
   userEvent.click(datasourceSelect);
   userEvent.type(datasourceSelect, 'fail');
 
-  await waitFor(() => expect(requestCount).toBe(2), { timeout: 3000 });
-  expect(screen.getByText('shared_source')).toBeInTheDocument();
+  // The failure is reported as such, not disguised as an empty result.
+  expect(
+    await screen.findByText('datasource load failed', {}, { timeout: 3000 }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText('No data', { selector: '.ant-empty-description' }),
+  ).toBeNull();
 
+  // The next search replaces the error with its results.
   userEvent.clear(datasourceSelect);
   userEvent.type(datasourceSelect, 'retry');
-  await waitFor(() => expect(requestCount).toBe(3), { timeout: 3000 });
-  expect(await screen.findByText('shared_source')).toBeInTheDocument();
+  expect(
+    await screen.findByText('retry_view', {}, { timeout: 3000 }),
+  ).toBeInTheDocument();
+  expect(screen.queryByText('datasource load failed')).not.toBeInTheDocument();
+
+  // The selection committed before the failure is still what gets created.
+  userEvent.click(screen.getByRole('tab', { name: /All charts/i }));
+  userEvent.dblClick(await screen.findByText('Table'));
+  expect(mockHistoryPush).toHaveBeenCalledWith(
+    '/explore/?viz_type=table&datasource=42__semantic_view',
+  );
 });
 
 test('uses generic picker terminology without changing the dataset action', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
+  enableSemanticLayers();
   fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
     body: { result: combinedDatasourceFixtures, count: 2 },
     status: 200,
@@ -778,9 +739,7 @@ test('keeps the legacy no-options state when semantic layers are disabled', asyn
 });
 
 test('uses the exact dataset endpoint for URL preload with semantic layers enabled', async () => {
-  mockIsFeatureEnabled.mockImplementation(
-    flag => flag === FeatureFlag.SemanticLayers,
-  );
+  enableSemanticLayers();
   fetchMock.clearHistory().removeRoutes();
   fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
     body: { result: legacyDatasetFixtures, count: 1 },
@@ -795,6 +754,10 @@ test('uses the exact dataset endpoint for URL preload with semantic layers enabl
   await renderComponent();
 
   expect(await screen.findByText('shared_source')).toBeInTheDocument();
+  // The preloaded selection is labelled the same way dropdown options are.
+  expect(
+    screen.getByText('Dataset', { selector: '.ant-tag' }),
+  ).toBeInTheDocument();
   expect(
     fetchMock.callHistory.calls().some(call => {
       const decodedUrl = decodeURIComponent(call.url);

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -18,12 +18,14 @@
  */
 
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
   waitFor,
 } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
+import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
 import { ChartCreation } from 'src/pages/ChartCreation';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 
@@ -32,6 +34,13 @@ jest.mock('src/components/DynamicPlugins', () => ({
     mountedPluginMetadata: { table: { name: 'Table', tags: [] } },
   }),
 }));
+
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockIsFeatureEnabled = jest.mocked(isFeatureEnabled);
 
 const mockDatasourceResponse = {
   result: [
@@ -46,9 +55,42 @@ const mockDatasourceResponse = {
   count: 1,
 };
 
-fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
-  body: mockDatasourceResponse,
-  status: 200,
+const legacyDatasetFixtures = [
+  {
+    id: 42,
+    table_name: 'shared_source',
+    datasource_type: 'table',
+    database: { database_name: 'examples' },
+    schema: 'public',
+  },
+];
+
+const combinedDatasourceFixtures = [
+  {
+    id: 42,
+    table_name: 'shared_source',
+    kind: 'physical',
+    source_type: 'database',
+    database: { database_name: 'examples' },
+    schema: 'public',
+  },
+  {
+    id: 42,
+    table_name: 'shared_source',
+    kind: 'semantic_view',
+    source_type: 'semantic_layer',
+    database: { database_name: 'Sales semantics' },
+    schema: null,
+  },
+];
+
+beforeEach(() => {
+  mockIsFeatureEnabled.mockReturnValue(false);
+  fetchMock.clearHistory().removeRoutes();
+  fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
+    body: mockDatasourceResponse,
+    status: 200,
+  });
 });
 
 const mockUser: UserWithPermissionsAndRoles = {
@@ -445,6 +487,329 @@ test('shows only exact match when loading dataset from URL, not partial matches'
 
   await screen.findByText('flights');
   expect(screen.queryByText('flights_delayed')).not.toBeInTheDocument();
+
+  locationSpy.mockRestore();
+});
+
+test('loads and labels mixed datasource results across pages', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, ({ url }) => {
+    const isSecondPage = url.includes('page:1');
+    return {
+      body: {
+        result: isSecondPage
+          ? [
+              {
+                id: 43,
+                table_name: 'second_page_view',
+                kind: 'semantic_view',
+                source_type: 'semantic_layer',
+                database: { database_name: 'Sales semantics' },
+                schema: null,
+              },
+            ]
+          : combinedDatasourceFixtures,
+        count: 101,
+      },
+      status: 200,
+    };
+  });
+
+  await renderComponent();
+  const datasourceSelect = screen.getByRole('combobox', {
+    name: 'Datasource',
+  });
+  userEvent.click(datasourceSelect);
+
+  expect(await screen.findAllByText('shared_source')).toHaveLength(2);
+  const datasetTypeLabel = screen.getByText('Dataset');
+  const semanticViewTypeLabel = screen.getByText('Semantic View');
+  expect(datasetTypeLabel).toBeInTheDocument();
+  expect(datasetTypeLabel).not.toHaveAttribute('aria-hidden', 'true');
+  expect(semanticViewTypeLabel).toBeInTheDocument();
+  expect(semanticViewTypeLabel).not.toHaveAttribute('aria-hidden', 'true');
+  await waitFor(() =>
+    expect(document.querySelector('.ant-select-suffix .ant-spin')).toBeNull(),
+  );
+
+  const scrollContainer = document.querySelector(
+    '.ant-select-dropdown-list-holder',
+  );
+  expect(scrollContainer).not.toBeNull();
+  if (!scrollContainer) {
+    throw new Error('Expected datasource options to have a scroll container');
+  }
+  Object.defineProperty(scrollContainer, 'scrollHeight', {
+    configurable: true,
+    get: () => 1000,
+  });
+  Object.defineProperty(scrollContainer, 'offsetHeight', {
+    configurable: true,
+    get: () => 100,
+  });
+  Object.defineProperty(scrollContainer, 'clientHeight', {
+    configurable: true,
+    get: () => 100,
+  });
+  Object.defineProperty(scrollContainer, 'scrollTop', {
+    configurable: true,
+    get: () => 900,
+    set: () => {},
+  });
+  fireEvent.scroll(scrollContainer);
+
+  expect(await screen.findByText('second_page_view')).toBeInTheDocument();
+  expect(
+    fetchMock.callHistory.calls().some(call => call.url.includes('page:1')),
+  ).toBe(true);
+});
+
+test('preserves unified server ordering without datasource type priority', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
+    body: {
+      result: [
+        {
+          id: 7,
+          table_name: 'alpha_semantic_view',
+          kind: 'semantic_view',
+          source_type: 'semantic_layer',
+          database: { database_name: 'Sales semantics' },
+          schema: null,
+        },
+        {
+          id: 8,
+          table_name: 'beta_dataset',
+          kind: 'physical',
+          source_type: 'database',
+          database: { database_name: 'examples' },
+          schema: 'public',
+        },
+      ],
+      count: 2,
+    },
+    status: 200,
+  });
+
+  await renderComponent();
+  userEvent.click(screen.getByRole('combobox', { name: 'Datasource' }));
+
+  const semanticView = await screen.findByText('alpha_semantic_view');
+  const dataset = screen.getByText('beta_dataset');
+  expect(
+    semanticView.compareDocumentPosition(dataset) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+  expect(
+    fetchMock.callHistory.calls().some(call => {
+      const decodedUrl = decodeURIComponent(call.url);
+      return (
+        decodedUrl.includes('order_column:table_name') &&
+        decodedUrl.includes('order_direction:asc')
+      );
+    }),
+  ).toBe(true);
+});
+
+test('searches semantic views and rejects unknown datasource kinds', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
+    body: {
+      result: [
+        combinedDatasourceFixtures[1],
+        {
+          id: 99,
+          table_name: 'unsupported_source',
+          kind: 'future_kind',
+          source_type: 'future_source',
+          database: null,
+          schema: null,
+        },
+      ],
+      count: 2,
+    },
+    status: 200,
+  });
+
+  await renderComponent();
+  const datasourceSelect = screen.getByRole('combobox', {
+    name: 'Datasource',
+  });
+  userEvent.click(datasourceSelect);
+  userEvent.type(datasourceSelect, 'shared');
+
+  expect(await screen.findByText('shared_source')).toBeInTheDocument();
+  expect(screen.queryByText('unsupported_source')).not.toBeInTheDocument();
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls().some(call => {
+        const decodedUrl = decodeURIComponent(call.url);
+        return (
+          decodedUrl.includes('/api/v1/datasource/') &&
+          decodedUrl.includes('col:table_name') &&
+          decodedUrl.includes('opr:ct') &&
+          decodedUrl.includes('shared')
+        );
+      }),
+    ).toBe(true),
+  );
+});
+
+test('navigates to Explore with the semantic view composite identity', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
+    body: { result: [combinedDatasourceFixtures[1]], count: 1 },
+    status: 200,
+  });
+
+  await renderComponent();
+  userEvent.click(screen.getByRole('combobox', { name: 'Datasource' }));
+  userEvent.click(await screen.findByText('shared_source'));
+  userEvent.click(screen.getByRole('tab', { name: /All charts/i }));
+  userEvent.dblClick(await screen.findByText('Table'));
+
+  expect(mockHistoryPush).toHaveBeenCalledWith(
+    '/explore/?viz_type=table&datasource=42__semantic_view',
+  );
+});
+
+test('recovers from a failed mixed datasource load without replacing selection', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  let requestCount = 0;
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, () => {
+    requestCount += 1;
+    if (requestCount === 2) {
+      return { throws: new Error('datasource load failed') };
+    }
+    return {
+      body: { result: [combinedDatasourceFixtures[1]], count: 26 },
+      status: 200,
+    };
+  });
+
+  await renderComponent();
+  const datasourceSelect = screen.getByRole('combobox', {
+    name: 'Datasource',
+  });
+  userEvent.click(datasourceSelect);
+  userEvent.click(await screen.findByText('shared_source'));
+  userEvent.click(datasourceSelect);
+  userEvent.type(datasourceSelect, 'fail');
+
+  await waitFor(() => expect(requestCount).toBe(2), { timeout: 3000 });
+  expect(screen.getByText('shared_source')).toBeInTheDocument();
+
+  userEvent.clear(datasourceSelect);
+  userEvent.type(datasourceSelect, 'retry');
+  await waitFor(() => expect(requestCount).toBe(3), { timeout: 3000 });
+  expect(await screen.findByText('shared_source')).toBeInTheDocument();
+});
+
+test('uses generic picker terminology without changing the dataset action', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.get(/\/api\/v1\/datasource\/\?q=.*/, {
+    body: { result: combinedDatasourceFixtures, count: 2 },
+    status: 200,
+  });
+
+  await renderComponent(mockUserWithDatasetWrite);
+
+  expect(
+    screen.getByRole('combobox', { name: 'Datasource' }),
+  ).toBeInTheDocument();
+  expect(screen.getAllByText('Choose a datasource')).toHaveLength(2);
+  const addDatasetLink = screen.getByRole('link', { name: 'Add a dataset' });
+  expect(addDatasetLink).toHaveAttribute('href', '/dataset/add/');
+});
+
+test('keeps the legacy dataset-only picker when semantic layers are disabled', async () => {
+  fetchMock.clearHistory().removeRoutes();
+  fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
+    body: { result: legacyDatasetFixtures, count: 1 },
+    status: 200,
+  });
+
+  await renderComponent();
+  const datasourceSelect = screen.getByRole('combobox', { name: 'Dataset' });
+  userEvent.click(datasourceSelect);
+  userEvent.click(await screen.findByText('shared_source'));
+
+  expect(screen.queryByText('Semantic View')).not.toBeInTheDocument();
+  expect(screen.queryByText('Dataset', { selector: '.ant-tag' })).toBeNull();
+  expect(
+    fetchMock.callHistory
+      .calls()
+      .some(call => call.url.includes('/api/v1/datasource/')),
+  ).toBe(false);
+
+  userEvent.click(screen.getByRole('tab', { name: /All charts/i }));
+  userEvent.dblClick(await screen.findByText('Table'));
+  expect(mockHistoryPush).toHaveBeenCalledWith(
+    '/explore/?viz_type=table&datasource=42__table',
+  );
+});
+
+test('keeps the legacy no-options state when semantic layers are disabled', async () => {
+  fetchMock.clearHistory().removeRoutes();
+  fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
+    body: { result: [], count: 0 },
+    status: 200,
+  });
+
+  await renderComponent();
+  userEvent.click(screen.getByRole('combobox', { name: 'Dataset' }));
+
+  expect(
+    await screen.findByText('No data', { selector: '.ant-empty-description' }),
+  ).toBeInTheDocument();
+  expect(screen.queryByText('Semantic View')).not.toBeInTheDocument();
+});
+
+test('uses the exact dataset endpoint for URL preload with semantic layers enabled', async () => {
+  mockIsFeatureEnabled.mockImplementation(
+    flag => flag === FeatureFlag.SemanticLayers,
+  );
+  fetchMock.clearHistory().removeRoutes();
+  fetchMock.get(/\/api\/v1\/dataset\/\?q=.*/, {
+    body: { result: legacyDatasetFixtures, count: 1 },
+    status: 200,
+  });
+
+  const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
+    ...window.location,
+    search: '?dataset=shared_source',
+  } as Location);
+
+  await renderComponent();
+
+  expect(await screen.findByText('shared_source')).toBeInTheDocument();
+  expect(
+    fetchMock.callHistory.calls().some(call => {
+      const decodedUrl = decodeURIComponent(call.url);
+      return (
+        decodedUrl.includes('/api/v1/dataset/') &&
+        decodedUrl.includes('opr:eq') &&
+        decodedUrl.includes('shared_source')
+      );
+    }),
+  ).toBe(true);
+  expect(
+    fetchMock.callHistory
+      .calls()
+      .some(call => call.url.includes('/api/v1/datasource/')),
+  ).toBe(false);
 
   locationSpy.mockRestore();
 });

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -19,7 +19,13 @@
 import { ReactNode, useState, useEffect, useCallback, useMemo } from 'react';
 import rison from 'rison';
 import { t } from '@apache-superset/core/translation';
-import { isDefined, JsonResponse, SupersetClient } from '@superset-ui/core';
+import {
+  FeatureFlag,
+  isDefined,
+  isFeatureEnabled,
+  JsonResponse,
+  SupersetClient,
+} from '@superset-ui/core';
 import { styled, useTheme } from '@apache-superset/core/theme';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { FilterPlugins, URL_PARAMS } from 'src/constants';
@@ -29,6 +35,7 @@ import {
   Button,
   Loading,
   Steps,
+  Tag,
 } from '@superset-ui/core/components';
 import { propertyComparator } from '@superset-ui/core/components/Select/utils';
 import withToasts from 'src/components/MessageToasts/withToasts';
@@ -53,6 +60,29 @@ export interface ChartCreationProps {
   user: UserWithPermissionsAndRoles;
   addSuccessToast: (arg: string) => void;
 }
+
+type ExploreDatasourceType = 'table' | 'semantic_view';
+
+type ParentDisplay = {
+  database_name: string;
+};
+
+type DatasourceListItem = {
+  id: number | string;
+  table_name: string;
+  datasource_type?: string;
+  kind?: string;
+  source_type?: string;
+  database?: ParentDisplay | null;
+  schema?: string | null;
+};
+
+type DatasourceOption = {
+  id: number | string;
+  label: ReactNode;
+  value: string;
+  table_name: string;
+};
 
 const ESTIMATED_NAV_HEIGHT = 56;
 const ELEMENTS_EXCEPT_VIZ_GALLERY = ESTIMATED_NAV_HEIGHT + 250;
@@ -167,12 +197,75 @@ const StyledStepDescription = styled.div`
   `}
 `;
 
+const StyledDatasourceOption = styled.div`
+  ${({ theme }) => `
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: ${theme.sizeUnit * 2}px;
+    align-items: center;
+    width: 100%;
+  `}
+`;
+
+const getExploreDatasourceType = (
+  item: DatasourceListItem,
+): ExploreDatasourceType | null => {
+  if (item.kind === 'semantic_view') {
+    return 'semantic_view';
+  }
+  if (
+    item.kind === 'physical' ||
+    item.kind === 'virtual' ||
+    item.datasource_type === 'table'
+  ) {
+    return 'table';
+  }
+  return null;
+};
+
+const createDatasourceOption = (
+  item: DatasourceListItem,
+  showType: boolean,
+): DatasourceOption | null => {
+  const datasourceType = getExploreDatasourceType(item);
+  if (!datasourceType) {
+    return null;
+  }
+  const labelItem: Dataset = {
+    id: Number(item.id),
+    table_name: item.table_name,
+    datasource_type: datasourceType,
+    kind: item.kind,
+    schema: item.schema ?? '',
+    database: item.database ?? undefined,
+  };
+  const datasourceLabel = DatasetSelectLabel(labelItem);
+  const label = showType ? (
+    <StyledDatasourceOption>
+      {datasourceLabel}
+      <Tag>
+        {datasourceType === 'semantic_view' ? t('Semantic View') : t('Dataset')}
+      </Tag>
+    </StyledDatasourceOption>
+  ) : (
+    datasourceLabel
+  );
+
+  return {
+    id: item.id,
+    value: `${item.id}__${datasourceType}`,
+    label,
+    table_name: item.table_name,
+  };
+};
+
 export const ChartCreation = ({
   user,
   addSuccessToast,
 }: ChartCreationProps) => {
   const theme = useTheme();
   const history = useHistory();
+  const semanticLayersEnabled = isFeatureEnabled(FeatureFlag.SemanticLayers);
 
   const canCreateDataset = useMemo(
     () => findPermission('can_write', 'Dataset', user.roles),
@@ -184,9 +277,7 @@ export const ChartCreation = ({
     [],
   );
 
-  const [datasource, setDatasource] = useState<
-    { label: string | ReactNode; value: string } | undefined
-  >(undefined);
+  const [datasource, setDatasource] = useState<DatasourceOption | undefined>();
   const [vizType, setVizType] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(hasDatasetParam);
 
@@ -203,12 +294,9 @@ export const ChartCreation = ({
     history.push(exploreUrl());
   }, [history, exploreUrl]);
 
-  const changeDatasource = useCallback(
-    (newDatasource: { label: string | ReactNode; value: string }) => {
-      setDatasource(newDatasource);
-    },
-    [],
-  );
+  const changeDatasource = useCallback((newDatasource: DatasourceOption) => {
+    setDatasource(newDatasource);
+  }, []);
 
   const changeVizType = useCallback((newVizType: string | null) => {
     setVizType(newVizType);
@@ -225,7 +313,7 @@ export const ChartCreation = ({
     }
   }, [isBtnDisabled, gotoSlice]);
 
-  const loadDatasources = useCallback(
+  const loadDatasetOptions = useCallback(
     (search: string, page: number, pageSize: number, exactMatch = false) => {
       const query = rison.encode({
         columns: [
@@ -246,17 +334,9 @@ export const ChartCreation = ({
       return SupersetClient.get({
         endpoint: `/api/v1/dataset/?q=${query}`,
       }).then((response: JsonResponse) => {
-        const list: {
-          id: number;
-          label: string | ReactNode;
-          value: string;
-          table_name: string;
-        }[] = response.json.result.map((item: Dataset) => ({
-          id: item.id,
-          value: `${item.id}__${item.datasource_type}`,
-          label: DatasetSelectLabel(item),
-          table_name: item.table_name,
-        }));
+        const list = (response.json.result as DatasourceListItem[])
+          .map(item => createDatasourceOption(item, false))
+          .filter((item): item is DatasourceOption => item !== null);
         return {
           data: list,
           totalCount: response.json.count,
@@ -266,10 +346,37 @@ export const ChartCreation = ({
     [],
   );
 
+  const loadDatasources = useCallback(
+    (search: string, page: number, pageSize: number) => {
+      if (!semanticLayersEnabled) {
+        return loadDatasetOptions(search, page, pageSize);
+      }
+      const query = rison.encode({
+        filters: [{ col: 'table_name', opr: 'ct', value: search }],
+        page,
+        page_size: pageSize,
+        order_column: 'table_name',
+        order_direction: 'asc',
+      });
+      return SupersetClient.get({
+        endpoint: `/api/v1/datasource/?q=${query}`,
+      }).then((response: JsonResponse) => {
+        const list = (response.json.result as DatasourceListItem[])
+          .map(item => createDatasourceOption(item, true))
+          .filter((item): item is DatasourceOption => item !== null);
+        return {
+          data: list,
+          totalCount: response.json.count,
+        };
+      });
+    },
+    [loadDatasetOptions, semanticLayersEnabled],
+  );
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search).get('dataset');
     if (params) {
-      loadDatasources(params, 0, 1, true)
+      loadDatasetOptions(params, 0, 1, true)
         .then(r => {
           const newDatasource = r.data[0];
           setDatasource(newDatasource);
@@ -280,7 +387,7 @@ export const ChartCreation = ({
         });
       addSuccessToast(t('The dataset has been saved'));
     }
-  }, [loadDatasources, addSuccessToast]);
+  }, [loadDatasetOptions, addSuccessToast]);
 
   const isButtonDisabled = isBtnDisabled();
   const VIEW_INSTRUCTIONS_TEXT = t('view instructions');

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -17,15 +17,8 @@
  * under the License.
  */
 import { ReactNode, useState, useEffect, useCallback, useMemo } from 'react';
-import rison from 'rison';
 import { t } from '@apache-superset/core/translation';
-import {
-  FeatureFlag,
-  isDefined,
-  isFeatureEnabled,
-  JsonResponse,
-  SupersetClient,
-} from '@superset-ui/core';
+import { FeatureFlag, isDefined, isFeatureEnabled } from '@superset-ui/core';
 import { styled, useTheme } from '@apache-superset/core/theme';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { FilterPlugins, URL_PARAMS } from 'src/constants';
@@ -50,6 +43,7 @@ import {
   Dataset,
   DatasetSelectLabel,
 } from 'src/features/datasets/DatasetSelectLabel';
+import { fetchDatasourceList } from 'src/features/datasets/fetchDatasourceList';
 import { Icons } from '@superset-ui/core/components/Icons';
 import {
   datasetLabel,
@@ -61,28 +55,18 @@ export interface ChartCreationProps {
   addSuccessToast: (arg: string) => void;
 }
 
-type ExploreDatasourceType = 'table' | 'semantic_view';
-
-type ParentDisplay = {
-  database_name: string;
-};
-
-type DatasourceListItem = {
-  id: number | string;
-  table_name: string;
-  datasource_type?: string;
-  kind?: string;
-  source_type?: string;
-  database?: ParentDisplay | null;
-  schema?: string | null;
-};
-
 type DatasourceOption = {
-  id: number | string;
+  id: number;
   label: ReactNode;
   value: string;
   table_name: string;
 };
+
+/**
+ * AsyncSelect reports the chosen option as a LabeledValue, so only the
+ * fields it carries can be relied on after selection.
+ */
+type SelectedDatasource = Pick<DatasourceOption, 'label' | 'value'>;
 
 const ESTIMATED_NAV_HEIGHT = 56;
 const ELEMENTS_EXCEPT_VIZ_GALLERY = ESTIMATED_NAV_HEIGHT + 250;
@@ -197,65 +181,42 @@ const StyledStepDescription = styled.div`
   `}
 `;
 
+// The first column shrinks to zero so the name ellipsizes and the tag stays
+// visible. AsyncSelect renders option labels inside a nowrap container, which
+// is what makes that ellipsis take effect.
 const StyledDatasourceOption = styled.div`
   ${({ theme }) => `
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
-    gap: ${theme.sizeUnit * 2}px;
+    gap: ${theme.sizeXS}px;
     align-items: center;
     width: 100%;
   `}
 `;
 
-const getExploreDatasourceType = (
-  item: DatasourceListItem,
-): ExploreDatasourceType | null => {
-  if (item.kind === 'semantic_view') {
-    return 'semantic_view';
-  }
-  if (
-    item.kind === 'physical' ||
-    item.kind === 'virtual' ||
-    item.datasource_type === 'table'
-  ) {
-    return 'table';
-  }
-  return null;
-};
-
+/**
+ * Builds a picker option whose value carries the Explore datasource identity
+ * (`<id>__table` or `<id>__semantic_view`). Datasets and semantic views are
+ * numbered independently, so the type suffix is what keeps them apart.
+ */
 const createDatasourceOption = (
-  item: DatasourceListItem,
-  showType: boolean,
-): DatasourceOption | null => {
-  const datasourceType = getExploreDatasourceType(item);
-  if (!datasourceType) {
-    return null;
-  }
-  const labelItem: Dataset = {
-    id: Number(item.id),
-    table_name: item.table_name,
-    datasource_type: datasourceType,
-    kind: item.kind,
-    schema: item.schema ?? '',
-    database: item.database ?? undefined,
-  };
-  const datasourceLabel = DatasetSelectLabel(labelItem);
-  const label = showType ? (
-    <StyledDatasourceOption>
-      {datasourceLabel}
-      <Tag>
-        {datasourceType === 'semantic_view' ? t('Semantic View') : t('Dataset')}
-      </Tag>
-    </StyledDatasourceOption>
-  ) : (
-    datasourceLabel
-  );
-
+  item: Dataset,
+  withTypeTag: boolean,
+): DatasourceOption => {
+  const isSemanticView = item.kind === 'semantic_view';
+  const datasourceLabel = DatasetSelectLabel(item);
   return {
     id: item.id,
-    value: `${item.id}__${datasourceType}`,
-    label,
+    value: `${item.id}__${isSemanticView ? 'semantic_view' : 'table'}`,
     table_name: item.table_name,
+    label: withTypeTag ? (
+      <StyledDatasourceOption>
+        {datasourceLabel}
+        <Tag>{isSemanticView ? t('Semantic View') : t('Dataset')}</Tag>
+      </StyledDatasourceOption>
+    ) : (
+      datasourceLabel
+    ),
   };
 };
 
@@ -277,7 +238,9 @@ export const ChartCreation = ({
     [],
   );
 
-  const [datasource, setDatasource] = useState<DatasourceOption | undefined>();
+  const [datasource, setDatasource] = useState<
+    SelectedDatasource | undefined
+  >();
   const [vizType, setVizType] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(hasDatasetParam);
 
@@ -294,9 +257,12 @@ export const ChartCreation = ({
     history.push(exploreUrl());
   }, [history, exploreUrl]);
 
-  const changeDatasource = useCallback((newDatasource: DatasourceOption) => {
-    setDatasource(newDatasource);
-  }, []);
+  // AsyncSelect's onChange is typed for every select value shape; narrow it
+  // to the labelled option this picker produces.
+  const changeDatasource = useCallback(
+    (selected: SelectedDatasource) => setDatasource(selected),
+    [],
+  );
 
   const changeVizType = useCallback((newVizType: string | null) => {
     setVizType(newVizType);
@@ -313,73 +279,34 @@ export const ChartCreation = ({
     }
   }, [isBtnDisabled, gotoSlice]);
 
-  const loadDatasetOptions = useCallback(
-    (search: string, page: number, pageSize: number, exactMatch = false) => {
-      const query = rison.encode({
-        columns: [
-          'id',
-          'table_name',
-          'datasource_type',
-          'database.database_name',
-          'schema',
-        ],
-        filters: [
-          { col: 'table_name', opr: exactMatch ? 'eq' : 'ct', value: search },
-        ],
-        page,
-        page_size: pageSize,
-        order_column: 'table_name',
-        order_direction: 'asc',
-      });
-      return SupersetClient.get({
-        endpoint: `/api/v1/dataset/?q=${query}`,
-      }).then((response: JsonResponse) => {
-        const list = (response.json.result as DatasourceListItem[])
-          .map(item => createDatasourceOption(item, false))
-          .filter((item): item is DatasourceOption => item !== null);
-        return {
-          data: list,
-          totalCount: response.json.count,
-        };
-      });
-    },
-    [],
+  // Type tags only make sense once the list can mix datasets and semantic
+  // views, so they follow the feature flag rather than the endpoint used.
+  const toDatasourceOption = useCallback(
+    (item: Dataset) => createDatasourceOption(item, semanticLayersEnabled),
+    [semanticLayersEnabled],
   );
 
   const loadDatasources = useCallback(
-    (search: string, page: number, pageSize: number) => {
-      if (!semanticLayersEnabled) {
-        return loadDatasetOptions(search, page, pageSize);
-      }
-      const query = rison.encode({
-        filters: [{ col: 'table_name', opr: 'ct', value: search }],
-        page,
-        page_size: pageSize,
-        order_column: 'table_name',
-        order_direction: 'asc',
-      });
-      return SupersetClient.get({
-        endpoint: `/api/v1/datasource/?q=${query}`,
-      }).then((response: JsonResponse) => {
-        const list = (response.json.result as DatasourceListItem[])
-          .map(item => createDatasourceOption(item, true))
-          .filter((item): item is DatasourceOption => item !== null);
-        return {
-          data: list,
-          totalCount: response.json.count,
-        };
-      });
-    },
-    [loadDatasetOptions, semanticLayersEnabled],
+    (search: string, page: number, pageSize: number) =>
+      fetchDatasourceList(search, page, pageSize).then(({ result, count }) => ({
+        data: result.map(toDatasourceOption),
+        totalCount: count,
+      })),
+    [toDatasourceOption],
   );
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search).get('dataset');
     if (params) {
-      loadDatasetOptions(params, 0, 1, true)
-        .then(r => {
-          const newDatasource = r.data[0];
-          setDatasource(newDatasource);
+      // The URL names a dataset that was just saved, so resolve it against
+      // datasets only: a semantic view with the same name must not win.
+      fetchDatasourceList(params, 0, 1, {
+        exactMatch: true,
+        datasetsOnly: true,
+      })
+        .then(({ result }) => {
+          const [dataset] = result;
+          setDatasource(dataset && toDatasourceOption(dataset));
           setLoading(false);
         })
         .catch(() => {
@@ -387,7 +314,7 @@ export const ChartCreation = ({
         });
       addSuccessToast(t('The dataset has been saved'));
     }
-  }, [loadDatasetOptions, addSuccessToast]);
+  }, [toDatasourceOption, addSuccessToast]);
 
   const isButtonDisabled = isBtnDisabled();
   const VIEW_INSTRUCTIONS_TEXT = t('view instructions');

--- a/superset/daos/datasource.py
+++ b/superset/daos/datasource.py
@@ -205,9 +205,13 @@ class DatasourceDAO(BaseDAO[Datasource]):
         sort_col = combined.c[sort_col_name]
         ordered_col = sort_col.desc() if order_direction == "desc" else sort_col.asc()
 
+        # None of the sortable columns is unique across the union (a dataset
+        # and a semantic view may share a name, two datasets may share a
+        # changed_on), so offset pagination needs a total order or rows can
+        # repeat or vanish at page boundaries.
         rows = db.session.execute(
             select(combined.c.item_id, combined.c.source_type)
-            .order_by(ordered_col)
+            .order_by(ordered_col, combined.c.source_type, combined.c.item_id)
             .offset(page * page_size)
             .limit(page_size)
         ).fetchall()

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -15,18 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import uuid
 from datetime import datetime
+from typing import cast
 from unittest.mock import ANY, patch
 
 import pytest
+from flask.wrappers import Response
+from flask_appbuilder.security.sqla.models import PermissionView, Role
 from sqlalchemy.sql.elements import TextClause
 
 from superset import db, security_manager
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.exceptions import DatasourceTypeNotSupportedError
 from superset.extensions import cache_manager
+from superset.semantic_layers.models import SemanticLayer, SemanticView
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
 
 
@@ -477,3 +483,99 @@ class TestDatasourceApi(SupersetTestCase):
         response = json.loads(rv.data.decode("utf-8"))
         assert response == {"count": 0, "result": []}
         run_mock.assert_called_once()
+
+
+class TestCombinedDatasourceApi(SupersetTestCase):
+    @with_feature_flags(SEMANTIC_LAYERS=True)
+    def test_combined_list_filters_semantic_views_for_gamma(self) -> None:
+        """Gamma receives granted semantic views without learning denied ones."""
+        suffix: str = uuid.uuid4().hex
+        permitted_layer: SemanticLayer = SemanticLayer(
+            uuid=uuid.uuid4(),
+            name=f"permitted_layer_{suffix}",
+            type="test",
+            configuration="{}",
+        )
+        denied_layer: SemanticLayer = SemanticLayer(
+            uuid=uuid.uuid4(),
+            name=f"denied_layer_{suffix}",
+            type="test",
+            configuration="{}",
+        )
+        permitted_view: SemanticView = SemanticView(
+            uuid=uuid.uuid4(),
+            name=f"permitted_view_{suffix}",
+            semantic_layer_uuid=permitted_layer.uuid,
+            configuration="{}",
+        )
+        denied_view: SemanticView = SemanticView(
+            uuid=uuid.uuid4(),
+            name=f"denied_view_{suffix}",
+            semantic_layer_uuid=denied_layer.uuid,
+            configuration="{}",
+        )
+        gamma_role: Role = security_manager.find_role("Gamma")
+        access_pvm: PermissionView | None = None
+        semantic_view_read_pvm: PermissionView | None = None
+        added_semantic_view_read: bool = False
+
+        try:
+            db.session.add_all(
+                [permitted_layer, denied_layer, permitted_view, denied_view]
+            )
+            db.session.commit()
+            db.session.refresh(permitted_layer)
+            db.session.refresh(denied_layer)
+            db.session.refresh(permitted_view)
+            db.session.refresh(denied_view)
+
+            assert permitted_layer.perm is not None
+            assert denied_layer.perm is not None
+            assert permitted_view.perm is not None
+            assert denied_view.perm is not None
+
+            access_pvm = security_manager.add_permission_view_menu(
+                "datasource_access", permitted_layer.perm
+            )
+            security_manager.add_permission_role(gamma_role, access_pvm)
+            semantic_view_read_pvm = security_manager.add_permission_view_menu(
+                "can_read", "SemanticView"
+            )
+            if semantic_view_read_pvm not in gamma_role.permissions:
+                security_manager.add_permission_role(gamma_role, semantic_view_read_pvm)
+                added_semantic_view_read = True
+            db.session.commit()
+
+            self.login(GAMMA_USERNAME)
+            assert security_manager.can_access("can_read", "SemanticView")
+            assert permitted_layer.perm in security_manager.user_view_menu_names(
+                "datasource_access"
+            )
+            assert denied_layer.perm not in security_manager.user_view_menu_names(
+                "datasource_access"
+            )
+            response: Response = self.client.get(
+                "api/v1/datasource/?q="
+                "(filters:!((col:source_type,opr:eq,value:semantic_layer)),"
+                "order_column:table_name,order_direction:asc,page:0,page_size:25)"
+            )
+            payload: dict[str, object] = json.loads(response.data.decode("utf-8"))
+            result: list[dict[str, object]] = cast(
+                list[dict[str, object]], payload["result"]
+            )
+            returned_names: set[str] = {str(item["table_name"]) for item in result}
+
+            assert response.status_code == 200
+            assert permitted_view.name in returned_names
+            assert denied_view.name not in returned_names
+        finally:
+            db.session.rollback()
+            if access_pvm is not None:
+                security_manager.del_permission_role(gamma_role, access_pvm)
+            if added_semantic_view_read and semantic_view_read_pvm is not None:
+                security_manager.del_permission_role(gamma_role, semantic_view_read_pvm)
+            db.session.delete(permitted_view)
+            db.session.delete(denied_view)
+            db.session.delete(permitted_layer)
+            db.session.delete(denied_layer)
+            db.session.commit()

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
-from typing import cast
 from unittest.mock import ANY, patch
 
 import pytest
-from flask.wrappers import Response
-from flask_appbuilder.security.sqla.models import PermissionView, Role
+from flask_appbuilder.security.sqla.models import PermissionView
 from sqlalchemy.sql.elements import TextClause
 
 from superset import db, security_manager
@@ -34,6 +34,80 @@ from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.conftest import with_feature_flags
 from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
+
+
+@contextmanager
+def _semantic_views(*layer_names: str) -> Iterator[list[SemanticView]]:
+    """Persist one semantic view per named layer and remove them on exit.
+
+    Names are suffixed to stay unique across runs. The layer and view insert
+    hooks create the matching ``datasource_access`` permissions; the delete
+    hooks remove them again together with any role associations.
+    """
+    suffix = uuid.uuid4().hex
+    layers = [
+        SemanticLayer(
+            uuid=uuid.uuid4(),
+            name=f"{name}_{suffix}",
+            type="test",
+            configuration="{}",
+        )
+        for name in layer_names
+    ]
+    views = [
+        SemanticView(
+            uuid=uuid.uuid4(),
+            name=f"{layer.name}_view",
+            semantic_layer_uuid=layer.uuid,
+            configuration="{}",
+        )
+        for layer in layers
+    ]
+    db.session.add_all([*layers, *views])
+    db.session.commit()
+    try:
+        for obj in [*layers, *views]:
+            db.session.refresh(obj)
+        yield views
+    finally:
+        db.session.rollback()
+        for obj in [*views, *layers]:
+            db.session.delete(obj)
+        db.session.commit()
+
+
+@contextmanager
+def _gamma_granted(*pvms: tuple[str, str]) -> Iterator[None]:
+    """Grant ``(permission, view_menu)`` pairs to Gamma for the block's duration.
+
+    A permission-view that does not exist yet (``can_read SemanticView`` is only
+    registered when the semantic view API is mounted) is created and removed
+    again afterwards; one that already exists is left in place.
+    """
+    gamma = security_manager.find_role("Gamma")
+    assert gamma is not None
+    created: list[PermissionView] = []
+    granted: list[PermissionView] = []
+    for permission, view_menu in pvms:
+        pvm = security_manager.find_permission_view_menu(permission, view_menu)
+        if pvm is None:
+            pvm = security_manager.add_permission_view_menu(permission, view_menu)
+            created.append(pvm)
+        if pvm not in gamma.permissions:
+            security_manager.add_permission_role(gamma, pvm)
+            granted.append(pvm)
+    db.session.commit()
+    try:
+        yield
+    finally:
+        db.session.rollback()
+        for pvm in granted:
+            security_manager.del_permission_role(gamma, pvm)
+        for pvm in created:
+            security_manager.del_permission_view_menu(
+                pvm.permission.name, pvm.view_menu.name
+            )
+        db.session.commit()
 
 
 class TestDatasourceApi(SupersetTestCase):
@@ -484,98 +558,73 @@ class TestDatasourceApi(SupersetTestCase):
         assert response == {"count": 0, "result": []}
         run_mock.assert_called_once()
 
+    def _list_semantic_views_as_gamma(self) -> tuple[int, set[str]]:
+        """Fetch the semantic-view slice of the combined list as Gamma."""
+        self.login(GAMMA_USERNAME)
+        rv = self.client.get(
+            "api/v1/datasource/?q="
+            "(filters:!((col:source_type,opr:eq,value:semantic_layer)),"
+            "order_column:table_name,order_direction:asc,page:0,page_size:25)"
+        )
+        payload = json.loads(rv.data.decode("utf-8"))
+        names = {item["table_name"] for item in payload.get("result", [])}
+        return rv.status_code, names
 
-class TestCombinedDatasourceApi(SupersetTestCase):
     @with_feature_flags(SEMANTIC_LAYERS=True)
-    def test_combined_list_filters_semantic_views_for_gamma(self) -> None:
-        """Gamma receives granted semantic views without learning denied ones."""
-        suffix: str = uuid.uuid4().hex
-        permitted_layer: SemanticLayer = SemanticLayer(
-            uuid=uuid.uuid4(),
-            name=f"permitted_layer_{suffix}",
-            type="test",
-            configuration="{}",
+    def test_combined_list_gamma_sees_views_of_granted_layers(self):
+        """A layer-level grant exposes that layer's views and no others."""
+        with _semantic_views("permitted", "denied") as (permitted, denied):
+            layer_perm = permitted.semantic_layer.perm
+            assert layer_perm is not None
+            # The layer insert hook creates this permission; a regression
+            # there must fail here rather than be papered over by the grant.
+            assert (
+                security_manager.find_permission_view_menu(
+                    "datasource_access", layer_perm
+                )
+                is not None
+            )
+            with _gamma_granted(
+                ("can_read", "SemanticView"), ("datasource_access", layer_perm)
+            ):
+                status, names = self._list_semantic_views_as_gamma()
+            assert status == 200
+            assert permitted.name in names
+            assert denied.name not in names
+
+    @with_feature_flags(SEMANTIC_LAYERS=True)
+    def test_combined_list_gamma_sees_individually_granted_views(self):
+        """A view-level grant exposes that view without touching other layers."""
+        with _semantic_views("granted", "other") as (granted, other):
+            view_perm = granted.perm
+            assert view_perm is not None
+            assert (
+                security_manager.find_permission_view_menu(
+                    "datasource_access", view_perm
+                )
+                is not None
+            )
+            with _gamma_granted(
+                ("can_read", "SemanticView"), ("datasource_access", view_perm)
+            ):
+                status, names = self._list_semantic_views_as_gamma()
+            assert status == 200
+            assert granted.name in names
+            assert other.name not in names
+
+    @with_feature_flags(SEMANTIC_LAYERS=True)
+    def test_combined_list_gamma_without_semantic_view_read_gets_none(self):
+        """Without can_read on SemanticView the semantic-layer slice is empty."""
+        gamma = security_manager.find_role("Gamma")
+        assert gamma is not None
+        read_pvm = security_manager.find_permission_view_menu(
+            "can_read", "SemanticView"
         )
-        denied_layer: SemanticLayer = SemanticLayer(
-            uuid=uuid.uuid4(),
-            name=f"denied_layer_{suffix}",
-            type="test",
-            configuration="{}",
-        )
-        permitted_view: SemanticView = SemanticView(
-            uuid=uuid.uuid4(),
-            name=f"permitted_view_{suffix}",
-            semantic_layer_uuid=permitted_layer.uuid,
-            configuration="{}",
-        )
-        denied_view: SemanticView = SemanticView(
-            uuid=uuid.uuid4(),
-            name=f"denied_view_{suffix}",
-            semantic_layer_uuid=denied_layer.uuid,
-            configuration="{}",
-        )
-        gamma_role: Role = security_manager.find_role("Gamma")
-        access_pvm: PermissionView | None = None
-        semantic_view_read_pvm: PermissionView | None = None
-        added_semantic_view_read: bool = False
-
-        try:
-            db.session.add_all(
-                [permitted_layer, denied_layer, permitted_view, denied_view]
-            )
-            db.session.commit()
-            db.session.refresh(permitted_layer)
-            db.session.refresh(denied_layer)
-            db.session.refresh(permitted_view)
-            db.session.refresh(denied_view)
-
-            assert permitted_layer.perm is not None
-            assert denied_layer.perm is not None
-            assert permitted_view.perm is not None
-            assert denied_view.perm is not None
-
-            access_pvm = security_manager.add_permission_view_menu(
-                "datasource_access", permitted_layer.perm
-            )
-            security_manager.add_permission_role(gamma_role, access_pvm)
-            semantic_view_read_pvm = security_manager.add_permission_view_menu(
-                "can_read", "SemanticView"
-            )
-            if semantic_view_read_pvm not in gamma_role.permissions:
-                security_manager.add_permission_role(gamma_role, semantic_view_read_pvm)
-                added_semantic_view_read = True
-            db.session.commit()
-
-            self.login(GAMMA_USERNAME)
-            assert security_manager.can_access("can_read", "SemanticView")
-            assert permitted_layer.perm in security_manager.user_view_menu_names(
-                "datasource_access"
-            )
-            assert denied_layer.perm not in security_manager.user_view_menu_names(
-                "datasource_access"
-            )
-            response: Response = self.client.get(
-                "api/v1/datasource/?q="
-                "(filters:!((col:source_type,opr:eq,value:semantic_layer)),"
-                "order_column:table_name,order_direction:asc,page:0,page_size:25)"
-            )
-            payload: dict[str, object] = json.loads(response.data.decode("utf-8"))
-            result: list[dict[str, object]] = cast(
-                list[dict[str, object]], payload["result"]
-            )
-            returned_names: set[str] = {str(item["table_name"]) for item in result}
-
-            assert response.status_code == 200
-            assert permitted_view.name in returned_names
-            assert denied_view.name not in returned_names
-        finally:
-            db.session.rollback()
-            if access_pvm is not None:
-                security_manager.del_permission_role(gamma_role, access_pvm)
-            if added_semantic_view_read and semantic_view_read_pvm is not None:
-                security_manager.del_permission_role(gamma_role, semantic_view_read_pvm)
-            db.session.delete(permitted_view)
-            db.session.delete(denied_view)
-            db.session.delete(permitted_layer)
-            db.session.delete(denied_layer)
-            db.session.commit()
+        assert read_pvm is None or read_pvm not in gamma.permissions
+        with _semantic_views("layer") as (view,):
+            layer_perm = view.semantic_layer.perm
+            assert layer_perm is not None
+            with _gamma_granted(("datasource_access", layer_perm)):
+                status, names = self._list_semantic_views_as_gamma()
+            assert status == 200
+            assert names == set()

--- a/tests/unit_tests/datasource/dao_tests.py
+++ b/tests/unit_tests/datasource/dao_tests.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from sqlalchemy import literal, select
@@ -145,6 +146,48 @@ def test_escape_ilike_fragment() -> None:
     from superset.daos.datasource import _escape_ilike_fragment
 
     assert _escape_ilike_fragment("foo%bar_baz\\") == "foo\\%bar\\_baz\\\\"
+
+
+def test_paginate_combined_query_orders_equal_names_deterministically(
+    session: Session,
+) -> None:
+    """Rows that tie on the sort column must not shuffle between pages."""
+    from sqlalchemy import union_all
+    from sqlalchemy.sql.selectable import Select
+
+    from superset.daos.datasource import DatasourceDAO
+
+    def row(item_id: int, source_type: str, table_name: str) -> Select[Any]:
+        return select(
+            literal(item_id).label("item_id"),
+            literal(source_type).label("source_type"),
+            literal("2026-01-01").label("changed_on"),
+            literal(table_name).label("table_name"),
+        )
+
+    combined = union_all(
+        row(2, "semantic_layer", "orders"),
+        row(3, "database", "orders"),
+        row(1, "semantic_layer", "orders"),
+        row(1, "database", "orders"),
+    ).subquery()
+
+    def page(index: int) -> list[tuple[int, str]]:
+        _, rows = DatasourceDAO.paginate_combined_query(
+            combined=combined,
+            order_column="table_name",
+            order_direction="asc",
+            page=index,
+            page_size=2,
+        )
+        return [(r.item_id, r.source_type) for r in rows]
+
+    assert page(0) + page(1) == [
+        (1, "database"),
+        (3, "database"),
+        (1, "semantic_layer"),
+        (2, "semantic_layer"),
+    ]
 
 
 def test_paginate_combined_query_invalid_sort_column() -> None:


### PR DESCRIPTION
### SUMMARY

With the `SEMANTIC_LAYERS` feature flag enabled, the datasource list, the Explore datasource switcher and the native-filter configuration all offer semantic views alongside datasets, but the **Create Chart** page still queried the dataset-only endpoint. A user who had connected a semantic layer could see their semantic views everywhere except the one place a new chart starts from; the picker even said "Choose a datasource" while listing only datasets.

This PR makes the Create Chart datasource picker load from the combined `/api/v1/datasource/` listing when the flag is on, and keeps the dataset-only behaviour byte-for-byte when it is off.

**What changes**

- `ChartCreation` loads options through a new shared `fetchDatasourceList` helper (`src/features/datasets/fetchDatasourceList.ts`), which the native-filter `DatasetSelect` now uses too, so both pickers follow one flag-switched contract instead of two diverging copies. Datasets and semantic views are numbered independently, so each option's value carries the Explore identity (`<id>__table` / `<id>__semantic_view`) and a same-numbered pair never collapses into one entry.
- In the mixed list every option carries a text-only **Dataset** / **Semantic View** tag (no colour-only distinction). The `?dataset=` preload after saving a dataset still resolves against datasets only, and its selection is tagged the same way.
- `AsyncSelect` now clears a previous fetch error when a new fetch starts. Before this, any `AsyncSelect` that hit one failed page stayed on the error banner for good: later searches fired requests but never rendered their results. This was pre-existing and affects every `AsyncSelect` consumer; the regression test lives with the component.
- The combined datasource listing orders by `source_type, item_id` after the requested sort column. None of the sortable columns is unique across the union (a dataset and a semantic view can share a name), so offset pagination could repeat or drop rows at page boundaries.
- Integration coverage for the combined list's authorization branches as a Gamma user: layer-level grant, view-level grant, and no `can_read` on `SemanticView`.

The "Add a dataset" link keeps its wording and destination on purpose: it is an action-specific link to the dataset form, and semantic views are created from the datasource list page.

Known cosmetic follow-up: the type tags sit next to each label rather than in a right-aligned column, because antd renders option labels in a shrink-to-fit wrapper. Left as is rather than styling the dropdown from outside the component.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Flag on, searching for "sales" on a stack with a `Sales` semantic view.

**Before** — the semantic view is missing; only datasets are listed:

![Before: dataset-only picker despite the flag](https://raw.githubusercontent.com/mikebridge/superset/sc-107907-screenshots/before-light.png)

**After** — datasets and the semantic view in one list, each tagged:

![After: mixed picker, light theme](https://raw.githubusercontent.com/mikebridge/superset/sc-107907-screenshots/after-light.png)

![After: mixed picker, dark theme](https://raw.githubusercontent.com/mikebridge/superset/sc-107907-screenshots/after-dark.png)

**After** — a semantic view selected (closed picker), light and dark:

![After: semantic view selected, light](https://raw.githubusercontent.com/mikebridge/superset/sc-107907-screenshots/after-selected-light.png)

![After: semantic view selected, dark](https://raw.githubusercontent.com/mikebridge/superset/sc-107907-screenshots/after-selected-dark.png)

### TESTING INSTRUCTIONS

1. Enable `SEMANTIC_LAYERS`, connect a semantic layer and add at least one semantic view (Datasets → **+** → Semantic view).
2. Open **Charts → + Chart**. The first step reads "Choose a datasource". Open the picker and search for part of the semantic view's name: it appears alongside matching datasets, each row tagged **Dataset** or **Semantic View**.
3. Pick the semantic view and a chart type, then **Create new chart**: Explore opens at `/explore/?viz_type=…&datasource=<id>__semantic_view` with the view's metrics and columns.
4. Pick a dataset that shares its numeric id with a semantic view (or vice versa): Explore opens the one you chose.
5. Failure recovery: with the picker open, make the listing fail once (for example block `/api/v1/datasource/` in devtools, then search). The dropdown shows the error rather than "No data"; unblock and search again: results render and the earlier selection is untouched.
6. Save a new dataset and land on Create Chart via `?dataset=<name>`: the dataset is preselected and tagged **Dataset**.
7. Disable `SEMANTIC_LAYERS`: the page reads "Choose a dataset", lists datasets only, and never calls `/api/v1/datasource/`.

Automated: `ChartCreation.test.tsx` (flag on and off, mixed labels, ordering request, search, Explore identity, error state and recovery, preload, no-options state), `AsyncSelect.test.tsx` (error cleared on a later fetch), `DatasetSelect.test.tsx` (unchanged behaviour through the shared loader), `tests/unit_tests/datasource/dao_tests.py` (deterministic ordering across a page boundary), `tests/integration_tests/datasource/api_tests.py` (three Gamma authorization branches).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SEMANTIC_LAYERS`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

_This description was drafted with Claude (AI) assistance on behalf of @mikebridge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
