### PR TITLE
feat(gtf): cancel orphaned warehouse queries + dedicated reaper beat job

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -111,20 +111,22 @@ per-principal messages) instead of the removed async-events streams; see
 Orphaned GTF tasks (a worker killed mid-execution) are now detected and cleaned
 up server-side. While a worker holds a task it writes a liveness heartbeat
 (`tasks.last_heartbeat`, every `GTF_TASK_HEARTBEAT_INTERVAL` seconds, default
-`15`); the existing `prune_tasks` Celery job now reaps any active task whose
-heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default `60`) — revoking its
-Celery job and marking it `FAILURE` so waiters unblock — before its usual
-deletion of old rows. Because reaping rides on `prune_tasks`, enable that beat
-schedule (and run it on a short interval, e.g. every minute) to bound how long an
-orphaned task and its warehouse query can linger. The heartbeat write is issued
-out-of-band and deliberately does not advance `changed_on`.
+`15`); a dedicated `reap_orphaned_tasks` Celery beat job reaps any active task
+whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default `60`) — revoking
+its Celery job, marking it `FAILURE` so waiters unblock, and (on engines that
+support query cancellation) cancelling the abandoned warehouse query out-of-band.
+Enable the `reap_orphaned_tasks` beat schedule on a short interval (e.g. every
+minute); it is separate from `prune_tasks` (a heavier retention delete run
+infrequently). The heartbeat write is issued out-of-band and deliberately does
+not advance `changed_on`.
 
 Async chart-data query tasks are now cancellable: a per-query timeout
 (`GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT`, default `None` = unbounded) or a user
 cancel aborts the task, and on database engines that support query cancellation
 (e.g. PostgreSQL, MySQL, Snowflake, Redshift) the abort also cancels the running
-warehouse query over a fresh connection. Engines without cancel support are
-unaffected — the task is still freed, but the query runs to completion.
+warehouse query over a fresh connection — including when the worker died (the
+reaper cancels it). Engines without cancel support are unaffected — the task is
+still freed, but the query runs to completion.
 
 - `SAMPLES_ROW_LIMIT` is now the default for `/datasource/samples` requests without a valid explicit `per_page`, rather than a hard per-request ceiling; explicit limits are honored up to the existing global row-limit ceiling, matching `/chart/data` SAMPLES requests.
 

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -414,12 +414,12 @@ See `superset/config.py` for a complete example configuration.
 
 ### Orphan Reaping
 
-A task whose worker dies mid-execution (OOM kill, crash, lost broker message) would otherwise stay `IN_PROGRESS` forever. To prevent this, a worker writes a liveness heartbeat while it holds a task, and the `prune_tasks` job reaps orphans (before the retention deletion described above):
+A task whose worker dies mid-execution (OOM kill, crash, lost broker message) would otherwise stay `IN_PROGRESS` forever. To prevent this, a worker writes a liveness heartbeat while it holds a task, and a dedicated `reap_orphaned_tasks` beat job reaps orphans:
 
 - **Heartbeat** — every `GTF_TASK_HEARTBEAT_INTERVAL` seconds (default 15) the executing worker refreshes `tasks.last_heartbeat`. This write is deliberately out-of-band and does not update `changed_on`.
-- **Reaping** — `prune_tasks` marks any active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60) as `FAILURE` so waiters and dependents unblock, and revokes its Celery job so a redelivered copy (with `task_acks_late`) will not run. A task still being worked on keeps a fresh heartbeat and is never reaped, so this never interferes with a live worker's cooperative abort/cleanup.
+- **Reaping** — `reap_orphaned_tasks` marks any active task whose heartbeat is older than `GTF_ORPHAN_TASK_TIMEOUT` (default 60) as `FAILURE` so waiters and dependents unblock, revokes its Celery job so a redelivered copy (with `task_acks_late`) will not run, and — on engines that support query cancellation, when the dead worker had captured a cancel handle — cancels the abandoned warehouse query out-of-band. A task still being worked on keeps a fresh heartbeat and is never reaped, so this never interferes with a live worker's cooperative abort/cleanup.
 
-Because reaping runs inside `prune_tasks`, enable that beat schedule (and run it on a short interval) so orphaned tasks do not linger. Keep `GTF_ORPHAN_TASK_TIMEOUT` comfortably larger than the heartbeat interval (≥ ~3×) so a brief pause or CPU-bound stretch is not mistaken for a dead worker.
+Enable the `reap_orphaned_tasks` beat schedule on a short interval (e.g. every minute) so orphaned tasks — and their warehouse queries — do not linger; it is separate from `prune_tasks` (a heavier retention delete that runs infrequently). Keep `GTF_ORPHAN_TASK_TIMEOUT` comfortably larger than the heartbeat interval (≥ ~3×) so a brief pause or CPU-bound stretch is not mistaken for a dead worker.
 
 :::note Cancelling the underlying query
 For long-running work backed by an external query, register an `on_abort` handler that cancels it (this is how async chart-data query tasks cancel the warehouse query on engines that support cancellation). Without such a handler an abort/timeout frees the task but cannot stop the external work.

--- a/superset-core/src/superset_core/tasks/types.py
+++ b/superset-core/src/superset_core/tasks/types.py
@@ -88,6 +88,13 @@ class TaskProperties(TypedDict, total=False):
     exception_type: str
     stack_trace: str
 
+    # Recovery handles used by the orphan reaper (see superset.commands.tasks.reap):
+    # the Celery job id to revoke, and the engine cancel handle for the running
+    # warehouse query so it can be cancelled out-of-band when the worker is dead.
+    celery_task_id: str
+    cancel_query_id: str
+    cancel_database_id: int
+
 
 @dataclass(frozen=True)
 class TaskOptions:

--- a/superset/commands/tasks/reap.py
+++ b/superset/commands/tasks/reap.py
@@ -91,6 +91,7 @@ class ReapOrphanedTasksCommand(BaseCommand):
             ),
         )
         self._revoke(properties.get("celery_task_id"), stats_logger)
+        self._cancel_orphaned_query(properties)
 
         properties["error_message"] = ORPHAN_ERROR_MESSAGE
         properties["exception_type"] = "OrphanedTaskError"
@@ -139,6 +140,27 @@ class ReapOrphanedTasksCommand(BaseCommand):
             logger.warning(
                 "Failed to revoke Celery task %s", celery_task_id, exc_info=True
             )
+
+    def _cancel_orphaned_query(self, properties: TaskProperties) -> None:
+        """Cancel the abandoned warehouse query, if one was captured.
+
+        The dead worker can't run its own ``on_abort`` handler, so the reaper
+        cancels out-of-band from the persisted handle (only present for engines
+        that expose a cancel id before execution). Best-effort: no handle, a
+        missing database, or a cancel failure never blocks the FAILURE transition.
+        """
+        cancel_query_id = properties.get("cancel_query_id")
+        database_id = properties.get("cancel_database_id")
+        if not cancel_query_id or database_id is None:
+            return
+
+        from superset.models.core import Database
+        from superset.tasks.query_cancel import cancel_chart_query
+
+        database = db.session.get(Database, database_id)
+        if database is None:
+            return
+        cancel_chart_query(database, cancel_query_id)
 
     def validate(self) -> None:
         pass

--- a/superset/config.py
+++ b/superset/config.py
@@ -1844,13 +1844,20 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         #     "schedule": crontab(minute="*", hour="*"),
         #     "kwargs": {"retention_period_days": 180, "max_rows_per_run": 10000},
         # },
-        # Uncomment to enable pruning of the tasks table. This job also reaps
-        # orphaned GTF tasks (abandoned by a dead worker) before deleting old
-        # rows, so run it on a short interval — reaping latency tracks this
-        # cadence, and an abandoned warehouse query keeps running until reaped.
+        # Uncomment to enable reaping of orphaned GTF tasks — active tasks whose
+        # worker died without finishing them. Runs on a short interval (reaping
+        # latency, incl. cancelling an abandoned warehouse query, tracks this
+        # cadence). Independent of prune_tasks below, which is a heavy retention
+        # delete better run infrequently.
+        # "reap_orphaned_tasks": {
+        #     "task": "reap_orphaned_tasks",
+        #     "schedule": crontab(minute="*", hour="*"),
+        # },
+        # Uncomment to enable pruning of the tasks table (retention delete of old
+        # terminal rows).
         # "prune_tasks": {
         #     "task": "prune_tasks",
-        #     "schedule": crontab(minute="*", hour="*"),
+        #     "schedule": crontab(minute=0, hour=0),
         #     "kwargs": {"retention_period_days": 90, "max_rows_per_run": 10000},
         # },
         # Uncomment to enable pruning of expired entries from the key-value store
@@ -3247,14 +3254,15 @@ TASK_ABORT_POLLING_DEFAULT_INTERVAL = 10
 TASK_PROGRESS_UPDATE_THROTTLE_INTERVAL = 2  # seconds
 
 # GTF worker-liveness heartbeat. While a worker holds a task it bumps
-# tasks.last_heartbeat every GTF_TASK_HEARTBEAT_INTERVAL seconds. The prune cron
-# (prune_tasks) reaps any ACTIVE task whose heartbeat is older than
-# GTF_ORPHAN_TASK_TIMEOUT — a worker that died mid-execution — by marking it
-# FAILURE (releasing waiters) and revoking its Celery job. A task still being
-# worked on keeps a fresh heartbeat and is left to its own cooperative abort, so
-# reaping never interferes with a live worker. Keep the timeout comfortably
-# larger than the interval (>= ~3x) so a brief GC pause or CPU-bound stretch does
-# not look like a dead worker. Reaping only runs when the prune_tasks beat
+# tasks.last_heartbeat every GTF_TASK_HEARTBEAT_INTERVAL seconds. The
+# reap_orphaned_tasks beat job reaps any ACTIVE task whose heartbeat is older
+# than GTF_ORPHAN_TASK_TIMEOUT — a worker that died mid-execution — by marking it
+# FAILURE (releasing waiters), revoking its Celery job, and, on engines that
+# support it, cancelling the abandoned warehouse query. A task still being worked
+# on keeps a fresh heartbeat and is left to its own cooperative abort, so reaping
+# never interferes with a live worker. Keep the timeout comfortably larger than
+# the interval (>= ~3x) so a brief GC pause or CPU-bound stretch does not look
+# like a dead worker. Reaping only runs when the reap_orphaned_tasks beat
 # schedule is enabled (see CELERY_CONFIG.beat_schedule).
 GTF_TASK_HEARTBEAT_INTERVAL = 15  # seconds
 GTF_ORPHAN_TASK_TIMEOUT = 60  # seconds

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -156,6 +156,11 @@ def _capture_query_cancellation(query_context: "QueryContext") -> Iterator[None]
             return
         captured = True
 
+        # Persist the handle so the orphan reaper can cancel the query if this
+        # worker dies. Set it before on_abort: registering the first handler
+        # flushes the whole property cache, persisting the handle in that write.
+        ctx.set_cancellation(database.id, cancel_id)
+
         # Registering the first abort handler marks the task abortable and starts
         # the abort listener; on abort it cancels the query on a fresh connection.
         def _cancel() -> None:

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -374,6 +374,19 @@ class TaskContext(CoreTaskContext):
             properties=self._properties_cache,
         ).run()
 
+    def set_cancellation(self, database_id: int, cancel_query_id: str) -> None:
+        """Record the engine cancel handle for the running warehouse query.
+
+        Merges the handle into the properties cache **without** writing: the task
+        registers its abort handler immediately after (see ``on_abort`` /
+        ``_set_abortable``), whose write flushes the whole cache, so the handle is
+        persisted together with ``is_abortable`` in that one UPDATE — no extra
+        write. The orphan reaper reads it to cancel the query out-of-band when
+        this worker dies; the live abort path uses its in-memory closure instead.
+        """
+        self._properties_cache["cancel_database_id"] = database_id
+        self._properties_cache["cancel_query_id"] = cancel_query_id
+
     def _start_abort_listener(self, interval: float) -> None:
         """
         Start background abort listener via TaskManager.

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -261,17 +261,27 @@ def prune_tasks(
             "retention period, please use `kwargs` instead."
         )
 
-    # Reap first: revoke + fail tasks abandoned by a dead/wedged worker so they
-    # reach a terminal state, then let the retention pass below delete old rows.
-    try:
-        ReapOrphanedTasksCommand().run()
-    except CommandException as ex:
-        logger.exception("An error occurred while reaping orphaned tasks: %s", ex)
-
     try:
         TaskPruneCommand(retention_period_days, max_rows_per_run).run()
     except CommandException as ex:
         logger.exception("An error occurred while pruning async tasks: %s", ex)
+
+
+@celery_app.task(name="reap_orphaned_tasks", bind=True)
+def reap_orphaned_tasks(self: Task, **kwargs: Any) -> None:
+    """Recover tasks abandoned by a worker that stopped refreshing its heartbeat.
+
+    Runs on its own (short) beat schedule, separate from ``prune_tasks``: reaping
+    wants to detect a dead worker — and cancel its warehouse query — promptly,
+    whereas the retention prune is a heavy, infrequent bulk delete.
+    """
+    stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
+    stats_logger.incr("reap_orphaned_tasks")
+
+    try:
+        ReapOrphanedTasksCommand().run()
+    except CommandException as ex:
+        logger.exception("An error occurred while reaping orphaned tasks: %s", ex)
 
 
 @celery_app.task(name="prune_key_value", bind=True)

--- a/tests/integration_tests/tasks/commands/test_reap.py
+++ b/tests/integration_tests/tasks/commands/test_reap.py
@@ -27,7 +27,15 @@ from superset.models.tasks import Task
 from superset.tasks.utils import naive_utcnow
 
 
-def _make_task(admin, key, status, *, heartbeat_offset=None, celery_task_id=None):
+def _make_task(
+    admin,
+    key,
+    status,
+    *,
+    heartbeat_offset=None,
+    celery_task_id=None,
+    cancel_handle=None,
+):
     """Create a task in a given state with an optional heartbeat age (seconds)."""
     task = TaskDAO.create_task(
         task_type="test_type",
@@ -41,6 +49,11 @@ def _make_task(admin, key, status, *, heartbeat_offset=None, celery_task_id=None
         task.last_heartbeat = naive_utcnow() - timedelta(seconds=heartbeat_offset)
     if celery_task_id is not None:
         task.update_properties({"celery_task_id": celery_task_id})
+    if cancel_handle is not None:
+        database_id, cancel_query_id = cancel_handle
+        task.update_properties(
+            {"cancel_database_id": database_id, "cancel_query_id": cancel_query_id}
+        )
     db.session.commit()
     return task
 
@@ -116,5 +129,39 @@ def test_reap_marks_orphan_failed_and_revokes(app_context, get_user, login_as) -
         assert orphan.status == TaskStatus.FAILURE.value
         assert orphan.ended_at is not None
         assert orphan.properties_dict["error_message"] == ORPHAN_ERROR_MESSAGE
+    finally:
+        _cleanup(orphan)
+
+
+def test_reap_cancels_orphaned_query_when_handle_present(
+    app_context, get_user, login_as
+) -> None:
+    """A reaped orphan with a persisted cancel handle → the query is cancelled."""
+    from superset.models.core import Database
+
+    login_as("admin")
+    admin = get_user("admin")
+    database = db.session.query(Database).first()
+    assert database is not None
+    orphan = _make_task(
+        admin,
+        "orphan_with_query",
+        TaskStatus.IN_PROGRESS,
+        heartbeat_offset=600,
+        cancel_handle=(database.id, "backend-pid-42"),
+    )
+    try:
+        with (
+            patch("superset.commands.tasks.reap.celery_app"),
+            patch("superset.tasks.query_cancel.cancel_chart_query") as cancel,
+        ):
+            ReapOrphanedTasksCommand().run()
+
+        cancel.assert_called_once()
+        called_db, called_id = cancel.call_args.args
+        assert called_db.id == database.id
+        assert called_id == "backend-pid-42"
+        db.session.refresh(orphan)
+        assert orphan.status == TaskStatus.FAILURE.value
     finally:
         _cleanup(orphan)

--- a/tests/unit_tests/tasks/test_query_cancel.py
+++ b/tests/unit_tests/tasks/test_query_cancel.py
@@ -152,6 +152,11 @@ def test_capture_registers_abort_handler_once_when_id_available() -> None:
             sink(MagicMock())  # second cursor -> no double registration
 
     ctx.on_abort.assert_called_once()
+    # The handle is persisted (for the orphan reaper) before on_abort, whose
+    # write flushes it — assert both the call and the ordering.
+    ctx.set_cancellation.assert_called_once_with(qc.datasource.database.id, "42")
+    ordered = [c[0] for c in ctx.method_calls]
+    assert ordered.index("set_cancellation") < ordered.index("on_abort")
 
 
 def test_capture_skips_abort_handler_when_engine_has_no_cancel_id() -> None:
@@ -169,6 +174,25 @@ def test_capture_skips_abort_handler_when_engine_has_no_cancel_id() -> None:
             sink(MagicMock())
 
     ctx.on_abort.assert_not_called()
+    ctx.set_cancellation.assert_not_called()
+
+
+def test_task_context_set_cancellation_merges_into_properties_cache() -> None:
+    from superset.tasks.context import TaskContext
+
+    task = MagicMock()
+    task.uuid = "u"
+    task.properties_dict = {"is_abortable": False}
+    task.payload_dict = {}
+    ctx = TaskContext(task)
+
+    ctx.set_cancellation(7, "42")
+
+    # Merged into the cache (no write); a later _set_abortable flush persists them
+    # together, and existing cached keys are preserved.
+    assert ctx._properties_cache["cancel_database_id"] == 7
+    assert ctx._properties_cache["cancel_query_id"] == "42"
+    assert ctx._properties_cache["is_abortable"] is False
 
 
 def test_capture_is_noop_without_a_database() -> None:

--- a/tests/unit_tests/tasks/test_reap.py
+++ b/tests/unit_tests/tasks/test_reap.py
@@ -26,6 +26,7 @@ from superset.commands.tasks.reap import ORPHAN_ERROR_MESSAGE, ReapOrphanedTasks
 from superset.utils import json
 
 TEST_UUID = UUID("b8b61b7b-1cd3-4a31-a74a-0a95341afc06")
+_UNSET = object()
 
 
 @contextmanager
@@ -89,3 +90,71 @@ def test_missing_celery_id_skips_revoke_but_still_reaps() -> None:
     assert reaped == 1
     celery.control.revoke.assert_not_called()
     publish.assert_called_once_with(TEST_UUID, TaskStatus.FAILURE.value)
+
+
+@contextmanager
+def _patched_with_handle(properties: str, database: object = _UNSET):
+    """Patch collaborators with a specific serialized `properties` blob."""
+    stats = MagicMock()
+    app = MagicMock()
+    app.config = {"STATS_LOGGER": stats, "GTF_ORPHAN_TASK_TIMEOUT": 60}
+    resolved_db = MagicMock() if database is _UNSET else database
+    with (
+        patch("superset.commands.tasks.reap.current_app", app),
+        patch("superset.commands.tasks.reap.db") as db,
+        patch("superset.daos.tasks.TaskDAO.find_orphaned", return_value=[TEST_UUID]),
+        patch(
+            "superset.daos.tasks.TaskDAO.conditional_status_update", return_value=True
+        ),
+        patch("superset.commands.tasks.reap.celery_app"),
+        patch("superset.tasks.manager.TaskManager.publish_completion"),
+        patch("superset.tasks.manager.TaskManager.publish_entity_change"),
+        patch("superset.tasks.query_cancel.cancel_chart_query") as cancel,
+    ):
+        db.session.query.return_value.filter.return_value.scalar.return_value = (
+            properties
+        )
+        db.session.get.return_value = resolved_db
+        yield cancel, resolved_db
+
+
+def test_orphaned_query_is_cancelled_when_handle_present() -> None:
+    """A persisted cancel handle → the reaper cancels the abandoned query."""
+    properties = json.dumps(
+        {"celery_task_id": "c1", "cancel_query_id": "42", "cancel_database_id": 7}
+    )
+    with _patched_with_handle(properties) as (cancel, database):
+        assert ReapOrphanedTasksCommand().run() == 1
+
+    cancel.assert_called_once_with(database, "42")
+
+
+def test_no_cancel_when_handle_absent() -> None:
+    """No cancel handle in properties → no query cancellation attempted."""
+    with _patched_with_handle(json.dumps({"celery_task_id": "c1"})) as (cancel, _db):
+        assert ReapOrphanedTasksCommand().run() == 1
+
+    cancel.assert_not_called()
+
+
+def test_no_cancel_when_database_missing() -> None:
+    """Handle present but the database is gone → skip cancel, still reap."""
+    properties = json.dumps({"cancel_query_id": "42", "cancel_database_id": 7})
+    with _patched_with_handle(properties, database=None) as (cancel, _db):
+        assert ReapOrphanedTasksCommand().run() == 1
+
+    cancel.assert_not_called()
+
+
+def test_reap_orphaned_tasks_beat_task_delegates_to_command() -> None:
+    """The reap_orphaned_tasks beat task runs the reaper (its own schedule)."""
+    from superset.tasks.scheduler import reap_orphaned_tasks
+
+    with (
+        patch("superset.tasks.scheduler.current_app") as app,
+        patch("superset.tasks.scheduler.ReapOrphanedTasksCommand") as cmd,
+    ):
+        app.config = {"STATS_LOGGER": MagicMock()}
+        reap_orphaned_tasks()
+
+    cmd.return_value.run.assert_called_once()


### PR DESCRIPTION
### SUMMARY

Follow-up to #43627 (merged), closing the one gap it explicitly deferred and tightening the reaper's schedule.

**1. Cancel the orphaned warehouse query.** #43627 made async chart-data query tasks cancellable *while the worker is alive* (an `on_abort` handler runs `db_engine_spec.cancel_query` over a fresh connection). But when a **worker dies**, there's no live thread to run that handler, so the reaper only marked the `Task` `FAILURE` and revoked the Celery job — the abandoned warehouse query kept running until the warehouse's own statement/idle timeout. Now the reaper cancels it out-of-band.

**2. Dedicated reaper beat job.** Reaping was folded into `prune_tasks`. Reaping wants a *short* cadence (detect a dead worker — and cancel its query — within ~a minute); retention pruning is a heavy, infrequent bulk DELETE. One shared cadence can't serve both, so reaping now runs on its own `reap_orphaned_tasks` beat schedule.

#### How the orphan-cancel works

The reaper runs in a different process from the dead worker, so the engine cancel-id must be on the `Task` row:

- **Persist at capture** — when the capture sink obtains a cancel-id, `TaskContext.set_cancellation(database_id, cancel_id)` merges `{cancel_database_id, cancel_query_id}` into the property cache. It does **not** write: the task registers its abort handler immediately after, and that `is_abortable` write already flushes the whole cache — so the handle is persisted in an existing write, **no extra DB write** on the hot path. Only engines that expose a cancel-id before execution (Postgres/MySQL/Snowflake/Redshift, as in the live path) persist a handle.
- **Reaper cancels** — `ReapOrphanedTasksCommand._reap` reads the handle, loads the `Database`, and reuses the existing `cancel_chart_query(database, cancel_id)` helper (fresh connection, id validation, `gtf.query.cancel` / `gtf.query.cancel_failed` metrics) **before** the revoke + CAS→`FAILURE`. Best-effort: no handle, a missing database, or a cancel failure never blocks the FAILURE transition. A dead worker holds no lock on the row, so this is race-free.

No new helper, config key, or migration — `cancel_chart_query` and the reaper already exist; this reuses them. The live abort path is unchanged (it still uses the in-memory closure).

#### Scheduling change

- `reap_orphaned_tasks` is a new Celery beat task; `prune_tasks` reverts to retention-only. `CELERY_CONFIG.beat_schedule` gains a commented `reap_orphaned_tasks` template on a short interval (e.g. every minute), separate from the `prune_tasks` retention template. Docs/UPDATING updated.

### TESTING INSTRUCTIONS

- Unit (`tests/unit_tests/tasks/`): `TaskContext.set_cancellation` merges the handle into the cache (persisted by the ensuing `is_abortable` write, existing keys preserved); the capture sink calls `set_cancellation` before `on_abort` (and neither without a cancel-id); `_reap` calls `cancel_chart_query` with the persisted `(database, cancel_id)` when present, skips it when absent or the database is gone, and reaps regardless; `reap_orphaned_tasks` delegates to the command.
- Integration (`tests/integration_tests/tasks/commands/test_reap.py`): an orphan with a persisted handle → the reaper invokes `cancel_chart_query` with the loaded `Database` and still ends the row `FAILURE`.
- Manual (Celery worker + `reap_orphaned_tasks` beat + `DISTRIBUTED_COORDINATION_CONFIG`, a cancellable engine like Postgres): run an async chart query, `kill -9` the worker mid-query → within `GTF_ORPHAN_TASK_TIMEOUT` the task is `FAILURE` and the backend query is gone from `pg_stat_activity`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_TASK_FRAMEWORK` (async chart data also needs `GLOBAL_ASYNC_QUERIES`)
- [ ] Changes UI
- [ ] Includes DB Migration (the `cancel_*` handle lives in the existing `properties` JSON blob — no schema change)
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
