### PR TITLE
feat(db_engine_specs): improve DB2 time grain expressions using DATE_TRUNC (#43231)

### DIFF
--- a/superset/db_engine_specs/db2.py
+++ b/superset/db_engine_specs/db2.py
@@ -95,21 +95,14 @@ class Db2EngineSpec(BaseEngineSpec):
 
     _time_grain_expressions = {
         None: "{col}",
-        TimeGrain.SECOND: "CAST({col} as TIMESTAMP) - MICROSECOND({col}) MICROSECONDS",
-        TimeGrain.MINUTE: "CAST({col} as TIMESTAMP)"
-        " - SECOND({col}) SECONDS"
-        " - MICROSECOND({col}) MICROSECONDS",
-        TimeGrain.HOUR: "CAST({col} as TIMESTAMP)"
-        " - MINUTE({col}) MINUTES"
-        " - SECOND({col}) SECONDS"
-        " - MICROSECOND({col}) MICROSECONDS ",
-        TimeGrain.DAY: "DATE({col})",
-        TimeGrain.WEEK: "{col} - (DAYOFWEEK({col})) DAYS",
-        TimeGrain.MONTH: "{col} - (DAY({col})-1) DAYS",
-        TimeGrain.QUARTER: "{col} - (DAY({col})-1) DAYS"
-        " - (MONTH({col})-1) MONTHS"
-        " + ((QUARTER({col})-1) * 3) MONTHS",
-        TimeGrain.YEAR: "{col} - (DAY({col})-1) DAYS - (MONTH({col})-1) MONTHS",
+        TimeGrain.SECOND: "DATE_TRUNC('SECOND', {col})",
+        TimeGrain.MINUTE: "DATE_TRUNC('MINUTE', {col})",
+        TimeGrain.HOUR: "DATE_TRUNC('HOUR', {col})",
+        TimeGrain.DAY: "DATE_TRUNC('DAY', {col})",
+        TimeGrain.WEEK: "DATE_TRUNC('WEEK', {col})",
+        TimeGrain.MONTH: "DATE_TRUNC('MONTH', {col})",
+        TimeGrain.QUARTER: "DATE_TRUNC('QUARTER', {col})",
+        TimeGrain.YEAR: "DATE_TRUNC('YEAR', {col})",
     }
 
     @classmethod

--- a/tests/unit_tests/db_engine_specs/test_db2.py
+++ b/tests/unit_tests/db_engine_specs/test_db2.py
@@ -109,33 +109,14 @@ def test_get_prequeries(mocker: MockerFixture) -> None:
     ("grain", "expected_expression"),
     [
         (None, "my_col"),
-        (
-            TimeGrain.SECOND,
-            "CAST(my_col as TIMESTAMP) - MICROSECOND(my_col) MICROSECONDS",
-        ),
-        (
-            TimeGrain.MINUTE,
-            "CAST(my_col as TIMESTAMP)"
-            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS",
-        ),
-        (
-            TimeGrain.HOUR,
-            "CAST(my_col as TIMESTAMP)"
-            " - MINUTE(my_col) MINUTES"
-            " - SECOND(my_col) SECONDS - MICROSECOND(my_col) MICROSECONDS ",
-        ),
-        (TimeGrain.DAY, "DATE(my_col)"),
-        (TimeGrain.WEEK, "my_col - (DAYOFWEEK(my_col)) DAYS"),
-        (TimeGrain.MONTH, "my_col - (DAY(my_col)-1) DAYS"),
-        (
-            TimeGrain.QUARTER,
-            "my_col - (DAY(my_col)-1) DAYS"
-            " - (MONTH(my_col)-1) MONTHS + ((QUARTER(my_col)-1) * 3) MONTHS",
-        ),
-        (
-            TimeGrain.YEAR,
-            "my_col - (DAY(my_col)-1) DAYS - (MONTH(my_col)-1) MONTHS",
-        ),
+        (TimeGrain.SECOND, "DATE_TRUNC('SECOND', my_col)"),
+        (TimeGrain.MINUTE, "DATE_TRUNC('MINUTE', my_col)"),
+        (TimeGrain.HOUR, "DATE_TRUNC('HOUR', my_col)"),
+        (TimeGrain.DAY, "DATE_TRUNC('DAY', my_col)"),
+        (TimeGrain.WEEK, "DATE_TRUNC('WEEK', my_col)"),
+        (TimeGrain.MONTH, "DATE_TRUNC('MONTH', my_col)"),
+        (TimeGrain.QUARTER, "DATE_TRUNC('QUARTER', my_col)"),
+        (TimeGrain.YEAR, "DATE_TRUNC('YEAR', my_col)"),
     ],
 )
 def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> None:
@@ -148,14 +129,29 @@ def test_time_grain_expressions(grain: TimeGrain, expected_expression: str) -> N
     assert actual == expected_expression
 
 
+def test_db2_properties() -> None:
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    assert Db2EngineSpec.engine == "db2"
+    assert Db2EngineSpec.engine_name == "IBM Db2"
+    assert Db2EngineSpec.max_column_name_length == 30
+    assert Db2EngineSpec.supports_dynamic_schema is True
+
+
+def test_db2_metadata() -> None:
+    from superset.db_engine_specs.db2 import Db2EngineSpec
+
+    metadata = Db2EngineSpec.metadata
+    assert "IBM Db2 is a family of data management products" in metadata["description"]
+    assert metadata["logo"] == "ibm-db2.svg"
+    assert "ibm_db_sa" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 50000
+
+
 def test_time_grain_day_parseable() -> None:
     """
     Test that the DAY time grain expression generates valid SQL
     that can be parsed by sqlglot.
-
-    This test addresses the bug where the previous expression
-    "CAST({col} as TIMESTAMP) - HOUR({col}) HOURS - ..."
-    could not be parsed by sqlglot.
     """
     from superset.db_engine_specs.db2 import Db2EngineSpec
 
@@ -170,3 +166,4 @@ def test_time_grain_day_parseable() -> None:
         assert parsed is not None
     except ParseError as e:
         pytest.fail(f"Failed to parse DAY time grain SQL: {e}")
+

--- a/tests/unit_tests/db_engine_specs/test_drill.py
+++ b/tests/unit_tests/db_engine_specs/test_drill.py
@@ -174,3 +174,22 @@ def test_connect_make_label_compatible(column_name: str, expected_result: str) -
 
     label = spec.make_label_compatible(column_name)
     assert label == expected_result
+
+
+def test_drill_properties() -> None:
+    from superset.db_engine_specs.drill import DrillEngineSpec
+
+    assert DrillEngineSpec.engine == "drill"
+    assert DrillEngineSpec.engine_name == "Apache Drill"
+    assert DrillEngineSpec.default_driver == "sadrill"
+
+
+def test_drill_metadata() -> None:
+    from superset.db_engine_specs.drill import DrillEngineSpec
+
+    metadata = DrillEngineSpec.metadata
+    assert "Apache Drill" in metadata["description"]
+    assert metadata["logo"] == "drill.png"
+    assert "sqlalchemy-drill" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 8047
+

--- a/tests/unit_tests/db_engine_specs/test_druid.py
+++ b/tests/unit_tests/db_engine_specs/test_druid.py
@@ -258,3 +258,23 @@ def test_unmask_encrypted_extra() -> None:
     assert DruidEngineSpec.unmask_encrypted_extra(old, new) == json.dumps(
         {"connect_args": {"scheme": "http", "jwt": "old-token", "password": "new"}}
     )
+
+
+def test_druid_properties() -> None:
+    from superset.db_engine_specs.druid import DruidEngineSpec
+
+    assert DruidEngineSpec.engine == "druid"
+    assert DruidEngineSpec.engine_name == "Apache Druid"
+    assert DruidEngineSpec.allows_joins is True
+    assert DruidEngineSpec.allows_subqueries is True
+
+
+def test_druid_metadata() -> None:
+    from superset.db_engine_specs.druid import DruidEngineSpec
+
+    metadata = DruidEngineSpec.metadata
+    assert "Apache Druid" in metadata["description"]
+    assert metadata["logo"] == "druid.png"
+    assert "pydruid" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 8082
+

--- a/tests/unit_tests/db_engine_specs/test_firebird.py
+++ b/tests/unit_tests/db_engine_specs/test_firebird.py
@@ -104,3 +104,22 @@ def test_convert_dttm(
     )
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_firebird_properties() -> None:
+    from superset.db_engine_specs.firebird import FirebirdEngineSpec
+
+    assert FirebirdEngineSpec.engine == "firebird"
+    assert FirebirdEngineSpec.engine_name == "Firebird"
+    assert FirebirdEngineSpec.default_driver == "fdb"
+
+
+def test_firebird_metadata() -> None:
+    from superset.db_engine_specs.firebird import FirebirdEngineSpec
+
+    metadata = FirebirdEngineSpec.metadata
+    assert "Firebird is an open-source relational database" in metadata["description"]
+    assert metadata["logo"] == "firebird.png"
+    assert "sqlalchemy-firebird" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 3050
+

--- a/tests/unit_tests/db_engine_specs/test_hana.py
+++ b/tests/unit_tests/db_engine_specs/test_hana.py
@@ -43,3 +43,25 @@ def test_convert_dttm(
     from superset.db_engine_specs.hana import HanaEngineSpec as spec  # noqa: N813
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_hana_properties() -> None:
+    from superset.db_engine_specs.hana import HanaEngineSpec
+    from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
+
+    assert HanaEngineSpec.engine == "hana"
+    assert HanaEngineSpec.engine_name == "SAP HANA"
+    assert issubclass(HanaEngineSpec, PostgresBaseEngineSpec)
+    assert HanaEngineSpec.max_column_name_length == 30
+    assert HanaEngineSpec._extended_aggregations == {}
+
+
+def test_hana_metadata() -> None:
+    from superset.db_engine_specs.hana import HanaEngineSpec
+
+    metadata = HanaEngineSpec.metadata
+    assert "SAP HANA is an in-memory relational database" in metadata["description"]
+    assert metadata["logo"] == "sap-hana.png"
+    assert "sqlalchemy-hana" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 30015
+

--- a/tests/unit_tests/db_engine_specs/test_hive.py
+++ b/tests/unit_tests/db_engine_specs/test_hive.py
@@ -274,3 +274,23 @@ def test_spark_identifier_quote_uses_backticks() -> None:
         "end": "`",
         "escape_by_doubling": True,
     }
+
+
+def test_hive_properties() -> None:
+    from superset.db_engine_specs.hive import HiveEngineSpec
+
+    assert HiveEngineSpec.engine == "hive"
+    assert HiveEngineSpec.engine_name == "Apache Hive"
+    assert HiveEngineSpec.default_driver == "pyhive"
+    assert HiveEngineSpec.max_column_name_length == 767
+
+
+def test_hive_metadata() -> None:
+    from superset.db_engine_specs.hive import HiveEngineSpec
+
+    metadata = HiveEngineSpec.metadata
+    assert "Apache Hive" in metadata["description"]
+    assert metadata["logo"] == "hive.png"
+    assert "pyhive" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 10000
+

--- a/tests/unit_tests/db_engine_specs/test_impala.py
+++ b/tests/unit_tests/db_engine_specs/test_impala.py
@@ -172,3 +172,23 @@ def test_cancel_query_allows_internal_host_with_opt_out(
         allow_redirects=False,
     )
     assert result is True
+
+
+def test_impala_properties() -> None:
+    from superset.db_engine_specs.impala import ImpalaEngineSpec
+
+    assert ImpalaEngineSpec.engine == "impala"
+    assert ImpalaEngineSpec.engine_name == "Apache Impala"
+    assert ImpalaEngineSpec.default_driver == "impala"
+    assert ImpalaEngineSpec.force_column_alias_quotes is True
+
+
+def test_impala_metadata() -> None:
+    from superset.db_engine_specs.impala import ImpalaEngineSpec
+
+    metadata = ImpalaEngineSpec.metadata
+    assert "Apache Impala" in metadata["description"]
+    assert metadata["logo"] == "impala.png"
+    assert "impyla" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 21050
+

--- a/tests/unit_tests/db_engine_specs/test_kusto.py
+++ b/tests/unit_tests/db_engine_specs/test_kusto.py
@@ -224,3 +224,27 @@ def test_kql_execute_array_processing(raw_query: str, expected_query: str) -> No
     KustoKqlEngineSpec.execute(mock_cursor, raw_query, mock_db)
 
     mock_cursor.execute.assert_called_once_with(expected_query)
+
+
+def test_kusto_properties() -> None:
+    from superset.db_engine_specs.kusto import KustoKqlEngineSpec, KustoSqlEngineSpec
+
+    assert KustoSqlEngineSpec.engine == "kustosql"
+    assert KustoSqlEngineSpec.engine_name == "Azure Data Explorer (Kusto SQL)"
+    assert KustoKqlEngineSpec.engine == "kustokql"
+    assert KustoKqlEngineSpec.engine_name == "Azure Data Explorer (Kusto KQL)"
+
+
+def test_kusto_metadata() -> None:
+    from superset.db_engine_specs.kusto import KustoKqlEngineSpec, KustoSqlEngineSpec
+
+    sql_meta = KustoSqlEngineSpec.metadata
+    assert "Azure Data Explorer" in sql_meta["description"]
+    assert sql_meta["logo"] == "azure.svg"
+    assert "sqlalchemy-kusto" in sql_meta["pypi_packages"]
+
+    kql_meta = KustoKqlEngineSpec.metadata
+    assert "Azure Data Explorer" in kql_meta["description"]
+    assert kql_meta["logo"] == "azure.svg"
+    assert "sqlalchemy-kusto" in kql_meta["pypi_packages"]
+

--- a/tests/unit_tests/db_engine_specs/test_kylin.py
+++ b/tests/unit_tests/db_engine_specs/test_kylin.py
@@ -40,3 +40,41 @@ def test_convert_dttm(
     from superset.db_engine_specs.kylin import KylinEngineSpec as spec  # noqa: N813
 
     assert_convert_dttm(spec, target_type, expected_result, dttm)
+
+
+def test_kylin_properties() -> None:
+    from superset.db_engine_specs.kylin import KylinEngineSpec
+
+    assert KylinEngineSpec.engine == "kylin"
+    assert KylinEngineSpec.engine_name == "Apache Kylin"
+
+
+def test_kylin_metadata() -> None:
+    from superset.db_engine_specs.kylin import KylinEngineSpec
+
+    metadata = KylinEngineSpec.metadata
+    assert "Apache Kylin is an open-source OLAP engine" in metadata["description"]
+    assert metadata["logo"] == "apache-kylin.png"
+    assert "kylinpy" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 7070
+
+
+@pytest.mark.parametrize(
+    "time_grain,expected",
+    [
+        (None, "ts"),
+        ("PT1S", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO SECOND) AS TIMESTAMP)"),
+        ("PT1M", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO MINUTE) AS TIMESTAMP)"),
+        ("PT1H", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO HOUR) AS TIMESTAMP)"),
+        ("P1D", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO DAY) AS DATE)"),
+        ("P1W", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO WEEK) AS DATE)"),
+        ("P1M", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO MONTH) AS DATE)"),
+        ("P3M", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO QUARTER) AS DATE)"),
+        ("P1Y", "CAST(FLOOR(CAST(ts AS TIMESTAMP) TO YEAR) AS DATE)"),
+    ],
+)
+def test_time_grain_expressions(time_grain: str | None, expected: str) -> None:
+    from superset.db_engine_specs.kylin import KylinEngineSpec
+
+    assert KylinEngineSpec._time_grain_expressions[time_grain].format(col="ts") == expected
+

--- a/tests/unit_tests/db_engine_specs/test_mariadb.py
+++ b/tests/unit_tests/db_engine_specs/test_mariadb.py
@@ -33,3 +33,17 @@ def test_mariadb_inherits_extended_aggregations() -> None:
     assert MariaDBEngineSpec.get_extended_aggregation_func("VAR_SAMP") is not None
     # Same as MySQL, MEDIAN is not supported.
     assert MariaDBEngineSpec.get_extended_aggregation_func("MEDIAN") is None
+
+
+def test_mariadb_properties() -> None:
+    assert MariaDBEngineSpec.engine == "mariadb"
+    assert MariaDBEngineSpec.engine_name == "MariaDB"
+
+
+def test_mariadb_metadata() -> None:
+    metadata = MariaDBEngineSpec.metadata
+    assert "MariaDB is a community-developed fork of MySQL" in metadata["description"]
+    assert metadata["logo"] == "mariadb.png"
+    assert "mysqlclient" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 3306
+

--- a/tests/unit_tests/db_engine_specs/test_pinot.py
+++ b/tests/unit_tests/db_engine_specs/test_pinot.py
@@ -55,3 +55,24 @@ def test_extras_without_ssl() -> None:
     database.server_cert = None
     extras = spec.get_extra_params(database)
     assert "connect_args" not in extras["engine_params"]
+
+
+def test_pinot_properties() -> None:
+    from superset.db_engine_specs.pinot import PinotEngineSpec
+
+    assert PinotEngineSpec.engine == "pinot"
+    assert PinotEngineSpec.engine_name == "Apache Pinot"
+    assert PinotEngineSpec.allows_joins is False
+    assert PinotEngineSpec.allows_subqueries is False
+    assert PinotEngineSpec.type_probe_needs_row is True
+
+
+def test_pinot_metadata() -> None:
+    from superset.db_engine_specs.pinot import PinotEngineSpec
+
+    metadata = PinotEngineSpec.metadata
+    assert "Apache Pinot is a real-time distributed OLAP" in metadata["description"]
+    assert metadata["logo"] == "apache-pinot.svg"
+    assert "pinotdb" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 8099
+

--- a/tests/unit_tests/db_engine_specs/test_redshift.py
+++ b/tests/unit_tests/db_engine_specs/test_redshift.py
@@ -109,3 +109,24 @@ def test_extended_aggregation_func_inherited_from_postgres() -> None:
 
     for aggregate in ("STDDEV_SAMP", "VAR_SAMP"):
         assert RedshiftEngineSpec.get_extended_aggregation_func(aggregate) is not None
+
+
+def test_redshift_properties() -> None:
+    from superset.db_engine_specs.postgres import PostgresBaseEngineSpec
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    assert RedshiftEngineSpec.engine == "redshift"
+    assert RedshiftEngineSpec.engine_name == "Amazon Redshift"
+    assert RedshiftEngineSpec.max_column_name_length == 127
+    assert issubclass(RedshiftEngineSpec, PostgresBaseEngineSpec)
+
+
+def test_redshift_metadata() -> None:
+    from superset.db_engine_specs.redshift import RedshiftEngineSpec
+
+    metadata = RedshiftEngineSpec.metadata
+    assert "Amazon Redshift is a fully managed, petabyte-scale" in metadata["description"]
+    assert metadata["logo"] == "aws.png"
+    assert "redshift_connector" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 5439
+

--- a/tests/unit_tests/db_engine_specs/test_singlestore.py
+++ b/tests/unit_tests/db_engine_specs/test_singlestore.py
@@ -218,3 +218,21 @@ def test_get_function_names_with_db() -> None:
     assert "is_prime" in functions
 
     mock_database.get_df.assert_called_once_with("SHOW FUNCTIONS IN `db``1`")
+
+
+def test_singlestore_properties() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    assert SingleStoreSpec.engine == "singlestoredb"
+    assert SingleStoreSpec.engine_name == "SingleStore"
+    assert issubclass(SingleStoreSpec, MySQLEngineSpec)
+    assert SingleStoreSpec.supports_dynamic_schema is True
+
+
+def test_singlestore_metadata() -> None:
+    metadata = SingleStoreSpec.metadata
+    assert "SingleStore" in metadata["description"]
+    assert metadata["logo"] == "singlestore.png"
+    assert "singlestoredb" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 3306
+

--- a/tests/unit_tests/db_engine_specs/test_starrocks.py
+++ b/tests/unit_tests/db_engine_specs/test_starrocks.py
@@ -385,3 +385,25 @@ def test_time_grain_expressions_inherit_mysql() -> None:
         "{col}", "my_col"
     )
     assert actual == "DATE_FORMAT(my_col, '%Y-%m-%d %H:00:00')"
+
+
+def test_starrocks_properties() -> None:
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+    from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+
+    assert StarRocksEngineSpec.engine == "starrocks"
+    assert StarRocksEngineSpec.engine_name == "StarRocks"
+    assert issubclass(StarRocksEngineSpec, MySQLEngineSpec)
+    assert StarRocksEngineSpec.default_driver == "starrocks"
+    assert StarRocksEngineSpec.supports_dynamic_schema is True
+
+
+def test_starrocks_metadata() -> None:
+    from superset.db_engine_specs.starrocks import StarRocksEngineSpec
+
+    metadata = StarRocksEngineSpec.metadata
+    assert "StarRocks" in metadata["description"]
+    assert metadata["logo"] == "starrocks.png"
+    assert "starrocks" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 9030
+

--- a/tests/unit_tests/db_engine_specs/test_tdengine.py
+++ b/tests/unit_tests/db_engine_specs/test_tdengine.py
@@ -32,3 +32,36 @@ def test_get_schema_from_engine_params() -> None:
         )
         == "dbname"
     )
+
+
+def test_tdengine_properties() -> None:
+    from superset.db_engine_specs.tdengine import TDengineEngineSpec
+
+    assert TDengineEngineSpec.engine == "taosws"
+    assert TDengineEngineSpec.engine_name == "TDengine"
+    assert TDengineEngineSpec.default_driver == "taosws"
+    assert TDengineEngineSpec.max_column_name_length == 64
+
+
+def test_tdengine_metadata() -> None:
+    from superset.db_engine_specs.tdengine import TDengineEngineSpec
+
+    metadata = TDengineEngineSpec.metadata
+    assert "TDengine is a high-performance time-series database" in metadata["description"]
+    assert metadata["logo"] == "tdengine.png"
+    assert "taospy" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 6041
+
+
+def test_time_grain_expressions() -> None:
+    from superset.db_engine_specs.tdengine import TDengineEngineSpec
+
+    assert (
+        TDengineEngineSpec._time_grain_expressions["PT1S"].format(col="ts")
+        == "TIMETRUNCATE(ts, 1s, 0)"
+    )
+    assert (
+        TDengineEngineSpec._time_grain_expressions["P1D"].format(col="ts")
+        == "TIMETRUNCATE(ts, 1d, 0)"
+    )
+

--- a/tests/unit_tests/db_engine_specs/test_timescaledb.py
+++ b/tests/unit_tests/db_engine_specs/test_timescaledb.py
@@ -35,3 +35,18 @@ def test_timescaledb_inherits_extended_aggregations() -> None:
         TimescaleDBEngineSpec.get_extended_aggregation_func("STDDEV_SAMP") is not None
     )
     assert TimescaleDBEngineSpec.get_extended_aggregation_func("VAR_SAMP") is not None
+
+
+def test_timescaledb_properties() -> None:
+    assert TimescaleDBEngineSpec.engine == "timescaledb"
+    assert TimescaleDBEngineSpec.engine_name == "TimescaleDB"
+    assert TimescaleDBEngineSpec.default_driver == "psycopg2"
+
+
+def test_timescaledb_metadata() -> None:
+    metadata = TimescaleDBEngineSpec.metadata
+    assert "TimescaleDB is an open-source relational database" in metadata["description"]
+    assert metadata["logo"] == "timescale.png"
+    assert "psycopg2" in metadata["pypi_packages"]
+    assert metadata["default_port"] == 5432
+

--- a/tests/unit_tests/db_engine_specs/test_ydb.py
+++ b/tests/unit_tests/db_engine_specs/test_ydb.py
@@ -81,3 +81,22 @@ def test_specify_credentials() -> None:
     YDBEngineSpec.update_params_from_encrypted_extra(database, params)
     connect_args = params.setdefault("connect_args", {})
     assert connect_args.get("credentials") == auth_params
+
+
+def test_ydb_properties() -> None:
+    from superset.db_engine_specs.ydb import YDBEngineSpec
+
+    assert YDBEngineSpec.engine == "yql"
+    assert YDBEngineSpec.engine_name == "YDB"
+    assert YDBEngineSpec.default_driver == "ydb"
+    assert YDBEngineSpec.allows_alias_in_orderby is True
+
+
+def test_ydb_metadata() -> None:
+    from superset.db_engine_specs.ydb import YDBEngineSpec
+
+    metadata = YDBEngineSpec.metadata
+    assert "YDB is a distributed SQL database" in metadata["description"]
+    assert metadata["logo"] == "ydb.svg"
+    assert "ydb" in metadata["pypi_packages"]
+


### PR DESCRIPTION
### Summary
This PR addresses **Issue #43231** by modernizing the IBM Db2 time grain expressions using the native `DATE_TRUNC` scalar function, and expands database engine spec test suites across 17 database dialects.

### Changes
1. **IBM Db2 Engine Spec (`superset/db_engine_specs/db2.py`)**:
   - Replaced arithmetic timestamp manipulation with native `DATE_TRUNC('SECOND'|'MINUTE'|'HOUR'|'DAY'|'WEEK'|'MONTH'|'QUARTER'|'YEAR', {col})` for clean execution and ISO-8601 week alignment.
   - Updated unit tests in `tests/unit_tests/db_engine_specs/test_db2.py`.
2. **Database Engine Specs Unit Test Hardening**:
   - Added and strengthened properties and metadata unit test suites across 16 database dialects:
     - Apache Drill (`test_drill.py`)
     - Apache Druid (`test_druid.py`)
     - Apache Hive (`test_hive.py`)
     - Apache Impala (`test_impala.py`)
     - Apache Kylin (`test_kylin.py`)
     - MariaDB (`test_mariadb.py`)
     - Apache Pinot (`test_pinot.py`)
     - Amazon Redshift (`test_redshift.py`)
     - SingleStore (`test_singlestore.py`)
     - StarRocks (`test_starrocks.py`)
     - TDengine (`test_tdengine.py`)
     - TimescaleDB (`test_timescaledb.py`)
     - YDB (`test_ydb.py`)
     - SAP HANA (`test_hana.py`)
     - Firebird (`test_firebird.py`)
     - Azure Data Explorer / Kusto (`test_kusto.py`)

### Testing Instructions
- Run `pytest tests/unit_tests/db_engine_specs/test_db2.py`
- Run `pytest tests/unit_tests/db_engine_specs/`