### PR TITLE
feat(gtf): per-tab task subscriptions for cross-tab cancel + async/ws follow-ups

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -103,10 +103,13 @@ secret rotation, set the websocket server's `previousJwtSecret` /
 `WEBSOCKET_JWT_SECRET`. The server is bundled in the official Superset image
 and launched via an alternate entrypoint — no separate image is required:
 `docker run <superset-image> /app/docker/entrypoints/run-websocket.sh` (or the
-opt-in `websocket` profile in `docker compose`). It now consumes Redis Pub/Sub
-channels (`entity-changes:*` broadcast nudges, `realtime:<channel_id>`
-per-principal messages) instead of the removed async-events streams; see
-`superset-websocket/README.md`.
+opt-in `websocket` profile in `docker compose`). It now **subscribes** to the
+Redis Pub/Sub channels `entity-changes:*` (broadcast entity-change nudges) and
+`task-status` (per-principal task-status messages) instead of the removed
+async-events streams, and republishes to browsers on `realtime:<channel_id>`
+after fanout — so a Redis ACL for the websocket server must allow
+`entity-changes:*` and `task-status` (omitting `task-status` prevents task
+updates from reaching clients); see `superset-websocket/README.md`.
 
 Orphaned GTF tasks (a worker killed mid-execution) are now detected and cleaned
 up server-side. While a worker holds a task it writes a liveness heartbeat

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -183,7 +183,9 @@ A task's state lives in three tiers:
      `task.update_framework_private({...})`.
    - `private.task` — freeform, task-type-specific internal handles (e.g. the
      chart-data query task's engine cancel handle,
-     `cancel_query_id`/`cancel_database_id`). Written by task/execution code via
+     `cancel_query_id`/`cancel_database_id`, or a
+     [subscription policy](#per-client-subscriptions-subscription-policies)'s
+     per-client bookkeeping). Written by task/execution code via
      `task.update_task_private({...})`.
    Both namespaces merge independently (a write to one never clobbers the other).
 3. **Results (`payload`)** — end-user-facing task output (intermediate/final):
@@ -283,6 +285,58 @@ The framework automatically skips execution if a task was aborted while pending:
 :::tip
 Always implement an abort handler for long-running tasks. This allows users to cancel unneeded tasks and free up worker capacity for other operations.
 :::
+
+### Per-client subscriptions (subscription policies)
+
+The framework subscribes tasks at **principal grain**: one subscriber row per
+authenticated user (or embedded guest). The abort-vs-unsubscribe decision above
+counts principals. For most task types that is exactly right.
+
+Some task types need a finer grain than the principal. The canonical case is
+async chart-data: a single `SHARED` task is deduplicated across every request
+for the same query, so one user viewing the same chart in **two browser tabs** is
+a single principal with a single subscriber row. If either tab's cancel (an
+explicit cancel, or the navigate-away teardown) were treated as *the* principal
+leaving, it would abort the shared task and kill the other tab's still-pending
+query.
+
+A **subscription policy** lets a task type refine this without the framework
+knowing anything about tabs (or any other per-client grain). Register one on the
+`@task` decorator:
+
+```python
+from superset_core.tasks.subscription import TaskSubscriptionPolicy
+
+class MyConsumerPolicy(TaskSubscriptionPolicy):
+    def on_subscribe(self, task, *, principal, client_ref):
+        # Record this client (e.g. append f"{principal}:{client_ref}" to a list
+        # in task.update_task_private({...})). Called after the framework has
+        # ensured the principal's subscriber row.
+        ...
+
+    def on_unsubscribe(self, task, *, principal, client_ref) -> bool:
+        # Drop this client. Return True if the principal now has no client left
+        # (the framework then proceeds with its normal principal-grain rule:
+        # unsubscribe the principal, and abort if it was the last subscriber);
+        # return False to keep the principal subscribed because another of its
+        # clients is still watching.
+        ...
+
+@task(name="my_task", scope=TaskScope.SHARED, subscription_policy=MyConsumerPolicy())
+def my_task() -> None:
+    ...
+```
+
+Both hooks run in the web request process, inside the lock that serializes
+concurrent submit/cancel for the task, so an implementation can safely
+read-modify-write task state (typically a list under `private.task`, which the
+framework never inspects) without extra locking. `client_ref` is the caller's
+opaque per-client id (for chart-data, the browser tab id sent as `tab_id` on the
+request); it is **not** an authorization token — the framework authorizes the
+calling principal before the policy runs, and the policy only ever records or
+removes entries scoped to that principal. A task type with no policy, or a
+request with no `client_ref`, keeps plain principal-grain behavior. An admin
+**Force abort** always aborts, bypassing the policy.
 
 ## Timeouts
 
@@ -437,6 +491,10 @@ def system_task(): ...
 | `SHARED`  | All subscribers | Last subscriber cancels; others unsubscribe |
 | `SYSTEM`  | Admins only     | Admin cancels                               |
 
+For `SHARED` tasks, "last subscriber" is at principal grain by default; a task
+type can refine cancel to a finer per-client (e.g. per browser tab) grain with a
+[subscription policy](#per-client-subscriptions-subscription-policies).
+
 ## Task Cleanup
 
 Completed tasks accumulate in the database over time. Configure a scheduled prune job to automatically remove old tasks:
@@ -493,13 +551,17 @@ By default, abort detection and sync join-and-wait poll the task row in the meta
 @task(
     name: str | None = None,
     scope: TaskScope = TaskScope.PRIVATE,
-    timeout: int | None = None
+    timeout: int | None = None,
+    subscription_policy: TaskSubscriptionPolicy | None = None,
 )
 ```
 
 - `name`: Task identifier (defaults to function name)
 - `scope`: `PRIVATE`, `SHARED`, or `SYSTEM`
 - `timeout`: Default timeout in seconds (can be overridden via `TaskOptions`)
+- `subscription_policy`: Optional per-client subscription policy that refines the
+  principal-grain cancel decision (see
+  [Per-client subscriptions](#per-client-subscriptions-subscription-policies))
 
 ### TaskContext Methods
 

--- a/superset-core/src/superset_core/tasks/decorators.py
+++ b/superset-core/src/superset_core/tasks/decorators.py
@@ -23,6 +23,7 @@ from superset_core.tasks.types import TaskContext, TaskScope
 
 if TYPE_CHECKING:
     from superset_core.tasks.models import Task
+    from superset_core.tasks.subscription import TaskSubscriptionPolicy
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -32,6 +33,7 @@ def task(
     name: str | None = None,
     scope: TaskScope = TaskScope.PRIVATE,
     timeout: int | None = None,
+    subscription_policy: "TaskSubscriptionPolicy | None" = None,
 ) -> Callable[[Callable[P, R]], "TaskWrapper[P]"]:
     """
     Decorator to register a task.
@@ -46,6 +48,13 @@ def task(
     :param timeout: Optional timeout in seconds. When the timeout is reached,
                     abort handlers are triggered if registered. Can be overridden
                     at call time via TaskOptions(timeout=...).
+    :param subscription_policy: Optional per-client subscription policy. The
+                    framework subscribes tasks at principal grain (one row per
+                    user/guest); a policy refines that with a finer per-client
+                    grain (e.g. one browser tab) so a cancel from one client does
+                    not abort a SHARED task another client of the same principal
+                    is still awaiting. See
+                    ``superset_core.tasks.subscription.TaskSubscriptionPolicy``.
     :returns: TaskWrapper with .schedule() method
 
     Note:

--- a/superset-core/src/superset_core/tasks/models.py
+++ b/superset-core/src/superset_core/tasks/models.py
@@ -120,11 +120,28 @@ class Task(CoreModel):
         """
         raise NotImplementedError("Property will be replaced during initialization")
 
+    @property
+    def properties_dict(self) -> "TaskProperties":
+        """
+        Get the parsed properties as a sparse ``TaskProperties`` dict.
+
+        The canonical read accessor for runtime state and execution config
+        (progress, error info, the internal ``private`` bucket). Always use
+        ``.get()`` since only explicitly-set keys are present.
+
+        Host implementations will replace this property during initialization.
+
+        :returns: Parsed ``TaskProperties`` dict
+        """
+        raise NotImplementedError("Property will be replaced during initialization")
+
     def update_properties(self, updates: "TaskProperties") -> None:
         """
         Update specific properties fields (merge semantics).
 
-        Only updates fields present in the updates dict.
+        Only updates fields present in the updates dict. The ``private`` subtree
+        is merged recursively (its ``framework`` and ``task`` namespaces merge
+        independently), so a write to one namespace never clobbers the other.
 
         Host implementations will replace this method during initialization.
 
@@ -132,6 +149,22 @@ class Task(CoreModel):
 
         Example:
             task.update_properties({"is_abortable": True})
+        """
+        raise NotImplementedError("Method will be replaced during initialization")
+
+    def update_task_private(self, updates: dict[str, Any]) -> None:
+        """
+        Merge keys into the task-owned ``private["task"]`` namespace.
+
+        The freeform, task-type-specific internal namespace (isolated from the
+        framework-owned ``private["framework"]`` keys) for handles a task type
+        needs to persist but that are not task output — e.g. an engine query
+        cancel handle, or a subscription policy's per-client bookkeeping. Never
+        surfaced to user-facing API payloads except in debug mode.
+
+        Host implementations will replace this method during initialization.
+
+        :param updates: Keys to merge into ``private["task"]``
         """
         raise NotImplementedError("Method will be replaced during initialization")
 

--- a/superset-core/src/superset_core/tasks/subscription.py
+++ b/superset-core/src/superset_core/tasks/subscription.py
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Task-type subscription policies for the Global Task Framework (GTF).
+
+The framework's own subscription model is **principal-oriented**: a task has one
+subscriber row per principal (an authenticated user, or an embedded guest keyed
+by a token-derived identity), and cancel/abort decisions are made from that
+principal-grain subscriber count. That model — and everything built on it
+(``TaskFilter`` visibility, ``subscriber_count``, ``raise_for_access``) — is
+intentionally kept free of any finer notion of "who exactly is watching".
+
+Some task types need a finer grain than the principal. The canonical case is
+async chart-data: a single ``SHARED`` task is deduplicated across every request
+for the same ``query_cache_key``, so one user watching it from **two browser
+tabs** is still a single principal. If either tab's "cancel" (an explicit cancel
+or a navigate-away teardown) were treated as *the* principal leaving, it would
+abort the shared task and kill the other tab's still-pending query.
+
+A **subscription policy** lets a task type refine this without the framework
+knowing anything about tabs (or any other per-client grain). A task registers a
+policy on its :func:`superset_core.tasks.decorators.task` decorator; the
+framework invokes it, under the same lock that serializes submit/cancel, at two
+points:
+
+- **on subscribe** — after the framework has ensured the principal's subscriber
+  row (create or dedup-join). The policy records the calling client.
+- **on unsubscribe** — when a principal cancels. The policy drops the calling
+  client and returns whether the principal has *any client left*. ``False`` means
+  "one client detached, keep the principal subscribed and the task running";
+  ``True`` means "the principal's last client is gone" and the framework then
+  applies its normal principal-grain rule (unsubscribe the principal, and abort
+  if it was the last subscriber).
+
+A task type with no policy behaves exactly as before (principal-grain). The
+policy owns its own bookkeeping — the chart-data policy, for instance, stores
+its per-tab set in the task's ``private["task"]`` namespace (see
+:class:`superset_core.tasks.types.PrivateProperties`), which the framework never
+inspects. ``client_ref`` is an opaque, client-supplied identifier (e.g. a
+browser-tab id); it is **not** an authorization token — the framework has
+already authorized the calling principal before the policy runs, and the policy
+only ever records/removes entries scoped to that principal.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from superset_core.tasks.models import Task
+
+
+class TaskSubscriptionPolicy(ABC):
+    """Per-client subscription refinement for a task type (see module docstring).
+
+    Register an instance on the ``@task`` decorator
+    (``@task(..., subscription_policy=MyPolicy())``). Both hooks run in the web
+    request process, inside the distributed lock that serializes concurrent
+    submit/cancel for the task, so an implementation may safely read-modify-write
+    task state (e.g. a list in ``private["task"]``) without additional locking.
+    """
+
+    @abstractmethod
+    def on_subscribe(
+        self,
+        task: "Task",
+        *,
+        principal: str,
+        client_ref: str | None,
+    ) -> None:
+        """Record that ``client_ref`` (a client of ``principal``) joined ``task``.
+
+        Called after the framework has ensured ``principal``'s subscriber row.
+        Should be idempotent: the same ``(principal, client_ref)`` may be
+        submitted more than once (e.g. a resubmit from the same tab).
+
+        :param task: the task being subscribed to
+        :param principal: the calling principal's stable routing id
+            (``user:<id>`` for a user, the guest key for an embedded guest)
+        :param client_ref: the opaque per-client id (e.g. a browser-tab id), or
+            ``None`` when the caller supplied none (the policy should then no-op,
+            preserving principal-grain behavior)
+        """
+
+    @abstractmethod
+    def on_unsubscribe(
+        self,
+        task: "Task",
+        *,
+        principal: str,
+        client_ref: str | None,
+    ) -> bool:
+        """Drop ``client_ref`` and report whether ``principal`` has any client left.
+
+        Called when ``principal`` cancels the task.
+
+        :param task: the task being cancelled
+        :param principal: the calling principal's stable routing id
+        :param client_ref: the opaque per-client id being removed, or ``None``
+        :returns: ``True`` if the framework should proceed to unsubscribe
+            ``principal`` (its last client is gone, or the caller supplied no
+            ``client_ref``); ``False`` to keep ``principal`` subscribed because it
+            still has other clients on this task (a single client detached).
+        """

--- a/superset-frontend/spec/helpers/shim.tsx
+++ b/superset-frontend/spec/helpers/shim.tsx
@@ -87,6 +87,7 @@ setupSupersetClient();
 // and https://github.com/facebook/jest/issues/6814 for more information.
 jest.mock('src/hooks/useTabId', () => ({
   useTabId: () => 1,
+  getTabId: () => 'test-tab-id',
 }));
 
 // Check https://github.com/remarkjs/react-markdown/issues/635

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -49,6 +49,7 @@ import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { AsyncJob, waitForAsyncData } from 'src/middleware/asyncEvent';
+import { getTabId } from 'src/hooks/useTabId';
 import {
   resolveAsyncMode,
   selectAsyncModeOverride,
@@ -460,8 +461,12 @@ const v1ChartDataRequest = async (
     allowDomainSharding,
   }).toString();
 
+  // In async mode, send the tab id so the backend can ref-count this tab as a
+  // consumer of the (shared) chart-data task — a later cancel/navigate-away from
+  // this tab then detaches only this tab rather than aborting a task another tab
+  // of the same user is still awaiting.
   const body = JSON.stringify(
-    asyncMode ? { ...payload, async_mode: true } : payload,
+    asyncMode ? { ...payload, async_mode: true, tab_id: getTabId() } : payload,
   );
 
   const querySettings: QuerySettings = {

--- a/superset-frontend/src/components/Chart/chartActions.test.ts
+++ b/superset-frontend/src/components/Chart/chartActions.test.ts
@@ -599,6 +599,13 @@ describe('chart actions', () => {
         const history = fetchMock.callHistory.calls(`glob:*${MOCK_URL}*`);
         expect(history).toHaveLength(2);
         expect(String(history[1].options.body)).not.toContain('async_mode');
+
+        // The initial async submit carries this tab's id, so the backend can
+        // ref-count the tab as a consumer of the (shared) chart-data task.
+        const initialBody = JSON.parse(String(history[0].options.body));
+        expect(initialBody.async_mode).toBe(true);
+        expect(typeof initialBody.tab_id).toBe('string');
+        expect(initialBody.tab_id.length).toBeGreaterThan(0);
       });
 
       test('re-issues synchronously after async completion, preserving force', async () => {

--- a/superset-frontend/src/hooks/useTabId.test.ts
+++ b/superset-frontend/src/hooks/useTabId.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The global test shim mocks 'src/hooks/useTabId' (BroadcastChannel leaks in
+// jest); use the real implementation here to exercise getTabId itself.
+const { getTabId } = jest.requireActual('src/hooks/useTabId');
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.localStorage.clear();
+});
+
+test('getTabId returns a stable id within the tab', () => {
+  const first = getTabId();
+  expect(first).toBeTruthy();
+  // Repeat calls in the same tab return the same id (persisted in sessionStorage).
+  expect(getTabId()).toBe(first);
+});
+
+test('getTabId reuses an id already stored by the useTabId hook', () => {
+  // The hook persists its id under sessionStorage['tab_id']; getTabId (used by
+  // non-React callers such as the async task middleware) must present the same
+  // id so a tab is identified consistently everywhere.
+  window.sessionStorage.setItem('tab_id', '42');
+  expect(getTabId()).toBe('42');
+});

--- a/superset-frontend/src/hooks/useTabId.ts
+++ b/superset-frontend/src/hooks/useTabId.ts
@@ -25,45 +25,82 @@ import {
 
 const TAB_ID_CHANNEL_NAME = 'tab_id_channel';
 
-const channel: StrictBroadcastChannel<TabIdChannelMessage> =
-  new BroadcastChannel(TAB_ID_CHANNEL_NAME);
+// Constructed lazily (on first hook use) rather than at module load: importing
+// this module must have no side effects, so non-React callers of getTabId (and
+// test environments without BroadcastChannel) don't need the native channel.
+let channel: StrictBroadcastChannel<TabIdChannelMessage> | undefined;
+
+function getChannel(): StrictBroadcastChannel<TabIdChannelMessage> {
+  if (!channel) {
+    channel = new BroadcastChannel(TAB_ID_CHANNEL_NAME);
+  }
+  return channel;
+}
+
+function isStorageAvailable() {
+  try {
+    return window.localStorage && window.sessionStorage;
+  } catch (error) {
+    return false;
+  }
+}
+
+// Fallback id for when storage is unavailable: stable for the page lifetime.
+let fallbackTabId: string | undefined;
+
+function createTabId(): string {
+  let lastTabId;
+  try {
+    lastTabId = window.localStorage.getItem('last_tab_id');
+  } catch (error) {
+    // continue regardless of error
+  }
+  const newTabId = String(lastTabId ? Number.parseInt(lastTabId, 10) + 1 : 1);
+  try {
+    window.sessionStorage.setItem('tab_id', newTabId);
+    window.localStorage.setItem('last_tab_id', newTabId);
+  } catch (error) {
+    // continue regardless of error
+  }
+  return newTabId;
+}
+
+/**
+ * Return this browser tab's stable id, creating (and persisting) one if absent.
+ *
+ * Shared by the `useTabId` hook and non-React callers (e.g. the async task
+ * middleware, which sends it as `tab_id` on chart-data submit/cancel so the
+ * backend can ref-count tabs of a shared task). Both read/write the same
+ * `sessionStorage['tab_id']`, so a tab presents one consistent id everywhere,
+ * whichever runs first.
+ */
+export function getTabId(): string {
+  if (!isStorageAvailable()) {
+    if (!fallbackTabId) {
+      fallbackTabId = nanoid();
+    }
+    return fallbackTabId;
+  }
+  let stored;
+  try {
+    stored = window.sessionStorage.getItem('tab_id');
+  } catch (error) {
+    // continue regardless of error
+  }
+  return stored || createTabId();
+}
 
 export function useTabId() {
   const [tabId, setTabId] = useState<string>();
 
-  function isStorageAvailable() {
-    try {
-      return window.localStorage && window.sessionStorage;
-    } catch (error) {
-      return false;
-    }
-  }
   useEffect(() => {
     if (!isStorageAvailable()) {
       if (!tabId) {
-        setTabId(nanoid());
+        setTabId(getTabId());
       }
       return;
     }
 
-    const updateTabId = () => {
-      let lastTabId;
-      try {
-        lastTabId = window.localStorage.getItem('last_tab_id');
-      } catch (error) {
-        // continue regardless of error
-      }
-      const newTabId = String(
-        lastTabId ? Number.parseInt(lastTabId, 10) + 1 : 1,
-      );
-      try {
-        window.sessionStorage.setItem('tab_id', newTabId);
-        window.localStorage.setItem('last_tab_id', newTabId);
-      } catch (error) {
-        // continue regardless of error
-      }
-      setTabId(newTabId);
-    };
     let storedTabId;
     try {
       storedTabId = window.sessionStorage.getItem('tab_id');
@@ -71,25 +108,25 @@ export function useTabId() {
       // continue regardless of error
     }
     if (storedTabId) {
-      channel.postMessage({
+      getChannel().postMessage({
         type: 'REQUESTING_TAB_ID',
         tabId: storedTabId,
       });
       setTabId(storedTabId);
     } else {
-      updateTabId();
+      setTabId(createTabId());
     }
 
-    channel.onmessage = messageEvent => {
+    getChannel().onmessage = messageEvent => {
       if (messageEvent.data.tabId === tabId) {
         if (messageEvent.data.type === 'REQUESTING_TAB_ID') {
           const message: TabIdChannelMessage = {
             type: 'TAB_ID_DENIED',
             tabId: messageEvent.data.tabId,
           };
-          channel.postMessage(message);
+          getChannel().postMessage(message);
         } else if (messageEvent.data.type === 'TAB_ID_DENIED') {
-          updateTabId();
+          setTabId(createTabId());
         }
       }
     };

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -144,7 +144,12 @@ test('aborting cancels the tasks and rejects with AbortError', async () => {
 
   await expect(promise).rejects.toThrow('Aborted');
   expect(refetch).not.toHaveBeenCalled();
-  expect(fetchMock.callHistory.calls(CANCEL_ENDPOINT)).toHaveLength(1);
+  const cancelCalls = fetchMock.callHistory.calls(CANCEL_ENDPOINT);
+  expect(cancelCalls).toHaveLength(1);
+  // The cancel carries this tab's id so the backend detaches only this tab.
+  const cancelBody = JSON.parse(String(cancelCalls[0].options.body));
+  expect(typeof cancelBody.tab_id).toBe('string');
+  expect(cancelBody.tab_id.length).toBeGreaterThan(0);
 });
 
 test('aborting one chart does not cancel a shared task another chart still awaits', async () => {

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -147,6 +147,39 @@ test('aborting cancels the tasks and rejects with AbortError', async () => {
   expect(fetchMock.callHistory.calls(CANCEL_ENDPOINT)).toHaveLength(1);
 });
 
+test('aborting one chart does not cancel a shared task another chart still awaits', async () => {
+  // Two charts for the same principal join one deduplicated SHARED task (one
+  // backend subscriber). Aborting one must NOT cancel the task while the other
+  // still awaits it — otherwise the server sees the last subscriber leave and
+  // aborts work the surviving chart needs. Cancellation is deferred until the
+  // last local waiter goes away.
+  queueStatuses(); // task never resolves on its own
+  asyncEvent.init(config);
+
+  const controllerA = new AbortController();
+  const controllerB = new AbortController();
+  const a = asyncEvent.waitForAsyncData(
+    { task_ids: ['shared'] },
+    jest.fn(),
+    controllerA.signal,
+  );
+  const b = asyncEvent.waitForAsyncData(
+    { task_ids: ['shared'] },
+    jest.fn(),
+    controllerB.signal,
+  );
+
+  // First abort: the other chart still awaits 'shared', so nothing is cancelled.
+  controllerA.abort();
+  await expect(a).rejects.toThrow('Aborted');
+  expect(fetchMock.callHistory.calls(CANCEL_ENDPOINT)).toHaveLength(0);
+
+  // Second abort: now the last waiter is gone, so the task is cancelled once.
+  controllerB.abort();
+  await expect(b).rejects.toThrow('Aborted');
+  expect(fetchMock.callHistory.calls(CANCEL_ENDPOINT)).toHaveLength(1);
+});
+
 test('settles every request awaiting a deduplicated shared task', async () => {
   // Two concurrent chart requests share the same (deduplicated) task uuid; both
   // must resolve when it completes — the later waiter must not overwrite the first.

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -152,6 +152,18 @@ const cancelTask = (taskId: string) => {
   });
 };
 
+// Cancel only tasks no local waiter still needs. A SHARED task can back several
+// charts for the same principal through a single backend subscriber, so
+// cancelling one chart while another local waiter still awaits the same task id
+// would tell the server the last subscriber left and abort work the other chart
+// needs. Call *after* removing the aborting waiter (or before registering it),
+// so a task id still present in the registry means another waiter depends on it.
+const cancelUnwaitedTasks = (taskIds: string[]) => {
+  taskIds.forEach(taskId => {
+    if (!waitersByTaskId.has(taskId)) cancelTask(taskId);
+  });
+};
+
 // Drop a waiter from the registry entry of every task it was awaiting, so a
 // settled/aborted waiter never leaks and completion of one task can't re-touch it.
 const unregister = (waiter: Waiter) => {
@@ -313,7 +325,7 @@ export const waitForAsyncData = async <T = unknown[]>(
   // waiter exists and be dropped.
   await new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
-      taskIds.forEach(cancelTask);
+      cancelUnwaitedTasks(taskIds);
       reject(new DOMException('Aborted', 'AbortError'));
       return;
     }
@@ -328,7 +340,7 @@ export const waitForAsyncData = async <T = unknown[]>(
     if (signal) {
       waiter.onAbort = () => {
         unregister(waiter);
-        taskIds.forEach(cancelTask);
+        cancelUnwaitedTasks(taskIds);
         reject(new DOMException('Aborted', 'AbortError'));
       };
       signal.addEventListener('abort', waiter.onAbort, { once: true });

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -34,6 +34,7 @@ import {
 } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { getTabId } from 'src/hooks/useTabId';
 import {
   connectRealtime,
   subscribeRealtime,
@@ -145,8 +146,14 @@ const cancelTask = (taskId: string) => {
   // Best-effort task abort/unsubscribe. This can prevent pending work from
   // starting, but chart tasks do not cancel an underlying warehouse query after
   // execution starts. Failures are non-fatal: the client has stopped waiting.
+  //
+  // Send this tab's id so the backend detaches only this tab from a shared task:
+  // if another tab of the same user is still watching it, the task keeps running
+  // and only aborts once its last tab leaves.
   SupersetClient.post({
     endpoint: `/api/v1/task/${taskId}/cancel`,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tab_id: getTabId() }),
   }).catch(error => {
     logging.warn('Failed to cancel task', taskId, error);
   });

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -200,9 +200,12 @@ this server's `config.json` (or its environment-variable overrides):
 | Cookie name                 | `WEBSOCKET_JWT_COOKIE_NAME` | `jwtCookieName` / `JWT_COOKIE_NAME`         |
 
 The Redis connection (`redis` / `REDIS_*`) must point at the same Redis instance
-Superset publishes to (`DISTRIBUTED_COORDINATION_CONFIG`). The Pub/Sub channel
-prefixes (`entity-changes:`, `realtime:`) are a fixed wire-protocol contract with
-the backend producer and are not configurable.
+Superset publishes to (`DISTRIBUTED_COORDINATION_CONFIG`). The channels the server
+**subscribes** to (`entity-changes:*` and `task-status`) are a fixed wire-protocol
+contract with the backend producer and are not configurable; the server
+republishes to browsers on the derived `realtime:<channel_id>` channel. A Redis
+ACL for this server must therefore allow subscribing to `entity-changes:*` and
+`task-status`.
 
 ## StatsD monitoring
 

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -56,6 +56,7 @@ from superset.exceptions import QueryObjectValidationError, SupersetSecurityExce
 from superset.extensions import cache_manager, event_logger
 from superset.models.sql_lab import Query
 from superset.tasks.async_queries import submit_chart_data_query_tasks
+from superset.tasks.guest import get_current_guest_subscriber_key
 from superset.utils import json
 from superset.utils.core import (
     create_zip,
@@ -361,6 +362,15 @@ class ChartDataRestApi(ChartRestApi):
         refused for it and the request runs synchronously — otherwise every chart
         would schedule tasks, succeed, and then loop on an uncacheable re-request.
 
+        Async also requires a subscribe-able identity — an authenticated user or
+        an embedded guest — because the task is observed/cancelled through a
+        per-principal subscription (see ``superset.tasks.subscription``). A fully
+        anonymous request (public dashboard viewed directly, no login and no guest
+        token) has no principal, so it would schedule a task it could never poll
+        or cancel; those requests run synchronously instead. Public async delivery
+        is supported via guest tokens (embedded dashboards), which do have a
+        principal.
+
         The eligibility check reads :meth:`QueryContext.get_cache_timeout`, which
         only resolves the explicitly configured chart/dataset/database TTL. That is
         deliberately the un-floored value: only an explicit
@@ -375,6 +385,10 @@ class ChartDataRestApi(ChartRestApi):
             and query_context.result_type == ChartDataResultType.FULL
             and query_context.get_cache_timeout() != CACHE_DISABLED_TIMEOUT
             and not isinstance(cache_manager.data_cache.cache, NullCache)
+            and (
+                get_user_id() is not None
+                or get_current_guest_subscriber_key() is not None
+            )
         )
 
     def _run_async(

--- a/superset/commands/tasks/cancel.py
+++ b/superset/commands/tasks/cancel.py
@@ -35,6 +35,8 @@ from superset.extensions import security_manager
 from superset.stats_logger import BaseStatsLogger
 from superset.tasks.guest import get_guest_subscriber_key_for
 from superset.tasks.locks import task_lock
+from superset.tasks.registry import TaskRegistry
+from superset.tasks.subscription import principal_channel
 from superset.tasks.utils import get_active_dedup_key
 from superset.utils.core import get_user_id
 from superset.utils.decorators import on_error, transaction
@@ -63,17 +65,24 @@ class CancelTaskCommand(BaseCommand):
     we only fetch the task once, then validate permissions on the fetched data.
     """
 
-    def __init__(self, task_uuid: UUID, force: bool = False):
+    def __init__(self, task_uuid: UUID, force: bool = False, tab_id: str | None = None):
         """
         Initialize the cancel command.
 
         :param task_uuid: UUID of the task to cancel
         :param force: If True, force abort even with multiple subscribers (admin only)
+        :param tab_id: Opaque per-client (e.g. browser-tab) id, when the caller
+            advertised one. Passed to the task type's subscription policy so a
+            cancel from one client of a principal detaches only that client rather
+            than aborting a SHARED task the principal's other clients still await
+            (see ``superset.tasks.subscription``). ``None`` keeps principal-grain
+            behavior.
         """
         self._task_uuid = task_uuid
         self._force = force
+        self._tab_id = tab_id
         self._action_taken: str = (
-            "cancelled"  # Will be set to 'aborted' or 'unsubscribed'
+            "cancelled"  # Will be set to 'aborted', 'unsubscribed', or 'detached'
         )
         self._should_publish_abort: bool = False
 
@@ -221,11 +230,39 @@ class CancelTaskCommand(BaseCommand):
         :returns: The updated task model
         """
         user_id = get_user_id()
+        force_abort = is_admin and self._force
 
-        # Determine action based on task scope and force flag
+        # Per-client subscription policy pre-gate. A task type may track a finer
+        # grain than the principal (e.g. one browser tab per client); consult it
+        # first so a cancel from one client of a principal detaches only that
+        # client, keeping the (SHARED) task running for the principal's other
+        # clients. Skipped for an admin force-abort, which must terminate the task
+        # regardless of how many clients are watching.
+        if not force_abort and (
+            policy := TaskRegistry.get_subscription_policy(task.task_type)
+        ):
+            guest_key = get_guest_subscriber_key_for(user_id)
+            principal = principal_channel(user_id, guest_key)
+            if principal is not None and not policy.on_unsubscribe(
+                task, principal=principal, client_ref=self._tab_id
+            ):
+                # One client detached but the principal still has other clients on
+                # this task: keep it subscribed and running.
+                self._action_taken = "detached"
+                stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
+                stats_logger.incr("gtf.task.detach")
+                logger.info("Client detached from shared task: %s", task.uuid)
+                return task
+
+        # Principal-grain decision (unchanged): abort for an admin force, a
+        # private/system task, or the last remaining subscriber; otherwise
+        # unsubscribe the calling principal. When a policy is active we only reach
+        # here once the principal's last client is gone (or for an admin force),
+        # so ``subscriber_count <= 1`` still correctly covers private/single-tab
+        # tasks.
         should_abort = (
             # Admin with force flag always aborts
-            (is_admin and self._force)
+            force_abort
             # Private tasks always abort (only one user)
             or task.is_private
             # System tasks always abort (admin only anyway)

--- a/superset/commands/tasks/submit.py
+++ b/superset/commands/tasks/submit.py
@@ -37,6 +37,8 @@ from superset.daos.exceptions import DAOCreateFailedError
 from superset.stats_logger import BaseStatsLogger
 from superset.tasks.guest import get_guest_subscriber_key_for
 from superset.tasks.locks import task_lock
+from superset.tasks.registry import TaskRegistry
+from superset.tasks.subscription import get_request_tab_id, principal_channel
 from superset.tasks.utils import generate_random_task_key, get_active_dedup_key
 from superset.utils.core import get_user_id
 from superset.utils.decorators import on_error, transaction
@@ -123,6 +125,11 @@ class SubmitTaskCommand(BaseCommand):
         # Embedded guests have no ab_user id; they subscribe by a token-derived
         # key so TaskFilter can grant them visibility of their own tasks.
         guest_key = get_guest_subscriber_key_for(user_id)
+        # Opaque per-client (e.g. browser-tab) id, when the caller advertised one.
+        # Passed to the task type's subscription policy so it can ref-count clients
+        # of a single principal (see superset.tasks.subscription); None for
+        # non-interactive callers, which keep principal-grain behavior.
+        tab_id = get_request_tab_id()
 
         # Build dedup_key for lock
         dedup_key = get_active_dedup_key(
@@ -135,7 +142,9 @@ class SubmitTaskCommand(BaseCommand):
         # Acquire the lock around the whole transaction (see docstring): it is
         # released only after _create_or_join commits.
         with task_lock(dedup_key):
-            return self._create_or_join(task_type, task_key, scope, user_id, guest_key)
+            return self._create_or_join(
+                task_type, task_key, scope, user_id, guest_key, tab_id
+            )
 
     @transaction(on_error=partial(on_error, reraise=TaskCreateFailedError))
     def _create_or_join(
@@ -145,6 +154,7 @@ class SubmitTaskCommand(BaseCommand):
         scope: str,
         user_id: int | None,
         guest_key: str | None,
+        tab_id: str | None,
     ) -> tuple["Task", bool]:
         """Find an existing task for ``dedup_key`` and join it, or create a new one.
 
@@ -159,7 +169,10 @@ class SubmitTaskCommand(BaseCommand):
 
         # Check for an existing task under the lock; join it if present.
         if existing := TaskDAO.find_by_task_key(task_type, task_key, scope, user_id):
-            return self._join_existing(existing, user_id, guest_key, task_key), False
+            return (
+                self._join_existing(existing, user_id, guest_key, task_key, tab_id),
+                False,
+            )
 
         # Create the new task. The task lock serializes concurrent submits for
         # this dedup_key, but as a backstop — the lock has a fixed TTL and could
@@ -191,10 +204,16 @@ class SubmitTaskCommand(BaseCommand):
             if existing is None:
                 raise
             current_app.config["STATS_LOGGER"].incr("gtf.task.create_race_joined")
-            return self._join_existing(existing, user_id, guest_key, task_key), False
+            return (
+                self._join_existing(existing, user_id, guest_key, task_key, tab_id),
+                False,
+            )
         except DAOCreateFailedError as ex:
             raise TaskCreateFailedError() from ex
 
+        # Record the creator as a client of the task for the subscription policy
+        # (the framework already added the creator's principal subscriber row).
+        self._apply_on_subscribe(task, task_type, user_id, guest_key, tab_id)
         current_app.config["STATS_LOGGER"].incr("gtf.task.create")
         return task, True  # is_new=True: created new task
 
@@ -204,6 +223,7 @@ class SubmitTaskCommand(BaseCommand):
         user_id: int | None,
         guest_key: str | None,
         task_key: str,
+        tab_id: str | None,
     ) -> "Task":
         """Join an existing task: bump its dedupe count and subscribe the caller.
 
@@ -235,7 +255,36 @@ class SubmitTaskCommand(BaseCommand):
             logger.debug(
                 "Deduplication hit for task: %s (user_id=%s)", task_key, user_id
             )
+        # Record this client under the caller's principal. The principal may
+        # already be subscribed (a second tab of the same user), which is exactly
+        # the case the policy ref-counts so a later cancel from one tab does not
+        # abort the shared task the other tab is still awaiting.
+        self._apply_on_subscribe(
+            existing, existing.task_type, user_id, guest_key, tab_id
+        )
         return existing
+
+    def _apply_on_subscribe(
+        self,
+        task: "Task",
+        task_type: str,
+        user_id: int | None,
+        guest_key: str | None,
+        tab_id: str | None,
+    ) -> None:
+        """Invoke the task type's subscription policy, if any, for this subscribe.
+
+        The framework's principal-grain subscriber row is already written by the
+        caller; this lets the task type additionally record the calling client
+        (e.g. a browser tab). No-op for task types without a policy or for callers
+        with no resolvable principal. Runs inside the submit lock + transaction.
+        """
+        policy = TaskRegistry.get_subscription_policy(task_type)
+        if policy is None:
+            return
+        if (principal := principal_channel(user_id, guest_key)) is None:
+            return
+        policy.on_subscribe(task, principal=principal, client_ref=tab_id)
 
     def _persist_dependencies(self, task: "Task", dao: type["TaskDAO"]) -> None:
         """

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -427,13 +427,15 @@ class TaskRestApi(BaseSupersetModelRestApi):
         from flask import request
 
         force = False
+        tab_id: str | None = None
         # Use get_json with silent=True to handle missing Content-Type gracefully
         json_data = request.get_json(silent=True)
         if json_data:
             parsed = self.cancel_request_schema.load(json_data)
             force = parsed.get("force", False)
+            tab_id = parsed.get("tab_id")
 
-        command = CancelTaskCommand(task_uuid, force=force)
+        command = CancelTaskCommand(task_uuid, force=force, tab_id=tab_id)
         updated_task = command.run()
         return command, updated_task
 
@@ -442,13 +444,13 @@ class TaskRestApi(BaseSupersetModelRestApi):
     ) -> Response:
         """Build the response for a successful cancel operation."""
         action = command.action_taken
-        message = (
-            "Task cancelled"
-            if action == "aborted"
-            else "You have been removed from this task"
-        )
+        messages = {
+            "aborted": "Task cancelled",
+            "unsubscribed": "You have been removed from this task",
+            "detached": "You have stopped watching this task",
+        }
         result = {
-            "message": message,
+            "message": messages.get(action, "You have been removed from this task"),
             "action": action,
             "task": self.show_model_schema.dump(updated_task),
         }

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -42,6 +42,7 @@ from superset.tasks.query_cancel import (
     capture_cancel_id,
     capture_cancel_query_id,
 )
+from superset.tasks.subscription import TaskSubscriptionPolicy
 from superset.tasks.utils import floored_status_cursor
 from superset.utils.core import override_user
 
@@ -63,6 +64,66 @@ logger = logging.getLogger(__name__)
 # type is versioned to allow the serialization/execution contract to evolve.
 CHART_QUERY_TASK = "superset.query_object_v1"
 CACHE_KEY_PAYLOAD_KEY = "cache_key"
+
+# Key under ``private["task"]`` holding the chart-data consumer list (see
+# ``ChartQueryConsumerPolicy``).
+CONSUMERS_PRIVATE_KEY = "consumers"
+
+
+class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
+    """Ref-count the browser tabs watching a shared chart-data task.
+
+    A chart-data task is ``SHARED`` and deduplicated across every request for the
+    same ``query_cache_key``, so one user viewing the same chart in two tabs is a
+    single principal with a single subscriber row. Treating either tab's cancel
+    (an explicit cancel, or the navigate-away teardown that cancels unwaited
+    tasks) as *the* principal leaving would abort the shared task and kill the
+    other tab's still-pending query.
+
+    This policy keeps a list of ``"<principal>:<tab_id>"`` entries in the task's
+    ``private["task"]`` namespace (framework-invisible, task-owned, debug-gated).
+    On subscribe it adds the calling tab; on unsubscribe it removes the calling
+    tab and reports whether the principal has any tab left, so the framework
+    aborts the task only once the principal's last tab is gone. Both hooks run
+    under the submit/cancel lock, so the read-modify-write on the list is
+    race-free.
+
+    A request without a ``tab_id`` (a non-interactive or legacy caller) is a
+    no-op on subscribe and proceeds (principal-grain) on unsubscribe; in practice
+    the chart-data client always supplies a stable per-tab id.
+    """
+
+    @staticmethod
+    def _consumers(task: "CoreTask") -> list[str]:
+        private = task.properties_dict.get("private") or {}
+        task_private = private.get("task") or {}
+        consumers = task_private.get(CONSUMERS_PRIVATE_KEY) or []
+        return [entry for entry in consumers if isinstance(entry, str)]
+
+    def on_subscribe(
+        self, task: "CoreTask", *, principal: str, client_ref: str | None
+    ) -> None:
+        if client_ref is None:
+            return
+        entry = f"{principal}:{client_ref}"
+        if entry not in (consumers := self._consumers(task)):
+            task.update_task_private({CONSUMERS_PRIVATE_KEY: [*consumers, entry]})
+
+    def on_unsubscribe(
+        self, task: "CoreTask", *, principal: str, client_ref: str | None
+    ) -> bool:
+        if client_ref is None:
+            # No per-tab id: fall back to principal-grain (proceed to unsubscribe).
+            return True
+        entry = f"{principal}:{client_ref}"
+        consumers = self._consumers(task)
+        remaining = [existing for existing in consumers if existing != entry]
+        if remaining != consumers:
+            task.update_task_private({CONSUMERS_PRIVATE_KEY: remaining})
+        # Proceed to unsubscribe the principal only once it has no tab left on
+        # this task; a surviving tab of the same principal keeps it subscribed.
+        prefix = f"{principal}:"
+        return not any(existing.startswith(prefix) for existing in remaining)
 
 
 def _resolve_user(user_id: int | None, guest_token: "GuestToken | None") -> User:
@@ -172,7 +233,11 @@ def _capture_query_cancellation(query_context: "QueryContext") -> Iterator[None]
         yield
 
 
-@task(name=CHART_QUERY_TASK, scope=TaskScope.SHARED)
+@task(
+    name=CHART_QUERY_TASK,
+    scope=TaskScope.SHARED,
+    subscription_policy=ChartQueryConsumerPolicy(),
+)
 def execute_chart_query(
     serialized_query: SerializedQuery,
     user_id: int | None = None,

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -44,6 +44,7 @@ from superset.tasks.utils import generate_random_task_key
 
 if TYPE_CHECKING:
     from superset.models.tasks import Task
+    from superset.tasks.subscription import TaskSubscriptionPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,7 @@ def task(
     name: str | None = None,
     scope: TaskScope = TaskScope.PRIVATE,
     timeout: int | None = None,
+    subscription_policy: "TaskSubscriptionPolicy | None" = None,
 ) -> Callable[[Callable[P, R]], "TaskWrapper[P]"]: ...
 
 
@@ -71,6 +73,7 @@ def task(
     name: str | None = None,
     scope: TaskScope = TaskScope.PRIVATE,
     timeout: int | None = None,
+    subscription_policy: "TaskSubscriptionPolicy | None" = None,
 ) -> Callable[[Callable[P, R]], "TaskWrapper[P]"] | "TaskWrapper[P]":
     """
     Decorator to register a task with default scope.
@@ -97,6 +100,12 @@ def task(
         timeout: Optional timeout in seconds. When the timeout is reached,
                  abort handlers are triggered if registered. Can be overridden
                  at call time via TaskOptions(timeout=...).
+        subscription_policy: Optional per-client subscription policy. The
+                 framework's subscriptions are principal-grain; a policy refines
+                 that with a finer per-client grain (e.g. one browser tab), so a
+                 cancel from one client of a principal does not abort a SHARED
+                 task another client of the same principal is still awaiting. See
+                 ``superset.tasks.subscription.TaskSubscriptionPolicy``.
 
     Usage:
         # Private task (default scope) - no parentheses
@@ -164,10 +173,12 @@ def task(
             )
 
         # Register task
-        TaskRegistry.register(task_name, f)
+        TaskRegistry.register(task_name, f, subscription_policy=subscription_policy)
 
         # Create wrapper with schedule() method, default options, scope, and timeout
-        wrapper = TaskWrapper(task_name, f, default_options, scope, timeout)
+        wrapper = TaskWrapper(
+            task_name, f, default_options, scope, timeout, subscription_policy
+        )
 
         # Preserve signature for introspection
         wrapper.__signature__ = sig  # type: ignore[attr-defined]
@@ -205,12 +216,14 @@ class TaskWrapper(Generic[P]):
         default_options: TaskOptions,
         scope: TaskScope = TaskScope.PRIVATE,
         default_timeout: int | None = None,
+        subscription_policy: "TaskSubscriptionPolicy | None" = None,
     ) -> None:
         self.name = name
         self.func = func
         self.default_options = default_options
         self.scope = scope
         self.default_timeout = default_timeout
+        self.subscription_policy = subscription_policy
         self.__name__ = func.__name__
         self.__doc__ = func.__doc__
         self.__module__ = func.__module__

--- a/superset/tasks/registry.py
+++ b/superset/tasks/registry.py
@@ -17,7 +17,10 @@
 """Task registry for the Global Task Framework (GTF)"""
 
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from superset.tasks.subscription import TaskSubscriptionPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -29,17 +32,32 @@ class TaskRegistry:
     Stores task functions by name, allowing the Celery executor to look up
     and execute registered tasks. This enables the decorator pattern where
     functions are registered at module import time.
+
+    A task type may also register a :class:`TaskSubscriptionPolicy`, which the
+    submit/cancel commands look up by ``task_type`` to refine per-client
+    subscription semantics (see ``superset.tasks.subscription``).
     """
 
     _tasks: dict[str, Callable[..., Any]] = {}
+    # Optional per-task-type subscription policies, keyed by the same task name
+    # as ``_tasks``. Absent for task types that use plain principal-grain
+    # subscriptions.
+    _subscription_policies: dict[str, "TaskSubscriptionPolicy"] = {}
 
     @classmethod
-    def register(cls, task_name: str, func: Callable[..., Any]) -> None:
+    def register(
+        cls,
+        task_name: str,
+        func: Callable[..., Any],
+        subscription_policy: "TaskSubscriptionPolicy | None" = None,
+    ) -> None:
         """
         Register a task function by name.
 
         :param task_name: Unique task identifier (e.g., "superset.generate_thumbnail")
         :param func: The task function to register
+        :param subscription_policy: Optional per-client subscription policy for
+            this task type (see ``superset.tasks.subscription``)
         :raises ValueError: If task name is already registered
         """
         if task_name in cls._tasks:
@@ -56,6 +74,8 @@ class TaskRegistry:
             return
 
         cls._tasks[task_name] = func
+        if subscription_policy is not None:
+            cls._subscription_policies[task_name] = subscription_policy
         logger.info(
             "Registered async task: %s -> %s.%s",
             task_name,
@@ -90,6 +110,17 @@ class TaskRegistry:
         return task_name in cls._tasks
 
     @classmethod
+    def get_subscription_policy(cls, task_name: str) -> "TaskSubscriptionPolicy | None":
+        """
+        Get the subscription policy for a task type, if one was registered.
+
+        :param task_name: Task identifier to look up
+        :returns: The registered policy, or ``None`` for plain principal-grain
+            subscriptions
+        """
+        return cls._subscription_policies.get(task_name)
+
+    @classmethod
     def list_tasks(cls) -> list[str]:
         """
         Get list of all registered task names.
@@ -107,4 +138,5 @@ class TaskRegistry:
         tasks should remain registered for the lifetime of the process.
         """
         cls._tasks.clear()
+        cls._subscription_policies.clear()
         logger.warning("Task registry cleared")

--- a/superset/tasks/schemas.py
+++ b/superset/tasks/schemas.py
@@ -275,6 +275,17 @@ class TaskCancelRequestSchema(Schema):
             "Only applicable for shared tasks with multiple subscribers."
         },
     )
+    tab_id = fields.String(
+        required=False,
+        allow_none=True,
+        load_default=None,
+        metadata={
+            "description": "Opaque per-client (browser tab) id. For task types with "
+            "a per-client subscription policy (e.g. chart-data), a cancel from one "
+            "tab detaches only that tab; the task keeps running while the "
+            "principal has other tabs watching it. Ignored otherwise."
+        },
+    )
 
 
 class TaskCancelResponseSchema(Schema):
@@ -283,8 +294,9 @@ class TaskCancelResponseSchema(Schema):
     message = fields.String(metadata={"description": "Success or status message"})
     action = fields.String(
         metadata={
-            "description": "The action taken: 'aborted' (task terminated) or "
-            "'unsubscribed' (user removed from shared task)"
+            "description": "The action taken: 'aborted' (task terminated), "
+            "'unsubscribed' (principal removed from a shared task), or 'detached' "
+            "(one client/tab of the principal stopped watching; the task continues)"
         }
     )
     task = fields.Nested(TaskResponseSchema, allow_none=True)

--- a/superset/tasks/subscription.py
+++ b/superset/tasks/subscription.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Framework support for task-type subscription policies (GTF).
+
+Re-exports the public :class:`TaskSubscriptionPolicy` interface and adds the two
+request-scoped helpers the framework uses to invoke a policy: the principal's
+stable routing id and the caller's opaque per-client id.
+"""
+
+from __future__ import annotations
+
+from flask import has_request_context, request
+from superset_core.tasks.subscription import TaskSubscriptionPolicy
+
+__all__ = ["TaskSubscriptionPolicy", "principal_channel", "get_request_tab_id"]
+
+# Body/query key a client uses to advertise its per-tab id on submit and cancel.
+TAB_ID_KEY = "tab_id"
+
+
+def principal_channel(user_id: int | None, guest_key: str | None) -> str | None:
+    """Return a principal's stable routing id, or ``None`` if unidentified.
+
+    ``user:<id>`` for an authenticated user; the guest's token-derived key
+    (already namespaced ``guest:<hmac>``) for an embedded guest; ``None`` when
+    neither identifies a principal. This is the single source of truth for the
+    principal-grain routing string — the websocket channel id
+    (``superset.websocket.channel.channel_id_for``) delegates to it, and a
+    subscription policy uses it to scope per-client bookkeeping to one principal.
+    """
+    if user_id is not None:
+        return f"user:{user_id}"
+    if guest_key:
+        return guest_key
+    return None
+
+
+def get_request_tab_id() -> str | None:
+    """Return the caller's opaque per-tab id from the current request, or ``None``.
+
+    Clients advertise a stable per-tab id (see ``superset-frontend`` ``getTabId``)
+    in the JSON body — falling back to a query arg — of chart-data submit and task
+    cancel requests. It is ``None`` outside a request context (e.g. a Celery
+    worker) or when the caller supplied none, in which case the task's
+    subscription policy falls back to principal-grain behavior.
+    """
+    if not has_request_context():
+        return None
+    body = request.get_json(silent=True)
+    if isinstance(body, dict):
+        tab_id = body.get(TAB_ID_KEY)
+        if isinstance(tab_id, str) and tab_id:
+            return tab_id
+    tab_id = request.args.get(TAB_ID_KEY)
+    return tab_id or None

--- a/superset/websocket/channel.py
+++ b/superset/websocket/channel.py
@@ -63,17 +63,16 @@ class RealtimePrincipal(TypedDict):
 def channel_id_for(user_id: int | None, guest_key: str | None) -> str | None:
     """Derive a principal's realtime channel from its identity, or ``None``.
 
-    The single source of truth for the socket routing-key format used by the
-    JWT cookie and the websocket server's targeted fanout. ``user:<id>`` for an
-    authenticated user; the guest's token-derived key (already namespaced
-    ``guest:<hmac>``) for an embedded guest; ``None`` when neither identifies a
-    principal.
+    The socket routing-key format used by the JWT cookie and the websocket
+    server's targeted fanout. ``user:<id>`` for an authenticated user; the
+    guest's token-derived key (already namespaced ``guest:<hmac>``) for an
+    embedded guest; ``None`` when neither identifies a principal. This is the
+    same principal-grain routing string GTF subscription policies key off, so it
+    delegates to the single source of truth in ``superset.tasks.subscription``.
     """
-    if user_id is not None:
-        return f"user:{user_id}"
-    if guest_key:
-        return guest_key
-    return None
+    from superset.tasks.subscription import principal_channel
+
+    return principal_channel(user_id, guest_key)
 
 
 def get_realtime_principal() -> RealtimePrincipal | None:

--- a/tests/integration_tests/tasks/commands/test_cancel.py
+++ b/tests/integration_tests/tasks/commands/test_cancel.py
@@ -492,3 +492,154 @@ def test_cancel_shared_task_not_subscribed_raises_not_found(
             # Cleanup
             db.session.delete(task)
             db.session.commit()
+
+
+def _consumers(task) -> list[str]:
+    """Read the chart-data per-tab consumer list off a task's private state."""
+    return task.properties_dict.get("private", {}).get("task", {}).get("consumers", [])
+
+
+def test_cancel_detaches_one_tab_and_keeps_task_alive(app_context, get_user) -> None:
+    """A tab cancel of a shared chart-data task the same user watches from two
+    tabs detaches only that tab; the task keeps running for the other tab."""
+    from superset.tasks.async_queries import CHART_QUERY_TASK
+
+    admin = get_user("admin")
+    unique_key = f"detach_test_{uuid4().hex[:8]}"
+
+    task = TaskDAO.create_task(
+        task_type=CHART_QUERY_TASK,
+        task_key=unique_key,
+        scope=TaskScope.SHARED,
+        user_id=admin.id,
+    )
+    task.created_by = admin
+    # Two tabs of the same principal are watching (single subscriber row).
+    task.update_task_private(
+        {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
+    )
+    db.session.commit()
+
+    try:
+        with override_user(admin):
+            command = CancelTaskCommand(task_uuid=task.uuid, tab_id="tabA")
+            result = command.run()
+
+        # tabA detaches; the task is untouched and tabB's entry remains.
+        assert command.action_taken == "detached"
+        assert result.status == TaskStatus.PENDING.value
+        db.session.refresh(task)
+        assert task.status == TaskStatus.PENDING.value
+        assert _consumers(task) == [f"user:{admin.id}:tabB"]
+        assert task.subscriber_count == 1
+    finally:
+        db.session.delete(task)
+        db.session.commit()
+
+
+def test_cancel_last_tab_aborts_shared_task(app_context, get_user) -> None:
+    """Cancelling the principal's last watching tab aborts the shared task."""
+    from superset.tasks.async_queries import CHART_QUERY_TASK
+
+    admin = get_user("admin")
+    unique_key = f"last_tab_test_{uuid4().hex[:8]}"
+
+    task = TaskDAO.create_task(
+        task_type=CHART_QUERY_TASK,
+        task_key=unique_key,
+        scope=TaskScope.SHARED,
+        user_id=admin.id,
+    )
+    task.created_by = admin
+    task.update_task_private({"consumers": [f"user:{admin.id}:tabA"]})
+    db.session.commit()
+
+    try:
+        with override_user(admin):
+            command = CancelTaskCommand(task_uuid=task.uuid, tab_id="tabA")
+            result = command.run()
+
+        # The principal's last tab left, so the (last-subscriber) task aborts.
+        assert command.action_taken == "aborted"
+        assert result.status == TaskStatus.ABORTED.value
+        db.session.refresh(task)
+        assert _consumers(task) == []
+    finally:
+        db.session.delete(task)
+        db.session.commit()
+
+
+def test_cancel_last_tab_of_one_user_unsubscribes_not_aborts(
+    app_context, get_user
+) -> None:
+    """When another user still watches a shared task, one user's last-tab cancel
+    unsubscribes only that user; the task keeps running."""
+    from superset.tasks.async_queries import CHART_QUERY_TASK
+
+    admin = get_user("admin")
+    gamma = get_user("gamma")
+    unique_key = f"multi_user_tab_test_{uuid4().hex[:8]}"
+
+    with app.test_request_context():
+        with override_user(admin):
+            task = TaskDAO.create_task(
+                task_type=CHART_QUERY_TASK,
+                task_key=unique_key,
+                scope=TaskScope.SHARED,
+                user_id=admin.id,
+            )
+            db.session.commit()
+        TaskDAO.add_subscriber(task.id, user_id=gamma.id)
+        task.update_task_private(
+            {"consumers": [f"user:{admin.id}:tabA", f"user:{gamma.id}:tabB"]}
+        )
+        db.session.commit()
+
+        try:
+            # gamma cancels its only tab: gamma is unsubscribed, task keeps running
+            # for admin.
+            with override_user(gamma):
+                command = CancelTaskCommand(task_uuid=task.uuid, tab_id="tabB")
+                result = command.run()
+
+            assert command.action_taken == "unsubscribed"
+            assert result.status == TaskStatus.PENDING.value
+            db.session.refresh(task)
+            assert not task.has_subscriber(gamma.id)
+            assert task.has_subscriber(admin.id)
+            assert _consumers(task) == [f"user:{admin.id}:tabA"]
+        finally:
+            db.session.delete(task)
+            db.session.commit()
+
+
+def test_force_cancel_aborts_regardless_of_tabs(app_context, get_user) -> None:
+    """An admin force-cancel aborts a shared chart-data task even while tabs
+    are watching (the per-tab policy pre-gate is skipped for force)."""
+    from superset.tasks.async_queries import CHART_QUERY_TASK
+
+    admin = get_user("admin")
+    unique_key = f"force_tab_test_{uuid4().hex[:8]}"
+
+    task = TaskDAO.create_task(
+        task_type=CHART_QUERY_TASK,
+        task_key=unique_key,
+        scope=TaskScope.SHARED,
+        user_id=admin.id,
+    )
+    task.created_by = admin
+    task.update_task_private(
+        {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
+    )
+    db.session.commit()
+
+    try:
+        with override_user(admin):
+            command = CancelTaskCommand(task_uuid=task.uuid, force=True, tab_id="tabA")
+            result = command.run()
+
+        assert command.action_taken == "aborted"
+        assert result.status == TaskStatus.ABORTED.value
+    finally:
+        db.session.delete(task)
+        db.session.commit()

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -89,6 +89,13 @@ def test_should_run_async_requires_async_mode_flag() -> None:
     with (
         patch("superset.charts.data.api.is_feature_enabled", return_value=True),
         patch("superset.charts.data.api.cache_manager") as cache_manager,
+        # A subscribe-able identity is required for async; an authenticated user
+        # satisfies it (the identity requirement is covered on its own below).
+        patch("superset.charts.data.api.get_user_id", return_value=1),
+        patch(
+            "superset.charts.data.api.get_current_guest_subscriber_key",
+            return_value=None,
+        ),
     ):
         # A real (non-null) DATA cache backend so async is viable.
         cache_manager.data_cache.cache = MagicMock()
@@ -117,6 +124,58 @@ def test_should_run_async_requires_async_mode_flag() -> None:
     # Feature flag off → always sync.
     with patch("superset.charts.data.api.is_feature_enabled", return_value=False):
         assert api._should_run_async({"async_mode": True}, qc) is False
+
+
+def test_should_run_async_requires_subscribeable_identity() -> None:
+    """Async needs a user or guest identity to subscribe/observe the task.
+
+    A fully anonymous request (no login, no guest token) can neither poll nor
+    cancel the scheduled task, so it runs synchronously instead. An embedded
+    guest — which has a token-derived subscriber key — keeps async delivery.
+    """
+    from flask_caching.backends import NullCache  # noqa: F401
+
+    api = ChartDataRestApi()
+    qc = MagicMock()
+    qc.result_format = ChartDataResultFormat.JSON
+    qc.result_type = ChartDataResultType.FULL
+    qc.get_cache_timeout.return_value = 300
+
+    with (
+        patch("superset.charts.data.api.is_feature_enabled", return_value=True),
+        patch("superset.charts.data.api.cache_manager") as cache_manager,
+    ):
+        cache_manager.data_cache.cache = MagicMock()
+
+        # Fully anonymous → sync.
+        with (
+            patch("superset.charts.data.api.get_user_id", return_value=None),
+            patch(
+                "superset.charts.data.api.get_current_guest_subscriber_key",
+                return_value=None,
+            ),
+        ):
+            assert api._should_run_async({"async_mode": True}, qc) is False
+
+        # Authenticated user → async.
+        with (
+            patch("superset.charts.data.api.get_user_id", return_value=1),
+            patch(
+                "superset.charts.data.api.get_current_guest_subscriber_key",
+                return_value=None,
+            ),
+        ):
+            assert api._should_run_async({"async_mode": True}, qc) is True
+
+        # Embedded guest (no user id, but a subscriber key) → async.
+        with (
+            patch("superset.charts.data.api.get_user_id", return_value=None),
+            patch(
+                "superset.charts.data.api.get_current_guest_subscriber_key",
+                return_value="guest:abc",
+            ),
+        ):
+            assert api._should_run_async({"async_mode": True}, qc) is True
 
 
 def test_get_data_sets_g_form_data_without_dashboard_filter() -> None:

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -16,6 +16,7 @@
 # under the License.
 """Unit tests for the GTF chart-data fan-out orchestrator."""
 
+from typing import Any
 from unittest import mock
 from uuid import uuid4
 
@@ -279,3 +280,85 @@ def test_task_name_disambiguates_multiple_queries(mocker: MockerFixture) -> None
 
     names = [s["kwargs"]["options"].task_name for s in scheduled]
     assert names == ["births (1)", "births (2)"]
+
+
+def _make_task(properties: dict[str, Any] | None = None):
+    """A real ``Task`` seeded with ``properties`` (no DB — property JSON only)."""
+    from superset.models.tasks import Task
+    from superset.tasks.utils import serialize_properties
+
+    task = Task()
+    task.properties = serialize_properties(properties or {})
+    return task
+
+
+def _consumers(task) -> list[str]:
+    return task.properties_dict.get("private", {}).get("task", {}).get("consumers", [])
+
+
+def test_chart_query_task_registers_subscription_policy() -> None:
+    """The chart-data task type wires its per-tab consumer policy at import."""
+    from superset.tasks.async_queries import (
+        CHART_QUERY_TASK,
+        ChartQueryConsumerPolicy,
+    )
+    from superset.tasks.registry import TaskRegistry
+
+    policy = TaskRegistry.get_subscription_policy(CHART_QUERY_TASK)
+    assert isinstance(policy, ChartQueryConsumerPolicy)
+
+
+def test_consumer_policy_on_subscribe_adds_dedups_and_preserves_framework() -> None:
+    from superset.tasks.async_queries import ChartQueryConsumerPolicy
+
+    policy = ChartQueryConsumerPolicy()
+    # Seed a framework-owned key to prove the task-namespace write leaves it intact.
+    task = _make_task({"private": {"framework": {"celery_task_id": "c1"}}})
+
+    policy.on_subscribe(task, principal="user:5", client_ref="A")
+    policy.on_subscribe(task, principal="user:5", client_ref="B")
+    policy.on_subscribe(task, principal="user:5", client_ref="A")  # idempotent
+
+    assert _consumers(task) == ["user:5:A", "user:5:B"]
+    assert task.properties_dict["private"]["framework"]["celery_task_id"] == "c1"
+
+
+def test_consumer_policy_detach_then_last_tab_aborts() -> None:
+    from superset.tasks.async_queries import ChartQueryConsumerPolicy
+
+    policy = ChartQueryConsumerPolicy()
+    task = _make_task()
+    policy.on_subscribe(task, principal="user:5", client_ref="A")
+    policy.on_subscribe(task, principal="user:5", client_ref="B")
+
+    # First tab leaving -> principal still has another tab -> keep task alive.
+    assert policy.on_unsubscribe(task, principal="user:5", client_ref="A") is False
+    assert _consumers(task) == ["user:5:B"]
+
+    # Last tab leaving -> principal is done -> proceed to unsubscribe/abort.
+    assert policy.on_unsubscribe(task, principal="user:5", client_ref="B") is True
+    assert _consumers(task) == []
+
+
+def test_consumer_policy_scopes_by_principal() -> None:
+    from superset.tasks.async_queries import ChartQueryConsumerPolicy
+
+    policy = ChartQueryConsumerPolicy()
+    task = _make_task()
+    policy.on_subscribe(task, principal="user:5", client_ref="A")
+    policy.on_subscribe(task, principal="user:7", client_ref="B")
+
+    # user 5's only tab leaving proceeds (its last tab), but user 7's entry stays.
+    assert policy.on_unsubscribe(task, principal="user:5", client_ref="A") is True
+    assert _consumers(task) == ["user:7:B"]
+
+
+def test_consumer_policy_without_client_ref_is_principal_grain() -> None:
+    from superset.tasks.async_queries import ChartQueryConsumerPolicy
+
+    policy = ChartQueryConsumerPolicy()
+    task = _make_task()
+    # No tab id: record nothing and proceed like a plain principal-grain cancel.
+    policy.on_subscribe(task, principal="user:5", client_ref=None)
+    assert _consumers(task) == []
+    assert policy.on_unsubscribe(task, principal="user:5", client_ref=None) is True

--- a/tests/unit_tests/tasks/test_decorators.py
+++ b/tests/unit_tests/tasks/test_decorators.py
@@ -146,6 +146,37 @@ class TestTaskDecorator:
             def bad_task(options, arg1: int) -> None:  # noqa: ARG001
                 pass
 
+    def test_decorator_registers_subscription_policy(self):
+        """A subscription policy passed to @task is carried on the wrapper and
+        resolvable from the registry by task type."""
+        from superset.tasks.subscription import TaskSubscriptionPolicy
+
+        class _Policy(TaskSubscriptionPolicy):
+            def on_subscribe(self, task, *, principal, client_ref):  # noqa: ARG002
+                pass
+
+            def on_unsubscribe(self, task, *, principal, client_ref):  # noqa: ARG002
+                return True
+
+        policy = _Policy()
+
+        @task(name="policy_task", scope=TaskScope.SHARED, subscription_policy=policy)
+        def my_task() -> None:
+            pass
+
+        assert my_task.subscription_policy is policy
+        assert TaskRegistry.get_subscription_policy("policy_task") is policy
+
+    def test_decorator_without_policy_defaults_to_none(self):
+        """A task without a subscription policy keeps principal-grain behavior."""
+
+        @task(name="no_policy_task")
+        def my_task() -> None:
+            pass
+
+        assert my_task.subscription_policy is None
+        assert TaskRegistry.get_subscription_policy("no_policy_task") is None
+
 
 class TestTaskWrapperMergeOptions:
     """Tests for TaskWrapper._merge_options()"""

--- a/tests/unit_tests/tasks/test_submit.py
+++ b/tests/unit_tests/tasks/test_submit.py
@@ -113,7 +113,7 @@ def test_create_race_joins_winner_on_unique_violation(
     mocker.patch("superset.db.session.begin_nested", return_value=_null_cm())
 
     task, is_new = SubmitTaskCommand({})._create_or_join(
-        "superset.query_object_v1", "k", "shared", 1, None
+        "superset.query_object_v1", "k", "shared", 1, None, None
     )
 
     assert is_new is False


### PR DESCRIPTION
### SUMMARY

Server-side fix for cross-tab cancellation of shared async chart-data tasks,
plus the async/ws review follow-ups from @sadpandajoe on the umbrella PR
(#43407).

**Root cause.** Chart-data tasks are `SHARED` and deduplicated by
`query_cache_key`, so one user viewing the same chart in **two browser tabs** is
a single principal with a single `task_subscribers` row. Any tab's cancel (an
explicit cancel, or the navigate-away teardown that cancels unwaited tasks) hit
`subscriber_count <= 1` and **aborted the shared task**, killing the other tab's
still-pending query. The earlier client-side guard only covered the intra-tab
case; it cannot see sibling tabs.

#### 1. Per-tab task subscriptions (task-type subscription policy)

The framework's subscriber model stays **principal-grain** — `task_subscribers`,
`subscriber_count`, `TaskFilter`, and `raise_for_access` are untouched. A task
type may now register a **`TaskSubscriptionPolicy`** on its `@task` decorator to
refine cancellation to a finer per-client (browser tab) grain:

- `on_subscribe(task, *, principal, client_ref)` / `on_unsubscribe(...) -> bool`,
  both invoked in the web request under the existing `task_lock` that serializes
  submit/cancel (so their read-modify-write on task state is race-free).
- `CancelTaskCommand._do_cancel` consults the policy as a **pre-gate**: if it
  reports the caller's principal still has other clients, the cancel is a
  **detach** (task keeps running); otherwise it falls through to the unchanged
  principal-grain abort/unsubscribe rule. An admin **force-abort** bypasses the
  policy.
- The chart-data policy (`ChartQueryConsumerPolicy`) ref-counts
  `"<principal>:<tab_id>"` entries in the task-owned, debug-gated
  `private["task"]` namespace (the framework never inspects it). A task with no
  policy, or a request with no `tab_id`, keeps today's principal-grain behavior.
- `tab_id` is an opaque per-tab id, **not** an authorization token: the caller's
  principal is authorized before the policy runs, and the policy only ever
  records/removes entries scoped to that principal.

Frontend: `getTabId()` is extracted from `useTabId` (and its `BroadcastChannel`
made lazy so importing the module has no side effect); the async chart-data POST
and the cancel POST now carry `tab_id`.

superset-core (extension API): adds the `TaskSubscriptionPolicy` interface, the
`subscription_policy=` arg on `@task`, and `Task.properties_dict` /
`Task.update_task_private`. Documented in `extensions/tasks.md`.

#### 2. Fully-anonymous chart-data runs synchronously

A fully-anonymous request (public dashboard viewed directly, no login and no
guest token) has no subscription, so it could neither poll nor cancel its task —
a `202` that never resolved. `_should_run_async` now also requires a
subscribe-able identity (user or guest key); anonymous falls back to the
synchronous `200` path. Embedded **guest** dashboards keep async delivery via
their token-derived key.

#### 3. Shared-task cancellation deferral (client guard)

`cancelUnwaitedTasks()` only cancels a task id when no local waiter still awaits
it (checked after unregistering the aborting waiter, or before registering on an
already-aborted signal), so aborting one chart no longer cancels a shared task
another local chart still needs. This is the intra-tab complement to the
server-side per-tab fix above.

#### 4. Websocket Pub/Sub channel docs

`UPDATING.md` and the websocket README listed `realtime:<channel_id>` — the
*browser-delivery* channel — as a channel the server consumes. The server
actually **subscribes** to `entity-changes:*` and `task-status` and republishes
to browsers on `realtime:*` after fanout. Corrected so a Redis ACL following the
guidance allows `task-status`.

Not included here (from the same review, handled separately):
- The 202 poll cursor microsecond-vs-seconds miss was already fixed on
  `gaq-to-gtf` (floored via the shared `floored_status_cursor()` helper).
- The Helm `GLOBAL_ASYNC_QUERIES_*` → `WEBSOCKET_*` migration is intentionally
  **not** done: the Helm chart is being deprecated (7.0), and first-class support
  for this feature will land in the official Superset Kubernetes operator.

Follow-up (not in this PR): per-tab **websocket channels** — scope the ws JWT to
a channel namespace (keeping `sub` for identity) so each tab can bind
`realtime:user:<id>:<tab_id>` under the shared per-browser cookie. Not required
for cross-tab cancel (fixed server-side here); sibling-tab status messages are
harmless today since the client filters by `task_id`.

### TESTING INSTRUCTIONS

- Backend unit: `pytest tests/unit_tests/tasks/test_async_queries.py
  tests/unit_tests/tasks/test_decorators.py tests/unit_tests/charts/test_chart_data_api.py`
  (policy behavior, decorator/registry wiring, anonymous-sync gate).
- Backend integration: `pytest tests/integration_tests/tasks/commands/test_cancel.py`
  (two-tab detach keeps the task alive; last-tab cancel aborts; cross-user;
  admin force).
- Frontend: `npm run test -- asyncEvent chartActions useTabId`.
- Manual: open the same chart in two tabs backed by one async query; cancel/close
  one tab and confirm the other still resolves; close the last tab and confirm
  the task aborts. Confirm a fully-anonymous public dashboard loads charts
  synchronously.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` / `GLOBAL_TASK_FRAMEWORK`
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
