### PR TITLE
fix(gtf): address findings from the full-migration review

### DIFF
--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -353,6 +353,23 @@ test('gives up (rejects) after the stale timeout with no progress', async () => 
   expect(refetch).not.toHaveBeenCalled();
 });
 
+test('poll mode gives up (rejects) on a persistent status_changes error', async () => {
+  // A sustained fetch error must age toward the give-up too — not spin forever.
+  fetchMock.removeRoutes().clearHistory();
+  fetchMock.get(STATUS_CHANGES_ENDPOINT, { throws: new Error('network down') });
+  fetchMock.post(CANCEL_ENDPOINT, { status: 200, body: { action: 'aborted' } });
+  asyncEvent.init({
+    ...config,
+    GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT: 40, // ms
+  });
+
+  const refetch = jest.fn();
+  await expect(
+    asyncEvent.waitForAsyncData({ task_ids: ['stuck-task'] }, refetch),
+  ).rejects.toThrow('Timed out waiting for chart-data query results');
+  expect(refetch).not.toHaveBeenCalled();
+});
+
 test('backs off while awaited tasks stay quiet, then polls eagerly again on progress', async () => {
   jest.useFakeTimers();
   queueStatuses(); // every poll comes back empty: no progress

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -355,8 +355,13 @@ test('gives up (rejects) after the stale timeout with no progress', async () => 
 
 test('poll mode gives up (rejects) on a persistent status_changes error', async () => {
   // A sustained fetch error must age toward the give-up too — not spin forever.
+  // Use a 400 (client error, not retried by SupersetClient) so it rejects fast
+  // and deterministically rather than retrying over real timers.
   fetchMock.removeRoutes().clearHistory();
-  fetchMock.get(STATUS_CHANGES_ENDPOINT, { throws: new Error('network down') });
+  fetchMock.get(STATUS_CHANGES_ENDPOINT, {
+    status: 400,
+    body: { message: 'bad' },
+  });
   fetchMock.post(CANCEL_ENDPOINT, { status: 200, body: { action: 'aborted' } });
   asyncEvent.init({
     ...config,

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -54,6 +54,16 @@ jest.mock('src/middleware/realtime', () => ({
   },
 }));
 
+// Bootstrap can carry no `conf` (e.g. a component test with no data-bootstrap);
+// init() runs at module load, so it must not throw when conf is undefined.
+/* eslint-disable no-var, vars-on-top */
+var mockBootstrapConf: object | undefined;
+/* eslint-enable no-var, vars-on-top */
+jest.mock('src/utils/getBootstrapData', () => ({
+  __esModule: true,
+  default: () => ({ common: { conf: mockBootstrapConf } }),
+}));
+
 const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
 
 const STATUS_CHANGES_ENDPOINT = 'glob:*/api/v1/task/status_changes*';
@@ -117,6 +127,15 @@ test('does not poll status changes until a chart is awaiting async data', () => 
   asyncEvent.init(config);
 
   expect(fetchMock.callHistory.calls(STATUS_CHANGES_ENDPOINT)).toHaveLength(0);
+});
+
+test('init does not throw when bootstrap carries no conf', () => {
+  // Regression: init() runs at module load; reading WEBSOCKET_ENABLE off an
+  // undefined conf (async off, no data-bootstrap) must not crash the module —
+  // which would break every test file that transitively imports it.
+  mockedIsFeatureEnabled.mockReturnValue(false);
+  mockBootstrapConf = undefined;
+  expect(() => asyncEvent.init()).not.toThrow();
 });
 
 test('waits for every task before re-issuing', async () => {

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -514,8 +514,9 @@ export const init = (appConfig?: AppConfig) => {
   // When the websocket transport is enabled it is the sole completion mechanism:
   // we never run the recurring poll, only a one-shot catch-up on
   // registration/reconnect. With it disabled, the interval poll below is the only
-  // mechanism.
-  wsEnabled = Boolean(config.WEBSOCKET_ENABLE);
+  // mechanism. (`config` can be undefined when bootstrap carries no conf — e.g.
+  // under test — so read it defensively; this runs before the feature gate.)
+  wsEnabled = Boolean(config?.WEBSOCKET_ENABLE);
 
   // (Re)connect the shared realtime socket whenever the websocket transport is
   // enabled — independent of GLOBAL_ASYNC_QUERIES, since realtime list views

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -249,6 +249,20 @@ const applyStatus = (taskId: string, status: string) => {
   waitersByTaskId.delete(taskId);
 };
 
+// Age the poll toward giving up when it isn't making progress (a quiet no-change
+// poll OR a persistent fetch error). Returns true when it has been stale past
+// `pollStaleTimeoutMs` — the caller then abandons its waiters and stops — else
+// backs off (bounded) so a stuck task or a degraded endpoint isn't polled at the
+// eager interval forever. `lastProgressAt` only resets on real progress.
+const backOffOrGiveUp = (): boolean => {
+  if (Date.now() - lastProgressAt >= pollStaleTimeoutMs) {
+    abandonPolling();
+    return true;
+  }
+  currentPollDelayMs = Math.min(currentPollDelayMs * 2, pollBackoffMaxMs);
+  return false;
+};
+
 const loadStatusChanges = async (generation: number) => {
   if (stopIfStale(generation)) return;
   if (waitersByTaskId.size) {
@@ -270,19 +284,20 @@ const loadStatusChanges = async (generation: number) => {
         // Reset to eager polling and restart the give-up clock on any change.
         currentPollDelayMs = pollingDelayMs;
         lastProgressAt = Date.now();
-      } else {
-        // No progress: give up if we've been stale too long (a stuck/orphaned
-        // task), else back off (bounded).
-        if (Date.now() - lastProgressAt >= pollStaleTimeoutMs) {
-          abandonPolling();
-          pollingActive = false;
-          return;
-        }
-        currentPollDelayMs = Math.min(currentPollDelayMs * 2, pollBackoffMaxMs);
+      } else if (backOffOrGiveUp()) {
+        pollingActive = false;
+        return;
       }
     } catch (err) {
       if (stopIfStale(generation)) return;
       logging.warn(err);
+      // A persistent status_changes failure must also age toward the give-up and
+      // back off — otherwise a WS-off chart spins forever with no error while
+      // hammering a degraded endpoint at the eager interval.
+      if (backOffOrGiveUp()) {
+        pollingActive = false;
+        return;
+      }
     }
   }
   // Reschedule from the tail so a slow request never overlaps the next tick.

--- a/superset-frontend/src/middleware/realtime.test.ts
+++ b/superset-frontend/src/middleware/realtime.test.ts
@@ -283,6 +283,9 @@ test('refreshes the cookie and reconnects before the token expires', async () =>
     // freshly minted token before the server terminates the socket at expiry.
     connectRealtime({ ...ENABLED, WEBSOCKET_JWT_EXPIRATION_SECONDS: 900 });
     expect(FakeWebSocket.instances).toHaveLength(1);
+    // Simulate the socket having connected — the keepalive only hands off a
+    // socket that is still OPEN (readyState 1).
+    FakeWebSocket.instances[0].readyState = 1;
 
     jest.advanceTimersByTime(540_000);
     expect(getSpy).toHaveBeenCalledWith({ endpoint: '/api/v1/me/' });
@@ -291,6 +294,44 @@ test('refreshes the cookie and reconnects before the token expires', async () =>
     await Promise.resolve();
     await Promise.resolve();
     expect(FakeWebSocket.instances).toHaveLength(2);
+  } finally {
+    getSpy.mockRestore();
+    jest.useRealTimers();
+  }
+});
+
+test('a socket that drops just before keepalive reconnects (not a keepalive handoff)', async () => {
+  jest.useFakeTimers();
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockResolvedValue({} as never);
+  const reasons: string[] = [];
+  subscribeRealtimeOpen(reason => reasons.push(reason));
+  try {
+    connectRealtime({ ...ENABLED, WEBSOCKET_JWT_EXPIRATION_SECONDS: 900 });
+    const ws = FakeWebSocket.instances[0];
+    ws.readyState = 1; // OPEN
+    ws.onopen?.();
+    expect(reasons).toEqual(['initial']);
+
+    // The socket really drops just before the keepalive (540s) fires; onclose
+    // schedules a real reconnect at +5s.
+    jest.advanceTimersByTime(539_000);
+    ws.readyState = 3; // CLOSED
+    ws.onclose?.();
+
+    // The keepalive timer fires while the socket is closed → it must bail (no
+    // refresh GET, no keepalive handoff), leaving the real reconnect to run.
+    jest.advanceTimersByTime(2_000);
+    await Promise.resolve();
+    expect(getSpy).not.toHaveBeenCalled();
+
+    // The scheduled reconnect opens with reason 'reconnect' — so list views still
+    // reconcile the outage rather than treating it as a seamless keepalive.
+    jest.advanceTimersByTime(5_000);
+    FakeWebSocket.instances[1].readyState = 1;
+    FakeWebSocket.instances[1].onopen?.();
+    expect(reasons).toEqual(['initial', 'reconnect']);
   } finally {
     getSpy.mockRestore();
     jest.useRealTimers();

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -217,14 +217,30 @@ const openSocket = (
   // seamless handover), so open-listeners can skip an expensive reconcile.
   if (enabled && tokenLifetimeMs > 0) {
     keepaliveTimeoutId = window.setTimeout(() => {
-      // Bail if this socket was already superseded (config change) or replaced by
-      // a reconnect (a blip's onclose reopens under the same generation), so the
-      // refresh can't tear down a newer, healthy socket.
-      if (thisGeneration !== generation || socket !== ws) return;
+      // Only hand off a socket that is still OPEN. Besides a superseded
+      // generation or a replaced socket, guard on readyState: `onclose` merely
+      // *schedules* a delayed reconnect (it doesn't clear `socket` or bump the
+      // generation), so a just-closed socket still satisfies `socket === ws`. A
+      // seamless keepalive handoff of a closed socket would cancel that real
+      // `reconnect` and reopen as `keepalive` — and list views skip reconcile on
+      // `keepalive`, so they'd miss entity changes from the actual outage.
+      if (
+        thisGeneration !== generation ||
+        socket !== ws ||
+        ws.readyState !== WS_OPEN
+      ) {
+        return;
+      }
       SupersetClient.get({ endpoint: COOKIE_REFRESH_ENDPOINT })
         .catch(() => {})
         .finally(() => {
-          if (thisGeneration !== generation || socket !== ws) return;
+          if (
+            thisGeneration !== generation ||
+            socket !== ws ||
+            ws.readyState !== WS_OPEN
+          ) {
+            return;
+          }
           generation += 1;
           teardownSocket();
           openSocket(generation, 'keepalive');

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -87,14 +87,27 @@ const handlersByTopic = new Map<string, Set<RealtimeHandler>>();
 // Fired every time a socket transitions to OPEN (initial connect and each
 // reconnect), so a feature can reconcile state it may have missed while the
 // socket was down (see asyncEvent's reconnect catch-up).
-const openListeners = new Set<() => void>();
+// Why a socket became OPEN, passed to open-listeners so a consumer can decide
+// whether to reconcile: `initial` (first connect), `reconnect` (recovered from a
+// drop — a message may have been missed), or `keepalive` (a planned pre-expiry
+// token refresh — seamless, so an expensive reconcile isn't warranted).
+export type RealtimeOpenReason = 'initial' | 'reconnect' | 'keepalive';
+
+type RealtimeOpenListener = (reason: RealtimeOpenReason) => void;
+
+// Fired every time a socket transitions to OPEN, with the reason (see above), so
+// a feature can reconcile state it may have missed while the socket was down.
+const openListeners = new Set<RealtimeOpenListener>();
 
 /**
  * Register a listener fired when the socket (re)connects (transitions to OPEN);
- * returns an unsubscribe function. Used to trigger a one-shot reconcile after a
- * drop, so realtime consumers need not poll while the socket is healthy.
+ * returns an unsubscribe function. The listener receives a `RealtimeOpenReason` so
+ * it can skip an expensive reconcile on a seamless `keepalive` reconnect and only
+ * reconcile on a real `reconnect` after a drop.
  */
-export const subscribeRealtimeOpen = (listener: () => void): (() => void) => {
+export const subscribeRealtimeOpen = (
+  listener: RealtimeOpenListener,
+): (() => void) => {
   openListeners.add(listener);
   return () => {
     openListeners.delete(listener);
@@ -178,7 +191,10 @@ const teardownSocket = (): void => {
   }
 };
 
-const openSocket = (thisGeneration: number): void => {
+const openSocket = (
+  thisGeneration: number,
+  reason: RealtimeOpenReason,
+): void => {
   if (thisGeneration !== generation) return;
   if (!enabled || !url || typeof WebSocket === 'undefined') return;
   const connectUrl = buildConnectUrl(url);
@@ -197,7 +213,8 @@ const openSocket = (thisGeneration: number): void => {
   // JWT expiry. The GET re-mints the httponly cookie via the Flask after_request
   // hook (inside its sliding window); the reconnect then rides the fresh token.
   // Best-effort: reconnect regardless of the GET's outcome (a stale cookie just
-  // fails the handshake, and onclose retries).
+  // fails the handshake, and onclose retries). This reconnect is `keepalive` (a
+  // seamless handover), so open-listeners can skip an expensive reconcile.
   if (enabled && tokenLifetimeMs > 0) {
     keepaliveTimeoutId = window.setTimeout(() => {
       // Bail if this socket was already superseded (config change) or replaced by
@@ -210,7 +227,7 @@ const openSocket = (thisGeneration: number): void => {
           if (thisGeneration !== generation || socket !== ws) return;
           generation += 1;
           teardownSocket();
-          openSocket(generation);
+          openSocket(generation, 'keepalive');
         });
     }, tokenLifetimeMs * KEEPALIVE_FRACTION);
   }
@@ -219,7 +236,7 @@ const openSocket = (thisGeneration: number): void => {
     if (thisGeneration !== generation) return;
     openListeners.forEach(listener => {
       try {
-        listener();
+        listener(reason);
       } catch (err) {
         logging.warn('Realtime open-listener error', err);
       }
@@ -232,7 +249,7 @@ const openSocket = (thisGeneration: number): void => {
   ws.onclose = () => {
     if (thisGeneration !== generation) return;
     reconnectTimeoutId = window.setTimeout(
-      () => openSocket(thisGeneration),
+      () => openSocket(thisGeneration, 'reconnect'),
       RECONNECT_DELAY_MS,
     );
   };
@@ -267,7 +284,7 @@ export const connectRealtime = (config?: RealtimeConfig): void => {
   enabled = nextEnabled;
   url = nextUrl;
   tokenLifetimeMs = (conf?.WEBSOCKET_JWT_EXPIRATION_SECONDS ?? 0) * 1000;
-  openSocket(generation);
+  openSocket(generation, 'initial');
 };
 
 /** Tear down the socket and stop reconnecting. */
@@ -310,7 +327,7 @@ subscribeTabIdChange(() => {
   if (!enabled || !hasActiveSocket()) return;
   generation += 1;
   teardownSocket();
-  openSocket(generation);
+  openSocket(generation, 'reconnect');
 });
 
 // Test-only: reset module state between cases.
@@ -324,6 +341,8 @@ export const resetRealtimeForTests = (): void => {
 };
 
 // Test-only: simulate a socket (re)connect firing the open-listeners.
-export const emitRealtimeOpenForTests = (): void => {
-  openListeners.forEach(listener => listener());
+export const emitRealtimeOpenForTests = (
+  reason: RealtimeOpenReason = 'reconnect',
+): void => {
+  openListeners.forEach(listener => listener(reason));
 };

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -736,6 +736,53 @@ test('useListViewResource: realtime reconciles displayed rows on reconnect', asy
   expect(endpoint).toContain('opr:in');
 });
 
+test('useListViewResource: realtime does NOT reconcile on a keepalive reconnect', async () => {
+  // A seamless keepalive token refresh must not trigger a full displayed-row
+  // re-fetch every cycle — only a real `reconnect` (drop recovery) reconciles.
+  const initial = [{ id: 1, name: 'A' }];
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockResolvedValueOnce({
+      json: { permissions: [] },
+    } as unknown as JsonResponse) // _info
+    .mockResolvedValueOnce({
+      json: { result: initial, count: 1 },
+    } as unknown as JsonResponse); // fetchData
+
+  const { result } = renderHook(() =>
+    useListViewResource(
+      'chart',
+      'Charts',
+      jest.fn(),
+      true,
+      [],
+      undefined,
+      true,
+      undefined,
+      true, // enableRealtime
+    ),
+  );
+
+  await act(async () => {
+    await result.current.fetchData({
+      pageIndex: 0,
+      pageSize: 25,
+      sortBy: [{ id: 'id', desc: false }],
+      filters: [],
+    });
+  });
+
+  const callsBefore = getSpy.mock.calls.length;
+  act(() => {
+    emitRealtimeOpenForTests('keepalive');
+  });
+  // No reconcile fetch for a keepalive reconnect.
+  await new Promise(resolve => {
+    setTimeout(resolve, 50);
+  });
+  expect(getSpy.mock.calls.length).toBe(callsBefore);
+});
+
 // useSingleViewResource
 test('useSingleViewResource: initial state has loading false and null resource', () => {
   const { result } = renderHook(() =>

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -287,6 +287,10 @@ export function useListViewResource<D extends object = any>(
     // count, and untouched row references so React re-renders only changed rows).
     const patchRows = (ids: string[]) => {
       if (!ids.length) return;
+      // Snapshot the latest full-fetch request id; if a newer page/filter/refresh
+      // (fetchData) lands before this background patch resolves, discard the patch
+      // so a stale reconcile snapshot can't overwrite fresher rows by id.
+      const requestId = latestRequestIdRef.current;
       const query = rison.encode_uri({
         filters: [{ col: 'id', opr: 'in', value: ids }],
         page: 0,
@@ -294,6 +298,7 @@ export function useListViewResource<D extends object = any>(
       });
       SupersetClient.get({ endpoint: `/api/v1/${resource}/?q=${query}` })
         .then(({ json = {} }) => {
+          if (latestRequestIdRef.current !== requestId) return;
           const fetched: D[] = json.result ?? [];
           if (!fetched.length) return;
           const byId = new Map(fetched.map(row => [rowId(row), row]));

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -339,10 +339,14 @@ export function useListViewResource<D extends object = any>(
       },
     );
 
-    // Nudges are lossy and not replayed, so on a socket (re)connect refetch the
-    // currently-displayed rows once to reconcile anything missed while the socket
-    // was down. In-place merge, no full-list redraw.
-    const unsubscribeOpen = subscribeRealtimeOpen(() => {
+    // Nudges are lossy and not replayed, so after recovering from a dropped
+    // socket refetch the currently-displayed rows once to reconcile anything
+    // missed while disconnected. Only on a real `reconnect` — not the initial
+    // connect (rows were just fetched) or a seamless `keepalive` token refresh —
+    // so a healthy socket doesn't trigger a full re-fetch every keepalive cycle.
+    // In-place merge, no full-list redraw.
+    const unsubscribeOpen = subscribeRealtimeOpen(reason => {
+      if (reason !== 'reconnect') return;
       patchRows(collectionRef.current.map(rowId));
     });
 

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -27,7 +27,7 @@ import time
 from typing import Any, Callable, TYPE_CHECKING, TypeVar, Union
 
 from flask import current_app
-from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis.exceptions import RedisError, TimeoutError as RedisTimeoutError
 
 from superset.coordination.exceptions import CoordinationBackendUnavailableError
 from superset.coordination.types import SignalListener
@@ -60,6 +60,10 @@ _DEFAULT_SIGNAL_STREAM_TTL_SECONDS = 86400
 _STREAM_BLOCK_MS = 5000
 # Shorter chunk for background listeners so stop() and signal detection stay prompt.
 _LISTEN_BLOCK_MS = 1000
+# Backoff after a transient stream-read error (connection drop/failover): xread
+# fails fast rather than honoring block_ms, so pause before retrying to avoid a
+# busy-spin while the backend is unavailable.
+_STREAM_ERROR_BACKOFF_SECONDS = 1.0
 
 
 class CoordinationService:
@@ -424,11 +428,22 @@ class CoordinationService:
 
         A socket timeout mid-block means "nothing arrived yet": the caller re-checks
         the predicate and reads again, so a short ``socket_timeout`` only affects
-        cadence, never correctness.
+        cadence, never correctness. A transient backend error (connection drop or
+        failover) is likewise non-fatal: the DB predicate is the source of truth, so
+        we degrade to re-checking it rather than letting the waiter/listener die —
+        with a short backoff, since ``xread`` fails fast on a broken connection.
         """
         try:
             entries = backend.xread({channel: last_id}, block_ms=block_ms)
         except (RedisTimeoutError, OSError):
+            return last_id
+        except RedisError:
+            logger.debug(
+                "Stream read on %s failed; degrading to predicate re-check",
+                channel,
+                exc_info=True,
+            )
+            time.sleep(min(block_ms / 1000, _STREAM_ERROR_BACKOFF_SECONDS))
             return last_id
         for _stream, items in entries:
             if items:

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -264,7 +264,17 @@ def execute_chart_query(
     DATA-cache entry. The query runs under ``_capture_query_cancellation`` so an
     abort/timeout can cancel it on engines that support query cancellation.
     """
+    from superset.charts.data.form_data import set_form_data
+
     with override_user(_resolve_user(user_id, guest_token), force=False):
+        # Re-establish ``g.form_data`` from the serialized payload. There is no
+        # request context in the worker, and Jinja helpers (``filter_values``,
+        # ``url_param``, ``get_filters``) resolve form data from ``g`` via
+        # ``get_form_data()``. Without this, a templated dataset renders empty
+        # filter values — executing/caching the wrong SQL AND computing a
+        # ``query_cache_key`` that diverges from the submit-time ``task_key`` (so
+        # the client's re-request never reads back the cache the task wrote).
+        set_form_data(serialized_query["form_data"] or {})
         query_context = load_serialized_query(serialized_query)
         # Floor the result-cache TTL: async caches the result for a follow-up
         # request to read back (see get_cache_timeout).

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -621,10 +621,14 @@ class TaskContext(CoreTaskContext):
             return  # Already started
 
         def on_timeout() -> None:
-            if self._abort_detected:
-                return  # Already aborting
-
-            self._timeout_triggered = True
+            # Elect under the same lock as abort detection, and skip if the work
+            # already finished — a timeout firing in the window between the task
+            # function returning and the terminal-state decision must not flip a
+            # completed task to TIMED_OUT (mirrors _on_abort_detected).
+            with self._abort_lock:
+                if self._execution_completed or self._abort_detected:
+                    return
+                self._timeout_triggered = True
             logger.info(
                 "Timeout reached for task %s after %d seconds",
                 self._task_uuid,

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -513,6 +513,10 @@ class TaskWrapper(Generic[P]):
             with use_context(ctx):
                 self.func(*args, **kwargs)
 
+            # The work finished; stop the abort listener from flipping this to
+            # ABORTED if a cancel signal lands now (mirrors the async executor).
+            ctx.mark_execution_completed()
+
             # Determine terminal status based on abort detection
             # Use atomic conditional updates to prevent overwriting concurrent abort
             if ctx._abort_detected or ctx.timeout_triggered:
@@ -570,6 +574,9 @@ class TaskWrapper(Generic[P]):
             return final_task if final_task else task
 
         except Exception as ex:
+            # The work is done (it raised); stop a late cancel signal from also
+            # running abort handlers on top of failure handling.
+            ctx.mark_execution_completed()
             # Atomic transition to FAILURE (only if still IN_PROGRESS)
             InternalStatusTransitionCommand(
                 task_uuid=task_uuid,

--- a/tests/unit_tests/coordination/test_service.py
+++ b/tests/unit_tests/coordination/test_service.py
@@ -252,6 +252,33 @@ def test_wait_for_signal_stream_socket_timeout_is_retried(
     assert backend.xread.call_count == 2
 
 
+def test_wait_for_signal_stream_connection_error_degrades_not_dies(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    """A transient backend error (connection drop/failover) must not propagate out
+    of the blocking read; the waiter degrades to re-checking the DB predicate."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    backend = mocker.MagicMock(name="backend")
+    backend.stream_last_id.return_value = "0-0"
+    # First read raises a connection error (not a socket timeout); the loop must
+    # swallow it, back off, and re-check rather than crashing.
+    backend.xread.side_effect = [
+        RedisConnectionError("connection lost"),
+        [["ch", [("1-0", {})]]],
+    ]
+    mocker.patch.object(CoordinationService, "get_backend", return_value=backend)
+    sleep = mocker.patch("superset.coordination.base.time.sleep")
+    results = iter([None, None, None, "done"])
+
+    result = CoordinationService.wait_for_signal(
+        "ch", lambda: next(results), timeout=5.0
+    )
+    assert result == "done"
+    assert backend.xread.call_count == 2
+    sleep.assert_called()  # backed off on the connection error rather than spinning
+
+
 def test_wait_for_signal_already_satisfied_skips_backend(
     app_context: None, mocker: MockerFixture
 ) -> None:

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -173,6 +173,68 @@ def test_execute_chart_query_publishes_cache_key_payload(
     )
 
 
+def test_execute_chart_query_reestablishes_form_data(
+    mocker: MockerFixture,
+) -> None:
+    """The worker has no request context, so g.form_data must be re-established
+    from the serialized payload — otherwise templated datasets render empty filter
+    values and the cache key diverges from the submit-time task_key."""
+    from superset.tasks.async_queries import execute_chart_query
+
+    query_context = mocker.MagicMock()
+    query_context.queries = [mocker.MagicMock()]
+    query_context.get_df_payload_result.return_value.payload = {}
+    mocker.patch(
+        "superset.tasks.async_queries._resolve_user", return_value=mocker.MagicMock()
+    )
+    mocker.patch("superset.tasks.async_queries.override_user")
+    load = mocker.patch(
+        "superset.tasks.async_queries.load_serialized_query",
+        return_value=query_context,
+    )
+    mocker.patch(
+        "superset.tasks.async_queries.get_context", return_value=mocker.MagicMock()
+    )
+    set_form_data = mocker.patch("superset.charts.data.form_data.set_form_data")
+
+    form_data = {"queries": [{"url_params": {"region": "EMEA"}}]}
+    serialized = _serialized_query()
+    serialized["form_data"] = form_data
+    execute_chart_query.func(serialized, user_id=7)
+
+    # form data is re-established from the payload, before the context is rebuilt.
+    set_form_data.assert_called_once_with(form_data)
+    assert set_form_data.call_count == 1
+    load.assert_called_once()
+
+
+def test_execute_chart_query_form_data_defaults_to_empty(
+    mocker: MockerFixture,
+) -> None:
+    from superset.tasks.async_queries import execute_chart_query
+
+    query_context = mocker.MagicMock()
+    query_context.queries = [mocker.MagicMock()]
+    query_context.get_df_payload_result.return_value.payload = {}
+    mocker.patch(
+        "superset.tasks.async_queries._resolve_user", return_value=mocker.MagicMock()
+    )
+    mocker.patch("superset.tasks.async_queries.override_user")
+    mocker.patch(
+        "superset.tasks.async_queries.load_serialized_query",
+        return_value=query_context,
+    )
+    mocker.patch(
+        "superset.tasks.async_queries.get_context", return_value=mocker.MagicMock()
+    )
+    set_form_data = mocker.patch("superset.charts.data.form_data.set_form_data")
+
+    # _serialized_query() carries form_data=None → set to {} (never None).
+    execute_chart_query.func(_serialized_query(), user_id=7)
+
+    set_form_data.assert_called_once_with({})
+
+
 def test_execute_chart_query_reads_totals_key_from_dependency_payload(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/unit_tests/tasks/test_decorators.py
+++ b/tests/unit_tests/tasks/test_decorators.py
@@ -400,6 +400,33 @@ class TestTaskWrapperCall:
         """Clear task registry before each test"""
         TaskRegistry._tasks.clear()
 
+    @patch("superset.tasks.context.TaskContext.mark_execution_completed")
+    @patch("superset.commands.tasks.internal_update.InternalStatusTransitionCommand")
+    @patch("superset.daos.tasks.TaskDAO.find_one_or_none")
+    @patch("superset.commands.tasks.submit.SubmitTaskCommand.run_with_info")
+    def test_call_marks_execution_completed_after_func(
+        self, mock_submit, mock_find, mock_transition, mock_mark
+    ):
+        """Sync inline execution marks completion after the body runs, so a late
+        cancel signal can't flip a finished task to ABORTED (mirrors async)."""
+        task_obj = MagicMock()
+        task_obj.uuid = TEST_UUID
+        task_obj.status = "pending"
+        mock_submit.return_value = (task_obj, True)  # new task → executes inline
+        mock_find.return_value = task_obj
+        mock_transition.return_value.run.return_value = True  # transitions succeed
+
+        ran = []
+
+        @task(name="test_mark_completed_unique")
+        def call_task(value: int) -> None:
+            ran.append(value)
+
+        call_task(7)
+
+        assert ran == [7]  # the body executed
+        mock_mark.assert_called_once()  # and completion was marked afterwards
+
     @patch("superset.commands.tasks.update.UpdateTaskCommand.run")
     @patch("superset.daos.tasks.TaskDAO.find_one_or_none")
     @patch("superset.commands.tasks.submit.SubmitTaskCommand.run_with_info")


### PR DESCRIPTION
### SUMMARY

A full design + implementation review of the `gaq-to-gtf` epic (7 parallel subsystem reviewers across coordination, the GTF core, task commands/DAO/models, the chart-data cutover, the websocket transport, the frontend, and security) turned up one HIGH regression and a set of MEDIUM edge-case correctness items. The security review came back clean (no in-scope boundary violation). This PR fixes the confirmed, contained findings; each is covered by a test.

**Why this matters.** The epic is architecturally sound, but the review found a real regression that would break a whole class of dashboards and several "something fired late/again after the work finished" edge cases that undermine the correctness properties the framework exists to guarantee. Better to close them before the epic merges to master.

#### Fixed

- **HIGH — async chart-data dropped `g.form_data`.** `execute_chart_query` never re-established form data in the worker (the old GAQ task called `set_form_data`). `get_form_data()` falls back to `g.form_data` "for cache warmup and async queries", and Jinja `filter_values`/`get_filters`/`get_time_filter` read through it — so a Jinja-templated dataset rendered **empty filter values** in the worker, both executing/caching the **wrong SQL** and computing a `query_cache_key` that **diverges from the submit-time `task_key`**, so the client's re-request never reads back the cache the task wrote (cache-miss reschedule loop). Fix: re-establish form data from the serialized payload. Every existing unit test mocked `load_serialized_query`, so nothing exercised this path — added regression tests asserting `set_form_data` is called with the payload's form data. (A templated-dataset end-to-end integration test is the durable guard and is called out as a follow-up; the existing async integration test is `@unittest.skip`-ped as MySQL-flaky.)

- **MEDIUM — coordination signal listener died on a transient `ConnectionError`.** `_read_stream` caught only `(RedisTimeoutError, OSError)`; a `redis.ConnectionError` escaped to `_run_listen_loop`'s broad except, which logged "crashed" and let the abort/signal listener thread exit permanently, so a live task might not honor a user-cancel until its GTF timeout. Fix: degrade any `RedisError` in the blocking read to a predicate re-check (with a bounded backoff so it can't busy-spin) — this fixes both the background listener and `wait_for_signal`, matching the "reconnect/failover-resilient" contract.

- **MEDIUM — keepalive turned "reconcile on drop" into a periodic full reconcile.** The sliding-window keepalive tears down + reopens a *healthy* socket every ~0.6×lifetime, firing the open-listeners — so every list view did a full displayed-row re-fetch each cycle, re-adding the load the no-polling design set out to avoid. Fix: tag each socket open with a `reason` (`initial` / `reconnect` / `keepalive`); list views reconcile only on a real `reconnect`. Chart-data catch-up still runs on all opens (it's cheap and coalesced, and covers the sub-second keepalive handover).

- **MEDIUM — poll mode never gave up on a persistent fetch error.** The stale-timeout give-up lived only in the success branch; the `catch` just logged and rescheduled at the eager 500ms interval, and `giveUpId` is WS-mode-only — so a websocket-off chart could spin forever (hammering a degraded endpoint) if `status_changes` failed persistently. Fix: the error path now ages toward the same give-up and backs off.

- **MEDIUM — sync inline path could flip a finished task to ABORTED.** `_execute_inline` never called `ctx.mark_execution_completed()` (the async executor does), so a cancel signal detected after the body completed still ran the abort branch. Fix: mark completion after the body in both the success and exception paths, mirroring the async executor.

#### Deferred (follow-ups, with rationale)

- **Multi-host status-poll clock skew** (`get_statuses_changed_since` uses host-local `changed_on >= cursor`). Real for multi-host, but the fix (move the cursor to the DB clock) is invasive and touches cursor semantics; matters mainly in websocket-off deployments. Tracked as a follow-up.
- **Timeout-path completion gating + dead `_refresh_task` fallback** (GTF core): narrow windows, and chart-data async uses the guarded path. Deferred to keep this PR focused on the confirmed, contained fixes.
- **Async failure traceback not persisted** (properties replaced wholesale on the FAILURE transition): logged today, minor.
- **Insecure-by-default websocket cookie flags** (`SameSite=None` without `Secure`; origin allowlist off): operator configuration; worth a docs/default hardening pass separately.
- **Authenticated co-subscriber name disclosure**: out-of-scope per `SECURITY.md` (optional privacy hardening).

### TESTING INSTRUCTIONS

- Python: `pytest tests/unit_tests/tasks tests/unit_tests/coordination` (492 pass; new coverage for `set_form_data` re-establishment, the coordination connection-error degrade, and the sync `mark_execution_completed`).
- Frontend: `npm run test -- asyncEvent realtime hooks` (new coverage for poll-mode give-up on persistent error, list-view no-reconcile on keepalive, and the keepalive-vs-reconnect reason).
- ruff/mypy/oxfmt/oxlint green on changed files; changed-file tsc clean (the frontend type-check hook has pre-existing unrelated `gaq-to-gtf` failures).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
