### PR TITLE
chore(deps-dev): bump nwsapi from 2.2.23 to 2.2.24 to fix the SqlEditor jest flake

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -30733,9 +30733,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
     },

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -416,7 +416,7 @@
       "brace-expansion": ">=5.0.8"
     },
     "nanoid@>=3 <4": "3.3.18",
-    "nwsapi": "^2.2.13",
+    "nwsapi": "^2.2.24",
     "puppeteer": "^22.4.1",
     "tar": "^7.5.16",
     "typescript-json-schema": "^0.68.0",


### PR DESCRIPTION
### SUMMARY

Fixes the `sharded-jest-tests (3)` flake in `SqlEditor.test.tsx` (`SyntaxError: 'button,,,,,,<id>-more.ant-tabs-nav-more .ant-tabs-tab-btn:focus-visible' is not a valid selector`) that has been costing unrelated PRs a re-run since ~08-27 (#42760, #43633, #43619, others).

Root cause is upstream: nwsapi 2.2.23's `:has()` resolver rewrites `:scope` into a malformed reference selector (dperini/nwsapi#157, closed 2026-07-10). jsdom reaches it while matching antd's Tabs rule `.ant-tabs-tab-focus:has(.ant-tabs-tab-btn:focus-visible)` during React Testing Library's accessible-name computation for the Tabs overflow "more" button — which `findByRole` polling in `SqlEditor.test.tsx` (added by #43330) now exercises. Full analysis and stack in #43656.

Dependency path: `jest-environment-jsdom@30.4.1 → jsdom@26.1.0 → nwsapi@2.2.23`, pinned by the lockfile within the existing `overrides` entry `"nwsapi": "^2.2.13"`. This raises the floor to `^2.2.24` and updates the lock entry. No code or test changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable.

### TESTING INSTRUCTIONS

```
cd superset-frontend && npm ci && npx jest src/SqlLab/components/SqlEditor/SqlEditor.test.tsx
```

Run it several times. On master (nwsapi 2.2.23) roughly one run in three fails with the selector `SyntaxError`; with this change six consecutive runs passed locally (2.2.25 was also verified 6/6). A single `-t` test does not reproduce the flake — the whole file has to run.

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #43656
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

*Analysis and fix produced with AI assistance (Claude); verified locally as described.*
