### PR TITLE
fix(ci): pin codeql-action/analyze to v4.37.8 to match init

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,6 +78,6 @@ jobs:
           # queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### SUMMARY

#43644 bumped `github/codeql-action/init` to v4.37.8 but left `analyze` at v4.37.7, so CodeQL fails on every PR with:

```
Error: Loaded a configuration file for version '4.37.8', but running version '4.37.7'
```

Bumps `analyze` to the same commit (`db488dde` = tag v4.37.8).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI config only.

### TESTING INSTRUCTIONS

The CodeQL job on this PR passes instead of erroring on the version mismatch.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [ ] Changes UI: No — CI workflow only
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No