### PR TITLE
fix(mcp): render virtual-dataset Jinja by seeding g.form_data in chart compile + preview (#40570)

### DIFF
--- a/superset/mcp_service/chart/compile.py
+++ b/superset/mcp_service/chart/compile.py
@@ -153,11 +153,11 @@ def _compile_chart(
         )
 
         # Seed ``g.form_data`` so the Jinja macros that back a virtual
-        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``,
-        # ``current_user_email``, …) can find the query's fields in the no-
-        # request-context branch of ``get_form_data()``. The HTTP chart-data
-        # endpoint does the equivalent via ``set_form_data(json_body)``;
-        # peer MCP tools ``get_chart_data`` and ``query_dataset`` do it via
+        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``)
+        # can find the query's fields in the no-request-context branch of
+        # ``get_form_data()``. The HTTP chart-data endpoint does the
+        # equivalent via ``set_form_data(json_body)``; peer MCP tools
+        # ``get_chart_data`` and ``query_dataset`` do it via
         # ``set_query_context_form_data`` — this compile path had missed it,
         # so any virtual dataset with Jinja in its SQL failed at compile
         # time with a misleading "Empty query?" from ``get_query_str_extended``.

--- a/superset/mcp_service/chart/compile.py
+++ b/superset/mcp_service/chart/compile.py
@@ -111,6 +111,7 @@ def _compile_chart(
     Returns a :class:`CompileResult` with ``success=True`` when the
     query executes cleanly.
     """
+    from superset.charts.data.form_data import set_query_context_form_data
     from superset.commands.chart.data.get_data_command import ChartDataCommand
     from superset.commands.chart.exceptions import (
         ChartDataCacheLoadError,
@@ -150,6 +151,18 @@ def _compile_chart(
             ],
             form_data=form_data,
         )
+
+        # Seed ``g.form_data`` so the Jinja macros that back a virtual
+        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``,
+        # ``current_user_email``, …) can find the query's fields in the no-
+        # request-context branch of ``get_form_data()``. The HTTP chart-data
+        # endpoint does the equivalent via ``set_form_data(json_body)``;
+        # peer MCP tools ``get_chart_data`` and ``query_dataset`` do it via
+        # ``set_query_context_form_data`` — this compile path had missed it,
+        # so any virtual dataset with Jinja in its SQL failed at compile
+        # time with a misleading "Empty query?" from ``get_query_str_extended``.
+        # See #40570.
+        set_query_context_form_data(query_context, dataset_id, "table")
 
         command = ChartDataCommand(query_context)
         command.validate()

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -116,12 +116,12 @@ def generate_preview_from_form_data(
         )
 
         # Seed ``g.form_data`` so the Jinja macros that back a virtual
-        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``,
-        # ``current_user_email``, …) can find the query's fields in the no-
-        # request-context branch of ``get_form_data()``. Mirrors what
-        # ``get_chart_data``/``query_dataset`` already do; without this,
-        # any virtual dataset with Jinja in its SQL renders unrendered and
-        # the preview fails at compile time. See #40570.
+        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``)
+        # can find the query's fields in the no-request-context branch of
+        # ``get_form_data()``. Mirrors what ``get_chart_data``/
+        # ``query_dataset`` already do; without this, any virtual dataset
+        # with Jinja in its SQL renders unrendered and the preview fails
+        # at compile time. See #40570.
         set_query_context_form_data(query_context_obj, dataset_id, "table")
 
         # Execute query

--- a/superset/mcp_service/chart/preview_utils.py
+++ b/superset/mcp_service/chart/preview_utils.py
@@ -65,6 +65,7 @@ def generate_preview_from_form_data(
     """
     try:
         # Execute query to get data
+        from superset.charts.data.form_data import set_query_context_form_data
         from superset.commands.chart.data.get_data_command import ChartDataCommand
         from superset.connectors.sqla.models import SqlaTable
         from superset.extensions import db
@@ -113,6 +114,15 @@ def generate_preview_from_form_data(
             ],
             form_data=form_data,
         )
+
+        # Seed ``g.form_data`` so the Jinja macros that back a virtual
+        # dataset's SQL (``url_param``, ``filter_values``, ``get_filters``,
+        # ``current_user_email``, …) can find the query's fields in the no-
+        # request-context branch of ``get_form_data()``. Mirrors what
+        # ``get_chart_data``/``query_dataset`` already do; without this,
+        # any virtual dataset with Jinja in its SQL renders unrendered and
+        # the preview fails at compile time. See #40570.
+        set_query_context_form_data(query_context_obj, dataset_id, "table")
 
         # Execute query
         command = ChartDataCommand(query_context_obj)

--- a/tests/unit_tests/mcp_service/chart/test_compile.py
+++ b/tests/unit_tests/mcp_service/chart/test_compile.py
@@ -572,3 +572,87 @@ def test_valid_configs_pass_tier1(config_factory):
     ds = _orm_dataset()
     result = validate_and_compile(config_factory(), {}, ds, run_compile_check=False)
     assert result.success, result.error
+
+
+@patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
+@patch("superset.common.query_context_factory.QueryContextFactory")
+@patch("superset.charts.data.form_data.set_query_context_form_data")
+def test_compile_chart_seeds_g_form_data_for_jinja_macros(
+    mock_set_form_data, mock_factory, mock_cmd_cls
+):
+    """Regression test for #40570.
+
+    A virtual dataset whose SQL uses Jinja macros (``url_param``,
+    ``filter_values``, ``get_filters``, ``current_user_email``, …) needs
+    ``g.form_data`` to be populated when there is no HTTP request context,
+    so those macros can resolve their fields from the ``get_form_data()``
+    fallback branch. The regular HTTP chart-data endpoint does this via
+    ``set_form_data(json_body)``; the MCP compile path had missed it, so
+    Jinja stayed unrendered and ``get_query_str_extended`` raised a
+    misleading "Empty query?".
+
+    Pins that ``_compile_chart`` calls ``set_query_context_form_data`` with
+    the built ``QueryContext`` and the correct ``dataset_id`` / ``"table"``
+    before ``ChartDataCommand.run()``.
+    """
+    from superset.mcp_service.chart.compile import _compile_chart
+
+    fake_query_context = Mock()
+    mock_factory.return_value.create.return_value = fake_query_context
+    mock_cmd_cls.return_value.validate.return_value = None
+    mock_cmd_cls.return_value.run.return_value = {"queries": [{"data": []}]}
+
+    result = _compile_chart(
+        form_data={
+            "metrics": [{"label": "count", "expressionType": "SIMPLE"}],
+            "adhoc_filters": [],
+        },
+        dataset_id=42,
+    )
+
+    assert result.success, result.error
+    mock_set_form_data.assert_called_once_with(fake_query_context, 42, "table")
+
+    # Order matters: the seed MUST happen before the command actually runs
+    # the query, otherwise the Jinja renderer wouldn't see g.form_data.
+    seed_order = mock_set_form_data.call_args_list[0]
+    run_order = mock_cmd_cls.return_value.run.call_args_list[0]
+    assert seed_order is not None
+    assert run_order is not None
+
+
+@patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
+@patch("superset.common.query_context_factory.QueryContextFactory")
+@patch("superset.charts.data.form_data.set_query_context_form_data")
+@patch("superset.mcp_service.chart.compile.has_request_context", create=True)
+def test_compile_chart_seeds_g_form_data_without_request_context(
+    mock_has_request,
+    mock_set_form_data,
+    mock_factory,
+    mock_cmd_cls,
+):
+    """The streamable-http transport does not push a Flask request context
+    (see ``tests/unit_tests/mcp_service/test_auth_api_key.py``). Under that
+    branch, Jinja macros like ``url_param`` fall back to reading
+    ``g.form_data`` via ``get_form_data()``. The compile path's seed call
+    must still fire on that branch — this test pins that.
+    """
+    from superset.mcp_service.chart.compile import _compile_chart
+
+    mock_has_request.return_value = False
+    mock_factory.return_value.create.return_value = Mock()
+    mock_cmd_cls.return_value.validate.return_value = None
+    mock_cmd_cls.return_value.run.return_value = {"queries": [{"data": []}]}
+
+    result = _compile_chart(
+        form_data={
+            "metrics": [{"label": "count", "expressionType": "SIMPLE"}],
+        },
+        dataset_id=7,
+    )
+
+    assert result.success, result.error
+    mock_set_form_data.assert_called_once()
+    args = mock_set_form_data.call_args.args
+    assert args[1] == 7
+    assert args[2] == "table"

--- a/tests/unit_tests/mcp_service/chart/test_compile.py
+++ b/tests/unit_tests/mcp_service/chart/test_compile.py
@@ -602,7 +602,16 @@ def test_compile_chart_seeds_g_form_data_for_jinja_macros(
     fake_query_context = Mock()
     mock_factory.return_value.create.return_value = fake_query_context
     mock_cmd_cls.return_value.validate.return_value = None
-    mock_cmd_cls.return_value.run.return_value = {"queries": [{"data": []}]}
+    # Record the seed / run call order so the "before ChartDataCommand.run"
+    # ordering claim is actually checked. Indexing ``call_args_list`` alone
+    # would only prove both were called, not their relative order — and if
+    # the seed runs *after* ``run()`` the fix is defeated (Jinja renders
+    # during ``run()``).
+    call_order: list[str] = []
+    mock_set_form_data.side_effect = lambda *a, **k: call_order.append("seed")
+    mock_cmd_cls.return_value.run.side_effect = lambda *a, **k: (
+        call_order.append("run") or {"queries": [{"data": []}]}
+    )
 
     result = _compile_chart(
         form_data={
@@ -614,47 +623,60 @@ def test_compile_chart_seeds_g_form_data_for_jinja_macros(
 
     assert result.success, result.error
     mock_set_form_data.assert_called_once_with(fake_query_context, 42, "table")
-
-    # Order matters: the seed MUST happen before the command actually runs
-    # the query, otherwise the Jinja renderer wouldn't see g.form_data.
-    seed_order = mock_set_form_data.call_args_list[0]
-    run_order = mock_cmd_cls.return_value.run.call_args_list[0]
-    assert seed_order is not None
-    assert run_order is not None
+    assert call_order == ["seed", "run"]
 
 
 @patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
 @patch("superset.common.query_context_factory.QueryContextFactory")
-@patch("superset.charts.data.form_data.set_query_context_form_data")
-@patch("superset.mcp_service.chart.compile.has_request_context", create=True)
-def test_compile_chart_seeds_g_form_data_without_request_context(
-    mock_has_request,
-    mock_set_form_data,
+def test_compile_chart_populates_g_form_data_for_jinja_macros(
     mock_factory,
     mock_cmd_cls,
 ):
-    """The streamable-http transport does not push a Flask request context
-    (see ``tests/unit_tests/mcp_service/test_auth_api_key.py``). Under that
-    branch, Jinja macros like ``url_param`` fall back to reading
-    ``g.form_data`` via ``get_form_data()``. The compile path's seed call
-    must still fire on that branch — this test pins that.
+    """The streamable-http transport does not push a Flask request context,
+    so Jinja macros like ``url_param``, ``filter_values``, and ``get_filters``
+    reach for ``g.form_data`` via ``get_form_data()``'s no-request-context
+    fallback (see ``superset/views/utils.py`` ``get_form_data`` and
+    ``tests/unit_tests/mcp_service/test_auth_api_key.py`` for context). This
+    test runs the real ``set_query_context_form_data`` and asserts the
+    resulting ``g.form_data`` carries the query shape those macros expect —
+    proving the seed is not just called but produces a usable payload.
     """
+    from types import SimpleNamespace
+
+    from flask import current_app, g
+
+    from superset.common.query_object import QueryObject
     from superset.mcp_service.chart.compile import _compile_chart
 
-    mock_has_request.return_value = False
-    mock_factory.return_value.create.return_value = Mock()
+    query = QueryObject(
+        filters=[{"col": "region", "op": "IN", "val": ["North"]}],
+        time_range="Last week",
+    )
+    fake_query_context = SimpleNamespace(
+        queries=[query],
+        form_data={"url_params": {"tenant": "acme"}},
+    )
+    mock_factory.return_value.create.return_value = fake_query_context
     mock_cmd_cls.return_value.validate.return_value = None
     mock_cmd_cls.return_value.run.return_value = {"queries": [{"data": []}]}
 
-    result = _compile_chart(
-        form_data={
-            "metrics": [{"label": "count", "expressionType": "SIMPLE"}],
-        },
-        dataset_id=7,
-    )
+    with current_app.app_context():
+        result = _compile_chart(
+            form_data={
+                "metrics": [{"label": "count", "expressionType": "SIMPLE"}],
+            },
+            dataset_id=7,
+        )
 
-    assert result.success, result.error
-    mock_set_form_data.assert_called_once()
-    args = mock_set_form_data.call_args.args
-    assert args[1] == 7
-    assert args[2] == "table"
+        assert result.success, result.error
+        # The seed ran and produced the shape the Jinja macros consume via
+        # ``get_form_data()``: identifies the datasource and carries the
+        # per-query fields (filters, time_range, url_params).
+        assert g.form_data["datasource"] == {"id": 7, "type": "table"}
+        seeded_queries = g.form_data["queries"]
+        assert len(seeded_queries) == 1
+        assert seeded_queries[0]["filters"] == [
+            {"col": "region", "op": "IN", "val": ["North"]}
+        ]
+        assert seeded_queries[0]["time_range"] == "Last week"
+        assert seeded_queries[0]["url_params"] == {"tenant": "acme"}

--- a/tests/unit_tests/mcp_service/chart/test_compile.py
+++ b/tests/unit_tests/mcp_service/chart/test_compile.py
@@ -465,11 +465,12 @@ class TestValidateAndCompileTier2:
         assert result.error_code == "DATASET_NOT_FOUND"
 
 
+@patch("superset.charts.data.form_data.set_query_context_form_data")
 @patch("superset.daos.dataset.DatasetDAO")
 @patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
 @patch("superset.common.query_context_factory.QueryContextFactory")
 def test_compile_chart_returns_database_error_when_wrapped_in_query_failed(
-    mock_factory, mock_cmd_cls, mock_dataset_dao
+    mock_factory, mock_cmd_cls, mock_dataset_dao, mock_set_form_data
 ):
     """ChartDataCommand converts OperationalError to a string inside
     ChartDataQueryFailedError (no __cause__ set). _classify_as_database_error
@@ -518,10 +519,11 @@ def test_compile_chart_returns_database_error_when_wrapped_in_query_failed(
     mock_db.db_engine_spec.extract_errors.assert_called_once()
 
 
+@patch("superset.charts.data.form_data.set_query_context_form_data")
 @patch("superset.commands.chart.data.get_data_command.ChartDataCommand")
 @patch("superset.common.query_context_factory.QueryContextFactory")
 def test_compile_chart_returns_database_error_on_raw_sqlalchemy_error(
-    mock_factory, mock_cmd_cls
+    mock_factory, mock_cmd_cls, mock_set_form_data
 ):
     """When SQLAlchemyError escapes unwrapped, _compile_chart should
     catch it and return a database_connection_error."""

--- a/tests/unit_tests/mcp_service/chart/test_preview_utils.py
+++ b/tests/unit_tests/mcp_service/chart/test_preview_utils.py
@@ -209,3 +209,43 @@ def test_build_query_columns_empty_columns_key_keeps_groupby():
     assert preview_utils._build_query_columns(
         {"groupby": ["country"], "columns": []}
     ) == ["country"]
+
+
+def test_generate_preview_seeds_g_form_data_for_jinja_macros():
+    """Regression test for #40570 — the preview path must seed ``g.form_data``.
+
+    ``generate_preview_from_form_data`` builds a ``QueryContext`` and runs
+    ``ChartDataCommand`` the same way ``_compile_chart`` does; without
+    calling ``set_query_context_form_data`` first, a virtual dataset with
+    Jinja in its SQL renders unrendered and the preview fails at compile
+    time. This test pins the seed call for the preview entry point.
+    """
+    from unittest.mock import MagicMock, patch
+
+    with (
+        patch(
+            "superset.charts.data.form_data.set_query_context_form_data"
+        ) as mock_set_form_data,
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand"
+        ) as mock_cmd_cls,
+        patch(
+            "superset.common.query_context_factory.QueryContextFactory"
+        ) as mock_factory,
+        patch("superset.extensions.db") as mock_db,
+    ):
+        dataset = MagicMock()
+        dataset.id = 12
+        mock_db.session.get.return_value = dataset
+        fake_query_context = MagicMock()
+        mock_factory.return_value.create.return_value = fake_query_context
+        mock_cmd_cls.return_value.validate.return_value = None
+        mock_cmd_cls.return_value.run.return_value = {"queries": [{"data": []}]}
+
+        preview_utils.generate_preview_from_form_data(
+            form_data={"metrics": [{"label": "count"}]},
+            dataset_id=12,
+            preview_format="table",
+        )
+
+    mock_set_form_data.assert_called_once_with(fake_query_context, 12, "table")


### PR DESCRIPTION
### SUMMARY

Fixes #40570 

The MCP `generate_chart` / `update_chart` / preview tools failed with `CHART_COMPILE_FAILED / Error: Empty query?` for any virtual dataset whose SQL contained Jinja templating. The same dataset worked from Explore.

**Root cause (caller-side, not model-side).** The HTTP chart-data endpoint at [`superset/charts/data/api.py:218`](https://github.com/apache/superset/blob/master/superset/charts/data/api.py#L218) calls `set_form_data(json_body)` before `ChartDataCommand.run()` so the Jinja macros that back a virtual dataset's SQL (`url_param`, `filter_values`, `get_filters`, `current_user_email`, …) can resolve their fields via the no-request-context fallback in [`get_form_data()`](https://github.com/apache/superset/blob/master/superset/views/utils.py#L341). Two MCP tools already do the equivalent via `set_query_context_form_data`:

- [`get_chart_data`](https://github.com/apache/superset/blob/master/superset/mcp_service/chart/tool/get_chart_data.py#L676)
- [`query_dataset`](https://github.com/apache/superset/blob/master/superset/mcp_service/dataset/tool/query_dataset.py#L314)

But the chart compile/preview paths had missed it, so the Jinja stayed unrendered and `get_query_str_extended` raised `"Empty query?"` from [`superset/models/helpers.py:4377`](https://github.com/apache/superset/blob/master/superset/models/helpers.py#L4377) as a misleading downstream symptom.

**The fix.** One `set_query_context_form_data(query_context, dataset_id, "table")` call inside each of the two entry points:

- [`_compile_chart`](https://github.com/apache/superset/blob/master/superset/mcp_service/chart/compile.py) — used by `generate_chart` and `update_chart` via `validate_and_compile`
- [`generate_preview_from_form_data`](https://github.com/apache/superset/blob/master/superset/mcp_service/chart/preview_utils.py) — used by chart-preview tools

Every chart-generation entry point routes through one of the two, so this covers all three tools without touching `generate_chart.py` or `update_chart.py` directly. The datasource-model side (`get_sqla_query`, `get_query_str_extended`) is unchanged — per @rusackas's [read on the issue](https://github.com/apache/superset/issues/40570#issuecomment-3159049001), that layer already handles `template_params_dict` correctly for any caller.

Alignment with the discussion:
- @rusackas ([2026-08-07](https://github.com/apache/superset/issues/40570#issuecomment-3159049001)) — model side is fine; fix belongs upstream in the caller ✓
- @sadpandajoe ([2026-06-05](https://github.com/apache/superset/issues/40570#issuecomment-2939858195)) — invited a PR from the reporter ✓
- @eudaimos also flagged #40732 (raw-mode table charts on physical datasets) as a related failure surface; this fix plausibly closes it too but that's for a maintainer to confirm.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — server-side fix, no visible UI change.

### TESTING INSTRUCTIONS

**Unit tests (added in this PR):**

- `tests/unit_tests/mcp_service/chart/test_compile.py::test_compile_chart_seeds_g_form_data_for_jinja_macros`
- `tests/unit_tests/mcp_service/chart/test_compile.py::test_compile_chart_seeds_g_form_data_without_request_context` — pins the streamable-http branch (`has_request_context() == False`), which is what the reporter's transport hits (see the note in `tests/unit_tests/mcp_service/test_auth_api_key.py`)
- `tests/unit_tests/mcp_service/chart/test_preview_utils.py::test_generate_preview_seeds_g_form_data_for_jinja_macros`

Run:
```bash
pytest tests/unit_tests/mcp_service/chart/test_compile.py \
       tests/unit_tests/mcp_service/chart/test_preview_utils.py -v
```

**End-to-end (repro from the original report):**

1. Create a virtual dataset with Jinja in the SQL, e.g.
   ```sql
   SELECT * FROM your_table WHERE email = '{{ url_param("member_email", "default@example.com") }}'
   ```
2. Call the MCP `generate_chart` tool against it (`save_chart=false`, table config with a single column).
3. Before this PR: `CHART_COMPILE_FAILED / Error: Empty query?`. After: chart compiles and returns data.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #40570 (and plausibly #40732)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

