### PR TITLE
fix(sql): use AST for disallowed function checks

### DIFF
--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -817,14 +817,9 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        # Check each statement for disallowed functions
-        found = set()
-        for statement in script.statements:
-            # Use the statement's AST to check for function calls
-            statement_str = str(statement).upper()
-            for func in engine_disallowed:
-                if func.upper() in statement_str:
-                    found.add(func)
+        found = {
+            func for func in engine_disallowed if script.check_functions_present({func})
+        }
 
         return found if found else None
 

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -817,9 +817,7 @@ class SQLExecutor:
         if not engine_disallowed:
             return None
 
-        found = {
-            func for func in engine_disallowed if script.check_functions_present({func})
-        }
+        found = script.get_disallowed_functions(engine_disallowed)
 
         return found if found else None
 

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -591,6 +591,15 @@ class BaseSQLStatement(Generic[InternalRepresentation]):
         :param functions: List of functions to check for
         :return: True if any of the functions are present
         """
+        return bool(self.get_disallowed_functions(functions))
+
+    def get_disallowed_functions(self, functions: set[str]) -> set[str]:
+        """
+        Return the subset of ``functions`` referenced by this statement.
+
+        :param functions: Set of function names to check for
+        :return: The matched entries, in their original denylist form
+        """
         raise NotImplementedError()
 
     def check_tables_present(
@@ -1159,12 +1168,12 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
 
         return SQLStatement(ast=optimized, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
+    def get_disallowed_functions(self, functions: set[str]) -> set[str]:
         """
-        Check if any of the given functions are present in the script.
+        Return the subset of ``functions`` referenced by this statement.
 
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
+        :param functions: Set of function names to check for
+        :return: The matched entries, in their original denylist form
         """
         # Build the set of SQL-level function names present in the AST. For
         # Anonymous nodes the name is stored directly; for named Func nodes we
@@ -1202,7 +1211,7 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         for param in self._parsed.find_all(exp.SessionParameter):
             present.add(param.name.upper())
 
-        return any(function.upper() in present for function in functions)
+        return {function for function in functions if function.upper() in present}
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None
@@ -1861,15 +1870,15 @@ class KustoKQLStatement(BaseSQLStatement[str]):
         """
         return KustoKQLStatement(ast=self._parsed, engine=self.engine)
 
-    def check_functions_present(self, functions: set[str]) -> bool:
+    def get_disallowed_functions(self, functions: set[str]) -> set[str]:
         """
-        Check if any of the given functions are present in the script.
+        Return the subset of ``functions`` referenced by this statement.
 
-        :param functions: List of functions to check for
-        :return: True if any of the functions are present
+        :param functions: Set of function names to check for
+        :return: The matched entries, in their original denylist form
         """
         logger.warning("Kusto KQL doesn't support checking for functions present.")
-        return False
+        return set()
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None
@@ -2090,6 +2099,18 @@ class SQLScript:
             statement.check_functions_present(functions)
             for statement in self.statements
         )
+
+    def get_disallowed_functions(self, functions: set[str]) -> set[str]:
+        """
+        Return the subset of ``functions`` referenced anywhere in the script.
+
+        :param functions: Set of function names to check for
+        :return: The matched entries, in their original denylist form
+        """
+        found: set[str] = set()
+        for statement in self.statements:
+            found |= statement.get_disallowed_functions(functions)
+        return found
 
     def check_tables_present(
         self, tables: set[str], default_schema: str | None = None

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -44,6 +44,7 @@ from superset_core.queries.types import (
 )
 
 from superset.models.core import Database
+from superset.sql.parse import SQLScript
 
 # Note: database, database_with_dml, mock_db_session fixtures and
 # mock_query_execution helper are imported from conftest.py
@@ -352,6 +353,39 @@ def test_execute_allowed_functions(
     result = database.execute("SELECT COUNT(*) FROM users")
 
     assert result.status == QueryStatus.SUCCESS
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ("SELECT version()", {"version"}),
+        ("SELECT pg_catalog.version()", {"version"}),
+        ("SELECT conversion FROM metrics", None),
+        ('SELECT "conversions_value" FROM metrics', None),
+        ("SELECT * FROM custom_skill_versions", None),
+        ("SELECT 'version conversion' AS label", None),
+        ("SELECT 1 /* version() conversion */", None),
+    ],
+)
+def test_check_disallowed_functions_matches_ast_function_nodes(
+    mocker: MockerFixture,
+    mock_database: MagicMock,
+    app_context: None,
+    sql: str,
+    expected: set[str] | None,
+) -> None:
+    """Disallowed functions match calls, not SQL text substrings."""
+    from superset.sql.execution.executor import SQLExecutor
+
+    mocker.patch.dict(
+        current_app.config,
+        {"DISALLOWED_SQL_FUNCTIONS": {"postgresql": {"version"}}},
+    )
+
+    executor = SQLExecutor(mock_database)
+    script = SQLScript(sql, engine="postgresql")
+
+    assert executor._check_disallowed_functions(script) == expected
 
 
 def test_execute_disallowed_tables(

--- a/tests/unit_tests/sql/execution/test_executor.py
+++ b/tests/unit_tests/sql/execution/test_executor.py
@@ -388,6 +388,30 @@ def test_check_disallowed_functions_matches_ast_function_nodes(
     assert executor._check_disallowed_functions(script) == expected
 
 
+def test_check_disallowed_functions_traverses_script_once(
+    mocker: MockerFixture,
+    mock_database: MagicMock,
+    app_context: None,
+) -> None:
+    """The executor checks the complete denylist in one AST traversal."""
+    from superset.sql.execution.executor import SQLExecutor
+
+    disallowed = {"version", "pg_sleep", "lo_export"}
+    mocker.patch.dict(
+        current_app.config,
+        {"DISALLOWED_SQL_FUNCTIONS": {"postgresql": disallowed}},
+    )
+    script = SQLScript("SELECT version()", engine="postgresql")
+    get_disallowed_functions = mocker.spy(
+        script.statements[0], "get_disallowed_functions"
+    )
+
+    executor = SQLExecutor(mock_database)
+
+    assert executor._check_disallowed_functions(script) == {"version"}
+    get_disallowed_functions.assert_called_once_with(disallowed)
+
+
 def test_execute_disallowed_tables(
     mocker: MockerFixture, database: Database, app_context: None
 ) -> None:


### PR DESCRIPTION
### SUMMARY

The unified SQL executor currently stringifies parsed SQL and checks each configured disallowed function with substring containment. For PostgreSQL, the default `version` denylist therefore rejects identifiers such as `conversion` and `custom_skill_versions`, as well as literals and comments containing that text.

Reuse the existing `SQLScript.check_functions_present` AST matcher so the denylist applies to actual function calls. This keeps `version()` and `pg_catalog.version()` blocked without weakening the configured check, while avoiding false positives in identifiers, literals, and comments.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; this is a backend SQL validation change.

### TESTING INSTRUCTIONS

1. Run `pytest tests/unit_tests/sql/execution/test_executor.py -k disallowed_functions`.
2. Verify `version()` and `pg_catalog.version()` are reported as disallowed.
3. Verify `conversion`, quoted identifiers, `custom_skill_versions`, string literals, and comments do not produce false positives.
4. Run `pre-commit run` against the staged files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API