### PR TITLE
docs(pivot-table): document DB-computed totals/subtotals behavior

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -154,14 +154,15 @@ to your existing Tutorial Dashboard you created earlier.
 :::note
 Row and column totals/subtotals for the Pivot Table are correct even for non-additive metrics,
 such as ratios (`SUM(a)/SUM(b)`), `COUNT_DISTINCT`, `AVG`, and percentiles, not just additive ones
-like `SUM` or `COUNT`. Additive metrics derive their totals client-side, by reducing the same
-full-detail query results used to build the table. Non-additive metrics can't be combined that
-way, so Superset instead issues a database query at each total's own granularity, so the total
-reflects the metric's definition evaluated at that level rather than an incorrect combination of
-the displayed cells. Because of this, there's no separate "Aggregation function" control for
-totals in the Pivot Table: a total always reflects the metric's own definition. The Table chart's
-**Show summary** row is different: its **Summary aggregation** control can override each metric's
-own aggregation (to Sum or Average) for the summary row only.
+like `SUM` or `COUNT`. Totals derive client-side, by reducing the same full-detail query results
+used to build the table, only when every selected metric is additive; if any selected metric is
+non-additive, Superset instead issues a database query at each total's own granularity for all
+metrics, so the total reflects each metric's own definition evaluated at that level rather than an
+incorrect combination of the displayed cells. Because of this, there's no separate "Aggregation
+function" control for totals in the Pivot Table: a total always reflects the metric's own
+definition. The Table chart's **Show summary** row is different: its **Summary aggregation**
+control can override a simple metric's own aggregation (to Sum or Average) for the summary row
+only — metrics built from custom SQL keep their own aggregation regardless.
 :::
 
 ### Line Chart

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -152,13 +152,16 @@ You should see months in the rows and Department and Travel Class in the columns
 to your existing Tutorial Dashboard you created earlier.
 
 :::note
-Row and column totals/subtotals for the Pivot Table are computed by the database, at the same
-granularity as the total itself, rather than by summing the already-aggregated cells shown in the
-table. This means totals are correct for non-additive metrics too, such as ratios
-(`SUM(a)/SUM(b)`), `COUNT_DISTINCT`, `AVG`, and percentiles, not just additive ones like `SUM` or
-`COUNT`. Because of this, there's no separate "Aggregation function" control for totals: a total
-always reflects the metric's own definition evaluated at that total's level. The Table chart's
-**Show summary** row behaves the same way for percentage metrics.
+Row and column totals/subtotals for the Pivot Table are correct even for non-additive metrics,
+such as ratios (`SUM(a)/SUM(b)`), `COUNT_DISTINCT`, `AVG`, and percentiles, not just additive ones
+like `SUM` or `COUNT`. Additive metrics derive their totals client-side, by reducing the same
+full-detail query results used to build the table. Non-additive metrics can't be combined that
+way, so Superset instead issues a database query at each total's own granularity, so the total
+reflects the metric's definition evaluated at that level rather than an incorrect combination of
+the displayed cells. Because of this, there's no separate "Aggregation function" control for
+totals in the Pivot Table: a total always reflects the metric's own definition. The Table chart's
+**Show summary** row is different: its **Summary aggregation** control can override each metric's
+own aggregation (to Sum or Average) for the summary row only.
 :::
 
 ### Line Chart

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -151,6 +151,16 @@ see some data!
 You should see months in the rows and Department and Travel Class in the columns. Publish this chart
 to your existing Tutorial Dashboard you created earlier.
 
+:::note
+Row and column totals/subtotals for the Pivot Table are computed by the database, at the same
+granularity as the total itself, rather than by summing the already-aggregated cells shown in the
+table. This means totals are correct for non-additive metrics too, such as ratios
+(`SUM(a)/SUM(b)`), `COUNT_DISTINCT`, `AVG`, and percentiles, not just additive ones like `SUM` or
+`COUNT`. Because of this, there's no separate "Aggregation function" control for totals: a total
+always reflects the metric's own definition evaluated at that total's level. The Table chart's
+**Show summary** row behaves the same way for percentage metrics.
+:::
+
 ### Line Chart
 
 In this section, we are going to create a line chart to understand the average price of a ticket by


### PR DESCRIPTION
### SUMMARY

#41184 removed the Pivot Table's client-side "Aggregation function" control and moved totals/subtotals computation to the database, at the same grouping level as the total itself, so non-additive metrics (ratios, `COUNT_DISTINCT`, `AVG`, percentiles) roll up correctly. That was documented as a breaking change in `UPDATING.md`, but not anywhere a user would land while reading the actual chart docs. This adds a short note to the Pivot Table section of the "Exploring Data" tutorial explaining the new behavior and why the old control is gone, and calls out that the Table chart's summary row works the same way.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, docs-only change.

### TESTING INSTRUCTIONS

Read the updated "Pivot Table" section in `docs/docs/using-superset/exploring-data.mdx`. Optionally build the docs site (`cd docs && npm run start`) and check the rendered note under Using Superset → Exploring Data.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up to #41184.