### PR TITLE
fix(chart): catch JSONDecodeError when parsing params on chart create

### DIFF
--- a/superset/commands/chart/create.py
+++ b/superset/commands/chart/create.py
@@ -29,6 +29,7 @@ from superset.commands.chart.exceptions import (
     ChartCreateFailedError,
     ChartForbiddenError,
     ChartInvalidError,
+    ChartParamsInvalidJSONValidationError,
     DashboardsForbiddenError,
     DashboardsNotFoundValidationError,
 )
@@ -47,7 +48,12 @@ class CreateChartCommand(CreateMixin, BaseCommand):
         self._properties = data.copy()
 
         if params_str := self._properties.get("params"):
-            params = json.loads(params_str)
+            try:
+                params = json.loads(params_str)
+            except json.JSONDecodeError as ex:
+                raise ChartInvalidError(
+                    exceptions=[ChartParamsInvalidJSONValidationError()]
+                ) from ex
             if isinstance(params, dict) and "viz_type" in params:
                 # Only fall back to params when no top-level viz_type was supplied;
                 # an explicit top-level field takes precedence.

--- a/superset/commands/chart/exceptions.py
+++ b/superset/commands/chart/exceptions.py
@@ -116,6 +116,15 @@ class ChartQueryContextDatasourceMismatchValidationError(ValidationError):
         )
 
 
+class ChartParamsInvalidJSONValidationError(ValidationError):
+    """
+    Raised when the params field is not valid JSON.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(_("Chart params contains invalid JSON"), field_name="params")
+
+
 class ChartNotFoundError(CommandException):
     message = "Chart not found."
 

--- a/tests/unit_tests/commands/chart/create_test.py
+++ b/tests/unit_tests/commands/chart/create_test.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from superset.commands.chart.create import CreateChartCommand
+from superset.commands.chart.exceptions import (
+    ChartInvalidError,
+    ChartParamsInvalidJSONValidationError,
+)
+
+
+def test_init_with_invalid_json_params_raises_chart_invalid_error():
+    """
+    A malformed ``params`` JSON string must surface as a ``ChartInvalidError``
+    (a 422-mapped validation error) rather than leaking a raw ``JSONDecodeError``.
+    """
+    with pytest.raises(ChartInvalidError) as ex:
+        CreateChartCommand(
+            {
+                "params": "{not valid json",
+                "datasource_id": 1,
+                "datasource_type": "table",
+            }
+        )
+
+    assert any(
+        isinstance(exc, ChartParamsInvalidJSONValidationError)
+        for exc in ex.value._exceptions
+    )
+
+
+def test_init_with_valid_json_params_populates_viz_type():
+    """
+    A valid ``params`` JSON string still falls back to its ``viz_type`` when no
+    top-level ``viz_type`` is supplied (happy path must not regress).
+    """
+    command = CreateChartCommand(
+        {
+            "params": '{"viz_type": "table"}',
+            "datasource_id": 1,
+            "datasource_type": "table",
+        }
+    )
+
+    assert command._properties["viz_type"] == "table"


### PR DESCRIPTION
### SUMMARY

`CreateChartCommand.__init__` parses the client-supplied `params` field with `json.loads` (backed by `simplejson`) without guarding it. The `params` marshmallow field on `POST /api/v1/chart` is a plain `fields.String()` with no JSON-validity check, so a client that posts a malformed JSON string in `params` triggers a raw `simplejson.errors.JSONDecodeError` (a `ValueError` subclass) straight out of `__init__` — before `run()`'s `@transaction` decorator or `validate()` ever execute.

The `create()` handler in `superset/charts/api.py` wraps `CreateChartCommand(item).run()` in `try/except DashboardsForbiddenError / ChartInvalidError / ChartCreateFailedError`, none of which catch `JSONDecodeError`, so it falls through to Flask-AppBuilder's `@safe` decorator as an opaque **500**. Malformed client input should be a **422**, not a server error.

**Problem**

```python
def __init__(self, data: dict[str, Any]):
    self._properties = data.copy()

    if params_str := self._properties.get("params"):
        params = json.loads(params_str)          # raw JSONDecodeError leaks here
        if isinstance(params, dict) and "viz_type" in params:
            self._properties.setdefault("viz_type", params["viz_type"])
```

**Fix**

Wrap the parse and re-raise as a `ChartInvalidError` composed from a new small `ChartParamsInvalidJSONValidationError` (field `params`), mirroring the established `*ValidationError` idiom already used throughout `commands/chart/exceptions.py` (e.g. `ChartQueryContextDatasourceMismatchValidationError`):

```python
if params_str := self._properties.get("params"):
    try:
        params = json.loads(params_str)
    except json.JSONDecodeError as ex:
        raise ChartInvalidError(
            exceptions=[ChartParamsInvalidJSONValidationError()]
        ) from ex
    if isinstance(params, dict) and "viz_type" in params:
        self._properties.setdefault("viz_type", params["viz_type"])
```

Because the command is constructed inside the same `try:` block as `.run()`, `charts/api.py`'s existing `except ChartInvalidError as ex: return self.response_422(...)` already covers it — **no change to `charts/api.py` is required**.

This follows the same sibling patterns already established in this codebase for the exact same field / bug class:
- `commands/chart/export.py` already does `try: payload["params"] = json.loads(payload["params"]) except json.JSONDecodeError: logger.info(...)`.
- `commands/chart/update.py::UpdateChartCommand._validate_query_context_datasource` already catches `(TypeError, ValueError)` around an equivalent `json.loads` and treats it as unverifiable input.

Part of the ongoing raw-exception-cleanup series; the most recent PR in the same series is #43651 ("catch sqlglot ParseError when parsing RLS predicates"). Referenced for context only — this change stands on its own and has no dependency on it.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend error-handling change.

### TESTING INSTRUCTIONS

New unit test file `tests/unit_tests/commands/chart/create_test.py` covers both paths:

- `test_init_with_invalid_json_params_raises_chart_invalid_error` — a malformed `params` string raises `ChartInvalidError` (not a raw `JSONDecodeError`), with a `ChartParamsInvalidJSONValidationError` present in the composed exceptions.
- `test_init_with_valid_json_params_populates_viz_type` — a valid `params` JSON string still falls back to its `viz_type` (happy path unchanged).

Run:

```bash
python3 -m pytest tests/unit_tests/commands/chart/create_test.py -q
```

Verified fail-before / pass-after: against pre-fix source the invalid-JSON test fails with the raw `simplejson.errors.JSONDecodeError` leaking out of `__init__`; with the fix applied both tests pass (`2 passed`). `ruff check`, `ruff format`, and `mypy` (via pre-commit) are clean on the changed files.

To reproduce the original 500 manually: `POST /api/v1/chart` with a body containing `"params": "{not valid json"` (plus a valid `datasource_id` / `datasource_type`). Before this change the response is a 500; after, it is a 422 with a `params` validation message.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API