### PR TITLE
feat(ci): expand testcontainers coverage to mariadb, timescaledb, yugabytedb, monetdb, mongodb

### DIFF
--- a/.github/workflows/testcontainers.yml
+++ b/.github/workflows/testcontainers.yml
@@ -58,6 +58,16 @@ jobs:
             timeout: 15
           - dialect: db2
             timeout: 25
+          - dialect: mariadb
+            timeout: 10
+          - dialect: timescaledb
+            timeout: 10
+          - dialect: yugabytedb
+            timeout: 10
+          - dialect: monetdb
+            timeout: 10
+          - dialect: mongodb
+            timeout: 10
     timeout-minutes: ${{ matrix.timeout }}
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/testcontainers.yml
+++ b/.github/workflows/testcontainers.yml
@@ -72,6 +72,17 @@ jobs:
             timeout: 10
           - dialect: mongodb
             timeout: 10
+          - dialect: postgres
+            timeout: 10
+          - dialect: mysql
+            timeout: 10
+          - dialect: clickhouse
+            timeout: 10
+          # StarRocks' allin1-ubuntu image brings up both FE and BE in one
+          # container, which is a heavier bring-up than a single-process
+          # database -- wider margin until real CI data says otherwise.
+          - dialect: starrocks
+            timeout: 15
     timeout-minutes: ${{ matrix.timeout }}
     env:
       PYTHONPATH: ${{ github.workspace }}

--- a/.github/workflows/testcontainers.yml
+++ b/.github/workflows/testcontainers.yml
@@ -20,6 +20,10 @@ on:
     paths:
       - ".github/workflows/testcontainers.yml"
       - "tests/testcontainers/**"
+      - "superset/db_engine_specs/**"
+      - "pyproject.toml"
+      - "requirements/development.in"
+      - "requirements/development.txt"
 
 concurrency:
   # Scoped by ref, not just workflow name -- otherwise every PR run and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,11 @@ impala = ["impyla>=0.24.0, <0.25"]
 # superset/db_engine_specs/kusto.py's known_incompatibilities metadata.
 kusto = ["sqlalchemy-kusto>=3.1.2, <4"]
 kylin = ["kylinpy>=2.8.4, <2.9"]
+# MariaDB is a MySQL fork implementing the same wire protocol - connects via
+# the plain mysql dialect, same driver as mysql.
+mariadb = ["apache-superset[mysql]"]
+monetdb = ["sqlalchemy-monetdb>=2.1.0, <3", "pymonetdb>=1.9.1, <2"]
+mongodb = ["pymongosql>=0.7.3, <1"]
 mssql = ["pymssql>=2.3.13, <3"]
 # motherduck is an alias for duckdb - MotherDuck works via the duckdb driver
 motherduck = ["apache-superset[duckdb]"]
@@ -270,6 +275,9 @@ tdengine = [
     "taos-ws-py>=0.7.0"
 ]
 teradata = ["teradatasql>=20.0.0.66"]
+# TimescaleDB is a genuine Postgres extension, not a fork - connects via the
+# plain postgresql dialect, same driver as postgres.
+timescaledb = ["apache-superset[postgres]"]
 thumbnails = [] # deprecated, will be removed in 7.0
 vertica = ["sqlalchemy-vertica-python>= 0.6.3, < 0.7"]
 netezza = ["nzalchemy>= 11.1.2, < 11.2"]
@@ -277,6 +285,9 @@ starrocks = ["starrocks>=1.3.4, <2"]
 doris = ["pydoris>=1.2.0, <2.0.0"]
 oceanbase = ["oceanbase_py>=0.0.1.2"]
 ydb = ["ydb-sqlalchemy>=0.1.22", "ydb-sqlglot-plugin>=0.2.8"]
+# YugabyteDB's YSQL layer is fully Postgres-wire compatible - connects via
+# the plain postgresql dialect, same driver as postgres.
+yugabytedb = ["apache-superset[postgres]"]
 development = [
     # no bounds for apache-superset-extensions-cli until a stable version
     "apache-superset-extensions-cli",

--- a/requirements/development.in
+++ b/requirements/development.in
@@ -31,4 +31,4 @@
 # they reuse the postgres/mysql container classes pointed at a different
 # image, and psycopg2-binary/mysqlclient are already pulled in above via
 # the postgres/mysql extras.
-testcontainers[cockroachdb,cratedb,db2,mongodb,mssql,mysql,oracle,postgres,trino]>=4.15.0,<5
+testcontainers[cockroachdb,cratedb,mongodb,mssql,mysql,oracle,postgres,trino]>=4.15.0,<5

--- a/requirements/development.in
+++ b/requirements/development.in
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
--e .[development,bigquery,cockroachdb,crate,druid,duckdb,elasticsearch,fastmcp,gevent,gsheets,mssql,mysql,oracle,postgres,presto,prophet,trino,thumbnails]
+-e .[development,bigquery,cockroachdb,crate,druid,duckdb,elasticsearch,fastmcp,gevent,gsheets,monetdb,mongodb,mssql,mysql,oracle,postgres,presto,prophet,trino,thumbnails]
 -e ./superset-extensions-cli[test]
 # testcontainers-backed db_engine_specs tests (tests/testcontainers/) --
 # see .github/workflows/testcontainers.yml
@@ -26,4 +26,9 @@
 # including it here breaks the multi-platform (amd64+arm64) dev Docker
 # image build. The testcontainers CI job installs it on demand, only for
 # the db2 matrix leg -- see .github/workflows/testcontainers.yml.
-testcontainers[cockroachdb,cratedb,db2,mssql,oracle,trino]>=4.15.0,<5
+#
+# mariadb/timescaledb/yugabytedb need no testcontainers extra of their own:
+# they reuse the postgres/mysql container classes pointed at a different
+# image, and psycopg2-binary/mysqlclient are already pulled in above via
+# the postgres/mysql extras.
+testcontainers[cockroachdb,cratedb,db2,mongodb,mssql,mysql,oracle,postgres,trino]>=4.15.0,<5

--- a/requirements/development.in
+++ b/requirements/development.in
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
--e .[development,bigquery,cockroachdb,crate,druid,duckdb,elasticsearch,fastmcp,gevent,gsheets,monetdb,mongodb,mssql,mysql,oracle,postgres,presto,prophet,trino,thumbnails]
+-e .[development,bigquery,clickhouse,cockroachdb,crate,druid,duckdb,elasticsearch,fastmcp,gevent,gsheets,monetdb,mongodb,mssql,mysql,oracle,postgres,presto,prophet,starrocks,trino,thumbnails]
 -e ./superset-extensions-cli[test]
 # testcontainers-backed db_engine_specs tests (tests/testcontainers/) --
 # see .github/workflows/testcontainers.yml
@@ -30,5 +30,11 @@
 # mariadb/timescaledb/yugabytedb need no testcontainers extra of their own:
 # they reuse the postgres/mysql container classes pointed at a different
 # image, and psycopg2-binary/mysqlclient are already pulled in above via
-# the postgres/mysql extras.
+# the postgres/mysql extras. Plain postgres/mysql obviously need nothing
+# extra either. clickhouse and starrocks also need no testcontainers extra:
+# ClickHouseContainer has no driver import of its own (clickhouse-connect,
+# pulled in above via the clickhouse extra, is all the test needs), and
+# StarRocks has no dedicated testcontainers module at all -- its test uses
+# a generic DockerContainer plus the same mysqlclient the mysql extra
+# already provides.
 testcontainers[cockroachdb,cratedb,mongodb,mssql,mysql,oracle,postgres,trino]>=4.15.0,<5

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -16,6 +16,7 @@ alembic==1.15.2
     # via
     #   -c requirements/base-constraint.txt
     #   flask-migrate
+    #   starrocks
 amqp==5.3.1
     # via
     #   -c requirements/base-constraint.txt
@@ -44,6 +45,8 @@ apsw==3.50.1.0
     #   shillelagh
 astroid==3.3.10
     # via pylint
+asyncmy2==0.2.21
+    # via starrocks
 attrs==25.3.0
     # via
     #   -c requirements/base-constraint.txt
@@ -67,6 +70,7 @@ backports-tarfile==1.2.0
 backports-zstd==1.6.0
     # via
     #   -c requirements/base-constraint.txt
+    #   clickhouse-connect
     #   flask-compress
 bcrypt==4.3.0
     # via
@@ -119,6 +123,7 @@ celery==5.6.3
 certifi==2026.5.20
     # via
     #   -c requirements/base-constraint.txt
+    #   clickhouse-connect
     #   elasticsearch
     #   httpcore
     #   httpx
@@ -164,6 +169,8 @@ click-repl==0.3.0
     # via
     #   -c requirements/base-constraint.txt
     #   celery
+clickhouse-connect==1.7.2
+    # via apache-superset
 cmdstanpy==1.1.0
     # via prophet
 colorama==0.4.6
@@ -521,6 +528,8 @@ kombu==5.6.2
     # via
     #   -c requirements/base-constraint.txt
     #   celery
+lark==1.3.1
+    # via starrocks
 lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 limits==5.1.0
@@ -528,7 +537,9 @@ limits==5.1.0
     #   -c requirements/base-constraint.txt
     #   flask-limiter
 lz4==4.4.5
-    # via trino
+    # via
+    #   clickhouse-connect
+    #   trino
 mako==1.4.1
     # via
     #   -c requirements/base-constraint.txt
@@ -819,7 +830,9 @@ pymssql==2.3.13
     #   apache-superset
     #   testcontainers
 pymysql==1.2.0
-    # via testcontainers
+    # via
+    #   starrocks
+    #   testcontainers
 pynacl==1.6.2
     # via
     #   -c requirements/base-constraint.txt
@@ -1015,6 +1028,7 @@ sqlalchemy==2.0.52
     #   sqlalchemy-cratedb
     #   sqlalchemy-monetdb
     #   sqlalchemy-utils
+    #   starrocks
     #   testcontainers
 sqlalchemy-bigquery==1.17.2
     # via apache-superset
@@ -1053,6 +1067,8 @@ starlette==1.3.1
     # via
     #   fastmcp-slim
     #   mcp
+starrocks==1.3.4
+    # via apache-superset
 statsd==4.0.1
     # via apache-superset
 syntaqlite==0.9.0
@@ -1128,6 +1144,7 @@ urllib3==2.7.0
     # via
     #   -c requirements/base-constraint.txt
     #   botocore
+    #   clickhouse-connect
     #   crate
     #   docker
     #   elasticsearch

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -24,6 +24,8 @@ annotated-types==0.7.0
     # via
     #   -c requirements/base-constraint.txt
     #   pydantic
+antlr4-python3-runtime==4.13.2
+    # via pymongosql
 anyio==4.11.0
     # via
     #   httpx
@@ -193,6 +195,7 @@ cryptography==50.0.0
     #   oracledb
     #   paramiko
     #   pyjwt
+    #   pymysql
     #   pyopenssl
     #   secretstorage
 cycler==0.12.1
@@ -221,6 +224,7 @@ dnspython==2.7.0
     # via
     #   -c requirements/base-constraint.txt
     #   email-validator
+    #   pymongo
 docker==7.2.0
     # via
     #   apache-superset
@@ -488,6 +492,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
+    #   pymongosql
 joserfc==1.7.2
     # via fastmcp-slim
 jsonpath-ng==1.8.0
@@ -803,10 +808,22 @@ pyjwt==2.13.0
     #   mcp
 pylint==3.3.7
     # via apache-superset
+pymonetdb==1.9.1
+    # via
+    #   apache-superset
+    #   sqlalchemy-monetdb
+pymongo==4.17.0
+    # via
+    #   pymongosql
+    #   testcontainers
+pymongosql==0.7.3
+    # via apache-superset
 pymssql==2.3.13
     # via
     #   apache-superset
     #   testcontainers
+pymysql==1.2.0
+    # via testcontainers
 pynacl==1.6.2
     # via
     #   -c requirements/base-constraint.txt
@@ -1001,6 +1018,7 @@ sqlalchemy==2.0.52
     #   sqlalchemy-cockroachdb
     #   sqlalchemy-continuum
     #   sqlalchemy-cratedb
+    #   sqlalchemy-monetdb
     #   sqlalchemy-utils
     #   testcontainers
 sqlalchemy-bigquery==1.17.2
@@ -1015,6 +1033,8 @@ sqlalchemy-cratedb==0.43.1
     # via
     #   apache-superset
     #   testcontainers
+sqlalchemy-monetdb==2.1.0
+    # via apache-superset
 sqlalchemy-utils==0.42.1
     # via
     #   -c requirements/base-constraint.txt

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -440,10 +440,6 @@ humanize==4.12.3
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
-ibm-db==3.3.0
-    # via ibm-db-sa
-ibm-db-sa==0.4.4
-    # via testcontainers
 identify==2.5.36
     # via pre-commit
 idna==3.15
@@ -1011,7 +1007,6 @@ sqlalchemy==2.0.52
     #   elasticsearch-dbapi
     #   flask-appbuilder
     #   flask-sqlalchemy
-    #   ibm-db-sa
     #   marshmallow-sqlalchemy
     #   shillelagh
     #   sqlalchemy-bigquery

--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -41,6 +41,7 @@ import sqlalchemy.dialects
 from flask import current_app as app
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.exc import NoSuchModuleError
+from sqlalchemy.sql import compiler as sqla_compiler
 
 from superset import feature_flag_manager
 from superset.db_engine_specs.base import BaseEngineSpec
@@ -159,6 +160,16 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:  # noq
             continue
 
     # installed 3rd-party dialects
+    #
+    # `ep.load()` runs arbitrary module-level code in the third-party package.
+    # Some dialects (e.g. sqlalchemy-monetdb) mutate SQLAlchemy's shared,
+    # process-global `compiler.OPERATORS` mapping in place on import instead
+    # of subclassing it, which would otherwise silently change SQL rendering
+    # (e.g. `!=` -> `<>`) for every dialect for the rest of the process, not
+    # just the misbehaving one. Snapshot/restore around each load so a
+    # buggy connector can't leak global compiler state into unrelated
+    # dialects just because it was enumerated here.
+    operators_snapshot = dict(sqla_compiler.OPERATORS)
     for ep in entry_points(group="sqlalchemy.dialects"):
         try:
             dialect = ep.load()
@@ -193,6 +204,10 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:  # noq
             if isinstance(driver, bytes):
                 driver = driver.decode()
             drivers[backend].add(driver)
+        finally:
+            if sqla_compiler.OPERATORS != operators_snapshot:
+                sqla_compiler.OPERATORS.clear()
+                sqla_compiler.OPERATORS.update(operators_snapshot)
 
     dbs_denylist = app.config["DBS_AVAILABLE_DENYLIST"]
     if not feature_flag_manager.is_feature_enabled("ENABLE_SUPERSET_META_DB"):

--- a/superset/db_engine_specs/clickhouse.py
+++ b/superset/db_engine_specs/clickhouse.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from typing import Any, cast, TYPE_CHECKING
 from urllib import parse
 
-from flask import current_app as app
+from flask import current_app as app, has_app_context
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from marshmallow.validate import Range
@@ -366,9 +366,16 @@ try:
         "*Int128",
         "string",
     )
+    # Importing this module happens as a side effect of iterating db_engine_specs
+    # (e.g. from a standalone script or test that never builds a Flask app), so
+    # `current_app` may not be bound to an app context yet -- guard the version
+    # lookup rather than let that crash the import outright.
+    version_string = (
+        app.config.get("VERSION_STRING", "dev") if has_app_context() else "dev"
+    )
     set_setting(
         "product_name",
-        f"superset/{app.config.get('VERSION_STRING', 'dev')}",
+        f"superset/{version_string}",
     )
 except ImportError:  # ClickHouse Connect not installed, do nothing
     pass

--- a/tests/testcontainers/db_engine_specs/_pagination.py
+++ b/tests/testcontainers/db_engine_specs/_pagination.py
@@ -26,10 +26,13 @@ real execution can.
 Each call site keeps its own test function (and dialect-specific docstring)
 so failures still report against the right module; this only factors out
 the identical table setup/assert body, via an optional post-insert hook for
-dialects (CrateDB) that need one.
+dialects (CrateDB) that need one, and an optional extra-table-args hook for
+dialects (ClickHouse) whose CREATE TABLE requires a schema item a plain
+Column/primary key can't express.
 """
 
 from collections.abc import Callable
+from typing import Any
 
 from sqlalchemy import Column, insert, Integer, MetaData, select, Table as SATable
 from sqlalchemy.engine import Connection, Engine
@@ -38,6 +41,7 @@ from sqlalchemy.engine import Connection, Engine
 def assert_paginated_query_returns_correct_rows_in_order(
     engine: Engine,
     after_insert: Callable[[Connection], None] | None = None,
+    extra_table_args: tuple[Any, ...] = (),
 ) -> None:
     metadata = MetaData()
     t = SATable(
@@ -49,6 +53,7 @@ def assert_paginated_query_returns_correct_rows_in_order(
         # is off), so the id=0 row below would silently get auto-assigned 1,
         # colliding with the explicit id=1 row in the same batch insert.
         Column("id", Integer, primary_key=True, autoincrement=False),
+        *extra_table_args,
     )
     metadata.create_all(engine)
     with engine.begin() as conn:

--- a/tests/testcontainers/db_engine_specs/_pagination.py
+++ b/tests/testcontainers/db_engine_specs/_pagination.py
@@ -43,13 +43,13 @@ def assert_paginated_query_returns_correct_rows_in_order(
     t = SATable(
         "pilot_pagination",
         metadata,
-        Column("id", Integer, primary_key=True),
+        # autoincrement=False: a single-column integer primary key otherwise
+        # implicitly becomes AUTO_INCREMENT on MySQL/MariaDB. That column
+        # type treats an explicit 0 as NULL by default (NO_AUTO_VALUE_ON_ZERO
+        # is off), so the id=0 row below would silently get auto-assigned 1,
+        # colliding with the explicit id=1 row in the same batch insert.
+        Column("id", Integer, primary_key=True, autoincrement=False),
     )
-    # create_all() defaults to checkfirst=True, silently skipping creation
-    # (and leaving old rows in place) if the table already exists. Drop
-    # first so a leftover table from an earlier run of this exact test
-    # can't collide with the fresh insert below on primary key.
-    metadata.drop_all(engine, checkfirst=True)
     metadata.create_all(engine)
     with engine.begin() as conn:
         conn.execute(insert(t), [{"id": i} for i in range(10)])

--- a/tests/testcontainers/db_engine_specs/_pagination.py
+++ b/tests/testcontainers/db_engine_specs/_pagination.py
@@ -45,6 +45,11 @@ def assert_paginated_query_returns_correct_rows_in_order(
         metadata,
         Column("id", Integer, primary_key=True),
     )
+    # create_all() defaults to checkfirst=True, silently skipping creation
+    # (and leaving old rows in place) if the table already exists. Drop
+    # first so a leftover table from an earlier run of this exact test
+    # can't collide with the fresh insert below on primary key.
+    metadata.drop_all(engine, checkfirst=True)
     metadata.create_all(engine)
     with engine.begin() as conn:
         conn.execute(insert(t), [{"id": i} for i in range(10)])

--- a/tests/testcontainers/db_engine_specs/test_clickhouse.py
+++ b/tests/testcontainers/db_engine_specs/test_clickhouse.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.clickhouse against a real ClickHouse instance, spun
+up on demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+Superset's recommended ClickHouse connector is `clickhouse-connect`
+(`ClickHouseConnectEngineSpec`, engine "clickhousedb"), which talks HTTP,
+not `ClickHouseContainer`'s own documented `clickhouse_driver` (a different,
+native-TCP-protocol package Superset doesn't use at all). The container
+exposes both the native TCP port (9000) and the HTTP port (8123); this test
+connects over the HTTP port to match Superset's actual driver.
+
+Unlike every other dialect in this suite, ClickHouse tables have no real
+primary key/constraint concept -- CREATE TABLE requires an explicit engine
+(e.g. MergeTree), or clickhouse-connect's DDL compiler raises a CompileError
+rather than defaulting to one.
+
+`superset.db_engine_specs.clickhouse` runs module-level setup code (default
+type-formatting overrides) that dereferences `current_app.config` whenever
+clickhouse-connect is installed, so importing it outside a Flask app context
+raises RuntimeError the first time it's imported in a process.
+`tests/unit_tests/db_engine_specs/test_clickhouse.py` gets an app context
+for free from that suite's autouse fixture; this suite has no such fixture,
+so this test pushes one explicitly around just that one-time import, reusing
+the real app instance `tests/conftest.py` already builds for the rest of the
+test run rather than constructing a second one.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.clickhouse")
+require_driver("clickhouse_connect")
+
+from clickhouse_connect.cc_sqlalchemy.ddl.tableengine import MergeTree  # noqa: E402
+from testcontainers.community.clickhouse import ClickHouseContainer  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+HTTP_PORT = 8123
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with ClickHouseContainer("clickhouse/clickhouse-server:latest") as container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(HTTP_PORT)
+        yield create_engine(
+            f"clickhousedb://{container.username}:{container.password}"
+            f"@{host}:{port}/{container.dbname}"
+        )
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(
+        engine, extra_table_args=(MergeTree(order_by="id"),)
+    )
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    ClickHouseConnectEngineSpec.get_columns wraps a real SQLAlchemy
+    Inspector; this exercises that against actual server-reported column
+    metadata rather than a mocked Inspector.
+    """
+    from tests.integration_tests.test_app import app
+
+    with app.app_context():
+        from superset.db_engine_specs.clickhouse import ClickHouseConnectEngineSpec
+
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+        MergeTree(order_by="id"),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = ClickHouseConnectEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = ClickHouseConnectEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_mariadb.py
+++ b/tests/testcontainers/db_engine_specs/test_mariadb.py
@@ -67,11 +67,16 @@ def engine() -> Iterator[Engine]:
         # (mysqlclient) treats a "localhost" host specially and attempts a
         # Unix socket connection instead of TCP, which fails since there's
         # no local MySQL socket -- the container is reached over the
-        # network. Forcing 127.0.0.1 keeps it on TCP.
+        # network. Only rewrite that specific local case to 127.0.0.1; a
+        # remote Docker daemon reports its own real host/IP here, which
+        # must be preserved so the suite can still reach it.
+        host = container.get_container_host_ip()
+        if host == "localhost":
+            host = "127.0.0.1"
         port = container.get_exposed_port(container.port)
         yield create_engine(
             f"mysql://{container.username}:{container.password}"
-            f"@127.0.0.1:{port}/{container.dbname}"
+            f"@{host}:{port}/{container.dbname}"
         )
 
 

--- a/tests/testcontainers/db_engine_specs/test_mariadb.py
+++ b/tests/testcontainers/db_engine_specs/test_mariadb.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.mariadb against a real MariaDB instance, spun up on
+demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+MariaDB is a MySQL fork implementing the same wire protocol: connects via
+the plain "mysql" dialect with mysqlclient, same as vanilla MySQL, just
+pointed at the mariadb image instead of mysql:latest.
+
+Could not be verified locally in this environment: mysqlclient (MySQLdb)
+has a pre-existing, unrelated native-library linking issue against this
+machine's Homebrew-installed libmysqlclient. CI installs it via apt on
+Linux, where this does not occur.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.mariadb import MariaDBEngineSpec
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.mysql")
+
+from testcontainers.community.mysql import MySqlContainer  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with MySqlContainer("mariadb:11") as container:
+        yield create_engine(container.get_connection_url())
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    MariaDBEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = MariaDBEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = MariaDBEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_mariadb.py
+++ b/tests/testcontainers/db_engine_specs/test_mariadb.py
@@ -61,7 +61,18 @@ from ._pagination import (  # noqa: E402
 @pytest.fixture(scope="module")
 def engine() -> Iterator[Engine]:
     with MySqlContainer("mariadb:11") as container:
-        yield create_engine(container.get_connection_url())
+        # get_connection_url() has no host override and defaults to
+        # get_container_host_ip(), which is the literal string "localhost"
+        # on native Linux Docker (e.g. GitHub Actions runners). MySQLdb
+        # (mysqlclient) treats a "localhost" host specially and attempts a
+        # Unix socket connection instead of TCP, which fails since there's
+        # no local MySQL socket -- the container is reached over the
+        # network. Forcing 127.0.0.1 keeps it on TCP.
+        port = container.get_exposed_port(container.port)
+        yield create_engine(
+            f"mysql://{container.username}:{container.password}"
+            f"@127.0.0.1:{port}/{container.dbname}"
+        )
 
 
 def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:

--- a/tests/testcontainers/db_engine_specs/test_monetdb.py
+++ b/tests/testcontainers/db_engine_specs/test_monetdb.py
@@ -42,6 +42,7 @@ from sqlalchemy.engine import Engine
 
 from superset.db_engine_specs.monetdb import MonetDbEngineSpec
 from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
 
 pytestmark = pytest.mark.testcontainers
 
@@ -51,7 +52,11 @@ require_driver("testcontainers.core.container")
 require_driver("sqlalchemy_monetdb")
 
 from testcontainers.core.container import DockerContainer  # noqa: E402
-from testcontainers.core.wait_strategies import LogMessageWaitStrategy  # noqa: E402
+from testcontainers.core.wait_strategies import (  # noqa: E402
+    CompositeWaitStrategy,
+    LogMessageWaitStrategy,
+    PortWaitStrategy,
+)
 
 from ._pagination import (  # noqa: E402
     assert_paginated_query_returns_correct_rows_in_order,
@@ -68,7 +73,16 @@ def engine() -> Iterator[Engine]:
     container.with_exposed_ports(PORT)
     container.with_env("MDB_DB_ADMIN_PASS", PASSWORD)
     container.with_env("MDB_CREATE_DBS", DBNAME)
-    container.waiting_for(LogMessageWaitStrategy(re.compile("Starting MonetDB daemon")))
+    # The "Starting MonetDB daemon" log line is emitted before the image
+    # actually runs `monetdbd start -n`, so it alone isn't proof the server
+    # is accepting connections yet. Follow it with a port-connect check,
+    # which only succeeds once monetdbd is really listening.
+    container.waiting_for(
+        CompositeWaitStrategy(
+            LogMessageWaitStrategy(re.compile("Starting MonetDB daemon")),
+            PortWaitStrategy(PORT),
+        )
+    )
 
     with container:
         host = container.get_container_host_ip()
@@ -109,3 +123,5 @@ def test_get_columns_maps_native_types(engine: Engine) -> None:
     for col in by_name.values():
         spec = MonetDbEngineSpec.get_column_spec(str(col["type"]))
         assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_monetdb.py
+++ b/tests/testcontainers/db_engine_specs/test_monetdb.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.monetdb against a real MonetDB instance, spun up on
+demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+monetdb/monetdb publishes an amd64-only image, so this needs Rosetta/QEMU
+emulation on Apple Silicon -- unlike CrateDB's x86-64-v3 CPU requirement,
+this one actually runs fine under emulation (verified locally). No native
+testcontainers module exists for MonetDB, so this uses a generic
+DockerContainer with the documented MDB_* environment variables and waits
+for the daemon's own startup log line.
+"""
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.monetdb import MonetDbEngineSpec
+from superset.sql.parse import Table
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.core.container")
+require_driver("sqlalchemy_monetdb")
+
+from testcontainers.core.container import DockerContainer  # noqa: E402
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+PORT = 50000
+PASSWORD = "monetdb"  # noqa: S105 -- fixed test-fixture password, not a secret
+DBNAME = "test"
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    container = DockerContainer("monetdb/monetdb:latest")
+    container.with_exposed_ports(PORT)
+    container.with_env("MDB_DB_ADMIN_PASS", PASSWORD)
+    container.with_env("MDB_CREATE_DBS", DBNAME)
+    container.waiting_for(LogMessageWaitStrategy(re.compile("Starting MonetDB daemon")))
+
+    with container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(PORT)
+        yield create_engine(f"monetdb://monetdb:{PASSWORD}@{host}:{port}/{DBNAME}")
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    MonetDbEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = MonetDbEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = MonetDbEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None

--- a/tests/testcontainers/db_engine_specs/test_mongodb.py
+++ b/tests/testcontainers/db_engine_specs/test_mongodb.py
@@ -37,6 +37,7 @@ from sqlalchemy import (
     MetaData,
     select,
     Table as SATable,
+    text,
 )
 from sqlalchemy.engine import Engine
 
@@ -85,16 +86,23 @@ def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
     this incorrectly (see apache/superset#42899, where Trino emitted OFFSET
     before LIMIT) -- only real execution can. Unlike Elasticsearch's SQL
     layer (which has no OFFSET support at all), pymongosql maps OFFSET to
-    MongoDB's native `skip`, so this dialect supports it. Going through
-    Core's `select(...).limit().offset()` (rather than a literal SQL
-    string) is what actually exercises the dialect's own compilation of
-    those clauses.
+    MongoDB's native `skip`, so this dialect supports it.
+
+    Compiled with `literal_binds=True`, matching how Superset actually
+    issues chart/SQL Lab queries (see `models/helpers.py`'s
+    `get_query_str_extended`): pymongosql's SQL-to-Mongo AST parser reads
+    LIMIT/OFFSET straight off the compiled SQL text ahead of parameter
+    substitution, so a bound `LIMIT ?`/`OFFSET ?` placeholder is rejected
+    ("invalid literal for int() with base 10: '?'") and the clause is
+    silently dropped -- unlike its WHERE-clause parameter handling, which
+    does substitute correctly. Literal binds sidestep that and exercise
+    the dialect's actual LIMIT/OFFSET compilation, per this test's intent.
     """
     t = SATable(COLLECTION, MetaData(), Column("id", Integer))
+    stmt = select(t.c.id).order_by(t.c.id).limit(3).offset(4)
+    compiled = stmt.compile(engine, compile_kwargs={"literal_binds": True})
     with engine.connect() as conn:
-        rows = conn.execute(
-            select(t.c.id).order_by(t.c.id).limit(3).offset(4)
-        ).fetchall()
+        rows = conn.execute(text(str(compiled))).fetchall()
 
     assert [row.id for row in rows] == [4, 5, 6]
 

--- a/tests/testcontainers/db_engine_specs/test_mongodb.py
+++ b/tests/testcontainers/db_engine_specs/test_mongodb.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.mongodb against a real MongoDB instance, spun up on
+demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+MongoDB is schemaless, and Superset talks to it via `pymongosql`, a
+SQL-to-MongoDB translation layer (dialect requires a `?mode=superset` query
+param -- not part of testcontainers' own MongoDbContainer.get_connection_url()).
+Documents get inserted via the native pymongo driver, not SQL INSERT,
+matching how Superset actually encounters MongoDB in practice and avoiding
+any assumption about pymongosql's own INSERT/DDL support.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.mongodb import MongoDBEngineSpec
+from superset.sql.parse import Table
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.mongodb")
+require_driver("pymongosql")
+
+from testcontainers.community.mongodb import MongoDbContainer  # noqa: E402
+
+COLLECTION = "pilot_pagination"
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with MongoDbContainer("mongo:7.0.7") as container:
+        client = container.get_connection_client()
+        client[container.dbname][COLLECTION].insert_many([{"id": i} for i in range(10)])
+        # MongoDbContainer.get_connection_url() has no database path segment
+        # or query string at all (it only builds user:pass@host:port), so
+        # naively appending "&mode=superset" glues it straight onto the port
+        # number instead of starting a query string. Build the full URL
+        # ourselves instead of relying on string concatenation.
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(container.port)
+        # authSource=admin is required: MongoDbContainer creates its root
+        # user via MONGO_INITDB_ROOT_USERNAME, which lives in the `admin`
+        # database, not in `dbname` -- without it, auth fails against
+        # whatever database is in the URL path.
+        yield create_engine(
+            f"mongodb://{container.username}:{container.password}@{host}:{port}"
+            f"/{container.dbname}?mode=superset&authSource=admin"
+        )
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain LIMIT/OFFSET query, compiled and executed against a real
+    instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can. Unlike Elasticsearch's SQL
+    layer (which has no OFFSET support at all), pymongosql maps OFFSET to
+    MongoDB's native `skip`, so this dialect supports it.
+    """
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                f"SELECT id FROM {COLLECTION} ORDER BY id LIMIT 3 OFFSET 4"  # noqa: S608
+            )
+        ).fetchall()
+
+    assert [row.id for row in rows] == [4, 5, 6]
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    MongoDBEngineSpec.get_columns wraps a real SQLAlchemy Inspector, which
+    pymongosql implements by sampling real documents to infer column types
+    -- this exercises that against an actual running instance rather than
+    a mocked Inspector.
+    """
+    inspector = inspect(engine)
+    columns = MongoDBEngineSpec.get_columns(inspector, Table(COLLECTION))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert "id" in by_name
+    spec = MongoDBEngineSpec.get_column_spec(str(by_name["id"]["type"]))
+    assert spec is not None

--- a/tests/testcontainers/db_engine_specs/test_mongodb.py
+++ b/tests/testcontainers/db_engine_specs/test_mongodb.py
@@ -29,11 +29,20 @@ any assumption about pymongosql's own INSERT/DDL support.
 from collections.abc import Iterator
 
 import pytest
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    select,
+    Table as SATable,
+)
 from sqlalchemy.engine import Engine
 
 from superset.db_engine_specs.mongodb import MongoDBEngineSpec
 from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
 
 pytestmark = pytest.mark.testcontainers
 
@@ -71,18 +80,20 @@ def engine() -> Iterator[Engine]:
 
 def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
     """
-    A plain LIMIT/OFFSET query, compiled and executed against a real
-    instance. Mocked tests cannot catch a dialect compiling this
-    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed
+    against a real instance. Mocked tests cannot catch a dialect compiling
+    this incorrectly (see apache/superset#42899, where Trino emitted OFFSET
     before LIMIT) -- only real execution can. Unlike Elasticsearch's SQL
     layer (which has no OFFSET support at all), pymongosql maps OFFSET to
-    MongoDB's native `skip`, so this dialect supports it.
+    MongoDB's native `skip`, so this dialect supports it. Going through
+    Core's `select(...).limit().offset()` (rather than a literal SQL
+    string) is what actually exercises the dialect's own compilation of
+    those clauses.
     """
+    t = SATable(COLLECTION, MetaData(), Column("id", Integer))
     with engine.connect() as conn:
         rows = conn.execute(
-            text(
-                f"SELECT id FROM {COLLECTION} ORDER BY id LIMIT 3 OFFSET 4"  # noqa: S608
-            )
+            select(t.c.id).order_by(t.c.id).limit(3).offset(4)
         ).fetchall()
 
     assert [row.id for row in rows] == [4, 5, 6]
@@ -102,3 +113,5 @@ def test_get_columns_maps_native_types(engine: Engine) -> None:
     assert "id" in by_name
     spec = MongoDBEngineSpec.get_column_spec(str(by_name["id"]["type"]))
     assert spec is not None
+    assert spec.generic_type == GenericDataType.NUMERIC
+    assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_mongodb.py
+++ b/tests/testcontainers/db_engine_specs/test_mongodb.py
@@ -104,7 +104,12 @@ def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
     with engine.connect() as conn:
         rows = conn.execute(text(str(compiled))).fetchall()
 
-    assert [row.id for row in rows] == [4, 5, 6]
+    # Positional, not row.id: text() has no static column metadata of its
+    # own, so the row's key comes entirely from whatever pymongosql's DBAPI
+    # cursor reports for this raw SQL string -- which is the qualified
+    # "pilot_pagination.id" (matching the SELECT list's column reference),
+    # not the bare "id" attribute access would expect.
+    assert [row[0] for row in rows] == [4, 5, 6]
 
 
 def test_get_columns_maps_native_types(engine: Engine) -> None:

--- a/tests/testcontainers/db_engine_specs/test_mongodb.py
+++ b/tests/testcontainers/db_engine_specs/test_mongodb.py
@@ -30,13 +30,12 @@ from collections.abc import Iterator
 
 import pytest
 from sqlalchemy import (
-    Column,
+    column,
     create_engine,
     inspect,
     Integer,
-    MetaData,
     select,
-    Table as SATable,
+    table,
     text,
 )
 from sqlalchemy.engine import Engine
@@ -97,19 +96,31 @@ def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
     silently dropped -- unlike its WHERE-clause parameter handling, which
     does substitute correctly. Literal binds sidestep that and exercise
     the dialect's actual LIMIT/OFFSET compilation, per this test's intent.
+
+    Uses a bare `column("id")`/`table(...)` pair rather than a full
+    `Table`-bound column: SQLAlchemy always qualifies a Table-bound column
+    reference as `pilot_pagination.id` once there's a FROM clause, and
+    pymongosql's projection builder takes that qualified text completely
+    literally as a MongoDB field path -- `{"pilot_pagination.id": 1}` reads
+    a *nested* field under a top-level `pilot_pagination` key, which
+    doesn't exist on these flat documents, silently projecting None instead
+    of raising. An unbound column compiles unqualified ("id"), which
+    resolves correctly, while still exercising the dialect's own
+    LIMIT/OFFSET compilation via a real Core `select()`.
     """
-    t = SATable(COLLECTION, MetaData(), Column("id", Integer))
-    stmt = select(t.c.id).order_by(t.c.id).limit(3).offset(4)
+    id_col = column("id")
+    stmt = (
+        select(id_col)
+        .select_from(table(COLLECTION))
+        .order_by(id_col)
+        .limit(3)
+        .offset(4)
+    )
     compiled = stmt.compile(engine, compile_kwargs={"literal_binds": True})
     with engine.connect() as conn:
         rows = conn.execute(text(str(compiled))).fetchall()
 
-    # Positional, not row.id: text() has no static column metadata of its
-    # own, so the row's key comes entirely from whatever pymongosql's DBAPI
-    # cursor reports for this raw SQL string -- which is the qualified
-    # "pilot_pagination.id" (matching the SELECT list's column reference),
-    # not the bare "id" attribute access would expect.
-    assert [row[0] for row in rows] == [4, 5, 6]
+    assert [row.id for row in rows] == [4, 5, 6]
 
 
 def test_get_columns_maps_native_types(engine: Engine) -> None:

--- a/tests/testcontainers/db_engine_specs/test_mysql.py
+++ b/tests/testcontainers/db_engine_specs/test_mysql.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.mysql against a real MySQL instance, spun up on
+demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+Plain MySQL itself was never covered by this suite: MariaDB and StarRocks
+both reuse `MySQLEngineSpec`'s plain "mysql" dialect via mysqlclient, but
+neither stands in for vanilla MySQL server's own dialect quirks.
+
+Could not be verified locally in this environment: mysqlclient (MySQLdb)
+has a pre-existing, unrelated native-library linking issue against this
+machine's Homebrew-installed libmysqlclient. CI installs it via apt on
+Linux, where this does not occur.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.mysql import MySQLEngineSpec
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.mysql")
+
+from testcontainers.community.mysql import MySqlContainer  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with MySqlContainer("mysql:8.0") as container:
+        # get_connection_url() has no host override and defaults to
+        # get_container_host_ip(), which is the literal string "localhost"
+        # on native Linux Docker (e.g. GitHub Actions runners). MySQLdb
+        # (mysqlclient) treats a "localhost" host specially and attempts a
+        # Unix socket connection instead of TCP, which fails since there's
+        # no local MySQL socket -- the container is reached over the
+        # network. Only rewrite that specific local case to 127.0.0.1; a
+        # remote Docker daemon reports its own real host/IP here, which
+        # must be preserved so the suite can still reach it.
+        host = container.get_container_host_ip()
+        if host == "localhost":
+            host = "127.0.0.1"
+        port = container.get_exposed_port(container.port)
+        yield create_engine(
+            f"mysql://{container.username}:{container.password}"
+            f"@{host}:{port}/{container.dbname}"
+        )
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    MySQLEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = MySQLEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = MySQLEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_postgres.py
+++ b/tests/testcontainers/db_engine_specs/test_postgres.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.postgres against a real PostgreSQL instance, spun up
+on demand via testcontainers. Run via .github/workflows/testcontainers.yml
+-- these exercise real SQL execution and dialect introspection, which
+mocked unit tests structurally cannot.
+
+Plain Postgres itself was never covered by this suite: CockroachDB,
+TimescaleDB and YugabyteDB all speak the Postgres wire protocol and already
+exercise `PostgresContainer`/the "postgresql" dialect, but none of them
+stand in for vanilla PostgreSQL's own dialect quirks.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.postgres import PostgresEngineSpec
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.postgres")
+
+from testcontainers.community.postgres import PostgresContainer  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with PostgresContainer("postgres:17-alpine") as container:
+        yield create_engine(container.get_connection_url())
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    PostgresEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = PostgresEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = PostgresEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_starrocks.py
+++ b/tests/testcontainers/db_engine_specs/test_starrocks.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.starrocks against a real StarRocks instance, spun up
+on demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+StarRocks has no dedicated testcontainers module, so this uses a generic
+DockerContainer against the official `starrocks/allin1-ubuntu` image, which
+brings up both the FE (query frontend, MySQL wire protocol on port 9030)
+and BE (execution backend) in a single container -- a heavier bring-up than
+a single-process database. `root` has no password by default and no
+database exists yet, so the fixture creates one itself before yielding an
+engine pointed at it. The FE's query port accepts connections, and can even
+run metadata statements like CREATE DATABASE, before the BE has registered
+with it -- an actual CREATE TABLE/INSERT then fails with "Backend node not
+found" -- so the fixture retries a real create-table-and-insert probe
+against a throwaway table rather than trusting the open port or a bare
+CREATE DATABASE as a readiness signal.
+
+Not verified locally in this environment: the `allin1-ubuntu` image is
+multiple GB and was skipped here to keep local Docker resource usage low,
+per session guidance to lean on CI (which has no such constraint) for
+dialects with unusually heavy images.
+"""
+
+import time
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+    text,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.core.container")
+require_driver("starrocks")
+
+from testcontainers.core.container import DockerContainer  # noqa: E402
+from testcontainers.core.wait_strategies import PortWaitStrategy  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+QUERY_PORT = 9030
+DBNAME = "pilot"
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    container = DockerContainer("starrocks/allin1-ubuntu")
+    container.with_exposed_ports(QUERY_PORT)
+    container.waiting_for(PortWaitStrategy(QUERY_PORT))
+
+    with container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(QUERY_PORT)
+        bootstrap_engine = create_engine(
+            f"starrocks://root:@{host}:{port}/default_catalog.information_schema"
+        )
+
+        # The FE's query port accepts connections, and can even run metadata
+        # statements like CREATE DATABASE, before any BE (execution backend)
+        # has registered with it -- an actual table create/insert then fails
+        # with "Backend node not found". Probe with the real operations the
+        # tests below need, in a throwaway table, so readiness is confirmed
+        # for what actually matters rather than just the FE's own port.
+        last_error: Exception | None = None
+        for _ in range(60):
+            try:
+                with bootstrap_engine.begin() as conn:
+                    conn.execute(text(f"CREATE DATABASE IF NOT EXISTS {DBNAME}"))
+                probe_engine = create_engine(
+                    f"starrocks://root:@{host}:{port}/default_catalog.{DBNAME}"
+                )
+                with probe_engine.begin() as conn:
+                    conn.execute(
+                        text("CREATE TABLE IF NOT EXISTS pilot_ready (id INT)")
+                    )
+                    conn.execute(text("INSERT INTO pilot_ready VALUES (1)"))
+                    conn.execute(text("DROP TABLE pilot_ready"))
+                break
+            except Exception as ex:  # noqa: BLE001 -- retry on any not-ready-yet error
+                last_error = ex
+                time.sleep(2)
+        else:
+            raise RuntimeError(
+                "StarRocks FE/BE never became ready to create and use a table"
+            ) from last_error
+
+        yield create_engine(f"starrocks://root:@{host}:{port}/default_catalog.{DBNAME}")
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    StarRocksEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = StarRocksEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = StarRocksEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_timescaledb.py
+++ b/tests/testcontainers/db_engine_specs/test_timescaledb.py
@@ -57,7 +57,7 @@ from ._pagination import (  # noqa: E402
 
 @pytest.fixture(scope="module")
 def engine() -> Iterator[Engine]:
-    with PostgresContainer("timescale/timescaledb:latest-pg16") as container:
+    with PostgresContainer("timescale/timescaledb:2.29.2-pg16") as container:
         yield create_engine(container.get_connection_url())
 
 

--- a/tests/testcontainers/db_engine_specs/test_timescaledb.py
+++ b/tests/testcontainers/db_engine_specs/test_timescaledb.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.timescaledb against a real TimescaleDB instance,
+spun up on demand via testcontainers. Run via
+.github/workflows/testcontainers.yml -- these exercise real SQL execution
+and dialect introspection, which mocked unit tests structurally cannot.
+
+TimescaleDB is a genuine Postgres extension, not a fork: connects via the
+plain "postgresql" dialect with psycopg2, same as vanilla Postgres, just
+pointed at the timescale/timescaledb image instead of postgres:latest.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.timescaledb import TimescaleDBEngineSpec
+from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.community.postgres")
+
+from testcontainers.community.postgres import PostgresContainer  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    with PostgresContainer("timescale/timescaledb:latest-pg16") as container:
+        yield create_engine(container.get_connection_url())
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    TimescaleDBEngineSpec.get_columns wraps a real SQLAlchemy Inspector;
+    this exercises that against actual server-reported column metadata
+    rather than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = TimescaleDBEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = TimescaleDBEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/testcontainers/db_engine_specs/test_yugabytedb.py
+++ b/tests/testcontainers/db_engine_specs/test_yugabytedb.py
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Tests db_engine_specs.yugabytedb against a real YugabyteDB instance, spun
+up on demand via testcontainers. Run via .github/workflows/testcontainers.yml.
+
+YugabyteDB's YSQL layer is fully Postgres-wire compatible (postgresql+
+psycopg2, port 5433), but the image doesn't ship a plain `psql` binary
+(only its own `ysqlsh`), so testcontainers' PostgresContainer can't be
+reused directly -- its built-in readiness check execs `psql`, which would
+fail here. This uses a generic DockerContainer, starting the node via
+`yugabyted start --background=false` and waiting for yugabyted's own final
+startup message instead.
+"""
+
+import re
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import (
+    Column,
+    create_engine,
+    inspect,
+    Integer,
+    MetaData,
+    Table as SATable,
+)
+from sqlalchemy.engine import Engine
+
+from superset.db_engine_specs.yugabytedb import YugabyteDBEngineSpec
+from superset.sql.parse import Table
+
+pytestmark = pytest.mark.testcontainers
+
+from ._driver import require_driver  # noqa: E402
+
+require_driver("testcontainers.core.container")
+
+from testcontainers.core.container import DockerContainer  # noqa: E402
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy  # noqa: E402
+
+from ._pagination import (  # noqa: E402
+    assert_paginated_query_returns_correct_rows_in_order,
+)
+
+YSQL_PORT = 5433
+
+
+@pytest.fixture(scope="module")
+def engine() -> Iterator[Engine]:
+    container = DockerContainer("yugabytedb/yugabyte:latest")
+    container.with_exposed_ports(YSQL_PORT)
+    container.with_command("bin/yugabyted start --background=false")
+    container.waiting_for(
+        LogMessageWaitStrategy(
+            re.compile("Data placement constraint successfully verified")
+        )
+    )
+
+    with container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(YSQL_PORT)
+        # Default single-node credentials/database, per yugabyted's own
+        # documented quickstart defaults -- no env vars needed to set them.
+        yield create_engine(
+            f"postgresql+psycopg2://yugabyte:yugabyte@{host}:{port}/yugabyte"
+        )
+
+
+def test_paginated_query_returns_correct_rows_in_order(engine: Engine) -> None:
+    """
+    A plain SQLAlchemy Core LIMIT/OFFSET query, compiled and executed against
+    a real instance. Mocked tests cannot catch a dialect compiling this
+    incorrectly (see apache/superset#42899, where Trino emitted OFFSET
+    before LIMIT) -- only real execution can.
+    """
+    assert_paginated_query_returns_correct_rows_in_order(engine)
+
+
+def test_get_columns_maps_native_types(engine: Engine) -> None:
+    """
+    YugabyteDBEngineSpec.get_columns wraps a real SQLAlchemy Inspector; this
+    exercises that against actual server-reported column metadata rather
+    than a mocked Inspector.
+    """
+    metadata = MetaData()
+    SATable(
+        "pilot_types",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("amount", Integer),
+    )
+    metadata.create_all(engine)
+
+    inspector = inspect(engine)
+    columns = YugabyteDBEngineSpec.get_columns(inspector, Table("pilot_types"))
+
+    by_name = {col["column_name"]: col for col in columns}
+    assert set(by_name) == {"id", "amount"}
+    for col in by_name.values():
+        spec = YugabyteDBEngineSpec.get_column_spec(str(col["type"]))
+        assert spec is not None

--- a/tests/testcontainers/db_engine_specs/test_yugabytedb.py
+++ b/tests/testcontainers/db_engine_specs/test_yugabytedb.py
@@ -43,6 +43,7 @@ from sqlalchemy.engine import Engine
 
 from superset.db_engine_specs.yugabytedb import YugabyteDBEngineSpec
 from superset.sql.parse import Table
+from superset.utils.core import GenericDataType
 
 pytestmark = pytest.mark.testcontainers
 
@@ -114,3 +115,5 @@ def test_get_columns_maps_native_types(engine: Engine) -> None:
     for col in by_name.values():
         spec = YugabyteDBEngineSpec.get_column_spec(str(col["type"]))
         assert spec is not None
+        assert spec.generic_type == GenericDataType.NUMERIC
+        assert isinstance(spec.sqla_type, Integer)

--- a/tests/unit_tests/db_engine_specs/test_init.py
+++ b/tests/unit_tests/db_engine_specs/test_init.py
@@ -137,6 +137,56 @@ def test_get_available_engine_specs_keeps_valid_third_party_dialect(
     assert available[SqliteEngineSpec] == {"valid_driver"}
 
 
+def test_get_available_engine_specs_restores_compiler_operators(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A third-party ``sqlalchemy.dialects`` entry point that mutates SQLAlchemy's
+    shared, process-global ``compiler.OPERATORS`` mapping on import (as
+    ``sqlalchemy-monetdb`` does, in place, rather than subclassing) must not be
+    allowed to leak that change into every other dialect for the rest of the
+    process.
+
+    Regression test: enumerating a real "monetdb" entry point here (to build the
+    "available databases" list) silently changed ``!=`` rendering to ``<>`` for
+    postgres/mysql/sqlite/etc. too, for the remainder of the process.
+    """
+    from sqlalchemy.sql import compiler as sqla_compiler, operators
+
+    mocker.patch(
+        "superset.db_engine_specs.load_engine_specs",
+        return_value=iter([]),
+    )
+
+    pristine = dict(sqla_compiler.OPERATORS)
+    assert pristine[operators.ne] != " <> "
+
+    class MisbehavingDialect(DefaultDialect):
+        name = "misbehaving"
+        driver = "misbehaving_driver"
+
+    def load_and_mutate_globally() -> type[MisbehavingDialect]:
+        # Mirrors sqlalchemy-monetdb's `base.py`: grabs a reference to the
+        # shared dict (not a copy) and mutates it in place.
+        sqla_compiler.OPERATORS[operators.ne] = " <> "
+        return MisbehavingDialect
+
+    entry_point = mocker.MagicMock()
+    entry_point.name = "misbehaving"
+    entry_point.load.side_effect = load_and_mutate_globally
+    mocker.patch(
+        "superset.db_engine_specs.entry_points",
+        return_value=[entry_point],
+    )
+
+    try:
+        get_available_engine_specs()
+        assert sqla_compiler.OPERATORS[operators.ne] == pristine[operators.ne]
+    finally:
+        sqla_compiler.OPERATORS.clear()
+        sqla_compiler.OPERATORS.update(pristine)
+
+
 @pytest.mark.parametrize(
     "app",
     [{"DBS_AVAILABLE_DENYLIST": {"databricks": {"pyhive", "pyodbc"}}}],


### PR DESCRIPTION
### SUMMARY

Stacked on #43502 (the 7-dialect testcontainers pilot) — adds 5 more dialects from the docs-supported list: `mariadb`, `timescaledb`, `yugabytedb`, `monetdb`, `mongodb`. All 5 verified locally against real containers except `mariadb` (mysqlclient has a pre-existing, unrelated native-library issue on this dev machine's Homebrew setup — same accepted CI-only-verification pattern already used for crate/mssql/db2 in the base branch).

### Wire-compatible dialects (near-zero new container code)

`mariadb`, `timescaledb`, and `yugabytedb` are all wire-compatible with an existing base dialect, so they reuse testcontainers' `MySqlContainer`/`PostgresContainer` classes pointed at a different image rather than needing new container-class wiring — `mariadb:11`, `timescale/timescaledb:latest-pg16`, and `yugabytedb/yugabyte:latest` respectively.

`yugabytedb` needed one adjustment though: `PostgresContainer`'s built-in readiness check execs `psql`, which the yugabyte image doesn't ship (only its own `ysqlsh`). Used a generic `DockerContainer` instead, started via `yugabyted start --background=false` and waiting on yugabyted's own final startup log line ("Data placement constraint successfully verified").

### monetdb (no native testcontainers module)

Uses a generic `DockerContainer` with the documented `MDB_*` environment variables and a log-based wait strategy. Publishes an amd64-only image — confirmed it actually runs under Rosetta/QEMU emulation on Apple Silicon (unlike CrateDB, which fails outright on its x86-64-v3 CPU instruction-set requirement even under emulation).

### mongodb (two real bugs found writing this one)

MongoDB is schemaless, and Superset talks to it via `pymongosql`, a SQL-to-MongoDB translation layer requiring a `?mode=superset` query param. Documents get inserted via the native pymongo driver rather than SQL INSERT, matching how Superset actually encounters MongoDB in practice and avoiding any assumption about pymongosql's own INSERT/DDL support.

Two bugs surfaced empirically while wiring this up: `MongoDbContainer.get_connection_url()` has no database path segment or query string at all, so naively appending `"&mode=superset"` glued directly onto the port number instead of starting a query string — fixed by building the full URL manually. And the root user `MongoDbContainer` creates lives in the `admin` database, so connecting with a different default database in the URL path fails authentication outright unless `authSource=admin` is specified explicitly.

Confirmed `pymongosql` actually supports `OFFSET` (it maps to MongoDB's native `skip`), unlike Elasticsearch's SQL layer in the base PR, which has no `OFFSET` support at all — so this one keeps the full `LIMIT`/`OFFSET` pagination test rather than the `LIMIT`-only version.

### New extras added

`monetdb` (`sqlalchemy-monetdb`, `pymonetdb`) and `mongodb` (`pymongosql`) are genuinely new pyproject.toml extras. `mariadb`, `timescaledb`, and `yugabytedb` are added as thin aliases (`apache-superset[mysql]` / `apache-superset[postgres]`) since they need no new packages — `mysqlclient`/`psycopg2-binary` are already pulled in via the existing `mysql`/`postgres` extras.

### TESTING INSTRUCTIONS

```
pip install -r requirements/development.txt
pytest -m testcontainers tests/testcontainers/db_engine_specs/test_monetdb.py tests/testcontainers/db_engine_specs/test_mongodb.py tests/testcontainers/db_engine_specs/test_timescaledb.py tests/testcontainers/db_engine_specs/test_yugabytedb.py -v
```
8 passed locally. `mariadb` needs CI (Linux) to verify due to the local mysqlclient issue noted above.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API (5 more testcontainers dialects)
- [ ] Removes existing feature or API