### PR TITLE
fix(postprocessing): preserve NULL grouping index values in pivot()

### DIFF
--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -302,7 +302,25 @@ def pivot(  # pylint: disable=too-many-arguments  # noqa: C901
         percent_mode = show_values_as
 
     if columns and column_fill_value:
+        for col in columns:
+            if (
+                isinstance(df[col].dtype, pd.CategoricalDtype)
+                and column_fill_value not in df[col].cat.categories
+            ):
+                df[col] = df[col].cat.add_categories([column_fill_value])
         df[columns] = df[columns].fillna(value=column_fill_value)
+
+    # Fill NULL/NaN values in the index columns with NULL_STRING so that
+    # NULL grouping keys survive as a real "<NULL>" row in the pivot output.
+    # Mirrors the column fill above; pivot_table() drops NaN index rows
+    # regardless of the dropna= setting (dropna only governs the column axis).
+    for col in index:
+        if (
+            isinstance(df[col].dtype, pd.CategoricalDtype)
+            and NULL_STRING not in df[col].cat.categories
+        ):
+            df[col] = df[col].cat.add_categories([NULL_STRING])
+    df[index] = df[index].fillna(value=NULL_STRING)
 
     aggregate_funcs = _get_aggregate_funcs(df, aggregates)
 

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -190,6 +190,31 @@ def _restore_dropped_metric_columns(
     return df
 
 
+def _fill_dimension_column(df: DataFrame, col: str, fill_value: str) -> None:
+    """Fill missing values in a groupby dimension column before pivoting.
+
+    Handles categorical dtypes (adding fill_value to categories) and datetime
+    dtypes (converting to string representation with fill_value for NaT) to prevent
+    dtype errors and preserve NULL/NaN/NaT keys through pivot_table().
+    """
+    s = df[col]
+    if (
+        isinstance(s.dtype, pd.CategoricalDtype)
+        and fill_value not in s.cat.categories
+    ):
+        df[col] = s.cat.add_categories([fill_value]).fillna(value=fill_value)
+    elif pd.api.types.is_datetime64_any_dtype(s.dtype) or getattr(s.dtype, "kind", None) == "M":
+        if s.isna().any():
+            df[col] = s.astype(str).replace({
+                "NaT": fill_value,
+                "<NA>": fill_value,
+                "nan": fill_value,
+                "None": fill_value,
+            })
+    else:
+        df[col] = s.fillna(value=fill_value)
+
+
 @validate_column_args("index", "columns")
 def pivot(  # pylint: disable=too-many-arguments  # noqa: C901
     df: DataFrame,
@@ -303,24 +328,14 @@ def pivot(  # pylint: disable=too-many-arguments  # noqa: C901
 
     if columns and column_fill_value:
         for col in columns:
-            if (
-                isinstance(df[col].dtype, pd.CategoricalDtype)
-                and column_fill_value not in df[col].cat.categories
-            ):
-                df[col] = df[col].cat.add_categories([column_fill_value])
-        df[columns] = df[columns].fillna(value=column_fill_value)
+            _fill_dimension_column(df, col, column_fill_value)
 
-    # Fill NULL/NaN values in the index columns with NULL_STRING so that
+    # Fill NULL/NaN/NaT values in the index columns with NULL_STRING so that
     # NULL grouping keys survive as a real "<NULL>" row in the pivot output.
     # Mirrors the column fill above; pivot_table() drops NaN index rows
     # regardless of the dropna= setting (dropna only governs the column axis).
     for col in index:
-        if (
-            isinstance(df[col].dtype, pd.CategoricalDtype)
-            and NULL_STRING not in df[col].cat.categories
-        ):
-            df[col] = df[col].cat.add_categories([NULL_STRING])
-    df[index] = df[index].fillna(value=NULL_STRING)
+        _fill_dimension_column(df, col, NULL_STRING)
 
     aggregate_funcs = _get_aggregate_funcs(df, aggregates)
 

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -198,19 +198,21 @@ def _fill_dimension_column(df: DataFrame, col: str, fill_value: str) -> None:
     dtype errors and preserve NULL/NaN/NaT keys through pivot_table().
     """
     s = df[col]
-    if (
-        isinstance(s.dtype, pd.CategoricalDtype)
-        and fill_value not in s.cat.categories
-    ):
+    if isinstance(s.dtype, pd.CategoricalDtype) and fill_value not in s.cat.categories:
         df[col] = s.cat.add_categories([fill_value]).fillna(value=fill_value)
-    elif pd.api.types.is_datetime64_any_dtype(s.dtype) or getattr(s.dtype, "kind", None) == "M":
+    elif (
+        pd.api.types.is_datetime64_any_dtype(s.dtype)
+        or getattr(s.dtype, "kind", None) == "M"
+    ):
         if s.isna().any():
-            df[col] = s.astype(str).replace({
-                "NaT": fill_value,
-                "<NA>": fill_value,
-                "nan": fill_value,
-                "None": fill_value,
-            })
+            df[col] = s.astype(str).replace(
+                {
+                    "NaT": fill_value,
+                    "<NA>": fill_value,
+                    "nan": fill_value,
+                    "None": fill_value,
+                }
+            )
     else:
         df[col] = s.fillna(value=fill_value)
 

--- a/tests/unit_tests/pandas_postprocessing/test_pivot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_pivot.py
@@ -1051,3 +1051,89 @@ def test_pivot_preserves_null_index_value_datetime_timezone_aware() -> None:
         f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
     )
     assert result.loc[NULL_STRING, "v"] == 99
+
+
+def test_pivot_preserves_null_index_value_categorical_already_in_categories() -> None:
+    """A categorical index that already has NULL_STRING in its categories
+    must not fail or attempt duplicate category insertion and must fill NULLs.
+    """
+    df = DataFrame(
+        {
+            "row": pd.Categorical(["r1", None, "r2"], categories=["r1", "r2", NULL_STRING]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, "v"] == 99
+
+
+def test_pivot_categorical_column_with_null() -> None:
+    """A categorical groupby column containing NULL values must add the
+    column_fill_value to categories and preserve '<NULL>' in MultiIndex columns.
+    """
+    df = DataFrame(
+        {
+            "row": ["r1", "r2", "r3"],
+            "col": pd.Categorical(["c1", None, "c2"]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        columns=["col"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert ("v", NULL_STRING) in result.columns
+    assert result.loc["r2", ("v", NULL_STRING)] == 99
+
+
+def test_pivot_categorical_column_already_in_categories() -> None:
+    """A categorical groupby column that already includes the fill value in its
+    categories must properly fill NULLs without error.
+    """
+    df = DataFrame(
+        {
+            "row": ["r1", "r2", "r3"],
+            "col": pd.Categorical(["c1", None, "c2"], categories=["c1", "c2", "CUSTOM_NULL"]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        columns=["col"],
+        column_fill_value="CUSTOM_NULL",
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert ("v", "CUSTOM_NULL") in result.columns
+    assert result.loc["r2", ("v", "CUSTOM_NULL")] == 99
+
+
+def test_pivot_preserves_null_numeric_index_value() -> None:
+    """A numeric index containing NaN must be converted/filled with NULL_STRING
+    so that the NaN row is preserved through pivot_table().
+    """
+    df = DataFrame(
+        {
+            "num_idx": [1.0, np.nan, 2.0],
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["num_idx"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, "v"] == 99
+

--- a/tests/unit_tests/pandas_postprocessing/test_pivot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_pivot.py
@@ -1059,7 +1059,9 @@ def test_pivot_preserves_null_index_value_categorical_already_in_categories() ->
     """
     df = DataFrame(
         {
-            "row": pd.Categorical(["r1", None, "r2"], categories=["r1", "r2", NULL_STRING]),
+            "row": pd.Categorical(
+                ["r1", None, "r2"], categories=["r1", "r2", NULL_STRING]
+            ),
             "v": [10, 99, 30],
         }
     )
@@ -1102,7 +1104,9 @@ def test_pivot_categorical_column_already_in_categories() -> None:
     df = DataFrame(
         {
             "row": ["r1", "r2", "r3"],
-            "col": pd.Categorical(["c1", None, "c2"], categories=["c1", "c2", "CUSTOM_NULL"]),
+            "col": pd.Categorical(
+                ["c1", None, "c2"], categories=["c1", "c2", "CUSTOM_NULL"]
+            ),
             "v": [10, 99, 30],
         }
     )
@@ -1136,4 +1140,3 @@ def test_pivot_preserves_null_numeric_index_value() -> None:
         f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
     )
     assert result.loc[NULL_STRING, "v"] == 99
-

--- a/tests/unit_tests/pandas_postprocessing/test_pivot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_pivot.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 from pandas import DataFrame, to_datetime
 
+from superset.constants import NULL_STRING
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.pandas_postprocessing import flatten, pivot
 from tests.unit_tests.fixtures.dataframes import categories_df
@@ -871,3 +872,113 @@ def test_pivot_show_values_as_preserves_structural_nan() -> None:
     assert pd.isna(result.loc["r1", ("v", "c2")])
     # r1's row-total is just c1 (10.0), so c1 is 100%.
     assert result.loc["r1", ("v", "c1")] == pytest.approx(1.0)
+
+
+# --- NULL index preservation tests (#43547) ----------------------------------
+#
+# pandas pivot_table() silently drops rows whose index columns contain NaN,
+# regardless of the dropna= setting (which only governs the column axis).
+# The fix fills index columns with NULL_STRING before calling pivot_table(),
+# mirroring the existing treatment of the columns= parameter.
+
+
+def test_pivot_preserves_null_index_value() -> None:
+    """A NULL value in a flat (no columns groupby) index column must appear
+    as a '<NULL>' row in the result rather than being silently dropped.
+
+    Regression for #43547: pivot_table() drops NaN index rows regardless of
+    dropna=; filling the index with NULL_STRING before the call preserves them.
+    """
+    df = DataFrame(
+        {
+            "row": ["r1", None, "r2"],  # middle row has a NULL index value
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    # The NULL group must survive as a real index label, not be dropped.
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    # The metric value for the NULL group must be correct.
+    assert result.loc[NULL_STRING, "v"] == 99
+
+
+def test_pivot_preserves_null_index_value_with_columns() -> None:
+    """A NULL value in an index column must survive as '<NULL>' even when a
+    columns= groupby is also active (MultiIndex column case).
+
+    Regression for #43547: the fix must work for both the flat pivot and the
+    MultiIndex pivot so that NULL row groups are never silently dropped.
+    """
+    df = DataFrame(
+        {
+            "row": ["r1", None, "r2"],  # middle row has a NULL index value
+            "col": ["c1", "c1", "c1"],
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        columns=["col"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    # The NULL group must survive as a real index label in the MultiIndex pivot.
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    # The metric value for the NULL-indexed group must be correct.
+    assert result.loc[NULL_STRING, ("v", "c1")] == 99
+
+
+def test_pivot_preserves_null_index_value_categorical() -> None:
+    """A categorical index column with a NULL value must have NULL_STRING added
+    as a valid category first and be preserved as '<NULL>' in the pivot output.
+
+    Regression for #43547: ensures fillna() on CategoricalDtype does not raise
+    and preserves the NULL index group.
+    """
+    df = DataFrame(
+        {
+            "row": pd.Categorical(["r1", None, "r2"]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, "v"] == 99
+
+
+def test_pivot_preserves_null_index_value_categorical_with_columns() -> None:
+    """Both index and column dimensions as categorical dtypes with NULL values
+    must properly add NULL_STRING to categories and preserve '<NULL>' rows and
+    columns in the MultiIndex output.
+    """
+    df = DataFrame(
+        {
+            "row": pd.Categorical(["r1", None, "r2"]),
+            "col": pd.Categorical(["c1", None, "c2"]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["row"],
+        columns=["col"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, ("v", NULL_STRING)] == 99

--- a/tests/unit_tests/pandas_postprocessing/test_pivot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_pivot.py
@@ -982,3 +982,72 @@ def test_pivot_preserves_null_index_value_categorical_with_columns() -> None:
         f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
     )
     assert result.loc[NULL_STRING, ("v", NULL_STRING)] == 99
+
+
+def test_pivot_preserves_null_index_value_datetime() -> None:
+    """A datetime index column containing NaT/NULL must not raise a TypeError
+    when filled and must be preserved as '<NULL>' in the pivot output.
+
+    Regression for #43547: datetime64 columns cannot store strings directly;
+    converting NaT-containing datetime columns to string ensures NaT keys
+    survive pivot_table() without dtype/sort errors.
+    """
+    df = DataFrame(
+        {
+            "dttm": to_datetime(["2019-01-01", None, "2019-01-03"]),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["dttm"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, "v"] == 99
+
+
+def test_pivot_preserves_null_index_value_datetime_with_columns() -> None:
+    """A datetime index column containing NaT/NULL with a columns groupby
+    must preserve '<NULL>' in the MultiIndex output without type errors.
+    """
+    df = DataFrame(
+        {
+            "dttm": to_datetime(["2019-01-01", None, "2019-01-03"]),
+            "col": ["c1", "c1", "c2"],
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["dttm"],
+        columns=["col"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, ("v", "c1")] == 99
+
+
+def test_pivot_preserves_null_index_value_datetime_timezone_aware() -> None:
+    """A timezone-aware datetime index containing NaT must preserve '<NULL>'
+    without dtype or timezone conversion errors.
+    """
+    df = DataFrame(
+        {
+            "dttm": to_datetime(["2019-01-01", None, "2019-01-03"], utc=True),
+            "v": [10, 99, 30],
+        }
+    )
+    result = pivot(
+        df=df,
+        index=["dttm"],
+        aggregates={"v": {"operator": "sum"}},
+    )
+    assert NULL_STRING in result.index, (
+        f"Expected '{NULL_STRING}' in pivot index; got {result.index.tolist()}"
+    )
+    assert result.loc[NULL_STRING, "v"] == 99


### PR DESCRIPTION
## Summary

Follow-up fix for #43547 to preserve `NULL`/`NaN` grouping values through the pandas post-processing `pivot()` operator.

## Problem

`NULL` values in the `columns` parameter were already handled using Superset's existing `NULL_STRING` before calling `pivot_table()`. However, `index` columns did not have equivalent handling.

As a result, when a `NULL` grouping value survived the `aggregate` step, pandas `pivot_table()` could drop that row during pivoting because the grouping key contained `NaN`.

This caused valid `NULL` groups to disappear from the pivot output.

## Solution

- Fill `NULL`/`NaN` values in `index` columns with the existing `NULL_STRING` before calling `pivot_table()`.
- Handle categorical `index` columns by adding `NULL_STRING` to their categories before filling.
- Handle categorical `columns` values when the configured fill value is not already present in the categories.
- Preserve the existing `drop_missing_columns` / `dropna` behavior.
- Reuse the existing `NULL_STRING` constant.
- Add regression tests covering NULL index values in flat and MultiIndex pivots, including categorical dtypes.

## Tests

Added regression tests for:

- Flat pivot with NULL index values
- Pivot with NULL index values and columns grouping
- Categorical index with NULL values
- Categorical index and columns with NULL values

Tested with:

```bash
pytest tests/unit_tests/pandas_postprocessing/test_pivot.py -v
```

@kokhlo I’ve submitted this follow-up PR for the NULL index handling issue identified in the discussion. The change preserves NULL grouping values through the pivot post-processing path and includes regression tests. Would appreciate your review!

Fixes #43547