### PR TITLE
fix(sql): catch sqlglot ParseError when parsing RLS predicates

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -1539,7 +1539,25 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         :return: The parsed predicate.
         """
         _check_script_length(predicate, self.engine)
-        return sqlglot.parse_one(predicate, dialect=self._dialect)
+        try:
+            return sqlglot.parse_one(predicate, dialect=self._dialect)
+        except sqlglot.errors.ParseError as ex:
+            kwargs = (
+                {
+                    "highlight": ex.errors[0]["highlight"],
+                    "line": ex.errors[0]["line"],
+                    "column": ex.errors[0]["col"],
+                }
+                if ex.errors
+                else {}
+            )
+            raise SupersetParseError(predicate, self.engine, **kwargs) from ex
+        except sqlglot.errors.SqlglotError as ex:
+            raise SupersetParseError(
+                predicate,
+                self.engine,
+                message="Unable to parse predicate",
+            ) from ex
 
     def apply_rls(
         self,

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -5592,6 +5592,27 @@ def test_parse_predicate_invalid_sql_raises_superset_parse_error() -> None:
     assert excinfo.value.status == 422
 
 
+def test_parse_predicate_sqlglot_error_raises_superset_parse_error(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A non-``ParseError`` ``sqlglot`` failure also surfaces as a typed error.
+
+    ``parse_predicate`` catches the generic ``SqlglotError`` base class as a
+    fallback so any sqlglot failure (e.g. tokenize errors) is converted into a
+    ``SupersetParseError`` rather than leaking a raw sqlglot exception.
+    """
+    # Build the statement before patching, since the constructor also parses.
+    stmt = SQLStatement("SELECT 1", "postgresql")
+    mocker.patch(
+        "sqlglot.parse_one",
+        side_effect=sqlglot.errors.SqlglotError("boom"),
+    )
+    with pytest.raises(SupersetParseError) as excinfo:
+        stmt.parse_predicate("a > 1")
+    assert excinfo.value.status == 422
+
+
 @pytest.mark.usefixtures("_small_parse_cap")
 def test_transpile_to_dialect_length_check() -> None:
     """

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -5578,6 +5578,20 @@ def test_parse_predicate_length_check() -> None:
         stmt.parse_predicate("x" * 101)
 
 
+def test_parse_predicate_invalid_sql_raises_superset_parse_error() -> None:
+    """
+    A syntactically invalid RLS predicate raises ``SupersetParseError``.
+
+    ``parse_predicate`` is reachable via ``apply_rls`` for any RLS clause
+    configured on a queried table; an invalid clause must surface as the
+    typed 422 parse error rather than leaking a raw ``sqlglot`` exception.
+    """
+    stmt = SQLStatement("SELECT 1", "postgresql")
+    with pytest.raises(SupersetParseError) as excinfo:
+        stmt.parse_predicate("a >")
+    assert excinfo.value.status == 422
+
+
 @pytest.mark.usefixtures("_small_parse_cap")
 def test_transpile_to_dialect_length_check() -> None:
     """


### PR DESCRIPTION
### SUMMARY

`SQLStatement.parse_predicate` in `superset/sql/parse.py` called `sqlglot.parse_one(...)` completely unguarded. When a Row-Level-Security predicate is syntactically invalid SQL, `sqlglot` raises a raw `sqlglot.errors.ParseError`, which propagated uncaught out of the parsing layer.

This change wraps the `parse_one` call in a try/except that converts `ParseError` (and the broader `SqlglotError`) into the codebase's existing typed `SupersetParseError`, extracting `highlight`/`line`/`column` from the sqlglot error the same way. This is the exact idiom already used by the sibling `SQLStatement._parse` classmethod a few hundred lines up in the same file for the same underlying `sqlglot.parse` failure mode — this PR simply extends that treatment to the one remaining unguarded `sqlglot` entry point.

This is the same bug class addressed in #42366 and #42401: a raw third-party library exception propagating instead of a typed `SupersetException`.

### PROBLEM

`parse_predicate` is reached from `superset/utils/rls.py::apply_rls()` for every RLS predicate configured on a table referenced by a query. The cleanest currently-reachable, unguarded end-to-end path is `POST /api/v1/sqllab/estimate/` (with the `RLS_IN_SQLLAB` feature flag enabled):

- `SqlLabRestApi.estimate_query_cost()` calls `QueryEstimationCommand.run()` with no try/except, and that endpoint has no Flask-AppBuilder `@safe` decorator.
- `QueryEstimationCommand.run()` → `_apply_sql_security()` → `apply_rls()` → `parse_predicate()`, all unguarded.

With the raw `sqlglot.errors.ParseError` escaping, Flask's generic `@app.errorhandler(Exception)` renders an opaque **500**. By raising `SupersetParseError` (status 422, `error_type=INVALID_SQL_ERROR`) instead, Superset's registered `@app.errorhandler(SupersetErrorException)` renders a proper typed **422** JSON response.

Other `apply_rls` callers (`sql_lab.py`, `sql/execution/executor.py`) already sit behind broad `except Exception` safety nets, so they degrade gracefully today and benefit automatically from this root-level fix — no changes needed there.

### FIX

Strictly additive: catch the sqlglot exceptions at their single origin point in `parse_predicate` and re-raise as `SupersetParseError(predicate, self.engine, ...)`. No success-path behavior changes; the only observable difference is the invalid-predicate case going from an opaque 500 to a typed 422.

### TESTING INSTRUCTIONS

Automated: added `test_parse_predicate_invalid_sql_raises_superset_parse_error` in `tests/unit_tests/sql/parse_tests.py`, verified failing on pre-fix code (raw `sqlglot.errors.ParseError` propagates) and passing after the fix.

```bash
pytest tests/unit_tests/sql/parse_tests.py -k predicate -q   # 30 passed
```

Manual: with `RLS_IN_SQLLAB` enabled, configure an RLS rule with a syntactically invalid clause (e.g. `a >`) on a table, then `POST /api/v1/sqllab/estimate/` a query against that table. Before: opaque 500. After: typed 422 with an `INVALID_SQL_ERROR` payload.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
