### PR TITLE
docs(theming): document resultsGrid* Superset-specific tokens

### DIFF
--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -240,6 +240,40 @@ Font URLs are validated against a configurable allowlist. By default, fonts from
 
 This feature works with the stock Docker image - no custom build required!
 
+## Results Grid Configuration Overrides
+
+Superset exposes a handful of opt-in tokens that customize the appearance of
+AG Grid-backed result tables, such as the results grid in SQL Lab. These
+tokens have no effect unless explicitly set, since the results grid otherwise
+falls back to its built-in defaults.
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        "colorPrimary": "#2893B3",
+        # ... other Ant Design tokens
+
+        # Results grid overrides
+        "resultsGridRowHeight": 32,
+        "resultsGridHeaderFontSize": 13,
+        "resultsGridHeaderFontWeight": 600,
+        "resultsGridBorderRadius": 4,
+        "resultsGridNoStriping": True,
+    }
+}
+```
+
+| Token | Type | Description |
+| --- | --- | --- |
+| `resultsGridRowHeight` | `number` | Row and header height, in pixels. |
+| `resultsGridHeaderFontSize` | `number` | Header cell font size, in pixels. |
+| `resultsGridHeaderFontWeight` | `number` | Header cell font weight. |
+| `resultsGridBorderRadius` | `number` | Border radius applied to the grid and its wrapper, in pixels. |
+| `resultsGridNoStriping` | `boolean` | When `true`, disables alternating row background striping. |
+
+These tokens can also be set through the theme CRUD interface's JSON editor,
+alongside any other Superset-specific tokens.
+
 ## ECharts Configuration Overrides
 
 :::note

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -243,9 +243,8 @@ This feature works with the stock Docker image - no custom build required!
 ## Results Grid Configuration Overrides
 
 Superset exposes a handful of opt-in tokens that customize the appearance of
-AG Grid-backed result tables, such as the results grid in SQL Lab. These
-tokens have no effect unless explicitly set, since the results grid otherwise
-falls back to its built-in defaults.
+the results grid in SQL Lab. These tokens have no effect unless explicitly
+set, since the results grid otherwise falls back to its built-in defaults.
 
 ```python
 THEME_DEFAULT = {


### PR DESCRIPTION
### SUMMARY
#41031 added five `resultsGrid*` Superset-specific theme tokens (`resultsGridRowHeight`, `resultsGridHeaderFontWeight`, `resultsGridHeaderFontSize`, `resultsGridBorderRadius`, `resultsGridNoStriping`) to customize the AG Grid-backed results grid in SQL Lab. They were never added to `theming.mdx`, which is where Superset-specific tokens (chart/dashboard chrome, fonts, etc.) are documented for deployers. This PR adds a "Results Grid Configuration Overrides" section describing each token and how to set it via `THEME_DEFAULT` or the theme CRUD JSON editor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
Read the updated section in `docs/admin_docs/configuration/theming.mdx` ("Results Grid Configuration Overrides") and confirm the token names/behavior match `superset-frontend/src/SqlLab/components/ResultSet/buildResultsGridThemeOverrides.ts`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API