### PR TITLE
fix(plugin-chart-echarts): misplaced first date label on horizontal bar charts

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -1276,10 +1276,15 @@ export default function transformProps(
       // at the axis boundary.
       ...(showMaxLabel && {
         showMaxLabel: true,
-        alignMaxLabel: 'right',
         showMinLabel: true,
-        alignMinLabel: 'left',
       }),
+      // The alignments assume the axis runs along the bottom; a horizontal
+      // chart puts this axis on the side, where they misplace the labels.
+      ...(showMaxLabel &&
+        !isHorizontal && {
+          alignMaxLabel: 'right',
+          alignMinLabel: 'left',
+        }),
     },
     minorTick: { show: minorTicks },
     axisTick: { show: axisTicks ? 'auto' : false },

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -2839,3 +2839,46 @@ test('applies gridlines to the value axis after a horizontal orientation swaps i
   // and the gridlines belonging to it — end up on xAxis.
   expect((echartOptions.xAxis as any).splitLine.show).toBe(false);
 });
+
+test('boundary label alignment is dropped when the orientation moves the time axis to the side', () => {
+  // The alignments position labels against the left and right edges of a
+  // bottom axis. A horizontal chart swaps the axes, so applying them there
+  // shifts the first label out of line with the rest (#43428 follow-up).
+  const monthData = [
+    { __timestamp: Date.UTC(2003, 4, 1), sales: 100 },
+    { __timestamp: Date.UTC(2003, 5, 1), sales: 200 },
+  ];
+  const build = (orientation: OrientationType) =>
+    transformProps(
+      createTestChartProps({
+        formData: {
+          granularity_sqla: 'ds',
+          timeGrainSqla: TimeGranularity.MONTH,
+          xAxisTimeFormat: 'smart_date',
+          seriesType: EchartsTimeseriesSeriesType.Bar,
+          orientation,
+        },
+        queriesData: [
+          createTestQueryData(monthData, {
+            colnames: ['__timestamp', 'sales'],
+            coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+          }),
+        ],
+      }),
+    ).echartOptions;
+
+  const vertical = build(OrientationType.Vertical).xAxis as any;
+  expect(vertical.axisLabel.alignMinLabel).toBe('left');
+  expect(vertical.axisLabel.alignMaxLabel).toBe('right');
+
+  // Horizontal swaps the axes, so the time axis is now yAxis.
+  const horizontal = build(OrientationType.Horizontal).yAxis as any;
+  expect(horizontal.axisLabel.alignMinLabel).toBeUndefined();
+  expect(horizontal.axisLabel.alignMaxLabel).toBeUndefined();
+
+  // The boundary labels themselves stay forced in both orientations.
+  expect(vertical.axisLabel.showMinLabel).toBe(true);
+  expect(vertical.axisLabel.showMaxLabel).toBe(true);
+  expect(horizontal.axisLabel.showMinLabel).toBe(true);
+  expect(horizontal.axisLabel.showMaxLabel).toBe(true);
+});


### PR DESCRIPTION
### SUMMARY

On a bar chart with **Orientation: Horizontal** and a time x-axis, the first
date label sits out of line with the rest and is partly cut off. Every other
label on that axis is fine.

The cause is an alignment written for a bottom axis being applied to one that
has moved to the side. The transform forces the boundary labels on a time axis
so the first and last dates stay visible, and aligns them inward so they do not
overhang the plot area:

```ts
...(showMaxLabel && {
  showMaxLabel: true,
  alignMaxLabel: 'right',
  showMinLabel: true,
  alignMinLabel: 'left',
}),
```

`alignMinLabel: 'left'` / `alignMaxLabel: 'right'` are horizontal text
alignments, correct for an axis running along the bottom: they pull the first
and last labels inward, away from the left and right edges.

But the condition that emits them tests the axis *type*, never the orientation:

```ts
const showMaxLabel =
  xAxisType === AxisType.Time && xAxisLabelRotation === 0 && !!resolvedTimeGrain;
```

A horizontal chart then swaps the axes (`[xAxis, yAxis] = [yAxis, xAxis]`), so
that block lands on a **vertical** axis, where labels normally sit right-aligned
against the axis line. Re-anchoring the minimum label to `'left'` shifts it out
of column with its neighbours. Only the minimum receives `alignMinLabel`, which
is why only the first label moves.

The fix keeps `showMinLabel`/`showMaxLabel` in both orientations — forcing the
boundary dates visible is wanted either way — and applies the alignment only
when the axis is actually along the bottom. There is precedent a few lines
below, where the rotated-label padding compensation is already guarded with
`!isHorizontal`.

Vertical charts are unaffected: `!isHorizontal` is true there, so both spreads
apply and the axis receives the same four properties as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Every label is identically right-aligned in both, except the bottom one:
clipped to "2…" before, a clean "2003" after.

<img width="882" height="1197" alt="label_misplaced_before_after" src="https://github.com/user-attachments/assets/501ab332-bbe7-45ee-8c9a-ce7e967935b4" />


### TESTING INSTRUCTIONS

Unit test: `npm run test -- plugins/plugin-chart-echarts/test/Timeseries/transformProps`

Manually:

1. Build a Bar chart on a temporal column with a time grain set (Month works),
   leave **X Axis label rotation** at 0, and set **Orientation: Horizontal**.
   The first date label lines up with the others.
2. On master, the same chart shows that label shifted sideways and partly cut
   off.
3. Switch back to **Vertical** and confirm nothing has changed: the first and
   last labels are still pulled inward, away from the chart edges.
4. Set **X Axis label rotation** to a non-zero value in either orientation.
   Boundary labels are not forced at all in that case, before or after this
   change.

Note the rotation control is a quick way to confirm the diagnosis rather than
part of the fix: a non-zero rotation makes `showMaxLabel` false, which disables
the whole block.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API