### PR TITLE
docs: fix superset-core component source links after src/ui removal

### DIFF
--- a/docs/developer_docs/extensions/components/alert.mdx
+++ b/docs/developer_docs/extensions/components/alert.mdx
@@ -114,8 +114,8 @@ function MyExtension() {
 
 ## Source Links
 
-- [Story file](https://github.com/apache/superset/blob/master/superset-frontend/packages/superset-core/src/ui/components/Alert/Alert.stories.tsx)
-- [Component source](https://github.com/apache/superset/blob/master/superset-frontend/packages/superset-core/src/ui/components/Alert/index.tsx)
+- [Story file](https://github.com/apache/superset/blob/master/superset-frontend/packages/superset-core/src/components/Alert/Alert.stories.tsx)
+- [Component source](https://github.com/apache/superset/blob/master/superset-frontend/packages/superset-core/src/components/Alert/index.tsx)
 
 ---
 

--- a/docs/developer_docs/extensions/components/index.mdx
+++ b/docs/developer_docs/extensions/components/index.mdx
@@ -47,8 +47,8 @@ export function MyExtensionPanel() {
 
 Components in `@apache-superset/core/components` are automatically documented here. To add a new extension component:
 
-1. Add the component to `superset-frontend/packages/superset-core/src/ui/components/`
-2. Export it from `superset-frontend/packages/superset-core/src/ui/components/index.ts`
+1. Add the component to `superset-frontend/packages/superset-core/src/components/`
+2. Export it from `superset-frontend/packages/superset-core/src/components/index.ts`
 3. Create a Storybook story with an `Interactive` export:
 
 ```tsx


### PR DESCRIPTION
### Summary

The extension component docs still point at `superset-frontend/packages/superset-core/src/ui/components/`, but that `src/ui/` layer no longer exists — the package was reorganized into a feature-based structure and the components now live directly under `src/components/`. So the "Source Links" in `alert.mdx` 404, and the "add a new component" steps in `index.mdx` tell you to add files to a path that isn't there anymore.

This just drops the stale `ui/` segment from the paths:

- `alert.mdx` — the Story file / Component source links now resolve (they currently 404).
- `index.mdx` — the two instruction lines now point at the real `src/components/` location.

Verified against current `master`:
- `.../src/components/Alert/index.tsx` and `.../src/components/index.ts` exist.
- The old `.../src/ui/...` paths return 404.

Docs-only, no code or behavior change.
