### PR TITLE
fix(dashboard): show loading state on + Dashboard during the create navigation

### DIFF
--- a/superset-frontend/src/features/home/DashboardTable.test.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.test.tsx
@@ -249,8 +249,16 @@ test('handles create dashboard button click', async () => {
   );
 
   const createButton = screen.getByRole('button', { name: /dashboard$/i });
+  // No pending state before the click — the button is idle.
+  expect(createButton).not.toHaveClass('ant-btn-loading');
   await userEvent.click(createButton);
   expect(assignMock).toHaveBeenCalledWith('/dashboard/new/');
+  // /dashboard/new/ is a hard navigation whose GET creates the dashboard
+  // server-side; the button must show a loading state for the whole
+  // round-trip instead of looking dead (issue #43385).
+  await waitFor(() => {
+    expect(createButton).toHaveClass('ant-btn-loading');
+  });
   locationSpy.mockRestore();
 });
 

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -92,6 +92,11 @@ function DashboardTable({
   const [activeTab, setActiveTab] = useState(defaultTab);
   const [preparingExport, setPreparingExport] = useState<boolean>(false);
   const [loaded, setLoaded] = useState<boolean>(false);
+  // Pending "+ Dashboard" navigation feedback — see the matching comment in
+  // pages/DashboardList/index.tsx: /dashboard/new/ is a hard navigation whose
+  // GET creates the dashboard server-side, so the button must show a loading
+  // state until the page unloads instead of looking dead.
+  const [creatingDashboard, setCreatingDashboard] = useState<boolean>(false);
   const [dashboardToDelete, setDashboardToDelete] = useState<Dashboard | null>(
     null,
   );
@@ -202,7 +207,9 @@ function DashboardTable({
             ),
             name: t('Dashboard'),
             buttonStyle: 'secondary',
+            loading: creatingDashboard,
             onClick: () => {
+              setCreatingDashboard(true);
               navigateTo('/dashboard/new/', { assign: true });
             },
           },

--- a/superset-frontend/src/pages/DashboardList/DashboardList.behavior.test.tsx
+++ b/superset-frontend/src/pages/DashboardList/DashboardList.behavior.test.tsx
@@ -26,6 +26,7 @@ import {
   mockDashboards,
   setupMocks,
   renderDashboardList,
+  waitForDashboardsPageReady,
 } from './DashboardList.testHelpers';
 
 jest.setTimeout(30000);
@@ -394,4 +395,33 @@ test('opens delete confirmation from list view trash icon', async () => {
       screen.queryByText(/Are you sure you want to delete/i),
     ).not.toBeInTheDocument();
   });
+});
+
+test('shows a loading state on the + Dashboard button while navigating', async () => {
+  // /dashboard/new/ is a hard navigation (window.location.assign) whose GET
+  // creates the dashboard server-side before redirecting to the editor —
+  // without a pending state the click looks dead for the whole round-trip
+  // on large instances (issue #43385).
+  const assignMock = jest.fn();
+  const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
+    ...window.location,
+    assign: assignMock,
+  } as Location);
+
+  renderDashboardList(mockUser);
+
+  await waitForDashboardsPageReady();
+
+  const createButton = screen.getByRole('button', { name: /dashboard$/i });
+  expect(createButton).not.toHaveClass('ant-btn-loading');
+
+  fireEvent.click(createButton);
+
+  await waitFor(() => {
+    expect(assignMock).toHaveBeenCalledWith('/dashboard/new/');
+  });
+  await waitFor(() => {
+    expect(createButton).toHaveClass('ant-btn-loading');
+  });
+  locationSpy.mockRestore();
 });

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -184,6 +184,12 @@ function DashboardList(props: DashboardListProps) {
   const isMobile = useIsMobile();
   const theme = useTheme();
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  // Tracks the pending "+ Dashboard" navigation: /dashboard/new/ is a hard
+  // navigation (window.location.assign) whose GET creates the dashboard
+  // server-side before redirecting to the editor, so the click can look dead
+  // for the whole round-trip on large instances. Flipping the button into its
+  // loading state gives immediate feedback until the page unloads.
+  const [creatingDashboard, setCreatingDashboard] = useState(false);
   const { roles } = useSelector<any, UserWithPermissionsAndRoles>(
     state => state.user,
   );
@@ -854,7 +860,9 @@ function DashboardList(props: DashboardListProps) {
       icon: <Icons.PlusOutlined iconSize="m" />,
       name: t('Dashboard'),
       buttonStyle: 'primary',
+      loading: creatingDashboard,
       onClick: () => {
+        setCreatingDashboard(true);
         navigateTo('/dashboard/new/', { assign: true });
       },
     });


### PR DESCRIPTION
### Summary

Fixes the UX half of #43385: with ~1000 dashboards, clicking **+ Dashboard** shows no loading indicator and the editor only appears after a long delay, so the click looks dead.

Root cause: the **+ Dashboard** button (Dashboards list `DashboardList/index.tsx` and home table `DashboardTable.tsx`) fires a hard `window.location.assign('/dashboard/new/')`. That GET creates the dashboard server-side (`Dashboard.new()` in `superset/views/dashboard/views.py`: subject lookups, INSERT, commit) before redirecting to the SSR editor page, and the click handler set no pending state — the `SubMenu` button already supports `loading`, it was simply never used.

Fix: flip the button into its loading state before the navigation, on both call sites. The state lives until the page unloads, giving immediate feedback for the whole round-trip. No routing or backend behavior changes.

For the record, the backend slowness in that issue is mostly addressed on master already: the list-payload perf PRs (#29121, #28609, #38567, #36246) are all merged, and `PUT /api/v1/dashboard/<pk>` is O(1) per dashboard. The reporter is on 6.1.0 without those. What remains reproducibly wrong on master is the missing pending state, which this PR fixes.

### Testing

RED first: with the source changes stashed, the two new loading-state assertions fail (`2 failed, 13 passed`); with the fix:

```
cd superset-frontend
npx jest src/pages/DashboardList/ src/features/home/DashboardTable.test.tsx src/features/home/Menu.test.tsx src/features/home/RightMenu.test.tsx --silent
Test Suites: 8 passed, 8 total
Tests:       119 passed, 119 total
Snapshots:   3 passed, 3 total
```

- `DashboardList.behavior.test.tsx` — new test: clicking + Dashboard calls `window.location.assign('/dashboard/new/')` and the button gains `ant-btn-loading` (was absent before the click).
- `DashboardTable.test.tsx` — the existing create-button test now also asserts the loading class appears after the click (and is absent before).

`npx oxlint --config oxlint.json` on the four touched files: no new findings (warning count identical to master). `npm run _format -- --check`: clean.

### Additional context

The existing duplicate-navigation suppression in `navigateTo` (PR #40833) is what makes the loading state safe to leave on: a double-click fires only one `assign`, and the button stays in loading state through the unload.

Fixes #43385