### PR TITLE
fix(dataset): preserve validation error messages

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/getClientErrorObject.ts
@@ -119,6 +119,20 @@ export function retrieveErrorMessage(
   return statusError || parseStringResponse(str);
 }
 
+function getFirstValidationError(message: JsonObject): string | undefined {
+  const [firstError] = Object.values(message);
+
+  if (typeof firstError === 'string') {
+    return firstError;
+  }
+
+  if (Array.isArray(firstError)) {
+    return firstError.find((item): item is string => typeof item === 'string');
+  }
+
+  return undefined;
+}
+
 export function parseErrorJson(responseJson: JsonObject): ClientErrorObject {
   let error = { ...responseJson };
   // Backwards compatibility for old error renderers with the new error object
@@ -126,13 +140,12 @@ export function parseErrorJson(responseJson: JsonObject): ClientErrorObject {
     error.error = error.description = error.errors[0].message;
     error.link = error.errors[0]?.extra?.link;
   }
-  // Marshmallow field validation returns the error message in the format
-  // of { message: { field1: [msg1, msg2], field2: [msg], } }
+  // Marshmallow field validation returns arrays for string messages, but
+  // serializes lazy translation messages as strings instead.
   if (!error.error && error.message) {
     if (typeof error.message === 'object') {
       error.error =
-        Object.values(error.message as Record<string, string[]>)[0]?.[0] ||
-        t('Invalid input');
+        getFirstValidationError(error.message) || t('Invalid input');
     }
     if (typeof error.message === 'string') {
       if (checkForHtml(error.message)) {

--- a/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/getClientErrorObject.test.ts
@@ -244,6 +244,24 @@ test('parseErrorJson with message', () => {
   });
 });
 
+test('parseErrorJson preserves string-valued validation messages', () => {
+  const calculatedColumnError =
+    'Custom SQL fields cannot be parsed as a single SQL statement.';
+
+  expect(
+    parseErrorJson({
+      message: {
+        'columns.0.expression': calculatedColumnError,
+      },
+    }),
+  ).toEqual({
+    message: {
+      'columns.0.expression': calculatedColumnError,
+    },
+    error: calculatedColumnError,
+  });
+});
+
 test('parseErrorJson with HTML message', () => {
   expect(
     parseErrorJson({


### PR DESCRIPTION
### SUMMARY

Fixes [Shortcut SC-115499](https://app.shortcut.com/preset/story/115499).

When a calculated-column expression fails server-side validation, the dataset API can return a scalar field error:

```json
{"message":{"columns.0.expression":"Custom SQL fields cannot be parsed as a single SQL statement."}}
```

Other dataset validation paths return array-valued field errors such as `{"message":{"columns":["One or more columns already exist"]}}`. The scalar shape occurs because Flask-Babel `LazyString` values are not treated as Python strings by Marshmallow's `ValidationError` constructor, so they are not list-wrapped before Flask serializes them.

`parseErrorJson()` asserted that every field value was `string[]` and unconditionally indexed `[0]`. For a scalar JSON string, JavaScript returned its first character, causing the dataset editor to display only `C`. This was also a structural weakness at the shared client-error normalization boundary: a valid backend response variant was forced through an unchecked type assertion.

This change normalizes both scalar-string and string-array field errors at that boundary, preserves the existing invalid-input fallback for unsupported/empty values, and adds a regression test using the exact calculated-column response shape.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No new screenshot attached.

- Before: **Error saving dataset** displayed `C`.
- After: it displays `Custom SQL fields cannot be parsed as a single SQL statement.`

### TESTING INSTRUCTIONS

Automated checks run:

```bash
# Focused regression suite: 23 passed
npx jest packages/superset-ui-core/test/query/getClientErrorObject.test.ts --runInBand

# Targeted formatting and lint
oxfmt --check packages/superset-ui-core/src/query/getClientErrorObject.ts packages/superset-ui-core/test/query/getClientErrorObject.test.ts
oxlint --config oxlint.json packages/superset-ui-core/src/query/getClientErrorObject.ts packages/superset-ui-core/test/query/getClientErrorObject.test.ts

# Relevant TypeScript project and repository staged-file checks
tsc --build packages/superset-ui-core
pre-commit run
```

Manual verification:

1. Open **Datasets → birth_names → Edit**.
2. Add a calculated column named `broken_calc` with expression `state = `.
3. Save and confirm.
4. Verify the error dialog shows the complete validation message rather than `C`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [Shortcut SC-115499](https://app.shortcut.com/preset/story/115499)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

