### PR TITLE
fix(trino): coerce string-typed values results back to source type

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -26,7 +26,7 @@ from collections import defaultdict, deque
 from datetime import datetime
 from re import Pattern
 from textwrap import dedent
-from typing import Any, cast, Optional, TYPE_CHECKING
+from typing import Any, Callable, cast, Optional, TYPE_CHECKING
 from urllib import parse
 
 import pandas as pd
@@ -181,6 +181,17 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     # expressions (e.g. columns defined as `(expiration = 1) AS expiration`),
     # which raises a query error. Use = true/false instead.
     use_equality_for_boolean_filters = True
+
+    # Presto/Trino's coordinator sends query results as JSON, which has no
+    # literal for NaN/Infinity/-Infinity, so REAL/DOUBLE columns holding
+    # those values arrive as quoted strings. Coerce them back to real
+    # floats so numeric post-processing (e.g. a pivot's mean) doesn't choke
+    # on a string value. (DECIMAL has the same class of issue, but that's
+    # handled per-driver: pyhive already converts it for Presto, so only
+    # TrinoEngineSpec needs its own DECIMAL entry.)
+    column_type_mutators: dict[types.TypeEngine, Callable[[Any], Any]] = {
+        types.FLOAT: lambda val: float(val) if isinstance(val, str) else val
+    }
 
     column_type_mappings = (
         (

--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -186,9 +186,7 @@ class PrestoBaseEngineSpec(BaseEngineSpec, metaclass=ABCMeta):
     # literal for NaN/Infinity/-Infinity, so REAL/DOUBLE columns holding
     # those values arrive as quoted strings. Coerce them back to real
     # floats so numeric post-processing (e.g. a pivot's mean) doesn't choke
-    # on a string value. (DECIMAL has the same class of issue, but that's
-    # handled per-driver: pyhive already converts it for Presto, so only
-    # TrinoEngineSpec needs its own DECIMAL entry.)
+    # on a string value.
     column_type_mutators: dict[types.TypeEngine, Callable[[Any], Any]] = {
         types.FLOAT: lambda val: float(val) if isinstance(val, str) else val
     }

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -82,11 +82,8 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
     # Trino's DBAPI driver can return DECIMAL columns as plain strings
     # (e.g. when a value's precision/scale can't be inferred from the
-    # column type alone), which later breaks numeric post-processing (e.g.
-    # pivot with a mean aggregate). Coerce them back to Decimal. Unlike
-    # Trino, Presto's driver (pyhive) already converts DECIMAL itself, so
-    # this entry lives here rather than on PrestoBaseEngineSpec -- merge
-    # with the inherited FLOAT entry rather than shadowing it.
+    # column type alone), which later breaks numeric post-processing
+    # (e.g. pivot with a mean aggregate). Coerce them back to Decimal.
     column_type_mutators: dict[TypeEngine, Callable[[Any], Any]] = {
         **PrestoBaseEngineSpec.column_type_mutators,
         DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val,

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -22,7 +22,8 @@ import math
 import threading
 import time
 from collections.abc import Sequence
-from typing import Any, TYPE_CHECKING
+from decimal import Decimal
+from typing import Any, Callable, TYPE_CHECKING
 
 import requests
 from flask import copy_current_request_context, ctx, current_app as app, Flask, g
@@ -30,6 +31,7 @@ from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchTableError
+from sqlalchemy.types import DECIMAL, TypeEngine
 
 from superset import cache_manager, db
 from superset.common.db_query_status import QueryStatus
@@ -76,6 +78,14 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
     encrypted_extra_sensitive_fields = {
         **PrestoBaseEngineSpec.encrypted_extra_sensitive_fields,
         "$.oauth2_client_info.secret": "OAuth2 client secret",
+    }
+
+    # Trino's DBAPI driver can return DECIMAL columns as plain strings
+    # (e.g. when a value's precision/scale can't be inferred from the
+    # column type alone), which later breaks numeric post-processing
+    # (e.g. pivot with a mean aggregate). Coerce them back to Decimal.
+    column_type_mutators: dict[TypeEngine, Callable[[Any], Any]] = {
+        DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val
     }
 
     # The full set of columns Trino's "<table>$partitions" exposes for an

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -31,7 +31,7 @@ from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy.types import DECIMAL, TypeEngine
+from sqlalchemy.types import DECIMAL, FLOAT, TypeEngine
 
 from superset import cache_manager, db
 from superset.common.db_query_status import QueryStatus
@@ -82,10 +82,14 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
     # Trino's DBAPI driver can return DECIMAL columns as plain strings
     # (e.g. when a value's precision/scale can't be inferred from the
-    # column type alone), which later breaks numeric post-processing
-    # (e.g. pivot with a mean aggregate). Coerce them back to Decimal.
+    # column type alone). REAL/DOUBLE columns hit the same issue for
+    # NaN/Infinity/-Infinity, since Trino's wire protocol has to encode
+    # those as quoted strings (JSON has no literal for them). Either one
+    # later breaks numeric post-processing (e.g. pivot with a mean
+    # aggregate), so coerce both back to their real numeric type.
     column_type_mutators: dict[TypeEngine, Callable[[Any], Any]] = {
-        DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val
+        DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val,
+        FLOAT: lambda val: float(val) if isinstance(val, str) else val,
     }
 
     # The full set of columns Trino's "<table>$partitions" exposes for an

--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -31,7 +31,7 @@ from flask_babel import gettext as __
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy.types import DECIMAL, FLOAT, TypeEngine
+from sqlalchemy.types import DECIMAL, TypeEngine
 
 from superset import cache_manager, db
 from superset.common.db_query_status import QueryStatus
@@ -82,14 +82,14 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
 
     # Trino's DBAPI driver can return DECIMAL columns as plain strings
     # (e.g. when a value's precision/scale can't be inferred from the
-    # column type alone). REAL/DOUBLE columns hit the same issue for
-    # NaN/Infinity/-Infinity, since Trino's wire protocol has to encode
-    # those as quoted strings (JSON has no literal for them). Either one
-    # later breaks numeric post-processing (e.g. pivot with a mean
-    # aggregate), so coerce both back to their real numeric type.
+    # column type alone), which later breaks numeric post-processing (e.g.
+    # pivot with a mean aggregate). Coerce them back to Decimal. Unlike
+    # Trino, Presto's driver (pyhive) already converts DECIMAL itself, so
+    # this entry lives here rather than on PrestoBaseEngineSpec -- merge
+    # with the inherited FLOAT entry rather than shadowing it.
     column_type_mutators: dict[TypeEngine, Callable[[Any], Any]] = {
+        **PrestoBaseEngineSpec.column_type_mutators,
         DECIMAL: lambda val: Decimal(val) if isinstance(val, str) else val,
-        FLOAT: lambda val: float(val) if isinstance(val, str) else val,
     }
 
     # The full set of columns Trino's "<table>$partitions" exposes for an

--- a/tests/unit_tests/db_engine_specs/test_presto.py
+++ b/tests/unit_tests/db_engine_specs/test_presto.py
@@ -14,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import math
 from datetime import datetime
 from typing import Any, Optional
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 import pytz
@@ -88,6 +90,37 @@ def test_get_column_spec(
     from superset.db_engine_specs.presto import PrestoEngineSpec as spec  # noqa: N813
 
     assert_column_spec(spec, native_type, sqla_type, attrs, generic_type, is_dttm)
+
+
+@pytest.mark.parametrize(
+    "string_value,expected_float",
+    [
+        ("NaN", math.nan),
+        ("Infinity", math.inf),
+        ("-Infinity", -math.inf),
+    ],
+)
+def test_column_type_mutator_double_special_values(
+    string_value: str, expected_float: float
+) -> None:
+    """
+    Presto's coordinator sends results as JSON, which has no literal for
+    NaN/Infinity/-Infinity, so REAL/DOUBLE columns holding those values
+    arrive as quoted strings. They must be coerced back to real floats
+    (inherited from PrestoBaseEngineSpec, shared with TrinoEngineSpec).
+    """
+    from superset.db_engine_specs.presto import PrestoEngineSpec
+
+    mock_cursor = Mock()
+    mock_cursor.fetchall.return_value = [[string_value]]
+    mock_cursor.description = [("val", "double")]
+
+    (result_value,) = PrestoEngineSpec.fetch_data(mock_cursor)[0]
+    assert isinstance(result_value, float)
+    if math.isnan(expected_float):
+        assert math.isnan(result_value)
+    else:
+        assert result_value == expected_float
 
 
 def test_get_schema_from_engine_params() -> None:

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import copy
 from collections import namedtuple
 from datetime import datetime
+from decimal import Decimal
 from typing import Any, Optional
 from unittest.mock import MagicMock, Mock, patch
 
@@ -324,6 +325,46 @@ def test_convert_dttm(
     from superset.db_engine_specs.trino import TrinoEngineSpec
 
     assert_convert_dttm(TrinoEngineSpec, target_type, expected_result, dttm)
+
+
+@pytest.mark.parametrize(
+    "data,description,expected_result",
+    [
+        (
+            [["1.846619834", "abc"]],
+            [("dec", "decimal(12,9)"), ("str", "varchar(3)")],
+            [(Decimal("1.846619834"), "abc")],
+        ),
+        (
+            [[Decimal("1.846619834"), "abc"]],
+            [("dec", "decimal(12,9)"), ("str", "varchar(3)")],
+            [(Decimal("1.846619834"), "abc")],
+        ),
+        (
+            [["1.846619834", "abc"]],
+            [("dec", "varchar(255)"), ("str", "varchar(3)")],
+            [["1.846619834", "abc"]],
+        ),
+    ],
+)
+def test_column_type_mutator(
+    data: list[Any],
+    description: list[Any],
+    expected_result: list[Any],
+) -> None:
+    """
+    Trino's DBAPI driver can return DECIMAL columns as plain strings.
+    Superset must coerce those back to ``Decimal`` at fetch time so that
+    downstream numeric post-processing (e.g. a pivot with a mean
+    aggregate) doesn't choke on a string value.
+    """
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    mock_cursor = Mock()
+    mock_cursor.fetchall.return_value = data
+    mock_cursor.description = description
+
+    assert TrinoEngineSpec.fetch_data(mock_cursor) == expected_result
 
 
 def test_get_extra_table_metadata(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -343,6 +343,16 @@ def test_convert_dttm(
         ),
         (
             [["1.846619834", "abc"]],
+            [("dec", "decimal(12)"), ("str", "varchar(3)")],
+            [(Decimal("1.846619834"), "abc")],
+        ),
+        (
+            [["1.846619834", "abc"]],
+            [("dec", "decimal"), ("str", "varchar(3)")],
+            [(Decimal("1.846619834"), "abc")],
+        ),
+        (
+            [["1.846619834", "abc"]],
             [("dec", "varchar(255)"), ("str", "varchar(3)")],
             [["1.846619834", "abc"]],
         ),

--- a/tests/unit_tests/db_engine_specs/test_trino.py
+++ b/tests/unit_tests/db_engine_specs/test_trino.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import copy
+import math
 from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
@@ -345,6 +346,16 @@ def test_convert_dttm(
             [("dec", "varchar(255)"), ("str", "varchar(3)")],
             [["1.846619834", "abc"]],
         ),
+        (
+            [["1.846619834", "abc"]],
+            [("val", "double"), ("str", "varchar(3)")],
+            [(1.846619834, "abc")],
+        ),
+        (
+            [[1.846619834, "abc"]],
+            [("val", "real"), ("str", "varchar(3)")],
+            [(1.846619834, "abc")],
+        ),
     ],
 )
 def test_column_type_mutator(
@@ -365,6 +376,36 @@ def test_column_type_mutator(
     mock_cursor.description = description
 
     assert TrinoEngineSpec.fetch_data(mock_cursor) == expected_result
+
+
+@pytest.mark.parametrize(
+    "string_value,expected_float",
+    [
+        ("NaN", math.nan),
+        ("Infinity", math.inf),
+        ("-Infinity", -math.inf),
+    ],
+)
+def test_column_type_mutator_double_special_values(
+    string_value: str, expected_float: float
+) -> None:
+    """
+    Trino's wire protocol has no JSON literal for NaN/Infinity/-Infinity, so
+    REAL/DOUBLE columns holding those values arrive as quoted strings. They
+    must be coerced back to real floats, same as string-typed DECIMALs.
+    """
+    from superset.db_engine_specs.trino import TrinoEngineSpec
+
+    mock_cursor = Mock()
+    mock_cursor.fetchall.return_value = [[string_value]]
+    mock_cursor.description = [("val", "double")]
+
+    (result_value,) = TrinoEngineSpec.fetch_data(mock_cursor)[0]
+    assert isinstance(result_value, float)
+    if math.isnan(expected_float):
+        assert math.isnan(result_value)
+    else:
+        assert result_value == expected_float
 
 
 def test_get_extra_table_metadata(mocker: MockerFixture) -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Trino's DBAPI driver can return `DECIMAL`-typed values as plain strings instead of `Decimal`. Superset's generic `column_type_mutators` hook in `BaseEngineSpec.fetch_data()` already handles this for MySQL's `DECIMAL` type, but was never wired up for Trino.

Presto/Trino's coordinator also sends results as JSON, which has no literal for `NaN`/`Infinity`/`-Infinity`, so `REAL`/`DOUBLE` columns holding those values arrive as quoted strings too. `pyhive` (Presto's driver) only auto-converts `decimal`/`varbinary`, not `double`/`real`, so `PrestoEngineSpec` is exposed to this same class of bug.

Symptom: numeric metrics (e.g. `approx_percentile`) intermittently crash with `TypeError: Could not convert string '1.846619834'` (or `'NaN'`) `to numeric` whenever post-processing numerically aggregates the affected column (e.g. a pivot's `mean`).

Fix: register a `DECIMAL` mutator on `TrinoEngineSpec` (Presto's driver already handles decimal itself, so this one is Trino-only) and a shared `FLOAT` mutator on `PrestoBaseEngineSpec` (inherited by both Presto and Trino).


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Added `test_column_type_mutator` + `test_column_type_mutator_double_special_values` to `test_trino.py`, and `test_column_type_mutator_double_special_values` to `test_presto.py`.
- `pytest tests/unit_tests/db_engine_specs/test_trino.py tests/unit_tests/db_engine_specs/test_presto.py` passes (149/149).
- `ruff check` clean on changed files.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
