### PR TITLE
fix(dashboard): reconcile stale results tab in Chart Data modal

### DIFF
--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -29,7 +29,7 @@ import {
 } from 'src/utils/localStorageHelpers';
 import { SamplesPane, useResultsPane } from './components';
 import { DataTablesPaneProps, ResultTypes } from './types';
-import { getStaleResultsTabFallback } from './utils';
+import { useStaleResultsTabFallback } from './utils';
 
 const StyledDiv = styled.div`
   ${() => `
@@ -215,16 +215,11 @@ export const DataTablesPane = ({
     };
   });
 
-  const resultsTabFallback = getStaleResultsTabFallback(
+  useStaleResultsTabFallback(
     activeTabKey,
     queryResultsPanes.map(({ key }) => key),
+    setActiveTabKey,
   );
-
-  useEffect(() => {
-    if (resultsTabFallback) {
-      setActiveTabKey(resultsTabFallback);
-    }
-  }, [resultsTabFallback]);
 
   // Hide the Samples tab for datasources that don't expose raw rows
   // (e.g. semantic views). The check is intentionally ``=== false`` so that

--- a/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/DataTablesPane.tsx
@@ -29,22 +29,7 @@ import {
 } from 'src/utils/localStorageHelpers';
 import { SamplesPane, useResultsPane } from './components';
 import { DataTablesPaneProps, ResultTypes } from './types';
-
-/**
- * A mixed chart can be reconfigured to return fewer result panes than before
- * (e.g. dropping a query), which removes the corresponding results tab. If the
- * selected tab was one of those, the active key goes stale and the data panel
- * renders blank until the user reselects a valid tab. Returns the first
- * results tab to fall back to in that case, otherwise undefined.
- */
-export const getStaleResultsTabFallback = (
-  activeTabKey: string,
-  resultsTabKeys: string[],
-): string | undefined =>
-  activeTabKey.startsWith(ResultTypes.Results) &&
-  !resultsTabKeys.includes(activeTabKey)
-    ? ResultTypes.Results
-    : undefined;
+import { getStaleResultsTabFallback } from './utils';
 
 const StyledDiv = styled.div`
   ${() => `

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -20,21 +20,14 @@ import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import Tabs from '@superset-ui/core/components/Tabs';
 import { ResultTypes, ResultsPaneProps } from '../types';
+import { getStaleResultsTabFallback } from '../utils';
 import { useResultsPane } from './useResultsPane';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-
-  .ant-tabs {
-    height: 100%;
-  }
-
-  .ant-tabs-body {
-    height: 100%;
-  }
 
   .ant-tabs-content {
     display: flex;
@@ -85,6 +78,17 @@ export const ResultsPaneOnDashboard = ({
       children: activeTabKey === tabKey ? pane : null,
     };
   });
+
+  const resultsTabFallback = getStaleResultsTabFallback(
+    activeTabKey,
+    items.map(({ key }) => key),
+  );
+
+  useEffect(() => {
+    if (resultsTabFallback) {
+      setActiveTabKey(resultsTabFallback);
+    }
+  }, [resultsTabFallback]);
 
   return (
     <Wrapper>

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -29,6 +29,14 @@ const Wrapper = styled.div`
   flex-direction: column;
   height: 100%;
 
+  .ant-tabs {
+    height: 100%;
+  }
+
+  .ant-tabs-body {
+    height: 100%;
+  }
+
   .ant-tabs-content {
     display: flex;
     flex-direction: column;

--- a/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/components/ResultsPaneOnDashboard.tsx
@@ -20,9 +20,9 @@ import { t } from '@apache-superset/core/translation';
 import { styled } from '@apache-superset/core/theme';
 import Tabs from '@superset-ui/core/components/Tabs';
 import { ResultTypes, ResultsPaneProps } from '../types';
-import { getStaleResultsTabFallback } from '../utils';
+import { useStaleResultsTabFallback } from '../utils';
 import { useResultsPane } from './useResultsPane';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const Wrapper = styled.div`
   display: flex;
@@ -79,16 +79,11 @@ export const ResultsPaneOnDashboard = ({
     };
   });
 
-  const resultsTabFallback = getStaleResultsTabFallback(
+  useStaleResultsTabFallback(
     activeTabKey,
     items.map(({ key }) => key),
+    setActiveTabKey,
   );
-
-  useEffect(() => {
-    if (resultsTabFallback) {
-      setActiveTabKey(resultsTabFallback);
-    }
-  }, [resultsTabFallback]);
 
   return (
     <Wrapper>

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -31,8 +31,6 @@ import { ResultsPaneOnDashboard } from '../components';
 import { useResultsPane } from '../components/useResultsPane';
 import { createResultsPaneOnDashboardProps } from './fixture';
 
-// `fullHeight`'s CSS isn't testable under jsdom (no `importSource` for the
-// `css` prop in jest's babel config), so spy on call args instead.
 jest.mock('@superset-ui/core/components/Tabs', () => {
   const actual = jest.requireActual('@superset-ui/core/components/Tabs');
   return { __esModule: true, ...actual, default: jest.fn(actual.default) };
@@ -134,8 +132,6 @@ describe('ResultsPaneOnDashboard', () => {
     expect(
       await findByText('No results were returned for this query'),
     ).toBeVisible();
-    const [tabsProps] = (Tabs as unknown as jest.Mock).mock.calls[0];
-    expect(tabsProps).toEqual(expect.objectContaining({ fullHeight: true }));
   });
 
   test('render errorMessage', async () => {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -134,10 +134,8 @@ describe('ResultsPaneOnDashboard', () => {
     expect(
       await findByText('No results were returned for this query'),
     ).toBeVisible();
-    expect(Tabs).toHaveBeenCalledWith(
-      expect.objectContaining({ fullHeight: true }),
-      expect.anything(),
-    );
+    const [tabsProps] = (Tabs as unknown as jest.Mock).mock.calls[0];
+    expect(tabsProps).toEqual(expect.objectContaining({ fullHeight: true }));
   });
 
   test('render errorMessage', async () => {

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -20,13 +20,33 @@ import fetchMock from 'fetch-mock';
 import {
   screen,
   render,
+  act,
   waitForElementToBeRemoved,
   waitFor,
 } from 'spec/helpers/testing-library';
 import { ChartMetadata, ChartPlugin, VizType } from '@superset-ui/core';
 import { setupAGGridModules } from '@superset-ui/core/components/ThemedAgGridReact';
+import Tabs from '@superset-ui/core/components/Tabs';
 import { ResultsPaneOnDashboard } from '../components';
+import { useResultsPane } from '../components/useResultsPane';
 import { createResultsPaneOnDashboardProps } from './fixture';
+
+// `fullHeight`'s CSS isn't testable under jsdom (no `importSource` for the
+// `css` prop in jest's babel config), so spy on call args instead.
+jest.mock('@superset-ui/core/components/Tabs', () => {
+  const actual = jest.requireActual('@superset-ui/core/components/Tabs');
+  return { __esModule: true, ...actual, default: jest.fn(actual.default) };
+});
+
+// Wraps the real hook; only overridden below to avoid mounting a second
+// real AG Grid instance, which jsdom doesn't support.
+jest.mock('../components/useResultsPane', () => {
+  const actual = jest.requireActual('../components/useResultsPane');
+  return {
+    __esModule: true,
+    useResultsPane: jest.fn(actual.useResultsPane),
+  };
+});
 
 beforeAll(() => {
   setupAGGridModules();
@@ -106,6 +126,10 @@ describe('ResultsPaneOnDashboard', () => {
     expect(
       await findByText('No results were returned for this query'),
     ).toBeVisible();
+    expect(Tabs).toHaveBeenCalledWith(
+      expect.objectContaining({ fullHeight: true }),
+      expect.anything(),
+    );
   });
 
   test('render errorMessage', async () => {
@@ -218,5 +242,37 @@ describe('ResultsPaneOnDashboard', () => {
     expect(tab1).toBeVisible();
     expect(tab2).toBeVisible();
     expect(tab3).toBeNull();
+  });
+
+  test('falls back to the first results tab when the active one disappears', async () => {
+    const mockedUseResultsPane = useResultsPane as jest.Mock;
+    mockedUseResultsPane.mockReturnValue([<div key="a" />, <div key="b" />]);
+
+    const props = createResultsPaneOnDashboardProps({ sliceId: 999 });
+    const { rerender } = render(<ResultsPaneOnDashboard {...props} />, {
+      useRedux: true,
+    });
+
+    const latestTabsProps = () => {
+      const { calls } = (Tabs as unknown as jest.Mock).mock;
+      return calls[calls.length - 1][0];
+    };
+    expect(latestTabsProps().items.map((i: { key: string }) => i.key)).toEqual([
+      'results',
+      'results 2',
+    ]);
+
+    act(() => {
+      latestTabsProps().onChange('results 2');
+    });
+    expect(latestTabsProps().activeKey).toBe('results 2');
+
+    // A mixed chart dropped from two query results to one, removing "results 2"
+    mockedUseResultsPane.mockReturnValue([<div key="a" />]);
+    rerender(<ResultsPaneOnDashboard {...props} />);
+
+    await waitFor(() => {
+      expect(latestTabsProps().activeKey).toBe('results');
+    });
   });
 });

--- a/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
+++ b/superset-frontend/src/explore/components/DataTablesPane/test/ResultsPaneOnDashboard.test.tsx
@@ -48,6 +48,10 @@ jest.mock('../components/useResultsPane', () => {
   };
 });
 
+const actualUseResultsPane = jest.requireActual(
+  '../components/useResultsPane',
+).useResultsPane;
+
 beforeAll(() => {
   setupAGGridModules();
 });
@@ -112,6 +116,10 @@ describe('ResultsPaneOnDashboard', () => {
   );
 
   const setForceQuery = jest.fn();
+
+  afterEach(() => {
+    (useResultsPane as jest.Mock).mockImplementation(actualUseResultsPane);
+  });
 
   afterAll(() => {
     fetchMock.clearHistory().removeRoutes();

--- a/superset-frontend/src/explore/components/DataTablesPane/utils.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/utils.ts
@@ -16,28 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { getStaleResultsTabFallback } from '../utils';
-import { ResultTypes } from '../types';
+import { ResultTypes } from './types';
 
-test('keeps the active tab when it still exists', () => {
-  expect(
-    getStaleResultsTabFallback('results 2', ['results', 'results 2']),
-  ).toBeUndefined();
-});
-
-test('keeps the first results tab as-is', () => {
-  expect(getStaleResultsTabFallback('results', ['results'])).toBeUndefined();
-});
-
-test('falls back to the first results tab when the active one disappears', () => {
-  // A mixed chart dropped from two query results to one, removing "results 2"
-  expect(getStaleResultsTabFallback('results 2', ['results'])).toBe(
-    ResultTypes.Results,
-  );
-});
-
-test('never redirects the Samples tab', () => {
-  expect(
-    getStaleResultsTabFallback(ResultTypes.Samples, ['results']),
-  ).toBeUndefined();
-});
+/**
+ * A mixed chart can be reconfigured to return fewer result panes than before
+ * (e.g. dropping a query), which removes the corresponding results tab. If the
+ * selected tab was one of those, the active key goes stale and the data panel
+ * renders blank until the user reselects a valid tab. Returns the first
+ * results tab to fall back to in that case, otherwise undefined.
+ */
+export const getStaleResultsTabFallback = (
+  activeTabKey: string,
+  resultsTabKeys: string[],
+): string | undefined =>
+  activeTabKey.startsWith(ResultTypes.Results) &&
+  !resultsTabKeys.includes(activeTabKey)
+    ? ResultTypes.Results
+    : undefined;

--- a/superset-frontend/src/explore/components/DataTablesPane/utils.ts
+++ b/superset-frontend/src/explore/components/DataTablesPane/utils.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useEffect } from 'react';
 import { ResultTypes } from './types';
 
 /**
@@ -33,3 +34,21 @@ export const getStaleResultsTabFallback = (
   !resultsTabKeys.includes(activeTabKey)
     ? ResultTypes.Results
     : undefined;
+
+/**
+ * Switches the active tab back to the first results tab when it goes stale,
+ * per `getStaleResultsTabFallback`.
+ */
+export const useStaleResultsTabFallback = (
+  activeTabKey: string,
+  tabKeys: string[],
+  setActiveTabKey: (key: string) => void,
+) => {
+  const fallback = getStaleResultsTabFallback(activeTabKey, tabKeys);
+
+  useEffect(() => {
+    if (fallback) {
+      setActiveTabKey(fallback);
+    }
+  }, [fallback, setActiveTabKey]);
+};


### PR DESCRIPTION
### SUMMARY
When a mixed chart's active results tab (Results/Samples/View query) disappeared — e.g. after a chart type or metric change that removes a tab — `ResultsPaneOnDashboard` rendered blank instead of falling back to a tab that still exists. `DataTablesPane` already handled this reconciliation; `ResultsPaneOnDashboard` did not.

Fix reuses `DataTablesPane`'s stale-tab fallback logic in `ResultsPaneOnDashboard`, then extracts the duplicated `getStaleResultsTabFallback` + `useEffect` pair from both components into a shared `useStaleResultsTabFallback` hook so there's a single implementation.

Split out of #43454, which now only carries the `fullHeight` grid-sizing fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!-- TODO: attach a before/after clip showing the Chart Data modal no longer going blank when the active results tab disappears -->

### TESTING INSTRUCTIONS
1. Build a chart whose "View as table" modal shows multiple result tabs (e.g. a chart with samples), and add it to a dashboard.
2. Open the chart's "View as table" (Chart Data) modal.
3. Trigger a change that removes the currently active tab (e.g. switch to a chart type/metric combination that drops the Samples tab).
4. Confirm the modal still renders a valid tab's contents instead of going blank.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API