### PR TITLE
chore(deps): bump js-yaml to patch quadratic-CPU DoS (superset-frontend)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -17804,9 +17804,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -26738,9 +26738,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27662,9 +27662,9 @@
       }
     },
     "node_modules/lerna/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -34750,9 +34750,9 @@
       }
     },
     "node_modules/react-diff-viewer-continued/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -38445,9 +38445,9 @@
       "license": "ISC"
     },
     "node_modules/stylelint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -383,6 +383,9 @@
     "@great-expectations/jsonforms-antd-renderers": {
       "antd": "$antd"
     },
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.1"
+    },
     "@jest/globals": "^30.4.0",
     "@jest/types": "^30.4.0",
     "@luma.gl/constants": "~9.2.5",
@@ -392,6 +395,9 @@
     "@luma.gl/shadertools": "~9.2.5",
     "@luma.gl/webgl": "~9.2.5",
     "core-js": "^3.38.1",
+    "cosmiconfig": {
+      "js-yaml": "^4.3.1"
+    },
     "dompurify": "^3.4.13",
     "esbuild": "^0.28.1",
     "eslint-plugin-import": {
@@ -408,9 +414,12 @@
     "jest-mock": "^30.4.0",
     "jest-runtime": "^30.4.0",
     "jest-util": "^30.4.0",
+    "js-yaml-loader": {
+      "js-yaml": "^3.15.1"
+    },
     "jspdf": "^4.2.0",
     "lerna": {
-      "js-yaml": "^4.3.0"
+      "js-yaml": "^4.3.1"
     },
     "minimatch@>=10": {
       "brace-expansion": ">=5.0.8"
@@ -418,6 +427,9 @@
     "nanoid@>=3 <4": "3.3.18",
     "nwsapi": "^2.2.24",
     "puppeteer": "^22.4.1",
+    "react-diff-viewer-continued": {
+      "js-yaml": "^4.3.1"
+    },
     "tar": "^7.5.16",
     "typescript-json-schema": "^0.68.0",
     "underscore": "^1.13.7",


### PR DESCRIPTION
### SUMMARY

Patches Dependabot alerts #1514 and #1513: js-yaml has a quadratic-CPU-consumption DoS in `!!omap` resolution, affecting both the 3.x and 4.x lines (fixed in 3.15.1 and 4.3.1 respectively).

`js-yaml` is transitive-only in `superset-frontend/package-lock.json` — five instances across two major-version lines:

| Instance | Required by | Before | After |
|---|---|---|---|
| top-level (dev) | `@istanbuljs/load-nyc-config`, `js-yaml-loader` | 3.15.0 | 3.15.1 |
| `cosmiconfig` (dev) | cosmiconfig ^4.1.0 | 4.3.0 | 4.3.1 |
| `lerna` (dev) | lerna, hard-pinned | 4.3.0 | 4.3.1 |
| `react-diff-viewer-continued` (runtime) | ^4.2.0 | 4.3.0 | 4.3.1 |
| `stylelint` (dev, via its own cosmiconfig) | ^4.1.0 | 4.3.0 | 4.3.1 |

Added per-consumer overrides in `package.json` rather than one blanket override, since the 3.x and 4.x consumers are on incompatible major versions with a different API (`safeLoad` vs `load`) — a single global override would force one line onto consumers expecting the other.

### TESTING INSTRUCTIONS

Transitive dependency patch only. Confirmed no application code imports `js-yaml` directly — `webpack.config.js` references the separate `js-yaml-loader` package by name (a build-time-only webpack loader for parsing YAML fixtures), not `js-yaml` itself. No new test needed; existing CI is the regression check.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API