### PR TITLE
chore(deps): bump brace-expansion to patch DoS in docs

### DIFF
--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6614,9 +6614,9 @@ boxen@^7.0.0:
     wrap-ansi "^8.1.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
### SUMMARY

`brace-expansion@^1.1.7` (required by `minimatch@3.1.5`, pulled in transitively via `eslint` and `eslint-plugin-react` in `docs/`) was resolved at 1.1.15 — vulnerable to a series of DoS classes fixed progressively through 1.1.16 → 1.1.18:

- unbounded expansion length causing an out-of-memory crash
- exponential-time expansion of consecutive non-expanding braces
- unbounded intermediate arrays bypassing an earlier partial fix for the above

`minimatch`'s own declared range (`^1.1.7`) already permits the patched version — yarn's classic resolver was simply reusing the older lockfile entry rather than re-resolving it, since `yarn install` alone doesn't upgrade a transitive dependency already satisfied by an existing lockfile entry. Bumped in place to 1.1.18.

The other two `brace-expansion` instances already in this lockfile (5.0.7, 5.0.9 — an unrelated major rewrite pulled in elsewhere in the docs toolchain) were already unaffected; these CVEs are scoped to the 1.x line.

Fixes Dependabot alerts #1482, #1477, #1402.

### TESTING INSTRUCTIONS

Transitive lockfile-only version bump — no source or docs content changed, so no new tests are needed. `yarn install` resolves cleanly with no dependency-graph shuffle beyond the one patched entry (diff is 3 changed lines: version, tarball URL, integrity hash). CI's docs build is the regression check.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API