### PR TITLE
chore(ci): skip Jest test HTML report generation to save up time

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -97,6 +97,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/superset-frontend/coverage
           docker run \
           -v ${{ github.workspace }}/superset-frontend/coverage:/app/superset-frontend/coverage \
+          -e CI=true \
           --rm $TAG \
           bash -c \
           "npm run test -- --coverage --shard=${{ matrix.shard }}/8 --coverageReporters=json"

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -18,6 +18,19 @@
  */
 // timezone for unit tests
 process.env.TZ = 'America/New_York';
+
+const reporters = ['default'];
+
+// HTML reporter is not used on CI so skipping its generation for saving time
+if (process.env.CI) {
+  reporters.push([
+    './node_modules/jest-html-reporter',
+    {
+      pageTitle: 'Test Report',
+    },
+  ]);
+}
+
 module.exports = {
   // [/\\] matches both path separators so the suite also collects on
   // native Windows, where jest hands the regex backslash-separated paths.
@@ -88,17 +101,6 @@ module.exports = {
     __DEV__: true,
     caches: true,
   },
-  reporters: [
-    'default',
-    // HTML reporter is not used on CI so skipping its generation for saving time
-    ...(process.env.CI
-      ? []
-      : [
-          './node_modules/jest-html-reporter',
-          {
-            pageTitle: 'Test Report',
-          },
-        ]),
-  ],
+  reporters: reporters,
   testTimeout: 20000,
 };

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -90,12 +90,15 @@ module.exports = {
   },
   reporters: [
     'default',
-    [
-      './node_modules/jest-html-reporter',
-      {
-        pageTitle: 'Test Report',
-      },
-    ],
+    // HTML reporter is not used on CI so skipping its generation for saving time
+    ...(process.env.CI
+      ? []
+      : [
+          './node_modules/jest-html-reporter',
+          {
+            pageTitle: 'Test Report',
+          },
+        ]),
   ],
   testTimeout: 20000,
 };

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -22,7 +22,7 @@ process.env.TZ = 'America/New_York';
 const reporters = ['default'];
 
 // HTML reporter is not used on CI so skipping its generation for saving time
-if (process.env.CI) {
+if (!process.env.CI) {
   reporters.push([
     './node_modules/jest-html-reporter',
     {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
chore(ci): skip Jest test HTML report generation to save up time

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Skips generating Jest tests's HTML-based summary result on CI as we don't use it for reporting, only at local. This should save up 8*~19 = ~2.5 minutes from total CI execution time. Hopefully this would scale up to good saving when applies to large amount of PRs.

<img width="1091" height="66" alt="image" src="https://github.com/user-attachments/assets/952cfb28-6e3d-44d1-aeac-dbf6e6137527" />

<img width="1091" height="77" alt="image" src="https://github.com/user-attachments/assets/63e2ee88-7723-4a7c-9271-041669edd09e" />



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Green CI as acceptance threshold

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
