### PR TITLE
feat(mcp): let get_dashboard_info accept filter_state directly

### DIFF
--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -272,6 +272,15 @@ class GetDashboardInfoRequest(MetadataCacheControl):
             "the shared active-tab and filter context; no identifier is required."
         ),
     )
+    filter_state: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Active filters supplied directly rather than via a permalink, so the "
+            "tool can describe the dashboard as the user currently views it, "
+            'filtered. Shape: {"applied_filters": [{"col", "op", "val"}]}. Ignored '
+            "when permalink_key is provided."
+        ),
+    )
     select_columns: Annotated[
         List[str],
         Field(

--- a/superset/mcp_service/dashboard/tool/get_dashboard_info.py
+++ b/superset/mcp_service/dashboard/tool/get_dashboard_info.py
@@ -40,25 +40,29 @@ from superset.mcp_service.dashboard.schemas import (
     dashboard_serializer,
     DashboardError,
     DashboardInfo,
-    DEFAULT_GET_DASHBOARD_INFO_COLUMNS,
     GetDashboardInfoRequest,
+    redact_filter_state_data_model_metadata,
 )
 from superset.mcp_service.mcp_core import ModelGetInfoCore
+from superset.mcp_service.privacy import user_can_view_data_model_metadata
 
 logger = logging.getLogger(__name__)
 
 
 def _apply_permalink_state(
     result: DashboardInfo,
-    permalink_key: str,
+    permalink_key: str | None,
     permalink_state: dict[str, object],
+    is_permalink: bool = True,
 ) -> DashboardInfo:
-    """Attach permalink fields without changing their stored values."""
+    """Attach the filter state without changing its stored values.
+    is_permalink is False when the state was supplied directly, not resolved
+    from a permalink."""
     return result.model_copy(
         update={
             "permalink_key": permalink_key,
             "filter_state": permalink_state,
-            "is_permalink_state": True,
+            "is_permalink_state": is_permalink,
         }
     )
 
@@ -214,6 +218,15 @@ async def get_dashboard_info(
                         "permalink_key provided but no permalink found. "
                         "The permalink may have expired or is invalid."
                     )
+            elif request.filter_state is not None:
+                # Filter context supplied directly (no permalink), e.g. embedded.
+                await ctx.info("Applying caller-supplied filter_state")
+                filter_state = request.filter_state
+                if not user_can_view_data_model_metadata():
+                    filter_state = redact_filter_state_data_model_metadata(filter_state)
+                result = _apply_permalink_state(
+                    result, None, filter_state, is_permalink=False
+                )
 
             await ctx.info(
                 "Dashboard information retrieved successfully: id=%s, title=%s, "
@@ -226,12 +239,13 @@ async def get_dashboard_info(
                     result.is_permalink_state,
                 )
             )
-            # When permalink_key is supplied and the caller did not explicitly
-            # override select_columns, ensure filter_state is present so the
-            # caller gets the data they came for.
+            # Include filter_state by default when present, but honor an explicit
+            # select_columns projection (model_fields_set = caller chose it).
             effective_select_columns = list(request.select_columns)
-            if result.is_permalink_state and effective_select_columns == list(
-                DEFAULT_GET_DASHBOARD_INFO_COLUMNS
+            if (
+                result.filter_state is not None
+                and "select_columns" not in request.model_fields_set
+                and "filter_state" not in effective_select_columns
             ):
                 effective_select_columns.append("filter_state")
 

--- a/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
@@ -976,6 +976,17 @@ class TestRequestSchemaAliasChoices:
         )
         assert req.select_columns == ["id", "dashboard_title"]
 
+    def test_get_dashboard_info_accepts_filter_state(self) -> None:
+        applied = {"applied_filters": [{"col": "gender", "op": "IN", "val": ["F"]}]}
+        req = GetDashboardInfoRequest.model_validate(
+            {"identifier": 42, "filter_state": applied}
+        )
+        assert req.filter_state == applied
+
+    def test_get_dashboard_info_filter_state_defaults_none(self) -> None:
+        req = GetDashboardInfoRequest.model_validate({"identifier": 42})
+        assert req.filter_state is None
+
     @pytest.mark.parametrize(
         "payload",
         [

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_dashboard_tools.py
@@ -31,6 +31,7 @@ from superset.mcp_service.app import mcp
 from superset.mcp_service.dashboard.schemas import (
     DashboardError,
     DashboardInfo,
+    DEFAULT_GET_DASHBOARD_INFO_COLUMNS,
     ListDashboardsRequest,
 )
 from superset.utils import json
@@ -1586,3 +1587,168 @@ async def test_list_dashboards_no_arguments(mock_list, mcp_server):
         result = await client.call_tool("list_dashboards", {})
     data = json.loads(result.content[0].text)
     assert "dashboards" in data
+
+
+def _minimal_dashboard() -> Mock:
+    dashboard = Mock()
+    dashboard.id = 1
+    dashboard.dashboard_title = "Test Dashboard"
+    dashboard.slug = "test-dashboard"
+    dashboard.description = None
+    dashboard.css = None
+    dashboard.certified_by = None
+    dashboard.certification_details = None
+    dashboard.json_metadata = json.dumps({"native_filter_configuration": []})
+    dashboard.published = True
+    dashboard.is_managed_externally = False
+    dashboard.external_url = None
+    dashboard.created_on = None
+    dashboard.changed_on = None
+    dashboard.created_by = None
+    dashboard.changed_by = None
+    dashboard.uuid = "dashboard-uuid-1"
+    dashboard.url = "/dashboard/1"
+    dashboard.thumbnail_url = None
+    dashboard.created_on_humanized = None
+    dashboard.changed_on_humanized = None
+    dashboard.slices = []
+    dashboard.editors = []
+    dashboard.tags = []
+    dashboard.embedded = []
+    dashboard.charts = []
+    return dashboard
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_direct_filter_state(mock_info, mcp_server):
+    """filter_state supplied directly (no permalink) is attached to the result."""
+    mock_info.return_value = _minimal_dashboard()
+    filter_state = {"applied_filters": [{"col": "gender", "op": "IN", "val": ["F"]}]}
+    with patch(
+        "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+        return_value=True,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {"request": {"identifier": 1, "filter_state": filter_state}},
+            )
+    assert result.data["is_permalink_state"] is False
+    assert result.data["permalink_key"] is None
+    assert result.data["filter_state"]["applied_filters"][0]["col"] == "gender"
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_direct_filter_state_redacts_data_model_metadata(mock_info, mcp_server):
+    """A caller without data-model metadata access gets dataMask/chartStates
+    stripped from a directly supplied filter_state, as on the permalink path."""
+    mock_info.return_value = _minimal_dashboard()
+    filter_state = {
+        "applied_filters": [{"col": "gender", "op": "IN", "val": ["F"]}],
+        "dataMask": {"native-1": {}},
+        "chartStates": {"c1": {}},
+    }
+    with (
+        patch(
+            "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.dashboard.tool.get_dashboard_info."
+            "user_can_view_data_model_metadata",
+            return_value=False,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {"request": {"identifier": 1, "filter_state": filter_state}},
+            )
+    assert "dataMask" not in result.data["filter_state"]
+    assert "chartStates" not in result.data["filter_state"]
+    assert "applied_filters" in result.data["filter_state"]
+
+
+@patch("superset.mcp_service.dashboard.permalink.get_dashboard_permalink")
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_get_dashboard_info_permalink_wins_over_filter_state(
+    mock_info, mock_permalink, mcp_server
+):
+    """When both are given, permalink_key takes precedence over filter_state."""
+    mock_info.return_value = _minimal_dashboard()
+    mock_permalink.return_value = (
+        "permalink-1",
+        {"dashboardId": "1", "state": {"dataMask": {"native-filter-1": {}}}},
+    )
+    filter_state = {"applied_filters": [{"col": "gender", "op": "IN", "val": ["F"]}]}
+    with (
+        patch(
+            "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+            return_value=True,
+        ),
+        patch(
+            "superset.mcp_service.dashboard.permalink."
+            "user_can_view_data_model_metadata",
+            return_value=True,
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {
+                    "request": {
+                        "identifier": 1,
+                        "permalink_key": "permalink-1",
+                        "filter_state": filter_state,
+                    }
+                },
+            )
+    assert result.data["permalink_key"] == "permalink-1"
+    assert "dataMask" in result.data["filter_state"]
+    assert "applied_filters" not in result.data["filter_state"]
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_direct_empty_filter_state_is_honored(mock_info, mcp_server):
+    """An explicit empty {} filter_state is a cleared context, not an absent one."""
+    mock_info.return_value = _minimal_dashboard()
+    with patch(
+        "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+        return_value=True,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {"request": {"identifier": 1, "filter_state": {}}},
+            )
+    assert result.data["is_permalink_state"] is False
+    assert result.data["filter_state"] == {}
+
+
+@patch("superset.daos.dashboard.DashboardDAO.find_by_id")
+@pytest.mark.asyncio
+async def test_explicit_default_columns_excludes_filter_state(mock_info, mcp_server):
+    """A caller who explicitly projects the default columns keeps that projection:
+    filter_state is not force-appended even though the values equal the defaults."""
+    mock_info.return_value = _minimal_dashboard()
+    filter_state = {"applied_filters": [{"col": "gender", "op": "IN", "val": ["F"]}]}
+    with patch(
+        "superset.mcp_service.dashboard.schemas.user_can_view_data_model_metadata",
+        return_value=True,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "get_dashboard_info",
+                {
+                    "request": {
+                        "identifier": 1,
+                        "filter_state": filter_state,
+                        "select_columns": list(DEFAULT_GET_DASHBOARD_INFO_COLUMNS),
+                    }
+                },
+            )
+    assert "filter_state" not in result.data


### PR DESCRIPTION
### SUMMARY

`get_dashboard_info` could only surface a dashboard's applied filters through `permalink_key`. Embedded guests cannot mint permalinks (least privilege), so the filtered view was unreachable for them, and any caller had to persist a permalink just to describe a dashboard as it is currently filtered.

This adds an optional `filter_state` input that feeds the same `_apply_permalink_state` path a permalink resolves into, so a caller holding the live filter context can describe the dashboard as the user currently sees it, filtered, without a permalink. `permalink_key` takes precedence when both are supplied.

The change is additive and backward compatible: existing callers are unaffected. Both paths behave the same on privacy: for callers without data model metadata access, `dataMask` and `chartStates` are stripped from the returned `filter_state`, whether it came from a permalink or was supplied directly.

#### Note on `is_permalink_state`

The response reuses the existing `filter_state` field. Previously that field was only populated from a permalink, and `is_permalink_state` doubled as the flag that included `filter_state` in the default response columns.

This PR decouples the two: the direct path sets `is_permalink_state=False` (accurate, since the state did not come from a permalink), and `filter_state` is now included in the response whenever it is present, regardless of source.

### TESTING INSTRUCTIONS
* Schema: `filter_state` is accepted and defaults to `None`.
* Tool: supplying `filter_state` attaches it to the result (`is_permalink_state=False`, `filter_state` populated); `permalink_key` takes precedence when both are supplied; a caller without data model metadata access gets `dataMask`/`chartStates` stripped.

Manual: call `get_dashboard_info` with

```json
{"identifier": 123, "filter_state": {"applied_filters": [{"col": "gender", "op": "IN", "val": ["Female"]}]}}
```

and confirm the response includes `filter_state`, with `is_permalink_state` false and `permalink_key` null.

### ADDITIONAL INFORMATION

- [x] Introduces new feature or API
