### PR TITLE
docs(theming): document new component sizing tokens and HIDE_NAVBAR_LOGO

### DIFF
--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -469,7 +469,8 @@ This feature provides powerful theming capabilities while maintaining the flexib
 ## Component Sizing & Style Tokens
 
 :::note
-Available since Superset 6.1
+These tokens landed after the Superset 6.1 release and are only available on
+`master`; they are not present in any tagged release yet.
 :::
 
 Beyond colors and fonts, a handful of Superset-specific tokens let you tune the

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -485,9 +485,9 @@ THEME_DEFAULT = {
         # ... other tokens
         "buttonControlHeight": 32,     # default button height, in px
         "buttonControlHeightSM": 30,   # small/dropdown button height, in px
-        "buttonControlHeightXS": 24,   # xsmall button height, in px
-        "buttonPaddingInline": 16,     # horizontal padding, in px
-        "buttonPaddingInlineSM": 12,   # horizontal padding for small buttons, in px
+        "buttonControlHeightXS": 22,   # xsmall button height, in px
+        "buttonPaddingInline": 18,     # horizontal padding, in px
+        "buttonPaddingInlineSM": 10,   # horizontal padding for small buttons, in px
         "buttonFontSize": 14,
         "buttonBorderRadius": 4,
     }

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -138,6 +138,18 @@ The existing `APP_NAME` Python config key continues to work for backward compati
 Email and alert/report notification subjects are driven by backend settings such as
 `EMAIL_REPORTS_SUBJECT_PREFIX` and `APP_NAME`, not by this theme token.
 
+To hide the logo image in the navbar entirely (for example, when a text-only
+brand is preferred), set `HIDE_NAVBAR_LOGO` in `superset_config.py`:
+
+```python
+# Hide the logo image in the navbar. The brand text (brandAppName / APP_NAME)
+# still renders if configured. Defaults to False.
+HIDE_NAVBAR_LOGO = True
+```
+
+`HIDE_NAVBAR_LOGO` is a Python config flag rather than a theme token, so it
+cannot be set through the theme CRUD UI or `THEME_DEFAULT`/`THEME_DARK`.
+
 ### Migration from Configuration to UI
 
 When `ENABLE_UI_THEME_ADMINISTRATION = True`:
@@ -453,6 +465,115 @@ THEME_DEFAULT = {
 ```
 
 This feature provides powerful theming capabilities while maintaining the flexibility of ECharts' extensive configuration options.
+
+## Component Sizing & Style Tokens
+
+:::note
+Available since Superset 6.1
+:::
+
+Beyond colors and fonts, a handful of Superset-specific tokens let you tune the
+sizing, radius, and outline behavior of individual UI components. All of these
+tokens are optional — omit them and components fall back to their existing
+defaults, so applying them is a zero-visual-change operation until you opt in.
+
+### Button & DropdownButton Sizing
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        # ... other tokens
+        "buttonControlHeight": 32,     # default button height, in px
+        "buttonControlHeightSM": 30,   # small/dropdown button height, in px
+        "buttonControlHeightXS": 24,   # xsmall button height, in px
+        "buttonPaddingInline": 16,     # horizontal padding, in px
+        "buttonPaddingInlineSM": 12,   # horizontal padding for small buttons, in px
+        "buttonFontSize": 14,
+        "buttonBorderRadius": 4,
+    }
+}
+```
+
+`buttonControlHeight` and `buttonBorderRadius` also drive the sizing of the
+menu-trigger button used by `PageHeaderWithActions`, so a single pair of tokens
+keeps page-header icon buttons visually consistent with regular buttons.
+
+For one-off overrides that shouldn't apply to every button in the app, pass a
+`styleConfig` prop directly to `Button` or `DropdownButton` instead of setting
+a theme token:
+
+```tsx
+<Button
+  styleConfig={{
+    controlHeight: 40,
+    paddingInline: 20,
+    fontSize: 16,
+    fontWeight: 700,
+    borderRadius: 8,
+    ctaMinWidth: 120,
+    ctaMinHeight: 40,
+    iconGap: 8,
+  }}
+>
+  Click me
+</Button>
+
+<DropdownButton
+  styleConfig={{
+    controlHeight: 32,
+    fontSize: 14,
+    fontWeight: 500,
+    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+  }}
+  menu={menuProps}
+>
+  Options
+</DropdownButton>
+```
+
+`styleConfig` values take precedence over the equivalent theme tokens, which in
+turn take precedence over the built-in defaults.
+
+### Label Border Radius
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        "labelBorderRadius": 4,  # defaults to 8px
+    }
+}
+```
+
+### Select Option Outline
+
+By default, hovering or navigating to an option in a `Select` dropdown draws a
+2px outline in `colorPrimary`. Set `selectOptionActiveOutline` to `False` for a
+more subtle hover style with no outline:
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        "selectOptionActiveOutline": False,
+    }
+}
+```
+
+### Dashboard Tile Appearance
+
+Chart tiles on a dashboard (not text/markdown tiles) can be restyled via
+`dashboardTile*` tokens. All fall back to the existing look — a
+`colorBgContainer` background with no border and a hairline `box-shadow`:
+
+```python
+THEME_DEFAULT = {
+    "token": {
+        "dashboardTileBg": "#ffffff",
+        "dashboardTileBorder": "1px solid #e0e0e0",
+        "dashboardTileBorderRadius": 8,
+        "dashboardTileBoxShadow": "0 1px 2px rgba(0, 0, 0, 0.08)",
+    }
+}
+```
 
 ## Advanced Features
 

--- a/docs/admin_docs/configuration/theming.mdx
+++ b/docs/admin_docs/configuration/theming.mdx
@@ -138,12 +138,12 @@ The existing `APP_NAME` Python config key continues to work for backward compati
 Email and alert/report notification subjects are driven by backend settings such as
 `EMAIL_REPORTS_SUBJECT_PREFIX` and `APP_NAME`, not by this theme token.
 
-To hide the logo image in the navbar entirely (for example, when a text-only
-brand is preferred), set `HIDE_NAVBAR_LOGO` in `superset_config.py`:
+To hide the entire brand area in the navbar (both the logo image and the
+brand text), set `HIDE_NAVBAR_LOGO` in `superset_config.py`:
 
 ```python
-# Hide the logo image in the navbar. The brand text (brandAppName / APP_NAME)
-# still renders if configured. Defaults to False.
+# Hide the entire brand area in the navbar, including the logo image and the
+# brand text (brandAppName / APP_NAME). Defaults to False.
 HIDE_NAVBAR_LOGO = True
 ```
 
@@ -562,7 +562,9 @@ THEME_DEFAULT = {
 
 Chart tiles on a dashboard (not text/markdown tiles) can be restyled via
 `dashboardTile*` tokens. All fall back to the existing look — a
-`colorBgContainer` background with no border and a hairline `box-shadow`:
+`colorBgContainer` background, a `1px solid colorBorder` border, and a
+hairline `box-shadow` while the tile is fading out (e.g. when a filter
+makes it irrelevant):
 
 ```python
 THEME_DEFAULT = {


### PR DESCRIPTION
### SUMMARY
#40985 adds a set of new theme tokens (button/label/select/dashboard-tile sizing and radius, plus a per-instance `styleConfig` prop on `Button`/`DropdownButton`) and a new `HIDE_NAVBAR_LOGO` config flag, none of which were documented anywhere. This adds a "Component Sizing & Style Tokens" section to the theming reference and documents `HIDE_NAVBAR_LOGO` alongside the existing App Branding docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - docs only.

### TESTING INSTRUCTIONS
Read `docs/admin_docs/configuration/theming.mdx` and confirm the new sections render correctly (`npm run start` under `docs/` to preview locally, if desired).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #40985.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>