### PR TITLE
fix(db_engine_specs): support SQLAlchemy 2 DBAPI discovery

### DIFF
--- a/superset/db_engine_specs/__init__.py
+++ b/superset/db_engine_specs/__init__.py
@@ -144,11 +144,14 @@ def get_available_engine_specs() -> dict[type[BaseEngineSpec], set[str]]:  # noq
                 issubclass(dialect, DefaultDialect)
                 and hasattr(dialect, "driver")
                 # adodbapi dialect is removed in SQLA 1.4 and doesn't implement the
-                # `dbapi` method, hence needs to be ignored to avoid logging a warning
+                # DBAPI import method, hence needs to be ignored to avoid a warning
                 and dialect.driver != "adodbapi"
             ):
                 try:
-                    dialect.dbapi()
+                    if hasattr(dialect, "import_dbapi"):
+                        dialect.import_dbapi()
+                    else:
+                        dialect.dbapi()
                 except ModuleNotFoundError:
                     continue
                 except Exception as ex:  # pylint: disable=broad-except

--- a/tests/unit_tests/db_engine_specs/test_init.py
+++ b/tests/unit_tests/db_engine_specs/test_init.py
@@ -137,6 +137,41 @@ def test_get_available_engine_specs_keeps_valid_third_party_dialect(
     assert available[SqliteEngineSpec] == {"valid_driver"}
 
 
+def test_get_available_engine_specs_supports_sqlalchemy_2_native_dialect(
+    mocker: MockerFixture,
+) -> None:
+    """A native SQLAlchemy 2 dialect is discovered through import_dbapi()."""
+    import sqlalchemy.dialects
+
+    from superset.db_engine_specs.mysql import MySQLEngineSpec
+
+    class ValidDialect(DefaultDialect):
+        driver = "mysqldb"
+
+        @classmethod
+        def import_dbapi(cls) -> object:
+            return object()
+
+    mocker.patch.object(sqlalchemy.dialects, "__all__", ["mysql"])
+    mocker.patch.object(
+        sqlalchemy.dialects.registry,
+        "load",
+        return_value=ValidDialect,
+    )
+    mocker.patch(
+        "superset.db_engine_specs.load_engine_specs",
+        return_value=iter([MySQLEngineSpec]),
+    )
+    mocker.patch(
+        "superset.db_engine_specs.entry_points",
+        return_value=[],
+    )
+
+    available = get_available_engine_specs()
+
+    assert available[MySQLEngineSpec] == {"mysqldb"}
+
+
 @pytest.mark.parametrize(
     "app",
     [{"DBS_AVAILABLE_DENYLIST": {"databricks": {"pyhive", "pyodbc"}}}],


### PR DESCRIPTION
### SUMMARY

Fix native SQLAlchemy dialect discovery after the SQLAlchemy 2 upgrade.

`get_available_engine_specs()` still called the SQLAlchemy 1.4 `dialect.dbapi()` API. Native SQLAlchemy 2 dialects expose `import_dbapi()` instead, so discovery logged an `AttributeError` and silently omitted installed drivers. For example, MySQL did not appear in `/api/v1/database/available/` even when `mysqlclient` was installed.

Use `import_dbapi()` when available and retain `dbapi()` as a fallback for older SQLAlchemy dialects. Add a regression test covering a native SQLAlchemy 2 MySQL dialect.

Fixes #43699

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. This changes backend driver discovery without UI changes.

### TESTING INSTRUCTIONS

1. Run `pytest tests/unit_tests/db_engine_specs/test_init.py` and verify all tests pass (`5 passed`).
2. Run Ruff formatting/lint checks on the two changed files.
3. Run Pylint on `superset/db_engine_specs/__init__.py`.
4. With `mysqlclient` installed, request `/api/v1/database/available/` and verify MySQL is returned with the `mysqldb` driver.

Local validation:

- `pytest tests/unit_tests/db_engine_specs/test_init.py -q`: 5 passed
- `ruff format` and `ruff check`: passed
- Pylint: 10.00/10
- Remaining applicable pre-commit hooks: passed
- Full Windows mypy hook is blocked by the existing `signal.SIGALRM`/`signal.alarm` platform errors in `superset/utils/core.py`; CI runs this check on Linux.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43699
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API