### PR TITLE
docs: fix docstring parameter names that do not match signatures

### DIFF
--- a/superset/cli/viz_migrations.py
+++ b/superset/cli/viz_migrations.py
@@ -160,7 +160,7 @@ def migrate_by_id(ids: tuple[int, ...], is_downgrade: bool = False) -> None:
     """
     Migrate a subset of charts by IDs.
 
-    :param id: Tuple of chart IDs to migrate
+    :param ids: Tuple of chart IDs to migrate
     :param is_downgrade: Whether to downgrade the charts. Default is upgrade.
     """
     slices = db.session.query(Slice).filter(Slice.id.in_(ids))

--- a/superset/migrations/shared/constraints.py
+++ b/superset/migrations/shared/constraints.py
@@ -45,9 +45,9 @@ def redefine(
     Redefine the foreign key constraint to include the ON DELETE and ON UPDATE
     constructs for cascading purposes.
 
-    :params foreign_key: The foreign key constraint
-    :param ondelete: If set, emit ON DELETE <value> when issuing DDL operations
-    :param onupdate: If set, emit ON UPDATE <value> when issuing DDL operations
+    :param foreign_key: The foreign key constraint
+    :param on_delete: If set, emit ON DELETE <value> when issuing DDL operations
+    :param on_update: If set, emit ON UPDATE <value> when issuing DDL operations
     """
 
     bind = op.get_bind()

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -333,7 +333,7 @@ class BaseScreenshot:
         Computes the thumbnail and caches the result
 
         :param user: If no user is given will use the current context
-        :param cache: The cache to keep the thumbnail payload
+        :param cache_key: The cache key to store the thumbnail payload under
         :param window_size: The window size from which will process the thumb
         :param thumb_size: The final thumbnail size
         :param force: Will force the computation even if it's already cached


### PR DESCRIPTION
### SUMMARY

Five docstring entries name parameters that their functions do not accept, so
Sphinx documents arguments a caller cannot pass. Each was checked against the
function signature before changing.

**`superset/migrations/shared/constraints.py`** — `redefine()`:
- The `foreign_key` entry uses the `:params` directive instead of `:param`, so it
  is not rendered as a parameter at all. This is the **only** `:params` in
  `superset/`, against 1389 correct `:param` uses, so it is a typo rather than a
  local convention.
- The same docstring documents `ondelete` and `onupdate`, but the parameters are
  `on_delete` and `on_update`.

**`superset/cli/viz_migrations.py`** — `migrate_by_id()` documents `id`; the
parameter is `ids`. The entry's own text ("Tuple of chart IDs to migrate") already
describes the plural.

**`superset/utils/screenshots.py`** — `compute_and_cache()` documents `cache`,
which is not a parameter; the cache itself is `self.cache`. The real parameter is
`cache_key`, used for the cache lookup and as the `DistributedLock` key, and it was
undocumented. The entry is relabelled to `cache_key` and its description corrected
to describe the key rather than the cache — keeping the old wording under the new
name would have read as accurate while being wrong.

Scope is deliberately narrow: parameters that were never documented are left
undocumented rather than newly described, and no wording changes beyond what the
incorrect names require. Docstring-only; no behaviour change.

This is the same class of defect as #42646, found the same way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no UI or rendered-output change.

### TESTING INSTRUCTIONS

Docstring-only, so there is no behaviour to exercise. Correctness is verifiable by
reading each signature against its docstring:

```
superset/migrations/shared/constraints.py:39   redefine(foreign_key, on_delete, on_update)
superset/cli/viz_migrations.py:159             migrate_by_id(ids, is_downgrade)
superset/utils/screenshots.py:324              compute_and_cache(force, user, window_size, thumb_size, cache_key)
```

Per `AGENTS.md`, `pre-commit` was run on the changed files before pushing, using the
pinned `ruff==0.9.7` from `requirements/development.txt`. All applicable hooks pass:
`mypy`, `ruff`, `ruff-format`, `pylint` (with the custom Superset plugins),
`auto-walrus`, `check-docstring-first`, `Blacklist`, and the whitespace/EOF hooks.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Note on the migrations file: `constraints.py` is a shared helper used *by*
migrations, not a migration script itself, and only its docstring is touched — no
DB migration is introduced.
