### PR TITLE
feat(dataset): expose dataset certification controls

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
@@ -23,10 +23,12 @@ import {
   fireEvent,
   cleanup,
   userEvent,
+  act,
   defaultStore as store,
 } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import { SupersetClient } from '@superset-ui/core';
+import { Constants } from '@superset-ui/core/components';
 import mockDatasource from 'spec/fixtures/mockDatasource';
 import React from 'react';
 import DatasourceModalComponent, { buildExtraJsonObject } from '.';
@@ -76,6 +78,10 @@ beforeEach(() => {
   fetchMock.put(SAVE_DATASOURCE_ENDPOINT, {});
   fetchMock.get(GET_DATASOURCE_ENDPOINT, { result: {} });
   fetchMock.get(GET_DATABASE_ENDPOINT, { result: [] });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 // eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
@@ -151,15 +157,26 @@ describe('DatasourceModal', () => {
 
     await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
 
+    const defaultUrlLabel = await screen.findByText('Default URL');
+    const defaultUrl = defaultUrlLabel
+      .closest('.ant-form-item')
+      ?.querySelector('input');
+    expect(defaultUrl).not.toBeNull();
     const certifiedBy = await screen.findByPlaceholderText('Certified by');
-    fireEvent.change(certifiedBy, { target: { value: 'E2E Team' } });
-    await new Promise(resolve => setTimeout(resolve, 500));
-
     const details = screen.getByPlaceholderText('Certification details');
+
+    jest.useFakeTimers();
+    fireEvent.change(defaultUrl as HTMLInputElement, {
+      target: { value: '/dashboard/7/' },
+    });
+    fireEvent.change(certifiedBy, { target: { value: 'E2E Team' } });
     fireEvent.change(details, {
       target: { value: 'Reviewed for production' },
     });
-    await new Promise(resolve => setTimeout(resolve, 500));
+    act(() => {
+      jest.advanceTimersByTime(Constants.FAST_DEBOUNCE);
+    });
+    jest.useRealTimers();
 
     fireEvent.click(screen.getByTestId('datasource-modal-save'));
     fireEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
@@ -175,6 +192,7 @@ describe('DatasourceModal', () => {
       expect(putCall).toBeDefined();
 
       const payload = JSON.parse(putCall?.options?.body as string);
+      expect(payload.default_endpoint).toBe('/dashboard/7/');
       expect(JSON.parse(payload.extra)).toEqual({
         custom_key: { enabled: true },
         warning_markdown: 'Use only finalized records',

--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
@@ -22,6 +22,7 @@ import {
   waitFor,
   fireEvent,
   cleanup,
+  userEvent,
   defaultStore as store,
 } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
@@ -133,6 +134,81 @@ describe('DatasourceModal', () => {
           call.options?.method === 'put',
       );
     expect(JSON.parse(putCall?.options?.body as string).editors).toEqual([1]);
+  });
+
+  test('saves dataset certification from Settings without dropping Extra metadata', async () => {
+    cleanup();
+    renderAndWait({
+      ...mockedProps,
+      datasource: {
+        ...mockedProps.datasource,
+        extra: JSON.stringify({
+          custom_key: { enabled: true },
+          warning_markdown: 'Use only finalized records',
+        }),
+      } as typeof mockedProps.datasource & { extra: string },
+    });
+
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    const certifiedBy = await screen.findByPlaceholderText('Certified by');
+    fireEvent.change(certifiedBy, { target: { value: 'E2E Team' } });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const details = screen.getByPlaceholderText('Certification details');
+    fireEvent.change(details, {
+      target: { value: 'Reviewed for production' },
+    });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    fireEvent.click(screen.getByTestId('datasource-modal-save'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      const putCall = fetchMock.callHistory
+        .calls()
+        .find(
+          call =>
+            call.url.includes('/api/v1/dataset/7') &&
+            call.options?.method === 'put',
+        );
+      expect(putCall).toBeDefined();
+
+      const payload = JSON.parse(putCall?.options?.body as string);
+      expect(JSON.parse(payload.extra)).toEqual({
+        custom_key: { enabled: true },
+        warning_markdown: 'Use only finalized records',
+        certification: {
+          certified_by: 'E2E Team',
+          details: 'Reviewed for production',
+        },
+      });
+    });
+  });
+
+  test('shows existing dataset certification in Settings', async () => {
+    cleanup();
+    renderAndWait({
+      ...mockedProps,
+      datasource: {
+        ...mockedProps.datasource,
+        extra: JSON.stringify({
+          certification: {
+            certified_by: 'Data Platform Team',
+            details: 'Source of truth',
+          },
+        }),
+      } as typeof mockedProps.datasource & { extra: string },
+    });
+
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    expect(await screen.findByPlaceholderText('Certified by')).toHaveValue(
+      'Data Platform Team',
+    );
+    expect(screen.getByPlaceholderText('Certification details')).toHaveValue(
+      'Source of truth',
+    );
   });
 
   test('should render error dialog', async () => {

--- a/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/index.tsx
@@ -41,6 +41,7 @@ import { ErrorMessageWithStackTrace } from 'src/components';
 import type { DatasetObject } from 'src/features/datasets/types';
 import { mapSubjectValuesToIds } from 'src/features/subjects/SubjectPicker';
 import type { DatasourceModalProps } from '../types';
+import { setDatasetCertification } from '../components/DatasourceEditor/datasetCertification';
 
 const DatasourceEditor = AsyncEsmComponent(
   () => import('../components/DatasourceEditor'),
@@ -134,7 +135,12 @@ const DatasourceModal: FunctionComponent<DatasourceModalProps> = ({
         datasource.cache_timeout === '' ? null : datasource.cache_timeout,
       is_sqllab_view: datasource.is_sqllab_view,
       template_params: datasource.template_params,
-      extra: datasource.extra,
+      extra: datasource.dataset_certification_changed
+        ? setDatasetCertification(datasource.extra, {
+            certified_by: datasource.certified_by,
+            certification_details: datasource.certification_details,
+          })
+        : datasource.extra,
       is_managed_externally: datasource.is_managed_externally,
       external_url: datasource.external_url,
       metrics: datasource?.metrics?.map(

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -108,6 +108,10 @@ import {
 } from '../../FoldersEditor/treeUtils';
 import FoldersEditor from '../../FoldersEditor';
 import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
+import {
+  getDatasetCertification,
+  setDatasetCertification,
+} from './datasetCertification';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -1631,6 +1635,49 @@ function DatasourceEditor({
     onDatasourceChange,
   ]);
 
+  const renderCertificationFieldset = useCallback(() => {
+    const certification = getDatasetCertification(datasource.extra);
+
+    return isSqla ? (
+      <Fieldset
+        title={t('Certification')}
+        item={certification}
+        onChange={updatedCertification => {
+          onDatasourceChange({
+            ...datasource,
+            extra: setDatasetCertification(
+              datasource.extra,
+              updatedCertification,
+            ),
+          });
+        }}
+      >
+        <Field
+          fieldKey="certified_by"
+          label={t('Certified by')}
+          description={t('Person or group that has certified this dataset')}
+          control={
+            <TextControl
+              controlId="dataset_certified_by"
+              placeholder={t('Certified by')}
+            />
+          }
+        />
+        <Field
+          fieldKey="certification_details"
+          label={t('Certification details')}
+          description={t('Details of the dataset certification')}
+          control={
+            <TextControl
+              controlId="dataset_certification_details"
+              placeholder={t('Certification details')}
+            />
+          }
+        />
+      </Fieldset>
+    ) : null;
+  }, [datasource, onDatasourceChange, isSqla]);
+
   const renderSettingsFieldset = useCallback(
     () => (
       <Fieldset
@@ -2548,7 +2595,10 @@ function DatasourceEditor({
         children: (
           <Row gutter={16}>
             <Col xs={24} md={12}>
-              <FormContainer>{renderSettingsFieldset()}</FormContainer>
+              <FormContainer>
+                {renderCertificationFieldset()}
+                {renderSettingsFieldset()}
+              </FormContainer>
             </Col>
             <Col xs={24} md={12}>
               <FormContainer>{renderAdvancedFieldset()}</FormContainer>
@@ -2578,6 +2628,7 @@ function DatasourceEditor({
       folders,
       folderCount,
       handleFoldersChange,
+      renderCertificationFieldset,
       renderSettingsFieldset,
       renderAdvancedFieldset,
       // `renderSpatialTab` is intentionally retained (see its definition above)

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -1648,11 +1648,16 @@ function DatasourceEditor({
       <Fieldset
         title={t('Certification')}
         item={datasource}
-        onChange={updatedCertification => {
+        onFieldChange={(fieldKey, value) => {
+          if (
+            fieldKey !== 'certified_by' &&
+            fieldKey !== 'certification_details'
+          ) {
+            return;
+          }
           setDatasource(previousDatasource => ({
             ...previousDatasource,
-            certified_by: updatedCertification.certified_by,
-            certification_details: updatedCertification.certification_details,
+            [fieldKey]: typeof value === 'string' ? value : undefined,
             dataset_certification_changed: true,
           }));
         }}
@@ -1692,7 +1697,9 @@ function DatasourceEditor({
       <Fieldset
         title={t('Basic')}
         item={datasource}
-        onChange={onDatasourceChange}
+        onFieldChange={(fieldKey, value) =>
+          onDatasourcePropChange(String(fieldKey), value)
+        }
       >
         <Field
           fieldKey="description"
@@ -1773,7 +1780,7 @@ function DatasourceEditor({
         )}
       </Fieldset>
     ),
-    [datasource, onDatasourceChange, onDatasourcePropChange, isSqla],
+    [datasource, onDatasourcePropChange, isSqla],
   );
 
   const renderAdvancedFieldset = useCallback(
@@ -1781,7 +1788,9 @@ function DatasourceEditor({
       <Fieldset
         title={t('Advanced')}
         item={datasource}
-        onChange={onDatasourceChange}
+        onFieldChange={(fieldKey, value) =>
+          onDatasourcePropChange(String(fieldKey), value)
+        }
       >
         <Field
           fieldKey="cache_timeout"
@@ -1829,7 +1838,7 @@ function DatasourceEditor({
         />
       </Fieldset>
     ),
-    [datasource, onDatasourceChange, isSqla],
+    [datasource, onDatasourcePropChange, isSqla],
   );
 
   const renderSourceFieldset = useCallback(

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -110,7 +110,7 @@ import FoldersEditor from '../../FoldersEditor';
 import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
 import {
   getDatasetCertification,
-  setDatasetCertification,
+  isDatasetExtraValid,
 } from './datasetCertification';
 
 const extensionsRegistry = getExtensionsRegistry();
@@ -188,6 +188,9 @@ interface DatasourceObject {
   description?: string;
   default_endpoint?: string;
   extra?: string;
+  certified_by?: string;
+  certification_details?: string;
+  dataset_certification_changed?: boolean;
   datasource_type?: string;
   type?: string;
   offset?: number;
@@ -903,6 +906,7 @@ function DatasourceEditor({
   // Initialize datasource state with transformed editors and metrics
   const [datasource, setDatasource] = useState<DatasourceObject>(() => ({
     ...propsDatasource,
+    ...getDatasetCertification(propsDatasource.extra),
     editors: normalizeSubjectsToPickerValues(propsDatasource.editors || []),
     metrics: propsDatasource.metrics?.map(hydrateMetricExtra),
   }));
@@ -1636,30 +1640,33 @@ function DatasourceEditor({
   ]);
 
   const renderCertificationFieldset = useCallback(() => {
-    const certification = getDatasetCertification(datasource.extra);
+    const certificationError = !isDatasetExtraValid(datasource.extra)
+      ? t('Fix the Extra JSON to edit certification')
+      : undefined;
 
     return isSqla ? (
       <Fieldset
         title={t('Certification')}
-        item={certification}
+        item={datasource}
         onChange={updatedCertification => {
-          onDatasourceChange({
-            ...datasource,
-            extra: setDatasetCertification(
-              datasource.extra,
-              updatedCertification,
-            ),
-          });
+          setDatasource(previousDatasource => ({
+            ...previousDatasource,
+            certified_by: updatedCertification.certified_by,
+            certification_details: updatedCertification.certification_details,
+            dataset_certification_changed: true,
+          }));
         }}
       >
         <Field
           fieldKey="certified_by"
           label={t('Certified by')}
           description={t('Person or group that has certified this dataset')}
+          errorMessage={certificationError}
           control={
             <TextControl
               controlId="dataset_certified_by"
               placeholder={t('Certified by')}
+              disabled={Boolean(certificationError)}
             />
           }
         />
@@ -1667,16 +1674,18 @@ function DatasourceEditor({
           fieldKey="certification_details"
           label={t('Certification details')}
           description={t('Details of the dataset certification')}
+          errorMessage={certificationError}
           control={
             <TextControl
               controlId="dataset_certification_details"
               placeholder={t('Certification details')}
+              disabled={Boolean(certificationError)}
             />
           }
         />
       </Fieldset>
     ) : null;
-  }, [datasource, onDatasourceChange, isSqla]);
+  }, [datasource, isSqla]);
 
   const renderSettingsFieldset = useCallback(
     () => (
@@ -1737,15 +1746,20 @@ function DatasourceEditor({
             }
           />
         )}
+        <EditorsSelector
+          datasource={datasource}
+          onChange={newEditors => {
+            onDatasourcePropChange('editors', newEditors);
+          }}
+        />
         {isSqla && (
           <Field
             fieldKey="extra"
             label={t('Extra')}
             description={t(
-              'Extra data to specify table metadata. Currently supports ' +
-                'metadata of the format: `{ "certification": { "certified_by": ' +
-                '"Data Platform Team", "details": "This table is the source of truth." ' +
-                '}, "warning_markdown": "This is a warning." }`.',
+              'Extra data to specify table metadata, such as ' +
+                '`{ "warning_markdown": "This is a warning." }`. ' +
+                'Use the Certification fields below for certification metadata.',
             )}
             control={
               <TextAreaControl
@@ -1757,15 +1771,9 @@ function DatasourceEditor({
             }
           />
         )}
-        <EditorsSelector
-          datasource={datasource}
-          onChange={newEditors => {
-            onDatasourceChange({ ...datasource, editors: newEditors });
-          }}
-        />
       </Fieldset>
     ),
-    [datasource, onDatasourceChange, isSqla],
+    [datasource, onDatasourceChange, onDatasourcePropChange, isSqla],
   );
 
   const renderAdvancedFieldset = useCallback(
@@ -2596,8 +2604,8 @@ function DatasourceEditor({
           <Row gutter={16}>
             <Col xs={24} md={12}>
               <FormContainer>
-                {renderCertificationFieldset()}
                 {renderSettingsFieldset()}
+                {renderCertificationFieldset()}
               </FormContainer>
             </Col>
             <Col xs={24} md={12}>

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export type DatasetCertification = Record<string, unknown> & {
+export type DatasetCertification = {
   certified_by?: string;
   certification_details?: string;
 };
@@ -39,6 +39,9 @@ const parseExtra = (extra?: string): JsonObject | undefined => {
     return undefined;
   }
 };
+
+export const isDatasetExtraValid = (extra?: string): boolean =>
+  parseExtra(extra) !== undefined;
 
 export const getDatasetCertification = (
   extra?: string,
@@ -63,25 +66,46 @@ export const getDatasetCertification = (
 export const setDatasetCertification = (
   extra: string | undefined,
   { certified_by, certification_details }: DatasetCertification,
-): string => {
+): string | undefined => {
   const parsedExtra = parseExtra(extra);
 
   // Do not replace malformed raw metadata while the user is correcting it in
   // the adjacent Extra editor.
   if (!parsedExtra) {
-    return extra ?? '';
+    return extra;
   }
 
-  if (certified_by || certification_details) {
-    const existingCertification = parsedExtra.certification;
-    parsedExtra.certification = {
-      ...(isJsonObject(existingCertification) ? existingCertification : {}),
-      certified_by: certified_by || undefined,
-      details: certification_details || undefined,
-    };
+  const normalizedCertifiedBy = certified_by || undefined;
+  const normalizedDetails = certification_details || undefined;
+  const existing = getDatasetCertification(extra);
+
+  // Avoid reformatting raw Extra JSON when the certification did not change.
+  if (
+    existing.certified_by === normalizedCertifiedBy &&
+    existing.certification_details === normalizedDetails
+  ) {
+    return extra;
+  }
+
+  const existingCertification = parsedExtra.certification;
+  const certification = isJsonObject(existingCertification)
+    ? { ...existingCertification }
+    : {};
+  delete certification.certified_by;
+  delete certification.details;
+
+  if (normalizedCertifiedBy) {
+    certification.certified_by = normalizedCertifiedBy;
+  }
+  if (normalizedDetails) {
+    certification.details = normalizedDetails;
+  }
+
+  if (Object.keys(certification).length > 0) {
+    parsedExtra.certification = certification;
   } else {
     delete parsedExtra.certification;
   }
 
-  return JSON.stringify(parsedExtra, null, 2);
+  return JSON.stringify(parsedExtra);
 };

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type DatasetCertification = Record<string, unknown> & {
+  certified_by?: string;
+  certification_details?: string;
+};
+
+type JsonObject = Record<string, unknown>;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseExtra = (extra?: string): JsonObject | undefined => {
+  if (!extra?.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(extra);
+    return isJsonObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const getDatasetCertification = (
+  extra?: string,
+): DatasetCertification => {
+  const certification = parseExtra(extra)?.certification;
+  if (!isJsonObject(certification)) {
+    return {};
+  }
+
+  return {
+    certified_by:
+      typeof certification.certified_by === 'string'
+        ? certification.certified_by
+        : undefined,
+    certification_details:
+      typeof certification.details === 'string'
+        ? certification.details
+        : undefined,
+  };
+};
+
+export const setDatasetCertification = (
+  extra: string | undefined,
+  { certified_by, certification_details }: DatasetCertification,
+): string => {
+  const parsedExtra = parseExtra(extra);
+
+  // Do not replace malformed raw metadata while the user is correcting it in
+  // the adjacent Extra editor.
+  if (!parsedExtra) {
+    return extra ?? '';
+  }
+
+  if (certified_by || certification_details) {
+    const existingCertification = parsedExtra.certification;
+    parsedExtra.certification = {
+      ...(isJsonObject(existingCertification) ? existingCertification : {}),
+      certified_by: certified_by || undefined,
+      details: certification_details || undefined,
+    };
+  } else {
+    delete parsedExtra.certification;
+  }
+
+  return JSON.stringify(parsedExtra, null, 2);
+};

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorDatasetCertification.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorDatasetCertification.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import fetchMock from 'fetch-mock';
+import {
+  fireEvent,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import {
+  cleanupAsyncOperations,
+  createProps,
+  DATASOURCE_ENDPOINT,
+  dismissDatasourceWarning,
+  fastRender,
+  setupDatasourceEditorMocks,
+} from './DatasourceEditor.test.utils';
+
+beforeEach(() => {
+  fetchMock.get(DATASOURCE_ENDPOINT, [], { name: DATASOURCE_ENDPOINT });
+  setupDatasourceEditorMocks();
+});
+
+afterEach(async () => {
+  await cleanupAsyncOperations();
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('rapid Basic and Certification edits keep every dataset field', async () => {
+  const testProps = createProps();
+  const extra = '{ "custom_key": true }';
+  testProps.datasource.extra = extra;
+  fastRender(testProps);
+  await dismissDatasourceWarning();
+
+  await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+  const defaultUrlLabel = await screen.findByText('Default URL');
+  const defaultUrl = defaultUrlLabel
+    .closest('.ant-form-item')
+    ?.querySelector('input');
+  expect(defaultUrl).not.toBeNull();
+
+  fireEvent.change(defaultUrl as HTMLInputElement, {
+    target: { value: '/dashboard/7/' },
+  });
+  fireEvent.change(await screen.findByPlaceholderText('Certified by'), {
+    target: { value: 'Data Team' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Certification details'), {
+    target: { value: 'Reviewed for production' },
+  });
+
+  await waitFor(() => {
+    const { calls } = testProps.onChange.mock;
+    expect(calls[calls.length - 1]?.[0]).toEqual(
+      expect.objectContaining({
+        default_endpoint: '/dashboard/7/',
+        certified_by: 'Data Team',
+        certification_details: 'Reviewed for production',
+        dataset_certification_changed: true,
+        extra,
+      }),
+    );
+  });
+});
+
+test('malformed Extra disables dataset certification controls', async () => {
+  const testProps = createProps();
+  testProps.datasource.extra = '{"custom_key":';
+  fastRender(testProps);
+  await dismissDatasourceWarning();
+
+  await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+  expect(await screen.findByPlaceholderText('Certified by')).toBeDisabled();
+  expect(screen.getByPlaceholderText('Certification details')).toBeDisabled();
+  expect(
+    screen.getAllByText('Fix the Extra JSON to edit certification'),
+  ).toHaveLength(2);
+});

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorDatasetCertification.test.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorDatasetCertification.test.tsx
@@ -17,7 +17,9 @@
  * under the License.
  */
 import fetchMock from 'fetch-mock';
+import { Constants } from '@superset-ui/core/components';
 import {
+  act,
   fireEvent,
   screen,
   userEvent,
@@ -38,11 +40,12 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  jest.useRealTimers();
   await cleanupAsyncOperations();
   fetchMock.clearHistory().removeRoutes();
 });
 
-test('rapid Basic and Certification edits keep every dataset field', async () => {
+test('a trailing Basic edit keeps pending Certification fields', async () => {
   const testProps = createProps();
   const extra = '{ "custom_key": true }';
   testProps.datasource.extra = extra;
@@ -56,16 +59,25 @@ test('rapid Basic and Certification edits keep every dataset field', async () =>
     .closest('.ant-form-item')
     ?.querySelector('input');
   expect(defaultUrl).not.toBeNull();
+  const certifiedBy = await screen.findByPlaceholderText('Certified by');
+  const certificationDetails = screen.getByPlaceholderText(
+    'Certification details',
+  );
 
+  jest.useFakeTimers();
+  fireEvent.change(certifiedBy, {
+    target: { value: 'Data Team' },
+  });
+  fireEvent.change(certificationDetails, {
+    target: { value: 'Reviewed for production' },
+  });
   fireEvent.change(defaultUrl as HTMLInputElement, {
     target: { value: '/dashboard/7/' },
   });
-  fireEvent.change(await screen.findByPlaceholderText('Certified by'), {
-    target: { value: 'Data Team' },
+  act(() => {
+    jest.advanceTimersByTime(Constants.FAST_DEBOUNCE);
   });
-  fireEvent.change(screen.getByPlaceholderText('Certification details'), {
-    target: { value: 'Reviewed for production' },
-  });
+  jest.useRealTimers();
 
   await waitFor(() => {
     const { calls } = testProps.onChange.mock;

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  getDatasetCertification,
+  setDatasetCertification,
+} from '../datasetCertification';
+
+test('reads dataset certification from Extra JSON', () => {
+  expect(
+    getDatasetCertification(
+      JSON.stringify({
+        certification: {
+          certified_by: 'Data Platform Team',
+          details: 'Source of truth',
+        },
+      }),
+    ),
+  ).toEqual({
+    certified_by: 'Data Platform Team',
+    certification_details: 'Source of truth',
+  });
+});
+
+test('writes dataset certification without discarding other Extra metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      custom_key: { enabled: true },
+      warning_markdown: 'Use only finalized records',
+    }),
+    {
+      certified_by: 'E2E Team',
+      certification_details: 'Reviewed for production',
+    },
+  );
+
+  expect(JSON.parse(result)).toEqual({
+    custom_key: { enabled: true },
+    warning_markdown: 'Use only finalized records',
+    certification: {
+      certified_by: 'E2E Team',
+      details: 'Reviewed for production',
+    },
+  });
+});
+
+test('clearing dataset certification preserves other Extra metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      certification: {
+        certified_by: 'Data Platform Team',
+        details: 'Source of truth',
+      },
+      warning_markdown: 'Use only finalized records',
+    }),
+    {},
+  );
+
+  expect(JSON.parse(result)).toEqual({
+    warning_markdown: 'Use only finalized records',
+  });
+});
+
+test('editing certification does not overwrite malformed Extra JSON', () => {
+  expect(
+    setDatasetCertification('{"custom_key":', {
+      certified_by: 'Data Platform Team',
+    }),
+  ).toBe('{"custom_key":');
+});

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
@@ -19,6 +19,7 @@
 
 import {
   getDatasetCertification,
+  isDatasetExtraValid,
   setDatasetCertification,
 } from '../datasetCertification';
 
@@ -50,12 +51,46 @@ test('writes dataset certification without discarding other Extra metadata', () 
     },
   );
 
-  expect(JSON.parse(result)).toEqual({
+  expect(JSON.parse(result ?? '')).toEqual({
     custom_key: { enabled: true },
     warning_markdown: 'Use only finalized records',
     certification: {
       certified_by: 'E2E Team',
       details: 'Reviewed for production',
+    },
+  });
+});
+
+test('writes certification details without requiring a certifier', () => {
+  const result = setDatasetCertification('{}', {
+    certification_details: 'Reviewed for production',
+  });
+
+  expect(JSON.parse(result ?? '')).toEqual({
+    certification: { details: 'Reviewed for production' },
+  });
+});
+
+test('editing certification preserves unknown certification metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      certification: {
+        certified_by: 'Data Platform Team',
+        details: 'Source of truth',
+        expires_at: '2030-01-01',
+      },
+    }),
+    {
+      certified_by: 'E2E Team',
+      certification_details: 'Reviewed for production',
+    },
+  );
+
+  expect(JSON.parse(result ?? '')).toEqual({
+    certification: {
+      certified_by: 'E2E Team',
+      details: 'Reviewed for production',
+      expires_at: '2030-01-01',
     },
   });
 });
@@ -69,12 +104,60 @@ test('clearing dataset certification preserves other Extra metadata', () => {
       },
       warning_markdown: 'Use only finalized records',
     }),
-    {},
+    { certified_by: '', certification_details: '' },
   );
 
-  expect(JSON.parse(result)).toEqual({
+  expect(JSON.parse(result ?? '')).toEqual({
     warning_markdown: 'Use only finalized records',
   });
+});
+
+test('clearing certification preserves unknown certification metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      certification: {
+        certified_by: 'Data Platform Team',
+        details: 'Source of truth',
+        expires_at: '2030-01-01',
+      },
+    }),
+    { certified_by: '', certification_details: '' },
+  );
+
+  expect(JSON.parse(result ?? '')).toEqual({
+    certification: { expires_at: '2030-01-01' },
+  });
+});
+
+test('an unchanged certification leaves Extra formatting untouched', () => {
+  const extra = '{\n    "certification": { "certified_by": "Data Team" }\n}';
+
+  expect(setDatasetCertification(extra, { certified_by: 'Data Team' })).toBe(
+    extra,
+  );
+  expect(
+    setDatasetCertification(undefined, {
+      certified_by: '',
+      certification_details: '',
+    }),
+  ).toBeUndefined();
+});
+
+test('handles non-object Extra and certification values', () => {
+  expect(getDatasetCertification('[]')).toEqual({});
+  expect(getDatasetCertification('{"certification":true}')).toEqual({});
+  expect(
+    setDatasetCertification('{"certification":true}', {
+      certified_by: 'Data Team',
+    }),
+  ).toBe('{"certification":{"certified_by":"Data Team"}}');
+});
+
+test('identifies malformed and non-object Extra JSON', () => {
+  expect(isDatasetExtraValid()).toBe(true);
+  expect(isDatasetExtraValid('{}')).toBe(true);
+  expect(isDatasetExtraValid('{"custom_key":')).toBe(false);
+  expect(isDatasetExtraValid('[]')).toBe(false);
 });
 
 test('editing certification does not overwrite malformed Extra JSON', () => {

--- a/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
@@ -51,10 +51,15 @@ export default function Fieldset({
 
   const handleChange = useCallback(
     (fieldKey: fieldKeyType, val: any) => {
-      onChange?.({
+      const updatedItem = {
         ...itemRef.current,
         [fieldKey]: val,
-      });
+      };
+      // Multiple debounced controls can commit in the same React batch, before
+      // the effect above has synchronized the item passed back by the parent.
+      // Advance the ref synchronously so the later commit includes its sibling.
+      itemRef.current = updatedItem;
+      onChange?.(updatedItem);
     },
     [onChange],
   );

--- a/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
+++ b/superset-frontend/src/components/Datasource/components/Fieldset/index.tsx
@@ -25,6 +25,7 @@ import Field from '../Field';
 export interface FieldsetProps {
   children: ReactNode;
   onChange?: (updatedItem: Record<string, any>) => void;
+  onFieldChange?: (fieldKey: fieldKeyType, value: unknown) => void;
   item?: Record<string, any>;
   title?: ReactNode;
   compact?: boolean;
@@ -35,6 +36,7 @@ type fieldKeyType = string | number;
 export default function Fieldset({
   children,
   onChange,
+  onFieldChange,
   item = {},
   title = null,
   compact = false,
@@ -59,9 +61,13 @@ export default function Fieldset({
       // the effect above has synchronized the item passed back by the parent.
       // Advance the ref synchronously so the later commit includes its sibling.
       itemRef.current = updatedItem;
-      onChange?.(updatedItem);
+      if (onFieldChange) {
+        onFieldChange(fieldKey, val);
+      } else {
+        onChange?.(updatedItem);
+      }
     },
-    [onChange],
+    [onChange, onFieldChange],
   );
 
   const propExtender = (field: { props: { fieldKey: fieldKeyType } }) => ({

--- a/superset-frontend/src/features/datasets/types.ts
+++ b/superset-frontend/src/features/datasets/types.ts
@@ -75,6 +75,9 @@ export type DatasetObject = {
   columns: ColumnObject[];
   metrics: MetricObject[];
   extra?: string;
+  certified_by?: string;
+  certification_details?: string;
+  dataset_certification_changed?: boolean;
   is_managed_externally: boolean;
   normalize_columns: boolean;
   always_filter_main_dttm: boolean;


### PR DESCRIPTION
### SUMMARY

The reported recording does not certify the dataset: it opens the Metrics tab and fills certification fields for a metric. Dataset-level certification is stored separately in `SqlaTable.extra.certification`. The dataset list already serializes that raw `extra` value and renders `CertifiedBadge` when the dataset-level key is present.

The user-facing gap is that metrics and columns have dedicated fields, while certifying the dataset itself requires hand-editing raw Extra JSON. This makes the scopes easy to confuse and leaves a valid list renderer with no dataset-level value to display.

This change adds an explicit **Certification** section beside Extra in Edit Dataset → Settings, using the existing `extra.certification` contract without a model, API, or migration change.

Following review, the editor hydrates certification into first-class form state and merges it into the latest Extra JSON only when saving. Settings fieldsets commit individual properties with functional updates, so debounced Basic, Advanced, and Certification callbacks cannot replace one another with stale whole-datasource snapshots. This avoids two controls writing the same JSON blob, prevents stale Basic/Extra edits from being lost, keeps the raw Extra editor authoritative when the dedicated fields were not used, and prevents no-op formatting changes. Malformed/non-object Extra disables the certification controls with a corrective message. Unknown top-level and certification subkeys survive edits and clears.

Shortcut: https://app.shortcut.com/preset/story/115268

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Dataset certification was available only by entering the nested certification object in the raw Extra JSON field. The visible certification fields under Metrics/Columns certified only that child item.

**After:** Edit Dataset → Settings has dedicated dataset-level “Certified by” and “Certification details” fields next to Extra. Saving them produces the metadata consumed by the existing Datasets list badge. A local Superset server was unavailable for an updated screenshot.

### TESTING INSTRUCTIONS

Automated:

```bash
cd superset-frontend
npx jest --runInBand --silent \
  src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts \
  src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorDatasetCertification.test.tsx \
  src/components/Datasource/components/DatasourceEditor/tests/DatasourceEditorMetricCertification.test.tsx \
  src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
# 4 suites, 30 tests passed

npx jest --runInBand --silent \
  src/pages/DatasetList/DatasetList.behavior.test.tsx \
  -t 'certified dataset shows badge'
# 1 passed

pre-commit run
# passed on all staged files, including oxfmt, oxlint, custom frontend rules,
# stylelint, and targeted TypeScript checking
```

Manual:

1. Open Data → Datasets and edit an SQLAlchemy dataset.
2. Open Settings and fill “Certified by” and “Certification details”.
3. Rapidly edit Default URL and both certification fields; save and confirm all values persist.
4. Edit unrelated Extra metadata after filling certification; save and confirm both the raw metadata and certification persist.
5. Clear both certification fields and confirm unrelated top-level and nested certification metadata remain.
6. With malformed Extra JSON, confirm certification fields are disabled until Extra is corrected.
7. Return to the dataset list and confirm the certified badge and tooltip appear beside the dataset name.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-115268](https://app.shortcut.com/preset/story/115268)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API


