### PR TITLE
fix(charts): resolve semantic-view datasource name and link in chart list

### DIFF
--- a/superset/commands/deletion_retention/purge_policy.py
+++ b/superset/commands/deletion_retention/purge_policy.py
@@ -553,6 +553,9 @@ def purge_policy_registry() -> Mapping[type[Any], PurgeEntityPolicy]:
                     fk("slices", "report_schedule", "id", "chart_id", "inbound"),
                     version("slices", "slices_version"),
                     relationship("slices", "tables", "manytoone", "table"),
+                    relationship(
+                        "slices", "semantic_views", "manytoone", "semantic_view"
+                    ),
                     fk("chart_editors", "slices", "chart_id", "id", "outbound"),
                     fk("chart_editors", "subjects", "subject_id", "id", "outbound"),
                     fk("chart_viewers", "slices", "chart_id", "id", "outbound"),
@@ -581,6 +584,7 @@ def purge_policy_registry() -> Mapping[type[Any], PurgeEntityPolicy]:
                     DependencyClassification.ASSOCIATION,
                     DependencyClassification.BLOCK,
                     DependencyClassification.VERSION_OWNED,
+                    DependencyClassification.PRESERVE,
                     DependencyClassification.PRESERVE,
                     DependencyClassification.PRESERVE,
                     DependencyClassification.PRESERVE,

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -59,6 +59,12 @@ if TYPE_CHECKING:
     from superset.common.query_context_factory import QueryContextFactory
     from superset.connectors.sqla.models import SqlaTable
 
+    # avoid circular import: superset.connectors.sqla.models imports this module,
+    # and superset.semantic_layers.models -> semantic_layers.mapper imports
+    # superset.connectors.sqla.models. The ``semantic_view`` relationship below
+    # names its target as a string, so the class is only needed for typing.
+    from superset.semantic_layers.models import SemanticView
+
 metadata = Model.metadata  # pylint: disable=no-member
 logger = logging.getLogger(__name__)
 
@@ -161,6 +167,24 @@ class Slice(  # pylint: disable=too-many-public-methods
         remote_side="SqlaTable.id",
         lazy="subquery",
     )
+    # Counterpart of ``table`` for charts built on a semantic view. ``datasource_id``
+    # is only unique within a ``datasource_type``, so the join is guarded on the
+    # type to keep a same-id dataset from being resolved by mistake. View-only:
+    # ``datasource_id`` is written by the chart, never through this relationship.
+    # ``selectin`` costs one extra bounded ``IN (...)`` query per batch of charts
+    # loaded (the type predicate rules out the FK-only shortcut); the default
+    # lazy load would be one query per semantic-view chart on a list page. The
+    # string target resolves because ``superset.daos.datasource`` imports
+    # ``SemanticView`` unconditionally during app initialisation.
+    semantic_view = relationship(
+        "SemanticView",
+        foreign_keys=[datasource_id],
+        primaryjoin="and_(Slice.datasource_id == SemanticView.id, "
+        "Slice.datasource_type == 'semantic_view')",
+        remote_side="SemanticView.id",
+        viewonly=True,
+        lazy="selectin",
+    )
 
     token = ""
 
@@ -186,6 +210,19 @@ class Slice(  # pylint: disable=too-many-public-methods
     def datasource(self) -> SqlaTable | None:
         return self.table
 
+    def _display_datasource(self) -> SqlaTable | SemanticView | None:
+        """Return the datasource used to name and link this chart in listings.
+
+        Display-only counterpart of ``datasource``: it also resolves semantic
+        views, selected strictly by ``datasource_type`` so a chart can never be
+        labelled with a same-id datasource of another kind. ``datasource`` itself
+        deliberately stays ``SqlaTable``-only because access checks and exports
+        depend on that type.
+        """
+        if self.datasource_type == utils.DatasourceType.SEMANTIC_VIEW:
+            return self.semantic_view
+        return self.table
+
     def clone(self) -> Slice:
         return Slice(
             slice_name=self.slice_name,
@@ -198,36 +235,26 @@ class Slice(  # pylint: disable=too-many-public-methods
             cache_timeout=self.cache_timeout,
         )
 
+    # The helpers below read the resolved datasource through ``getattr`` so an
+    # unresolved reference (``None``) or a datasource kind lacking the attribute
+    # yields ``None`` for that one chart instead of failing a whole listing.
+
     @renders("datasource_name")
     def datasource_link(self) -> Markup | None:
-        datasource = self.datasource
-        return datasource.link if datasource else None
+        return getattr(self._display_datasource(), "link", None)
 
     @renders("datasource_url")
     def datasource_url(self) -> str | None:
-        # Use getattr to guard against datasource types that don't have explore_url
-        # (e.g. Query objects), which would otherwise raise AttributeError and cause
-        # the entire chart list response to fail.
-        if self.table:
-            return getattr(self.table, "explore_url", None)
-        datasource = self.datasource
-        return getattr(datasource, "explore_url", None) if datasource else None
+        return getattr(self._display_datasource(), "explore_url", None)
 
     def datasource_name_text(self) -> str | None:
-        if self.table:
-            if self.table.schema:
-                return f"{self.table.schema}.{self.table.table_name}"
-            return self.table.table_name
-        if self.datasource:
-            if self.datasource.schema:
-                return f"{self.datasource.schema}.{self.datasource.name}"
-            return self.datasource.name
-        return None
+        # ``SqlaTable.name`` is ``schema.table_name`` when a schema is set;
+        # ``SemanticView.name`` is the view's name.
+        return getattr(self._display_datasource(), "name", None)
 
     @property
     def datasource_edit_url(self) -> str | None:
-        datasource = self.datasource
-        return datasource.url if datasource else None
+        return getattr(self._display_datasource(), "url", None)
 
     @property
     def description_markeddown(self) -> str:
@@ -368,7 +395,7 @@ class Slice(  # pylint: disable=too-many-public-methods
         # Escape the data-controlled datasource name and edit URL before they
         # are interpolated into HTML attributes.
         url = escape(self.datasource_edit_url)
-        datasource = escape(self.datasource)
+        datasource = escape(self.datasource_name_text() or "")
         return f"""
         <a
                 href="{url}"

--- a/tests/unit_tests/charts/test_chart_list_datasource.py
+++ b/tests/unit_tests/charts/test_chart_list_datasource.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Chart listings must name and link the semantic view behind a chart.
+
+A chart's ``datasource_id`` is only unique within its ``datasource_type``, so a
+semantic view and a regular dataset routinely share a numeric id. These tests
+use real rows with a deliberate id collision to pin that a chart always resolves
+to a datasource of its own kind. They drive the ORM relationship directly: the
+chart list API serialises these same model helpers (``datasource_name_text``,
+``datasource_url``) without transformation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from superset.connectors.sqla.models import SqlaTable
+from superset.models.core import Database
+from superset.models.slice import Slice
+from superset.semantic_layers.models import SemanticLayer, SemanticView
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+SHARED_ID = 7
+
+# The resolver does not consult the feature flag; this pins that charts already
+# built on a semantic view keep resolving after SEMANTIC_LAYERS is turned off.
+FLAG_OFF = pytest.mark.parametrize(
+    "app",
+    [{"FEATURE_FLAGS": {"SEMANTIC_LAYERS": False}}],
+    ids=["semantic_layers_off"],
+    indirect=True,
+)
+
+
+def _seed(session: Session) -> tuple[Slice, Slice]:
+    """Insert a semantic view and a dataset sharing an id, and a chart on each."""
+    SqlaTable.metadata.create_all(session.get_bind())  # pylint: disable=no-member
+    database = Database(database_name="db", sqlalchemy_uri="sqlite://")
+    table = SqlaTable(
+        id=SHARED_ID, table_name="aaa_table", schema="public", database=database
+    )
+    layer = SemanticLayer(name="demo", type="demo", configuration={})
+    view = SemanticView(
+        id=SHARED_ID, name="orders", semantic_layer=layer, configuration={}
+    )
+    view_chart = Slice(
+        slice_name="On the view",
+        datasource_type="semantic_view",
+        datasource_id=SHARED_ID,
+        datasource_name="orders",
+        viz_type="table",
+        params="{}",
+    )
+    table_chart = Slice(
+        slice_name="On the table",
+        datasource_type="table",
+        datasource_id=SHARED_ID,
+        datasource_name="aaa_table",
+        viz_type="table",
+        params="{}",
+    )
+    session.add_all([database, table, layer, view, view_chart, table_chart])
+    session.flush()
+    session.expire_all()
+    return view_chart, table_chart
+
+
+@FLAG_OFF
+def test_semantic_view_chart_resolves_to_the_view_not_the_colliding_table(
+    app: object,
+    session: Session,
+) -> None:
+    """The display name/link come from the semantic view sharing the id."""
+    view_chart, table_chart = _seed(session)
+
+    assert view_chart.datasource_name_text() == "orders"
+    assert (
+        view_chart.datasource_url()
+        == f"/explore/?datasource_type=semantic_view&datasource_id={SHARED_ID}"
+    )
+    assert (
+        view_chart.datasource_edit_url
+        == f"/semantic_view/{view_chart.semantic_view.uuid}/"
+    )
+    # No legacy HTML renderer exists for semantic views; the helper degrades.
+    assert view_chart.datasource_link() is None
+    # The dataset chart on the same numeric id is untouched by the new path.
+    assert table_chart.datasource_name_text() == "public.aaa_table"
+    assert (
+        table_chart.datasource_url()
+        == f"/explore/?datasource_type=table&datasource_id={SHARED_ID}"
+    )
+
+
+def test_semantic_view_chart_with_deleted_view_degrades_to_empty(
+    session: Session,
+) -> None:
+    """A dangling semantic-view id yields empty fields, never an error."""
+    view_chart, _ = _seed(session)
+    session.delete(session.get(SemanticView, SHARED_ID))
+    session.flush()
+    session.expire_all()
+
+    assert view_chart.datasource_name_text() is None
+    assert view_chart.datasource_url() is None
+    assert view_chart.datasource_edit_url is None
+    assert view_chart.datasource_link() is None
+
+
+def test_charts_sort_by_stored_datasource_name_across_kinds(
+    session: Session,
+) -> None:
+    """Characterisation: list sorting uses the stored ``datasource_name`` column.
+
+    The chart list orders by the name captured when the chart was saved, not by
+    the resolved display name, for datasets and semantic views alike; the two
+    can disagree after a rename. Pinned here so the split is deliberate.
+    """
+    view_chart, table_chart = _seed(session)
+
+    ordered = [
+        slc.id for slc in session.query(Slice).order_by(Slice.datasource_name).all()
+    ]
+
+    assert ordered.index(table_chart.id) < ordered.index(view_chart.id)
+    assert view_chart.datasource_name == "orders"

--- a/tests/unit_tests/models/slice_test.py
+++ b/tests/unit_tests/models/slice_test.py
@@ -125,6 +125,87 @@ class TestSlice:
         result = slc.datasource_url()
         assert result is None
 
+    @staticmethod
+    def _semantic_view_slice() -> Slice:
+        """Build a chart on a semantic view, with a colliding table also attached.
+
+        The table stands in for a regular dataset that happens to share the
+        numeric id; it must never leak into the semantic-view chart's display.
+        """
+        slc = Slice()
+        slc.id = 1
+        slc.datasource_type = "semantic_view"
+        slc.datasource_id = 2
+        view = MagicMock()
+        view.name = "orders"
+        view.url = "/semantic_view/abc/"
+        view.explore_url = "/explore/?datasource_type=semantic_view&datasource_id=2"
+        view.link = "<a>orders</a>"
+        slc.semantic_view = view
+        table = MagicMock()
+        table.name = "public.colliding_table"
+        table.explore_url = "/explore/?datasource_type=table&datasource_id=2"
+        slc.table = table
+        return slc
+
+    def test_datasource_url_uses_semantic_view_explore_url(self) -> None:
+        """A semantic-view chart links to the view's Explore page, not a table's."""
+        slc = self._semantic_view_slice()
+
+        assert (
+            slc.datasource_url()
+            == "/explore/?datasource_type=semantic_view&datasource_id=2"
+        )
+
+    def test_datasource_name_text_uses_semantic_view_name(self) -> None:
+        """A semantic-view chart is named after the view (no schema prefix)."""
+        slc = self._semantic_view_slice()
+
+        assert slc.datasource_name_text() == "orders"
+
+    def test_display_datasource_never_falls_back_across_types(self) -> None:
+        """A semantic-view chart with no view resolves to None, not to a table."""
+        slc = self._semantic_view_slice()
+        slc.semantic_view = None
+
+        assert slc._display_datasource() is None
+        assert slc.datasource_url() is None
+        assert slc.datasource_name_text() is None
+
+    def test_table_chart_display_is_unchanged_by_semantic_view_relationship(
+        self,
+    ) -> None:
+        """A table chart ignores ``semantic_view`` even if it is populated."""
+        slc = self._semantic_view_slice()
+        slc.datasource_type = "table"
+
+        assert slc.datasource_url() == "/explore/?datasource_type=table&datasource_id=2"
+        assert slc.datasource_name_text() == "public.colliding_table"
+
+    def test_datasource_edit_url_and_link_use_semantic_view(self) -> None:
+        """Edit URL and legacy link come from the view for a semantic-view chart."""
+        slc = self._semantic_view_slice()
+
+        assert slc.datasource_edit_url == "/semantic_view/abc/"
+        assert slc.datasource_link() == "<a>orders</a>"
+
+    def test_datasource_link_is_none_when_unresolved(self) -> None:
+        """A chart whose datasource cannot be resolved has no link, no error."""
+        slc = self._semantic_view_slice()
+        slc.semantic_view = None
+
+        assert slc.datasource_link() is None
+        assert slc.datasource_edit_url is None
+
+    def test_icons_names_the_semantic_view(self) -> None:
+        """icons uses the semantic view's name and edit URL for its tooltip."""
+        slc = self._semantic_view_slice()
+
+        html = slc.icons
+
+        assert 'title="orders"' in html
+        assert 'href="/semantic_view/abc/"' in html
+
     def test_icons_escapes_datasource_html(self):
         """icons must HTML-escape the datasource name and edit URL."""
         slc = Slice()
@@ -137,8 +218,7 @@ class TestSlice:
             ),
             patch.object(
                 Slice,
-                "datasource",
-                new_callable=PropertyMock,
+                "datasource_name_text",
                 return_value="<img src=x onerror=alert(1)>",
             ),
         ):


### PR DESCRIPTION
### SUMMARY

With `SEMANTIC_LAYERS` enabled, a chart can be built on a **semantic view** instead of a dataset. In the Charts list, the **Datasource** column for every such chart was blank (no name, no link), and the chart API returned `datasource_name_text: null` / `datasource_url: null` for it — regular-dataset charts on the same page rendered normally.

**Root cause.** `Slice`'s display helpers (`datasource_url`, `datasource_name_text`, `datasource_link`, `datasource_edit_url`, `icons`) resolve the datasource only through the `SqlaTable` relationship (`Slice.table`, which is correctly guarded on `datasource_type == 'table'`), so for a `semantic_view` chart they saw `None`.

**Fix.**
- Add a type-guarded, view-only `Slice.semantic_view` relationship mirroring `Slice.table` (`primaryjoin` on `datasource_id` **and** `datasource_type == 'semantic_view'`, `viewonly=True`, `lazy="selectin"`).
- Add a display-only `Slice._display_datasource()` that dispatches on `datasource_type` and never falls back across types; route the five display helpers through it with `getattr` guards, so an unresolved reference yields `None` for that one chart instead of failing the listing.
- `datasource_name_text` now delegates to the datasource's own `name` (`schema.table_name` for datasets, the view name for semantic views) — identical output for datasets.
- Register the new relationship in the soft-delete purge policy for charts (`PRESERVE`, like `table`); the policy validates every mapper relationship on `Slice`.

**Design notes.**
- `Slice.datasource` is intentionally unchanged: it is read by access checks, dashboard dataset collection and exports that depend on it being a `SqlaTable`. Reconciling that is a separate follow-up.
- `datasource_id` is only unique within a `datasource_type` — a semantic view and a dataset routinely share an id. The guarded join means a semantic-view chart can never be labelled with a same-id dataset (tested with a deliberate collision on real rows).
- Loading cost: `selectin` adds one bounded `IN (...)` query per batch of charts loaded (measured: 3 statements for a page of table-only charts, up from 2), in exchange for no per-chart query on semantic-view-heavy list pages.
- The `SemanticView` import in `slice.py` is `TYPE_CHECKING`-only: a module-top import is a real cycle (`connectors/sqla/models` → `models/slice` → `semantic_layers/models` → `semantic_layers/mapper` → `connectors/sqla/models`). The relationship names its target as a string.

No migration, no new API fields, no frontend change (the list already renders `datasource_name_text` / `datasource_url`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Charts list, chart on a Snowflake semantic view (`TPCDS_SEMANTIC_VIEW_SM`):

**Before** — empty Datasource cell:

![before](https://raw.githubusercontent.com/mikebridge/superset/sc-107813-assets/before-chart-list.jpg)

**After** — view name linked to Explore:

![after](https://raw.githubusercontent.com/mikebridge/superset/sc-107813-assets/after-chart-list.jpg)

API, same chart:

```json
// before
{"datasource_type": "semantic_view", "datasource_name_text": null, "datasource_url": null}
// after
{"datasource_type": "semantic_view", "datasource_name_text": "TPCDS_SEMANTIC_VIEW_SM",
 "datasource_url": "/explore/?datasource_type=semantic_view&datasource_id=2"}
```

### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/models/slice_test.py tests/unit_tests/charts/test_chart_list_datasource.py tests/unit_tests/commands/deletion_retention/ -W error::sqlalchemy.exc.SAWarning
```

`test_chart_list_datasource.py` uses real SQLite rows with a semantic view and a dataset sharing the same id, plus a chart on each: the semantic-view chart resolves to the view, the dataset chart to the dataset; a dangling view id degrades to `null` fields without error; holds with `SEMANTIC_LAYERS` off.

Manual (feature flag `SEMANTIC_LAYERS` on):
1. Add a semantic layer + semantic view (any provider; the in-memory demo layer works) and save a chart on it.
2. **Charts** list → the Datasource cell shows the view's name as a link; clicking it opens Explore on `datasource_type=semantic_view&datasource_id=<id>`.
3. `GET /api/v1/chart/<id>` → `datasource_name_text` and `datasource_url` are populated.
4. A chart on a regular dataset renders exactly as before.
5. Optional collision check: if a dataset with the same numeric id as the view exists, the semantic-view chart still names the view.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `SEMANTIC_LAYERS` (to reproduce; the fix itself is flag-independent)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Known adjacent gaps, deliberately not in this PR: the Charts-list "Dataset" filter dropdown and text search still only cover regular datasets, and the chart access filter joins `datasource_id` to datasets without a type guard — same id-collision family, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
