### PR TITLE
fix(pivot-table): apply "Show values as" percent to exports and reports

### DIFF
--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -61,6 +61,15 @@ logger = logging.getLogger(__name__)
 # ``transformProps`` formatter selection.
 PERCENT_3_POINT = ",.3%"
 
+# ``showValuesAs`` percent modes, mirroring ``ShowValuesAsEnum`` in the pivot
+# table plugin's ``types.ts``. Any other value (including "actual") is a no-op.
+PERCENT_OF_ROW = "percent_row"
+PERCENT_OF_COLUMN = "percent_col"
+PERCENT_OF_TOTAL = "percent_total"
+SHOW_VALUES_AS_PERCENT_MODES = frozenset(
+    {PERCENT_OF_ROW, PERCENT_OF_COLUMN, PERCENT_OF_TOTAL}
+)
+
 
 def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...]:
     """
@@ -75,6 +84,75 @@ def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...
     return tuple(parts)
 
 
+def _apply_show_values_as(  # pylint: disable=too-many-arguments
+    df: pd.DataFrame,
+    mode: str,
+    axis: dict[str, int],
+    metrics: list[str],
+    combine_metrics: bool,
+    inserted_rows: list[Any],
+    inserted_columns: list[Any],
+) -> pd.DataFrame:
+    """
+    Express each cell as a fraction of its row, column, or grand total.
+
+    Mirrors the client's ``fractionOf`` aggregator in
+    ``plugin-chart-pivot-table/src/react-pivottable/utilities.ts``. Two details
+    it inherits from there:
+
+    - Denominators are summed over leaf cells only. Totals and subtotals
+      inserted into the frame are numerators like any other cell -- a "% of
+      row" grand total row reads ``column total / grand total``, not the sum of
+      the fractions above it.
+    - A total is summed within a single metric, so a cell is never divided by a
+      total that mixes in another metric. Cross-metric totals (whose metric
+      level holds a total label rather than a metric name) divide by the
+      denominator spanning every metric.
+
+    A zero denominator yields NaN (blank) rather than infinity, matching
+    ``pandas_postprocessing.pivot``'s ``show_values_as``.
+    """
+    numeric = df.apply(pd.to_numeric, errors="coerce").astype(float)
+    is_multi_index = isinstance(df.columns, pd.MultiIndex)
+    # `combine_metrics` has already moved the metric to the lowest column level.
+    metric_level = df.columns.nlevels - 1 if combine_metrics and is_multi_index else 0
+    metric_names = set(metrics)
+    metric_of_column = [
+        key if key in metric_names else None
+        for key in df.columns.get_level_values(metric_level)
+    ]
+    leaf_rows = ~df.index.isin(inserted_rows)
+    leaf_columns = ~df.columns.isin(inserted_columns)
+
+    result = numeric.copy()
+    for metric in dict.fromkeys(metric_of_column):
+        selection = np.array([column == metric for column in metric_of_column])
+        denominator_selection = (
+            selection if metric is not None else np.ones(len(selection), dtype=bool)
+        )
+        block = numeric.loc[:, selection]
+        if mode == PERCENT_OF_TOTAL:
+            leaf = numeric.loc[leaf_rows, leaf_columns & denominator_selection]
+            grand_total = leaf.to_numpy().sum()
+            fraction = block / (np.nan if grand_total == 0 else grand_total)
+        else:
+            summed, divided = (
+                (axis["rows"], axis["columns"])
+                if mode == PERCENT_OF_COLUMN
+                else (axis["columns"], axis["rows"])
+            )
+            # The metric lives on the column axis, so only a sum taken along
+            # that axis has to stay within one metric.
+            leaf = (
+                numeric.loc[:, leaf_columns & denominator_selection]
+                if summed == 1
+                else numeric.loc[leaf_rows, :]
+            )
+            fraction = block.div(leaf.sum(axis=summed).replace(0, np.nan), axis=divided)
+        result.loc[:, selection] = fraction
+    return result
+
+
 def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-statements, too-many-branches  # noqa: C901
     df: pd.DataFrame,
     rows: list[str],
@@ -87,8 +165,16 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     show_columns_total: bool = False,
     apply_metrics_on_rows: bool = False,
     metric_name_aggfunc: Optional[str] = None,
+    show_values_as: Optional[str] = None,
 ) -> pd.DataFrame:
     metric_name = __("Total (%(aggfunc)s)", aggfunc=metric_name_aggfunc or aggfunc)
+    percent_mode = (
+        show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
+    )
+    # Labels of the total/subtotal rows and columns inserted below, so the
+    # `showValuesAs` denominators can be summed over leaf cells only.
+    inserted_rows: list[Any] = []
+    inserted_columns: list[Any] = []
 
     if transpose_pivot:
         rows, columns = columns, rows
@@ -150,16 +236,19 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
         # of metrics defined by the user
         df = df[metrics]
 
-    # compute fractions, if needed
-    if aggfunc.endswith(" as Fraction of Total"):
-        total = df.sum().sum()
-        df = df.astype(total.dtypes) / total
-    elif aggfunc.endswith(" as Fraction of Columns"):
-        total = df.sum(axis=axis["rows"])
-        df = df.astype(total.dtypes).div(total, axis=axis["columns"])
-    elif aggfunc.endswith(" as Fraction of Rows"):
-        total = df.sum(axis=axis["columns"])
-        df = df.astype(total.dtypes).div(total, axis=axis["rows"])
+    # Compute fractions, if needed. `showValuesAs` supersedes the pre-SIP-216
+    # "... as Fraction of ..." aggregate functions, and is applied after the
+    # totals below so each total divides by its own rollup, as the chart does.
+    if not percent_mode:
+        if aggfunc.endswith(" as Fraction of Total"):
+            total = df.sum().sum()
+            df = df.astype(total.dtypes) / total
+        elif aggfunc.endswith(" as Fraction of Columns"):
+            total = df.sum(axis=axis["rows"])
+            df = df.astype(total.dtypes).div(total, axis=axis["columns"])
+        elif aggfunc.endswith(" as Fraction of Rows"):
+            total = df.sum(axis=axis["columns"])
+            df = df.astype(total.dtypes).div(total, axis=axis["rows"])
 
     # convert to a MultiIndex to simplify logic
     if not isinstance(df.index, pd.MultiIndex):
@@ -193,6 +282,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 subtotal_name = tuple([*subgroup, total, *([""] * depth)])  # noqa: C409
                 # insert column after subgroup
                 df.insert(int(slice_.stop), subtotal_name, subtotal)
+                inserted_columns.append(subtotal_name)
 
     if rows and show_columns_total:
         # add subtotal for each group and overall total; we start from the
@@ -224,6 +314,18 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 df = pd.concat(
                     [df[: slice_.stop], subtotal.to_frame().T, df[slice_.stop :]]
                 )
+                inserted_rows.append(subtotal.name)
+
+    if percent_mode:
+        df = _apply_show_values_as(
+            df,
+            percent_mode,
+            axis,
+            metrics,
+            combine_metrics,
+            inserted_rows,
+            inserted_columns,
+        )
 
     # if we want to apply the metrics on the rows we need to pivot the
     # dataframe back
@@ -452,6 +554,9 @@ def build_pivot_currency_context(
         **pivot_options,
         "aggfunc": CURRENCY_CONTEXT_AGGREGATION,
         "metric_name_aggfunc": pivot_options["aggfunc"],
+        # Cells here hold currency-code sets, not numbers, so a percent
+        # transform would coerce them away.
+        "show_values_as": None,
     }
     return pivot_df(currency_source, **currency_pivot_options)
 
@@ -531,6 +636,10 @@ def pivot_table_v2(
     """
     verbose_map = datasource.data["verbose_map"] if datasource else None
     metrics = get_metric_names(form_data["metrics"], verbose_map)
+    show_values_as = form_data.get("showValuesAs")
+    percent_mode = (
+        show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
+    )
     pivot_options: dict[str, Any] = {
         "rows": get_column_names(form_data.get("groupbyRows"), verbose_map),
         "columns": get_column_names(form_data.get("groupbyColumns"), verbose_map),
@@ -541,10 +650,22 @@ def pivot_table_v2(
         "show_rows_total": bool(form_data.get("rowTotals")),
         "show_columns_total": bool(form_data.get("colTotals")),
         "apply_metrics_on_rows": form_data.get("metricsLayout") == "ROWS",
+        "show_values_as": percent_mode,
     }
 
     pivoted = pivot_df(df, **pivot_options)
     if apply_number_format:
+        if percent_mode:
+            # A ratio has no currency and ignores per-metric value formats, the
+            # same way the client skips `formattedAggregators` while a fraction
+            # is active.
+            return apply_pivot_number_formats(
+                pivoted,
+                form_data,
+                detected_currency,
+                datasource,
+                force_number_format=PERCENT_3_POINT,
+            )
         currency_context = None
         if (
             pivot_options["aggfunc"] not in PIVOT_AGGREGATIONS_WITHOUT_CURRENCY_CONTEXT
@@ -573,6 +694,7 @@ def apply_pivot_number_formats(
     detected_currency: Optional[str] = None,
     datasource: Optional[Union["BaseDatasource", "Query"]] = None,
     currency_context: Optional[pd.DataFrame] = None,
+    force_number_format: Optional[str] = None,
 ) -> pd.DataFrame:
     """
     Apply `valueFormat`/`columnFormats` and currency config to pivot values.
@@ -580,11 +702,20 @@ def apply_pivot_number_formats(
     The metric name is the first column level, or the last when `combineMetric`
     moves it there; in the ROWS metrics layout it is on the index instead.
     Per-metric overrides fall back to the global value format.
+
+    `force_number_format` applies one d3 format to every metric and drops the
+    currency config, for values whose configured format no longer applies.
     """
     value_format = form_data.get("valueFormat")
     column_formats = merge_column_formats(form_data, datasource)
     currency_format = get_pivot_currency_format(form_data)
     currency_formats = merge_currency_formats(form_data, datasource)
+    if force_number_format:
+        value_format = force_number_format
+        column_formats = {}
+        currency_format = {}
+        currency_formats = {}
+        currency_context = None
     metric_level = -1 if form_data.get("combineMetric") else 0
     metrics_on_rows = form_data.get("metricsLayout") == "ROWS"
 

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -25,6 +25,7 @@ In order to do that, we reproduce the post-processing in Python for these chart 
 """
 
 import logging
+from collections.abc import Callable
 from functools import partial
 from io import BytesIO, StringIO
 from typing import Any, Optional, TYPE_CHECKING, Union
@@ -200,15 +201,33 @@ def _reduce(
     return method(axis=axis) if axis is not None else method()
 
 
-def _keyed_rollup(
-    frame: pd.DataFrame, dimensions: list[str]
-) -> dict[tuple[str, ...], dict[str, Any]]:
-    """Index a rollup level by its grouped dimension values, as strings."""
-    filled = frame.fillna("SUPERSET_PANDAS_NAN")
-    return {
-        tuple(str(record[dimension]) for dimension in dimensions): record
-        for record in filled.to_dict("records")
-    }
+def _rollup_index(
+    rollup_levels: dict[frozenset[str], pd.DataFrame],
+) -> Callable[[list[str]], dict[tuple[str, ...], dict[str, Any]]]:
+    """
+    Index each rollup level by its grouped dimension values, on first use.
+
+    Reshaping a level costs a `fillna` and a `to_dict` over the whole frame, so
+    it is done once per level rather than once per cell -- the difference
+    between linear and quadratic on a large pivot.
+    """
+    cache: dict[tuple[str, ...], dict[tuple[str, ...], dict[str, Any]]] = {}
+
+    def keyed(dimensions: list[str]) -> dict[tuple[str, ...], dict[str, Any]]:
+        cache_key = tuple(dimensions)
+        if cache_key not in cache:
+            level = rollup_levels.get(frozenset(dimensions))
+            cache[cache_key] = (
+                {}
+                if level is None
+                else {
+                    tuple(str(record[dimension]) for dimension in dimensions): record
+                    for record in level.fillna("SUPERSET_PANDAS_NAN").to_dict("records")
+                }
+            )
+        return cache[cache_key]
+
+    return keyed
 
 
 def _rollup_key(
@@ -235,15 +254,18 @@ def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
     """
     Replace inserted totals with the values the database computed.
 
-    A total grouping ``i`` row dimensions and ``j`` column dimensions is exactly
-    the rollup level over ``rows[:i] + columns[:j]``, which
-    ``buildGroupbyCombinations`` requests whenever the chart displays that
-    total. Reading it keeps the export equal to the chart for a non-additive
-    metric, where reducing the leaf cells gives a different number.
+    A total grouping ``i`` row and ``j`` column dimensions is exactly the rollup
+    level over ``rows[:i] + columns[:j]``, which ``buildGroupbyCombinations``
+    requests whenever the chart displays that total. Reading it keeps the export
+    equal to the chart for a non-additive metric, where reducing the leaf cells
+    gives a different number.
 
-    Any total whose level or key is absent keeps its leaf-derived value, so a
-    missing level degrades to the previous behaviour rather than to a blank.
+    A total the chart did not request keeps its leaf-derived value, so a missing
+    level degrades to the previous behaviour. A total the database returned as
+    NULL is kept as NULL, which is not the same thing -- the chart renders that
+    cell blank.
     """
+    keyed = _rollup_index(rollup_levels)
     metric_names = set(metrics)
 
     def metric_of(column: Any) -> Any:
@@ -252,28 +274,25 @@ def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
             name if name in metric_names else _collapsed_metric(list(metrics), metrics)
         )
 
-    def lookup(row: Any, column: Any) -> Any:
+    def lookup(row: Any, column: Any) -> tuple[bool, Any]:
         row_depth = row_prefix_depth.get(row, len(rows))
         column_depth = column_prefix_depth.get(column, len(columns))
-        level = rollup_levels.get(frozenset(rows[:row_depth] + columns[:column_depth]))
-        if level is None:
-            return None
+        grouped = rows[:row_depth] + columns[:column_depth]
         key = _rollup_key(row, row_depth, metric_level, is_column=False) + _rollup_key(
             column, column_depth, metric_level, is_column=True
         )
-        record = _keyed_rollup(level, rows[:row_depth] + columns[:column_depth]).get(
-            key
-        )
-        return record.get(metric_of(column)) if record else None
+        record = keyed(grouped).get(key)
+        if record is None:
+            return False, None
+        return True, record.get(metric_of(column))
 
-    # Index positionally: a tuple label on a MultiIndex is ambiguous to `.loc`,
-    # which resolves some of these keys to the wrong row.
+    # Index positionally: a tuple label on a MultiIndex is ambiguous to `.loc`.
     for column_position, column in enumerate(df.columns):
         for row_position, row in enumerate(df.index):
             if row not in row_prefix_depth and column not in column_prefix_depth:
                 continue  # a leaf cell, already carrying its own value
-            value = lookup(row, column)
-            if value is not None and not pd.isna(value):
+            found, value = lookup(row, column)
+            if found:
                 df.iloc[row_position, column_position] = value
     return df
 
@@ -288,7 +307,8 @@ def _rollup_denominators(  # pylint: disable=too-many-arguments,too-many-locals
     metric_level: int,
     row_prefix_depth: dict[Any, int],
     column_prefix_depth: dict[Any, int],
-) -> Optional[pd.DataFrame]:
+    metrics_on_rows: bool,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Each cell's denominator, taken from the database-computed rollup levels.
 
@@ -298,12 +318,14 @@ def _rollup_denominators(  # pylint: disable=too-many-arguments,too-many-locals
     subtotal divides by its own prefix, not by the grand total -- an "EU"
     subtotal row divides by the ``{region}`` rollup.
 
-    For a non-additive metric these are the only correct totals. Cells whose
-    level or key is absent come back NaN, leaving the caller to fall back to a
-    denominator derived from the leaf cells.
+    The metrics layout decides which frame axis carries the displayed rows, so
+    "% of row" groups the column dimensions when metrics sit on rows.
+
+    :return: the denominators, and a mask of the cells the database resolved.
+        A resolved cell holding NULL stays NULL, where an unresolved one lets
+        the caller fall back to a leaf-derived total.
     """
-    if not rollup_levels:
-        return None
+    keyed = _rollup_index(rollup_levels)
     metric_names = set(metrics)
 
     def metric_of(column: Any) -> Any:
@@ -312,33 +334,39 @@ def _rollup_denominators(  # pylint: disable=too-many-arguments,too-many-locals
             name if name in metric_names else _collapsed_metric(list(metrics), metrics)
         )
 
-    def denominator(row: Any, column: Any) -> Any:
-        row_depth = row_prefix_depth.get(row, len(rows))
-        column_depth = column_prefix_depth.get(column, len(columns))
-        if mode == ShowValuesAs.PERCENT_OF_ROW:
-            grouped, key = (
-                rows[:row_depth],
-                _rollup_key(row, row_depth, metric_level, is_column=False),
-            )
-        elif mode == ShowValuesAs.PERCENT_OF_COLUMN:
-            grouped, key = (
-                columns[:column_depth],
-                _rollup_key(column, column_depth, metric_level, is_column=True),
-            )
+    def denominator(row: Any, column: Any) -> tuple[bool, Any]:
+        if mode == ShowValuesAs.PERCENT_OF_TOTAL:
+            grouped: list[str] = []
+            key: tuple[str, ...] = ()
         else:
-            grouped, key = [], ()
-        level = rollup_levels.get(frozenset(grouped))
-        if level is None:
-            return None
-        record = _keyed_rollup(level, grouped).get(key)
-        return record.get(metric_of(column)) if record else None
+            # The displayed row axis is the frame index, unless the metrics
+            # layout moved it to the columns.
+            along_index = (mode == ShowValuesAs.PERCENT_OF_ROW) != metrics_on_rows
+            if along_index:
+                depth = row_prefix_depth.get(row, len(rows))
+                grouped = rows[:depth]
+                key = _rollup_key(row, depth, metric_level, is_column=False)
+            else:
+                depth = column_prefix_depth.get(column, len(columns))
+                grouped = columns[:depth]
+                key = _rollup_key(column, depth, metric_level, is_column=True)
+        record = keyed(grouped).get(key)
+        if record is None:
+            return False, None
+        return True, record.get(metric_of(column))
 
-    built = pd.DataFrame(
-        [[denominator(row, column) for column in df.columns] for row in df.index],
+    resolved = [[denominator(row, column) for column in df.columns] for row in df.index]
+    values = pd.DataFrame(
+        [[value for _, value in row] for row in resolved],
         index=df.index,
         columns=df.columns,
     )
-    return built.apply(pd.to_numeric, errors="coerce").astype(float)
+    found = pd.DataFrame(
+        [[hit for hit, _ in row] for row in resolved],
+        index=df.index,
+        columns=df.columns,
+    )
+    return values.apply(pd.to_numeric, errors="coerce").astype(float), found
 
 
 def _apply_show_values_as(  # pylint: disable=too-many-arguments
@@ -350,7 +378,7 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     inserted_rows: list[Any],
     inserted_columns: list[Any],
     reducers: dict[str, str],
-    denominators: Optional[pd.DataFrame] = None,
+    denominators: Optional[tuple[pd.DataFrame, pd.DataFrame]] = None,
 ) -> pd.DataFrame:
     """
     Express each cell as a fraction of its row, column, or grand total.
@@ -439,9 +467,12 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
 
     denominator = derived
     if denominators is not None:
-        # Database-computed rollups win wherever the chart requested the level;
-        # anything it did not cover falls back to the leaf-derived total.
-        denominator = denominators.combine_first(derived)
+        # Database-computed rollups win wherever the chart requested the level.
+        # Mask on whether the level resolved, not on whether the value is null:
+        # a rollup the database returned as NULL leaves the cell blank, as the
+        # chart does, while an unrequested level falls back to the leaf total.
+        values, found = denominators
+        denominator = derived.mask(found, values)
     return numeric / denominator.replace(0, np.nan)
 
 
@@ -662,7 +693,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 inserted_rows.append(subtotal.name)
                 row_prefix_depth[subtotal.name] = level
 
-    if percent_mode and not apply_metrics_on_rows and rollup_levels:
+    if percent_mode and rollup_levels:
         df = _apply_rollup_totals(
             df,
             rows,
@@ -694,8 +725,9 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 totals_metric_level,
                 row_prefix_depth,
                 column_prefix_depth,
+                apply_metrics_on_rows,
             )
-            if not apply_metrics_on_rows
+            if rollup_levels
             else None,
         )
 

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -1444,7 +1444,8 @@ def apply_client_processing(  # noqa: C901
                 # workbook reads like the chart and still calculates.
                 number_format=(
                     EXCEL_PERCENT_FORMAT
-                    if form_data.get("showValuesAs") in SHOW_VALUES_AS_PERCENT_MODES
+                    if viz_type == "pivot_table_v2"
+                    and form_data.get("showValuesAs") in SHOW_VALUES_AS_PERCENT_MODES
                     else None
                 ),
                 **{

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -525,6 +525,13 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     # returning it
     if apply_metrics_on_rows:
         rows, columns = columns, rows
+        # The frame is transposed on the way out, which flips the axis each
+        # total was inserted on. Swap the toggles too, so `rowTotals` still
+        # means the right-hand Total column of the rendered table. The
+        # `columns and not rows` branch below transposes once more on its own,
+        # cancelling that flip, so it keeps the toggles as given.
+        if rows:
+            show_rows_total, show_columns_total = show_columns_total, show_rows_total
         axis = {"columns": 0, "rows": 1}
     else:
         axis = {"columns": 1, "rows": 0}

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -172,6 +172,19 @@ def _collapsed_metric(present: list[Any], metrics: list[str]) -> Any:
     return None
 
 
+def _broadcast(total: pd.Series, block: pd.DataFrame, axis: int) -> pd.DataFrame:
+    """Spread a per-row (`axis` 0) or per-column (`axis` 1) total over `block`."""
+    if axis == 0:
+        spread = pd.concat([total] * len(block.columns), axis=1)
+        spread.columns = block.columns
+        return spread
+    return pd.DataFrame(
+        np.tile(total.reindex(block.columns).to_numpy(), (len(block.index), 1)),
+        index=block.index,
+        columns=block.columns,
+    )
+
+
 def _metric_of_column(column: Any, metric_level: int) -> Any:
     """The metric a pivoted column belongs to."""
     return column[metric_level] if isinstance(column, tuple) else column
@@ -198,6 +211,17 @@ def _keyed_rollup(
     }
 
 
+def _rollup_key(
+    label: Any, depth: int, metric_level: int, is_column: bool
+) -> tuple[str, ...]:
+    """The grouped dimension values a pivoted row or column label carries."""
+    parts = list(label) if isinstance(label, tuple) else [label]
+    if is_column:
+        # The column label interleaves the metric with the dimension values.
+        parts = [part for index, part in enumerate(parts) if index != metric_level]
+    return tuple(str(part) for part in parts[:depth])
+
+
 def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
     df: pd.DataFrame,
     rows: list[str],
@@ -205,27 +229,21 @@ def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
     metrics: list[str],
     rollup_levels: dict[frozenset[str], pd.DataFrame],
     metric_level: int,
-    full_total_rows: list[Any],
-    full_total_columns: list[Any],
+    row_prefix_depth: dict[Any, int],
+    column_prefix_depth: dict[Any, int],
 ) -> pd.DataFrame:
     """
-    Replace whole-axis totals with the values the database computed.
+    Replace inserted totals with the values the database computed.
 
-    The totals inserted above are reductions of the leaf cells, which is exact
-    only for an additive metric. Where the chart requested a rollup level, use
-    it, so that a total matches the chart and still divides by itself -- the
-    denominators come from the same levels.
+    A total grouping ``i`` row dimensions and ``j`` column dimensions is exactly
+    the rollup level over ``rows[:i] + columns[:j]``, which
+    ``buildGroupbyCombinations`` requests whenever the chart displays that
+    total. Reading it keeps the export equal to the chart for a non-additive
+    metric, where reducing the leaf cells gives a different number.
 
-    Subtotals over a prefix of an axis are left as leaf reductions: the chart
-    gates those on their own toggles, so the matching level is not always
-    requested.
+    Any total whose level or key is absent keeps its leaf-derived value, so a
+    missing level degrades to the previous behaviour rather than to a blank.
     """
-    by_row = rollup_levels.get(frozenset(rows))
-    by_column = rollup_levels.get(frozenset(columns))
-    grand = rollup_levels.get(frozenset())
-    if grand is None:
-        return df
-
     metric_names = set(metrics)
 
     def metric_of(column: Any) -> Any:
@@ -234,34 +252,29 @@ def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
             name if name in metric_names else _collapsed_metric(list(metrics), metrics)
         )
 
-    grand_record = next(iter(_keyed_rollup(grand, []).values()), {})
+    def lookup(row: Any, column: Any) -> Any:
+        row_depth = row_prefix_depth.get(row, len(rows))
+        column_depth = column_prefix_depth.get(column, len(columns))
+        level = rollup_levels.get(frozenset(rows[:row_depth] + columns[:column_depth]))
+        if level is None:
+            return None
+        key = _rollup_key(row, row_depth, metric_level, is_column=False) + _rollup_key(
+            column, column_depth, metric_level, is_column=True
+        )
+        record = _keyed_rollup(level, rows[:row_depth] + columns[:column_depth]).get(
+            key
+        )
+        return record.get(metric_of(column)) if record else None
 
-    if by_row is not None and full_total_columns:
-        keyed = _keyed_rollup(by_row, rows)
-        for column in full_total_columns:
-            metric = metric_of(column)
-            df[column] = [
-                (keyed.get(tuple(str(part) for part in row)) or {}).get(metric)
-                for row in df.index
-            ]
-
-    if by_column is not None and full_total_rows:
-        keyed = _keyed_rollup(by_column, columns)
-        for row in full_total_rows:
-            values = []
-            for column in df.columns:
-                metric = metric_of(column)
-                if column in full_total_columns:
-                    values.append(grand_record.get(metric))
-                    continue
-                key = tuple(
-                    str(part)
-                    for index, part in enumerate(column)
-                    if index != (metric_level % len(column))
-                )
-                values.append((keyed.get(key) or {}).get(metric))
-            df.loc[row] = values
-
+    # Index positionally: a tuple label on a MultiIndex is ambiguous to `.loc`,
+    # which resolves some of these keys to the wrong row.
+    for column_position, column in enumerate(df.columns):
+        for row_position, row in enumerate(df.index):
+            if row not in row_prefix_depth and column not in column_prefix_depth:
+                continue  # a leaf cell, already carrying its own value
+            value = lookup(row, column)
+            if value is not None and not pd.isna(value):
+                df.iloc[row_position, column_position] = value
     return df
 
 
@@ -273,62 +286,52 @@ def _rollup_denominators(  # pylint: disable=too-many-arguments,too-many-locals
     metrics: list[str],
     rollup_levels: dict[frozenset[str], pd.DataFrame],
     metric_level: int,
-    inserted_rows: list[Any],
-    inserted_columns: list[Any],
+    row_prefix_depth: dict[Any, int],
+    column_prefix_depth: dict[Any, int],
 ) -> Optional[pd.DataFrame]:
     """
     Each cell's denominator, taken from the database-computed rollup levels.
 
-    A percent mode makes the chart request the rollup level its denominator
-    needs -- all rows with the columns collapsed for "% of row", the reverse for
-    "% of column", both collapsed for "% of total" (see
-    ``buildGroupbyCombinations``). Those values are the totals the database
-    computed, so for a non-additive metric they are the only correct ones.
+    A percent mode makes the chart request the level its denominator needs: for
+    "% of row" the cell's own row with the columns collapsed, for "% of column"
+    the reverse, for "% of total" both (see ``buildGroupbyCombinations``). A
+    subtotal divides by its own prefix, not by the grand total -- an "EU"
+    subtotal row divides by the ``{region}`` rollup.
 
-    Returns ``None`` when the level is absent, leaving the caller to derive the
-    denominators from the leaf cells instead: additive metrics never request
-    rollup levels in the first place, and re-deriving is exact for them.
+    For a non-additive metric these are the only correct totals. Cells whose
+    level or key is absent come back NaN, leaving the caller to fall back to a
+    denominator derived from the leaf cells.
     """
-    grouped_for_mode = {
-        ShowValuesAs.PERCENT_OF_ROW: rows,
-        ShowValuesAs.PERCENT_OF_COLUMN: columns,
-        ShowValuesAs.PERCENT_OF_TOTAL: [],
-    }[ShowValuesAs(mode)]
-    level = rollup_levels.get(frozenset(grouped_for_mode))
-    grand = rollup_levels.get(frozenset())
-    if level is None or grand is None:
+    if not rollup_levels:
         return None
-
-    by_key = _keyed_rollup(level, grouped_for_mode)
-    grand_record = next(iter(_keyed_rollup(grand, []).values()), {})
+    metric_names = set(metrics)
 
     def metric_of(column: Any) -> Any:
         name = _metric_of_column(column, metric_level)
         return (
-            name if name in set(metrics) else _collapsed_metric(list(metrics), metrics)
+            name if name in metric_names else _collapsed_metric(list(metrics), metrics)
         )
 
     def denominator(row: Any, column: Any) -> Any:
-        metric = metric_of(column)
-        # A total collapses its axis entirely, so it divides by the grand total.
-        collapsed = (
-            row in inserted_rows
-            if mode == ShowValuesAs.PERCENT_OF_ROW
-            else column in inserted_columns
-        )
-        if mode == ShowValuesAs.PERCENT_OF_TOTAL or collapsed:
-            return grand_record.get(metric)
-        source = row if mode == ShowValuesAs.PERCENT_OF_ROW else column
-        values = tuple(str(part) for part in source)
-        # The column key carries the metric alongside the dimension values.
-        if mode == ShowValuesAs.PERCENT_OF_COLUMN:
-            values = tuple(
-                part
-                for index, part in enumerate(values)
-                if index != (metric_level % len(values))
+        row_depth = row_prefix_depth.get(row, len(rows))
+        column_depth = column_prefix_depth.get(column, len(columns))
+        if mode == ShowValuesAs.PERCENT_OF_ROW:
+            grouped, key = (
+                rows[:row_depth],
+                _rollup_key(row, row_depth, metric_level, is_column=False),
             )
-        record = by_key.get(values)
-        return record.get(metric) if record else None
+        elif mode == ShowValuesAs.PERCENT_OF_COLUMN:
+            grouped, key = (
+                columns[:column_depth],
+                _rollup_key(column, column_depth, metric_level, is_column=True),
+            )
+        else:
+            grouped, key = [], ()
+        level = rollup_levels.get(frozenset(grouped))
+        if level is None:
+            return None
+        record = _keyed_rollup(level, grouped).get(key)
+        return record.get(metric_of(column)) if record else None
 
     built = pd.DataFrame(
         [[denominator(row, column) for column in df.columns] for row in df.index],
@@ -370,10 +373,6 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     ``pandas_postprocessing.pivot``'s ``show_values_as``.
     """
     numeric = df.apply(pd.to_numeric, errors="coerce").astype(float)
-    if denominators is not None:
-        # Database-computed rollups: the only correct totals for a non-additive
-        # metric, and what the chart divides by.
-        return numeric / denominators.replace(0, np.nan)
     is_multi_index = isinstance(df.columns, pd.MultiIndex)
     # `combine_metrics` has already moved the metric to the lowest column level.
     metric_level = df.columns.nlevels - 1 if combine_metrics and is_multi_index else 0
@@ -385,7 +384,7 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     leaf_rows = ~df.index.isin(inserted_rows)
     leaf_columns = ~df.columns.isin(inserted_columns)
 
-    result = numeric.copy()
+    derived = pd.DataFrame(np.nan, index=numeric.index, columns=numeric.columns)
     for metric in dict.fromkeys(metric_of_column):
         selection = np.array([column == metric for column in metric_of_column])
         denominator_selection = (
@@ -416,8 +415,10 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
             # cells whose group had no rows, and numpy would propagate that to
             # the grand total, blanking every cell.
             grand_total = _reduce(_reduce(leaf, reducer, axis=0), reducer)
-            fraction = block / (
-                np.nan if pd.isna(grand_total) or grand_total == 0 else grand_total
+            group_denominator = pd.DataFrame(
+                np.nan if pd.isna(grand_total) else grand_total,
+                index=block.index,
+                columns=block.columns,
             )
         else:
             summed, divided = (
@@ -432,10 +433,16 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
                 if summed == 1
                 else numeric.loc[leaf_rows, :]
             )
-            total = _reduce(leaf, reducer, axis=summed).replace(0, np.nan)
-            fraction = block.div(total, axis=divided)
-        result.loc[:, selection] = fraction
-    return result
+            total = _reduce(leaf, reducer, axis=summed)
+            group_denominator = _broadcast(total, block, divided)
+        derived.loc[:, selection] = group_denominator
+
+    denominator = derived
+    if denominators is not None:
+        # Database-computed rollups win wherever the chart requested the level;
+        # anything it did not cover falls back to the leaf-derived total.
+        denominator = denominators.combine_first(derived)
+    return numeric / denominator.replace(0, np.nan)
 
 
 def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-statements, too-many-branches  # noqa: C901
@@ -470,11 +477,11 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     # `showValuesAs` denominators can be summed over leaf cells only.
     inserted_rows: list[Any] = []
     inserted_columns: list[Any] = []
-    # Totals that collapse their entire axis, as opposed to subtotals over a
-    # prefix of it. Only these correspond to a rollup level the chart requests
-    # for a percent mode, so only these can take database-computed values.
-    full_total_rows: list[Any] = []
-    full_total_columns: list[Any] = []
+    # How many dimensions of its own axis each inserted total still groups; 0
+    # collapses the axis entirely. Together with the other axis they name the
+    # rollup level holding that total's database-computed value.
+    row_prefix_depth: dict[Any, int] = {}
+    column_prefix_depth: dict[Any, int] = {}
 
     if transpose_pivot:
         rows, columns = columns, rows
@@ -613,9 +620,9 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 # insert column after subgroup
                 df.insert(int(slice_.stop), subtotal_name, subtotal)
                 inserted_columns.append(subtotal_name)
-                covered = level if combine_metrics else max(0, level - 1)
-                if covered == 0:
-                    full_total_columns.append(subtotal_name)
+                column_prefix_depth[subtotal_name] = (
+                    level if combine_metrics else max(0, level - 1)
+                )
 
     if rows and show_columns_total:
         # add subtotal for each group and overall total; we start from the
@@ -653,8 +660,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                     [df[: slice_.stop], subtotal.to_frame().T, df[slice_.stop :]]
                 )
                 inserted_rows.append(subtotal.name)
-                if level == 0:
-                    full_total_rows.append(subtotal.name)
+                row_prefix_depth[subtotal.name] = level
 
     if percent_mode and not apply_metrics_on_rows and rollup_levels:
         df = _apply_rollup_totals(
@@ -664,8 +670,8 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             metrics,
             rollup_levels,
             totals_metric_level,
-            full_total_rows,
-            full_total_columns,
+            row_prefix_depth,
+            column_prefix_depth,
         )
 
     if percent_mode:
@@ -686,8 +692,8 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                 metrics,
                 rollup_levels or {},
                 totals_metric_level,
-                inserted_rows,
-                inserted_columns,
+                row_prefix_depth,
+                column_prefix_depth,
             )
             if not apply_metrics_on_rows
             else None,

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -62,6 +62,11 @@ logger = logging.getLogger(__name__)
 # ``transformProps`` formatter selection.
 PERCENT_3_POINT = ",.3%"
 
+# The pivot renderer formats a fraction with ``usFmtPct``
+# (``react-pivottable/utilities.ts``), which is one decimal place -- not the
+# Table plugin's three.
+PERCENT_1_POINT = ",.1%"
+
 
 def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...]:
     """
@@ -668,7 +673,7 @@ def pivot_table_v2(
                 form_data,
                 detected_currency,
                 datasource,
-                force_number_format=PERCENT_3_POINT,
+                force_number_format=PERCENT_1_POINT,
             )
         currency_context = None
         if (

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -35,6 +35,7 @@ from flask import current_app
 from flask_babel import gettext as __
 
 from superset.common.chart_data import ChartDataResultFormat
+from superset.constants import SHOW_VALUES_AS_PERCENT_MODES, ShowValuesAs
 from superset.extensions import event_logger
 from superset.utils import csv, excel
 from superset.utils.core import (
@@ -60,15 +61,6 @@ logger = logging.getLogger(__name__)
 # ``number-format/NumberFormats.ts::PERCENT_3_POINT`` as used in the frontend's
 # ``transformProps`` formatter selection.
 PERCENT_3_POINT = ",.3%"
-
-# ``showValuesAs`` percent modes, mirroring ``ShowValuesAsEnum`` in the pivot
-# table plugin's ``types.ts``. Any other value (including "actual") is a no-op.
-PERCENT_OF_ROW = "percent_row"
-PERCENT_OF_COLUMN = "percent_col"
-PERCENT_OF_TOTAL = "percent_total"
-SHOW_VALUES_AS_PERCENT_MODES = frozenset(
-    {PERCENT_OF_ROW, PERCENT_OF_COLUMN, PERCENT_OF_TOTAL}
-)
 
 
 def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...]:
@@ -131,14 +123,14 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
             selection if metric is not None else np.ones(len(selection), dtype=bool)
         )
         block = numeric.loc[:, selection]
-        if mode == PERCENT_OF_TOTAL:
+        if mode == ShowValuesAs.PERCENT_OF_TOTAL:
             leaf = numeric.loc[leaf_rows, leaf_columns & denominator_selection]
             grand_total = leaf.to_numpy().sum()
             fraction = block / (np.nan if grand_total == 0 else grand_total)
         else:
             summed, divided = (
                 (axis["rows"], axis["columns"])
-                if mode == PERCENT_OF_COLUMN
+                if mode == ShowValuesAs.PERCENT_OF_COLUMN
                 else (axis["columns"], axis["rows"])
             )
             # The metric lives on the column axis, so only a sum taken along

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -35,12 +35,14 @@ from flask import current_app
 from flask_babel import gettext as __
 
 from superset.common.chart_data import ChartDataResultFormat
+from superset.common.grouping_sets import GROUPING_MARKER_SUFFIX
 from superset.constants import SHOW_VALUES_AS_PERCENT_MODES, ShowValuesAs
 from superset.extensions import event_logger
 from superset.utils import csv, excel
 from superset.utils.core import (
     extract_dataframe_dtypes,
     get_column_names,
+    get_metric_name,
     get_metric_names,
 )
 from superset.utils.number_format import (
@@ -81,6 +83,68 @@ def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...
     return tuple(parts)
 
 
+# How a metric's rollup total is derived from its cells, mirroring
+# `additiveReducerFor` in the pivot plugin's `plugin/utilities.ts`: SUM and
+# COUNT add up, MIN takes the lowest, MAX the highest. Everything else (saved
+# metrics, adhoc SQL, AVG, ...) is non-additive and has no correct answer at
+# this layer, so it falls back to summing the cells.
+_ROLLUP_REDUCERS: dict[str, str] = {"MIN": "min", "MAX": "max"}
+DEFAULT_ROLLUP_REDUCER = "sum"
+
+
+def drop_grouping_sets_rollups(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Keep only the leaf rows of a GROUPING SETS result.
+
+    A pivot chart with non-additive metrics asks for every rollup level in one
+    frame, tagging each row with a ``GROUPING()`` marker per groupby column
+    (see ``common/grouping_sets.py``). The chart splits those levels apart, but
+    the server-side render derives its own totals from the leaf rows, so the
+    rollup rows must not reach ``pivot_df`` -- it would pivot them as ordinary
+    rows, inflating every denominator and adding phantom rows and columns whose
+    collapsed dimensions render as NULL.
+    """
+    markers = [
+        column
+        for column in df.columns
+        if isinstance(column, str) and column.endswith(GROUPING_MARKER_SUFFIX)
+    ]
+    if not markers:
+        return df
+    is_leaf = (df[markers] == 0).all(axis=1)
+    return df[is_leaf].drop(columns=markers).reset_index(drop=True)
+
+
+def get_metric_rollup_reducers(
+    metrics: list[Any], verbose_map: Optional[dict[str, Any]] = None
+) -> dict[str, str]:
+    """Map each metric's label to the reducer that rolls its cells up."""
+    reducers: dict[str, str] = {}
+    for metric in metrics:
+        reducer = DEFAULT_ROLLUP_REDUCER
+        if isinstance(metric, dict) and metric.get("expressionType") == "SIMPLE":
+            reducer = _ROLLUP_REDUCERS.get(
+                metric.get("aggregate") or "", DEFAULT_ROLLUP_REDUCER
+            )
+        reducers[get_metric_name(metric, verbose_map)] = reducer
+    return reducers
+
+
+def _metric_of_column(column: Any, metric_level: int) -> Any:
+    """The metric a pivoted column belongs to."""
+    return column[metric_level] if isinstance(column, tuple) else column
+
+
+def _reduce(
+    data: Union[pd.DataFrame, pd.Series],
+    reducer: str,
+    axis: Optional[int] = None,
+) -> Any:
+    """Apply a rollup reducer (``sum``/``min``/``max``), skipping empty cells."""
+    method = getattr(data, reducer)
+    return method(axis=axis) if axis is not None else method()
+
+
 def _apply_show_values_as(  # pylint: disable=too-many-arguments
     df: pd.DataFrame,
     mode: str,
@@ -89,6 +153,7 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     combine_metrics: bool,
     inserted_rows: list[Any],
     inserted_columns: list[Any],
+    reducers: dict[str, str],
 ) -> pd.DataFrame:
     """
     Express each cell as a fraction of its row, column, or grand total.
@@ -101,10 +166,11 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
       inserted into the frame are numerators like any other cell -- a "% of
       row" grand total row reads ``column total / grand total``, not the sum of
       the fractions above it.
-    - A total is summed within a single metric, so a cell is never divided by a
-      total that mixes in another metric. Cross-metric totals (whose metric
-      level holds a total label rather than a metric name) divide by the
-      denominator spanning every metric.
+    - A total is rolled up within a single metric, so a cell is never divided by
+      a total that mixes in another metric, and each metric uses its own
+      reducer -- a MIN/MAX metric divides by the row's minimum/maximum rather
+      than its sum. Cross-metric totals (whose metric level holds a total label
+      rather than a metric name) sum across every metric.
 
     A zero denominator yields NaN (blank) rather than infinity, matching
     ``pandas_postprocessing.pivot``'s ``show_values_as``.
@@ -127,13 +193,29 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
         denominator_selection = (
             selection if metric is not None else np.ones(len(selection), dtype=bool)
         )
+        # Derive the reducer from the columns forming the denominator, not from
+        # the numerator's own label: a total column carries a total label, but
+        # must still divide by a rollup of the metric it totals. A denominator
+        # spanning several metrics has no single reducer, so it sums.
+        denominator_metrics = {
+            column_metric
+            for column_metric, keep in zip(
+                metric_of_column, denominator_selection, strict=True
+            )
+            if keep and column_metric is not None
+        }
+        reducer = (
+            reducers.get(str(next(iter(denominator_metrics))), DEFAULT_ROLLUP_REDUCER)
+            if len(denominator_metrics) == 1
+            else DEFAULT_ROLLUP_REDUCER
+        )
         block = numeric.loc[:, selection]
         if mode == ShowValuesAs.PERCENT_OF_TOTAL:
             leaf = numeric.loc[leaf_rows, leaf_columns & denominator_selection]
-            # Sum through pandas, not numpy: a sparse pivot leaves NaN in cells
-            # whose group had no rows, and numpy would propagate that to the
-            # grand total, blanking every cell.
-            grand_total = leaf.sum().sum()
+            # Reduce through pandas, not numpy: a sparse pivot leaves NaN in
+            # cells whose group had no rows, and numpy would propagate that to
+            # the grand total, blanking every cell.
+            grand_total = _reduce(_reduce(leaf, reducer, axis=0), reducer)
             fraction = block / (
                 np.nan if pd.isna(grand_total) or grand_total == 0 else grand_total
             )
@@ -143,14 +225,15 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
                 if mode == ShowValuesAs.PERCENT_OF_COLUMN
                 else (axis["columns"], axis["rows"])
             )
-            # The metric lives on the column axis, so only a sum taken along
+            # The metric lives on the column axis, so only a rollup taken along
             # that axis has to stay within one metric.
             leaf = (
                 numeric.loc[:, leaf_columns & denominator_selection]
                 if summed == 1
                 else numeric.loc[leaf_rows, :]
             )
-            fraction = block.div(leaf.sum(axis=summed).replace(0, np.nan), axis=divided)
+            total = _reduce(leaf, reducer, axis=summed).replace(0, np.nan)
+            fraction = block.div(total, axis=divided)
         result.loc[:, selection] = fraction
     return result
 
@@ -168,16 +251,18 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     apply_metrics_on_rows: bool = False,
     metric_name_aggfunc: Optional[str] = None,
     show_values_as: Optional[str] = None,
+    metric_rollup_reducers: Optional[dict[str, str]] = None,
 ) -> pd.DataFrame:
     percent_mode = (
         show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
     )
+    reducers = metric_rollup_reducers or {}
     if percent_mode:
         # The chart ignores `aggregateFunction` post-SIP-216: cells arrive
-        # pre-aggregated from the database and totals are plain rollups of them.
-        # Match that here so the totals and the percent denominators cannot
-        # disagree -- otherwise a total stops dividing by itself and the Total
-        # row/column reads something other than 100%.
+        # pre-aggregated from the database and totals are per-metric rollups of
+        # them. Match that here so the totals and the percent denominators
+        # cannot disagree -- otherwise a total stops dividing by itself and the
+        # Total row/column reads something other than 100%.
         aggfunc = "Sum"
     metric_name = __("Total (%(aggfunc)s)", aggfunc=metric_name_aggfunc or aggfunc)
     # Labels of the total/subtotal rows and columns inserted below, so the
@@ -265,6 +350,29 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     if not isinstance(df.columns, pd.MultiIndex):
         df.columns = pd.MultiIndex.from_tuples([(str(i),) for i in df.columns])
 
+    # Rollups follow each metric's own reducer under a percent mode, so a total
+    # still divides by itself: a MAX metric's row total is the row's maximum,
+    # and dividing that maximum by itself reads 100%.
+    totals_metric_level = df.columns.nlevels - 1 if combine_metrics else 0
+    # A column carrying a total label rather than a metric name rolls up
+    # everything, so it follows the sole metric's reducer when there is one.
+    cross_metric_reducer = (
+        reducers.get(metrics[0], DEFAULT_ROLLUP_REDUCER)
+        if len(set(metrics)) == 1
+        else DEFAULT_ROLLUP_REDUCER
+    )
+
+    def reducer_for(pivot_columns: Any) -> str:
+        found = {
+            reducers.get(
+                str(_metric_of_column(column, totals_metric_level)),
+                cross_metric_reducer,
+            )
+            for column in pivot_columns
+        }
+        # A total spanning several metrics has no single reducer; sum it.
+        return found.pop() if len(found) == 1 else DEFAULT_ROLLUP_REDUCER
+
     if show_rows_total:
         # add subtotal for each group and overall total; we start from the
         # overall group, and iterate deeper into subgroups
@@ -285,7 +393,12 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             subgroups = {group[:level] for group in groups}
             for subgroup in subgroups:
                 slice_ = df.columns.get_loc(subgroup)
-                subtotal = pivot_v2_aggfunc_map[aggfunc](df.iloc[:, slice_], axis=1)
+                block = df.iloc[:, slice_]
+                subtotal = (
+                    _reduce(block, reducer_for(block.columns), axis=1)
+                    if percent_mode
+                    else pivot_v2_aggfunc_map[aggfunc](block, axis=1)
+                )
                 depth = df.columns.nlevels - len(subgroup) - 1
                 total = metric_name if level == 0 else __("Subtotal")
                 subtotal_name = tuple([*subgroup, total, *([""] * depth)])  # noqa: C409
@@ -315,7 +428,13 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                     subtotal_values = subtotal_values.apply(
                         pd.to_numeric, errors="coerce"
                     )
-                subtotal = pivot_v2_aggfunc_map[aggfunc](subtotal_values, axis=0)
+                subtotal = (
+                    subtotal_values.apply(
+                        lambda series: _reduce(series, reducer_for([series.name]))
+                    )
+                    if percent_mode
+                    else pivot_v2_aggfunc_map[aggfunc](subtotal_values, axis=0)
+                )
                 depth = groups.nlevels - len(subgroup) - 1
                 total = metric_name if level == 0 else __("Subtotal")
                 subtotal.name = tuple([*subgroup, total, *([""] * depth)])  # noqa: C409
@@ -334,6 +453,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             combine_metrics,
             inserted_rows,
             inserted_columns,
+            reducers,
         )
 
     # if we want to apply the metrics on the rows we need to pivot the
@@ -645,6 +765,9 @@ def pivot_table_v2(
     """
     verbose_map = datasource.data["verbose_map"] if datasource else None
     metrics = get_metric_names(form_data["metrics"], verbose_map)
+    # A non-additive metric makes the chart query every rollup level at once;
+    # only the leaf rows describe the table being rendered.
+    df = drop_grouping_sets_rollups(df)
     show_values_as = form_data.get("showValuesAs")
     percent_mode = (
         show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
@@ -660,6 +783,9 @@ def pivot_table_v2(
         "show_columns_total": bool(form_data.get("colTotals")),
         "apply_metrics_on_rows": form_data.get("metricsLayout") == "ROWS",
         "show_values_as": percent_mode,
+        "metric_rollup_reducers": get_metric_rollup_reducers(
+            form_data["metrics"], verbose_map
+        ),
     }
 
     pivoted = pivot_df(df, **pivot_options)

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -70,6 +70,9 @@ PERCENT_3_POINT = ",.3%"
 # Table plugin's three.
 PERCENT_1_POINT = ",.1%"
 
+# The Excel equivalent, applied as a cell format so the value stays numeric.
+EXCEL_PERCENT_FORMAT = "0.0%"
+
 
 def get_column_key(label: tuple[str, ...], metrics: list[str]) -> tuple[Any, ...]:
     """
@@ -1429,6 +1432,14 @@ def apply_client_processing(  # noqa: C901
             excel.apply_column_types(processed_df, query["coltypes"])
             query["data"] = excel.df_to_excel(
                 processed_df,
+                # A percent mode leaves every cell a fraction. Excel can render
+                # those as percentages without turning them into text, so the
+                # workbook reads like the chart and still calculates.
+                number_format=(
+                    EXCEL_PERCENT_FORMAT
+                    if form_data.get("showValuesAs") in SHOW_VALUES_AS_PERCENT_MODES
+                    else None
+                ),
                 **{
                     **current_app.config["EXCEL_EXPORT"],
                     "index": show_default_index,

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -527,11 +527,9 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
         rows, columns = columns, rows
         # The frame is transposed on the way out, which flips the axis each
         # total was inserted on. Swap the toggles too, so `rowTotals` still
-        # means the right-hand Total column of the rendered table. The
-        # `columns and not rows` branch below transposes once more on its own,
-        # cancelling that flip, so it keeps the toggles as given.
-        if rows:
-            show_rows_total, show_columns_total = show_columns_total, show_rows_total
+        # means the right-hand Total column of the rendered table, whether or
+        # not there are column dimensions to group by.
+        show_rows_total, show_columns_total = show_columns_total, show_rows_total
         axis = {"columns": 0, "rows": 1}
     else:
         axis = {"columns": 1, "rows": 0}
@@ -650,6 +648,12 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             for subgroup in subgroups:
                 slice_ = df.columns.get_loc(subgroup)
                 block = df.iloc[:, slice_]
+                if aggfunc != CURRENCY_CONTEXT_AGGREGATION:
+                    # A metric column can hold non-numeric values (a literal
+                    # "NULL", say), which a reduction across columns cannot add
+                    # to a number. The row totals below already coerce; do the
+                    # same here so a total means the same thing on both axes.
+                    block = block.apply(pd.to_numeric, errors="coerce")
                 if percent_mode:
                     source, reducer = collapse(block)
                     subtotal = _reduce(source, reducer, axis=1)

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -125,8 +125,13 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
         block = numeric.loc[:, selection]
         if mode == ShowValuesAs.PERCENT_OF_TOTAL:
             leaf = numeric.loc[leaf_rows, leaf_columns & denominator_selection]
-            grand_total = leaf.to_numpy().sum()
-            fraction = block / (np.nan if grand_total == 0 else grand_total)
+            # Sum through pandas, not numpy: a sparse pivot leaves NaN in cells
+            # whose group had no rows, and numpy would propagate that to the
+            # grand total, blanking every cell.
+            grand_total = leaf.sum().sum()
+            fraction = block / (
+                np.nan if pd.isna(grand_total) or grand_total == 0 else grand_total
+            )
         else:
             summed, divided = (
                 (axis["rows"], axis["columns"])

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -164,10 +164,17 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     metric_name_aggfunc: Optional[str] = None,
     show_values_as: Optional[str] = None,
 ) -> pd.DataFrame:
-    metric_name = __("Total (%(aggfunc)s)", aggfunc=metric_name_aggfunc or aggfunc)
     percent_mode = (
         show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
     )
+    if percent_mode:
+        # The chart ignores `aggregateFunction` post-SIP-216: cells arrive
+        # pre-aggregated from the database and totals are plain rollups of them.
+        # Match that here so the totals and the percent denominators cannot
+        # disagree -- otherwise a total stops dividing by itself and the Total
+        # row/column reads something other than 100%.
+        aggfunc = "Sum"
+    metric_name = __("Total (%(aggfunc)s)", aggfunc=metric_name_aggfunc or aggfunc)
     # Labels of the total/subtotal rows and columns inserted below, so the
     # `showValuesAs` denominators can be summed over leaf cells only.
     inserted_rows: list[Any] = []

--- a/superset/charts/client_processing.py
+++ b/superset/charts/client_processing.py
@@ -92,17 +92,25 @@ _ROLLUP_REDUCERS: dict[str, str] = {"MIN": "min", "MAX": "max"}
 DEFAULT_ROLLUP_REDUCER = "sum"
 
 
-def drop_grouping_sets_rollups(df: pd.DataFrame) -> pd.DataFrame:
+def split_grouping_sets_levels(
+    df: pd.DataFrame,
+) -> tuple[pd.DataFrame, dict[frozenset[str], pd.DataFrame]]:
     """
-    Keep only the leaf rows of a GROUPING SETS result.
+    Separate a GROUPING SETS result into its leaf frame and rollup levels.
 
     A pivot chart with non-additive metrics asks for every rollup level in one
     frame, tagging each row with a ``GROUPING()`` marker per groupby column
-    (see ``common/grouping_sets.py``). The chart splits those levels apart, but
-    the server-side render derives its own totals from the leaf rows, so the
-    rollup rows must not reach ``pivot_df`` -- it would pivot them as ordinary
-    rows, inflating every denominator and adding phantom rows and columns whose
-    collapsed dimensions render as NULL.
+    (see ``common/grouping_sets.py``): ``0`` where the column is grouped at that
+    row's level, ``1`` where it has been rolled up. The rollup rows must not be
+    pivoted as ordinary rows -- their collapsed dimensions are NULL, so they
+    would add phantom rows and columns and inflate every denominator.
+
+    They are not discardable either: for a non-additive metric the database
+    rollup is the only correct total, and re-deriving one from the leaf cells
+    gives a different number (the mean of means, say, rather than the mean).
+    The chart divides by these values, so the export has to as well.
+
+    :return: the leaf frame, and each rollup level keyed by its grouped columns
     """
     markers = [
         column
@@ -110,9 +118,24 @@ def drop_grouping_sets_rollups(df: pd.DataFrame) -> pd.DataFrame:
         if isinstance(column, str) and column.endswith(GROUPING_MARKER_SUFFIX)
     ]
     if not markers:
-        return df
-    is_leaf = (df[markers] == 0).all(axis=1)
-    return df[is_leaf].drop(columns=markers).reset_index(drop=True)
+        return df, {}
+
+    grouped_of = {marker: marker[: -len(GROUPING_MARKER_SUFFIX)] for marker in markers}
+    levels: dict[frozenset[str], pd.DataFrame] = {}
+    leaf = df
+    for keys, rows_at_level in df.groupby(markers, sort=False):
+        # `groupby` yields a scalar key for a single column and a tuple beyond.
+        marker_values = keys if isinstance(keys, tuple) else (keys,)
+        grouped = frozenset(
+            grouped_of[marker]
+            for marker, rolled_up in zip(markers, marker_values, strict=True)
+            if not rolled_up
+        )
+        level = rows_at_level.drop(columns=markers).reset_index(drop=True)
+        levels[grouped] = level
+        if len(grouped) == len(markers):
+            leaf = level
+    return leaf, levels
 
 
 def get_metric_rollup_reducers(
@@ -130,6 +153,25 @@ def get_metric_rollup_reducers(
     return reducers
 
 
+def _collapsed_metric(present: list[Any], metrics: list[str]) -> Any:
+    """
+    The metric a rollup spanning `present` stands for.
+
+    A total that collapses the metric axis is undefined in the renderer, which
+    resolves it to the last metric pushed into the shared slot (see the
+    ``metricAxis`` handling in ``react-pivottable/utilities.ts``). Mirror that
+    by taking the last metric in the configured order, so exported percentages
+    match the chart rather than summing metrics that share no unit.
+    """
+    distinct = set(present)
+    if len(distinct) == 1:
+        return distinct.pop()
+    for metric in reversed(metrics):
+        if metric in distinct:
+            return metric
+    return None
+
+
 def _metric_of_column(column: Any, metric_level: int) -> Any:
     """The metric a pivoted column belongs to."""
     return column[metric_level] if isinstance(column, tuple) else column
@@ -145,6 +187,157 @@ def _reduce(
     return method(axis=axis) if axis is not None else method()
 
 
+def _keyed_rollup(
+    frame: pd.DataFrame, dimensions: list[str]
+) -> dict[tuple[str, ...], dict[str, Any]]:
+    """Index a rollup level by its grouped dimension values, as strings."""
+    filled = frame.fillna("SUPERSET_PANDAS_NAN")
+    return {
+        tuple(str(record[dimension]) for dimension in dimensions): record
+        for record in filled.to_dict("records")
+    }
+
+
+def _apply_rollup_totals(  # pylint: disable=too-many-arguments,too-many-locals
+    df: pd.DataFrame,
+    rows: list[str],
+    columns: list[str],
+    metrics: list[str],
+    rollup_levels: dict[frozenset[str], pd.DataFrame],
+    metric_level: int,
+    full_total_rows: list[Any],
+    full_total_columns: list[Any],
+) -> pd.DataFrame:
+    """
+    Replace whole-axis totals with the values the database computed.
+
+    The totals inserted above are reductions of the leaf cells, which is exact
+    only for an additive metric. Where the chart requested a rollup level, use
+    it, so that a total matches the chart and still divides by itself -- the
+    denominators come from the same levels.
+
+    Subtotals over a prefix of an axis are left as leaf reductions: the chart
+    gates those on their own toggles, so the matching level is not always
+    requested.
+    """
+    by_row = rollup_levels.get(frozenset(rows))
+    by_column = rollup_levels.get(frozenset(columns))
+    grand = rollup_levels.get(frozenset())
+    if grand is None:
+        return df
+
+    metric_names = set(metrics)
+
+    def metric_of(column: Any) -> Any:
+        name = _metric_of_column(column, metric_level)
+        return (
+            name if name in metric_names else _collapsed_metric(list(metrics), metrics)
+        )
+
+    grand_record = next(iter(_keyed_rollup(grand, []).values()), {})
+
+    if by_row is not None and full_total_columns:
+        keyed = _keyed_rollup(by_row, rows)
+        for column in full_total_columns:
+            metric = metric_of(column)
+            df[column] = [
+                (keyed.get(tuple(str(part) for part in row)) or {}).get(metric)
+                for row in df.index
+            ]
+
+    if by_column is not None and full_total_rows:
+        keyed = _keyed_rollup(by_column, columns)
+        for row in full_total_rows:
+            values = []
+            for column in df.columns:
+                metric = metric_of(column)
+                if column in full_total_columns:
+                    values.append(grand_record.get(metric))
+                    continue
+                key = tuple(
+                    str(part)
+                    for index, part in enumerate(column)
+                    if index != (metric_level % len(column))
+                )
+                values.append((keyed.get(key) or {}).get(metric))
+            df.loc[row] = values
+
+    return df
+
+
+def _rollup_denominators(  # pylint: disable=too-many-arguments,too-many-locals
+    df: pd.DataFrame,
+    mode: str,
+    rows: list[str],
+    columns: list[str],
+    metrics: list[str],
+    rollup_levels: dict[frozenset[str], pd.DataFrame],
+    metric_level: int,
+    inserted_rows: list[Any],
+    inserted_columns: list[Any],
+) -> Optional[pd.DataFrame]:
+    """
+    Each cell's denominator, taken from the database-computed rollup levels.
+
+    A percent mode makes the chart request the rollup level its denominator
+    needs -- all rows with the columns collapsed for "% of row", the reverse for
+    "% of column", both collapsed for "% of total" (see
+    ``buildGroupbyCombinations``). Those values are the totals the database
+    computed, so for a non-additive metric they are the only correct ones.
+
+    Returns ``None`` when the level is absent, leaving the caller to derive the
+    denominators from the leaf cells instead: additive metrics never request
+    rollup levels in the first place, and re-deriving is exact for them.
+    """
+    grouped_for_mode = {
+        ShowValuesAs.PERCENT_OF_ROW: rows,
+        ShowValuesAs.PERCENT_OF_COLUMN: columns,
+        ShowValuesAs.PERCENT_OF_TOTAL: [],
+    }[ShowValuesAs(mode)]
+    level = rollup_levels.get(frozenset(grouped_for_mode))
+    grand = rollup_levels.get(frozenset())
+    if level is None or grand is None:
+        return None
+
+    by_key = _keyed_rollup(level, grouped_for_mode)
+    grand_record = next(iter(_keyed_rollup(grand, []).values()), {})
+
+    def metric_of(column: Any) -> Any:
+        name = _metric_of_column(column, metric_level)
+        return (
+            name if name in set(metrics) else _collapsed_metric(list(metrics), metrics)
+        )
+
+    def denominator(row: Any, column: Any) -> Any:
+        metric = metric_of(column)
+        # A total collapses its axis entirely, so it divides by the grand total.
+        collapsed = (
+            row in inserted_rows
+            if mode == ShowValuesAs.PERCENT_OF_ROW
+            else column in inserted_columns
+        )
+        if mode == ShowValuesAs.PERCENT_OF_TOTAL or collapsed:
+            return grand_record.get(metric)
+        source = row if mode == ShowValuesAs.PERCENT_OF_ROW else column
+        values = tuple(str(part) for part in source)
+        # The column key carries the metric alongside the dimension values.
+        if mode == ShowValuesAs.PERCENT_OF_COLUMN:
+            values = tuple(
+                part
+                for index, part in enumerate(values)
+                if index != (metric_level % len(values))
+            )
+        record = by_key.get(values)
+        return record.get(metric) if record else None
+
+    built = pd.DataFrame(
+        [[denominator(row, column) for column in df.columns] for row in df.index],
+        index=df.index,
+        columns=df.columns,
+    )
+    return built.apply(pd.to_numeric, errors="coerce").astype(float)
+
+
 def _apply_show_values_as(  # pylint: disable=too-many-arguments
     df: pd.DataFrame,
     mode: str,
@@ -154,6 +347,7 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     inserted_rows: list[Any],
     inserted_columns: list[Any],
     reducers: dict[str, str],
+    denominators: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """
     Express each cell as a fraction of its row, column, or grand total.
@@ -169,13 +363,17 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
     - A total is rolled up within a single metric, so a cell is never divided by
       a total that mixes in another metric, and each metric uses its own
       reducer -- a MIN/MAX metric divides by the row's minimum/maximum rather
-      than its sum. Cross-metric totals (whose metric level holds a total label
-      rather than a metric name) sum across every metric.
+      than its sum. A total that collapses the metric axis resolves to a single
+      metric the way the renderer does; see ``_collapsed_metric``.
 
     A zero denominator yields NaN (blank) rather than infinity, matching
     ``pandas_postprocessing.pivot``'s ``show_values_as``.
     """
     numeric = df.apply(pd.to_numeric, errors="coerce").astype(float)
+    if denominators is not None:
+        # Database-computed rollups: the only correct totals for a non-additive
+        # metric, and what the chart divides by.
+        return numeric / denominators.replace(0, np.nan)
     is_multi_index = isinstance(df.columns, pd.MultiIndex)
     # `combine_metrics` has already moved the metric to the lowest column level.
     metric_level = df.columns.nlevels - 1 if combine_metrics and is_multi_index else 0
@@ -195,20 +393,22 @@ def _apply_show_values_as(  # pylint: disable=too-many-arguments
         )
         # Derive the reducer from the columns forming the denominator, not from
         # the numerator's own label: a total column carries a total label, but
-        # must still divide by a rollup of the metric it totals. A denominator
-        # spanning several metrics has no single reducer, so it sums.
-        denominator_metrics = {
-            column_metric
-            for column_metric, keep in zip(
-                metric_of_column, denominator_selection, strict=True
-            )
-            if keep and column_metric is not None
-        }
-        reducer = (
-            reducers.get(str(next(iter(denominator_metrics))), DEFAULT_ROLLUP_REDUCER)
-            if len(denominator_metrics) == 1
-            else DEFAULT_ROLLUP_REDUCER
+        # must still divide by a rollup of the metric it totals.
+        denominator_metric = _collapsed_metric(
+            [
+                column_metric
+                for column_metric, keep in zip(
+                    metric_of_column, denominator_selection, strict=True
+                )
+                if keep and column_metric is not None
+            ],
+            metrics,
         )
+        reducer = reducers.get(str(denominator_metric), DEFAULT_ROLLUP_REDUCER)
+        if denominator_metric is not None:
+            denominator_selection = denominator_selection & np.array(
+                [column == denominator_metric for column in metric_of_column]
+            )
         block = numeric.loc[:, selection]
         if mode == ShowValuesAs.PERCENT_OF_TOTAL:
             leaf = numeric.loc[leaf_rows, leaf_columns & denominator_selection]
@@ -252,6 +452,7 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     metric_name_aggfunc: Optional[str] = None,
     show_values_as: Optional[str] = None,
     metric_rollup_reducers: Optional[dict[str, str]] = None,
+    rollup_levels: Optional[dict[frozenset[str], pd.DataFrame]] = None,
 ) -> pd.DataFrame:
     percent_mode = (
         show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
@@ -269,6 +470,11 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     # `showValuesAs` denominators can be summed over leaf cells only.
     inserted_rows: list[Any] = []
     inserted_columns: list[Any] = []
+    # Totals that collapse their entire axis, as opposed to subtotals over a
+    # prefix of it. Only these correspond to a rollup level the chart requests
+    # for a percent mode, so only these can take database-computed values.
+    full_total_rows: list[Any] = []
+    full_total_columns: list[Any] = []
 
     if transpose_pivot:
         rows, columns = columns, rows
@@ -355,23 +561,25 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
     # and dividing that maximum by itself reads 100%.
     totals_metric_level = df.columns.nlevels - 1 if combine_metrics else 0
     # A column carrying a total label rather than a metric name rolls up
-    # everything, so it follows the sole metric's reducer when there is one.
+    # everything; with no metric to resolve it to, it sums.
     cross_metric_reducer = (
         reducers.get(metrics[0], DEFAULT_ROLLUP_REDUCER)
         if len(set(metrics)) == 1
         else DEFAULT_ROLLUP_REDUCER
     )
 
-    def reducer_for(pivot_columns: Any) -> str:
-        found = {
-            reducers.get(
-                str(_metric_of_column(column, totals_metric_level)),
-                cross_metric_reducer,
-            )
-            for column in pivot_columns
-        }
-        # A total spanning several metrics has no single reducer; sum it.
-        return found.pop() if len(found) == 1 else DEFAULT_ROLLUP_REDUCER
+    def collapse(block: pd.DataFrame) -> tuple[pd.DataFrame, str]:
+        """Narrow a total's source columns to one metric, and pick its reducer."""
+        metric_names = set(metrics)
+        present = [
+            _metric_of_column(column, totals_metric_level) for column in block.columns
+        ]
+        known = [metric for metric in present if metric in metric_names]
+        metric = _collapsed_metric(known, metrics) if known else None
+        if metric is None:
+            return block, cross_metric_reducer
+        keep = [column == metric for column in present]
+        return block.loc[:, keep], reducers.get(str(metric), DEFAULT_ROLLUP_REDUCER)
 
     if show_rows_total:
         # add subtotal for each group and overall total; we start from the
@@ -394,17 +602,20 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             for subgroup in subgroups:
                 slice_ = df.columns.get_loc(subgroup)
                 block = df.iloc[:, slice_]
-                subtotal = (
-                    _reduce(block, reducer_for(block.columns), axis=1)
-                    if percent_mode
-                    else pivot_v2_aggfunc_map[aggfunc](block, axis=1)
-                )
+                if percent_mode:
+                    source, reducer = collapse(block)
+                    subtotal = _reduce(source, reducer, axis=1)
+                else:
+                    subtotal = pivot_v2_aggfunc_map[aggfunc](block, axis=1)
                 depth = df.columns.nlevels - len(subgroup) - 1
                 total = metric_name if level == 0 else __("Subtotal")
                 subtotal_name = tuple([*subgroup, total, *([""] * depth)])  # noqa: C409
                 # insert column after subgroup
                 df.insert(int(slice_.stop), subtotal_name, subtotal)
                 inserted_columns.append(subtotal_name)
+                covered = level if combine_metrics else max(0, level - 1)
+                if covered == 0:
+                    full_total_columns.append(subtotal_name)
 
     if rows and show_columns_total:
         # add subtotal for each group and overall total; we start from the
@@ -428,13 +639,12 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                     subtotal_values = subtotal_values.apply(
                         pd.to_numeric, errors="coerce"
                     )
-                subtotal = (
-                    subtotal_values.apply(
-                        lambda series: _reduce(series, reducer_for([series.name]))
+                if percent_mode:
+                    subtotal = subtotal_values.apply(
+                        lambda series: _reduce(series, collapse(series.to_frame())[1])
                     )
-                    if percent_mode
-                    else pivot_v2_aggfunc_map[aggfunc](subtotal_values, axis=0)
-                )
+                else:
+                    subtotal = pivot_v2_aggfunc_map[aggfunc](subtotal_values, axis=0)
                 depth = groups.nlevels - len(subgroup) - 1
                 total = metric_name if level == 0 else __("Subtotal")
                 subtotal.name = tuple([*subgroup, total, *([""] * depth)])  # noqa: C409
@@ -443,6 +653,20 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
                     [df[: slice_.stop], subtotal.to_frame().T, df[slice_.stop :]]
                 )
                 inserted_rows.append(subtotal.name)
+                if level == 0:
+                    full_total_rows.append(subtotal.name)
+
+    if percent_mode and not apply_metrics_on_rows and rollup_levels:
+        df = _apply_rollup_totals(
+            df,
+            rows,
+            columns,
+            metrics,
+            rollup_levels,
+            totals_metric_level,
+            full_total_rows,
+            full_total_columns,
+        )
 
     if percent_mode:
         df = _apply_show_values_as(
@@ -454,6 +678,19 @@ def pivot_df(  # pylint: disable=too-many-locals, too-many-arguments, too-many-s
             inserted_rows,
             inserted_columns,
             reducers,
+            _rollup_denominators(
+                df,
+                percent_mode,
+                rows,
+                columns,
+                metrics,
+                rollup_levels or {},
+                totals_metric_level,
+                inserted_rows,
+                inserted_columns,
+            )
+            if not apply_metrics_on_rows
+            else None,
         )
 
     # if we want to apply the metrics on the rows we need to pivot the
@@ -765,9 +1002,10 @@ def pivot_table_v2(
     """
     verbose_map = datasource.data["verbose_map"] if datasource else None
     metrics = get_metric_names(form_data["metrics"], verbose_map)
-    # A non-additive metric makes the chart query every rollup level at once;
-    # only the leaf rows describe the table being rendered.
-    df = drop_grouping_sets_rollups(df)
+    # A non-additive metric makes the chart query every rollup level at once:
+    # the leaf rows describe the table, the rest are its database-computed
+    # totals.
+    df, rollup_levels = split_grouping_sets_levels(df)
     show_values_as = form_data.get("showValuesAs")
     percent_mode = (
         show_values_as if show_values_as in SHOW_VALUES_AS_PERCENT_MODES else None
@@ -786,6 +1024,7 @@ def pivot_table_v2(
         "metric_rollup_reducers": get_metric_rollup_reducers(
             form_data["metrics"], verbose_map
         ),
+        "rollup_levels": rollup_levels,
     }
 
     pivoted = pivot_df(df, **pivot_options)

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -241,6 +241,26 @@ class PandasAxis(int, Enum):
     COLUMN = 1
 
 
+class ShowValuesAs(StrEnum):
+    """
+    Pivot table "Show values as" modes.
+
+    Mirrors ``ShowValuesAsEnum`` in the pivot table plugin's ``types.ts``. The
+    value reaches the backend verbatim in the chart's form data, and is honored
+    by both the pandas postprocessing ``pivot`` operator and the server-side
+    render of the chart used for exports and reports.
+    """
+
+    ACTUAL = "actual"
+    PERCENT_OF_ROW = "percent_row"
+    PERCENT_OF_COLUMN = "percent_col"
+    PERCENT_OF_TOTAL = "percent_total"
+
+
+# The modes that transform values; ``ACTUAL`` (like ``None``) is a no-op.
+SHOW_VALUES_AS_PERCENT_MODES = frozenset(ShowValuesAs) - {ShowValuesAs.ACTUAL}
+
+
 class PandasPostprocessingCompare(StrEnum):
     DIFF = "difference"
     PCT = "percentage"

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -16,7 +16,7 @@
 # under the License.
 import io
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 import pandas as pd
 
@@ -91,7 +91,17 @@ def quote_formulas(df: pd.DataFrame) -> pd.DataFrame:
     return df.rename_axis(index=_quote_formula, columns=_quote_formula)
 
 
-def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
+def df_to_excel(
+    df: pd.DataFrame, number_format: Optional[str] = None, **kwargs: Any
+) -> Any:
+    """
+    Serialize a DataFrame to an xlsx workbook.
+
+    :param number_format: optional Excel format code applied to the data
+           columns, e.g. ``"0.0%"``. Applying it as a cell format rather than
+           writing formatted text keeps the underlying value numeric, so the
+           spreadsheet still sums and charts it.
+    """
     output = io.BytesIO()
 
     # make sure formulas are quoted, to prevent malicious injections
@@ -100,6 +110,17 @@ def df_to_excel(df: pd.DataFrame, **kwargs: Any) -> Any:
     # pylint: disable=abstract-class-instantiated
     with pd.ExcelWriter(output, engine="xlsxwriter") as writer:
         df.to_excel(writer, **kwargs)
+
+        if number_format and writer.sheets:
+            worksheet = next(iter(writer.sheets.values()))
+            # The index occupies the leading columns when it is written out.
+            first_data_column = df.index.nlevels if kwargs.get("index", True) else 0
+            worksheet.set_column(
+                first_data_column,
+                first_data_column + len(df.columns) - 1,
+                None,
+                writer.book.add_format({"num_format": number_format}),
+            )
 
         # Reset workbook document properties so the exported file does not
         # carry identifying details (authoring info, generation timestamps).

--- a/superset/utils/excel.py
+++ b/superset/utils/excel.py
@@ -113,8 +113,11 @@ def df_to_excel(
 
         if number_format and writer.sheets:
             worksheet = next(iter(writer.sheets.values()))
-            # The index occupies the leading columns when it is written out.
-            first_data_column = df.index.nlevels if kwargs.get("index", True) else 0
+            # The sheet may start past column A, and the index occupies the
+            # leading columns when it is written out.
+            first_data_column = kwargs.get("startcol", 0) + (
+                df.index.nlevels if kwargs.get("index", True) else 0
+            )
             worksheet.set_column(
                 first_data_column,
                 first_data_column + len(df.columns) - 1,

--- a/superset/utils/pandas_postprocessing/pivot.py
+++ b/superset/utils/pandas_postprocessing/pivot.py
@@ -20,14 +20,17 @@ import pandas as pd
 from flask_babel import gettext as _
 from pandas import DataFrame
 
-from superset.constants import NULL_STRING, PandasAxis
+from superset.constants import (
+    NULL_STRING,
+    PandasAxis,
+    SHOW_VALUES_AS_PERCENT_MODES,
+    ShowValuesAs,
+)
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.pandas_postprocessing.utils import (
     _get_aggregate_funcs,
     validate_column_args,
 )
-
-_PERCENT_MODES = frozenset({"percent_row", "percent_col", "percent_total"})
 
 # Aggregate operator names that produce additive results across groups —
 # the sum of the per-cell values equals the row/column/grand rollup the
@@ -60,10 +63,10 @@ def _apply_percent_transform_to_group(g: DataFrame, mode: str) -> DataFrame:
     from division-by-zero, matching the client's ``if (acc === null)
     return null`` guard in ``fractionOf``.
     """
-    if mode == "percent_row":
+    if mode == ShowValuesAs.PERCENT_OF_ROW:
         row_totals = g.sum(axis=PandasAxis.COLUMN, skipna=True).replace(0, float("nan"))
         return _div_preserving_nan(g, row_totals, axis=PandasAxis.ROW)
-    if mode == "percent_col":
+    if mode == ShowValuesAs.PERCENT_OF_COLUMN:
         col_totals = g.sum(axis=PandasAxis.ROW, skipna=True).replace(0, float("nan"))
         return _div_preserving_nan(g, col_totals, axis=PandasAxis.COLUMN)
     # percent_total
@@ -250,8 +253,8 @@ def pivot(  # pylint: disable=too-many-arguments  # noqa: C901
     # ``""`` / ``"actual"`` are the no-op sentinels — anything else must
     # be a known percent mode.
     percent_mode: Optional[str] = None
-    if show_values_as not in (None, "", "actual"):
-        if show_values_as not in _PERCENT_MODES:
+    if show_values_as not in (None, "", ShowValuesAs.ACTUAL):
+        if show_values_as not in SHOW_VALUES_AS_PERCENT_MODES:
             raise InvalidPostProcessingError(
                 _(
                     "Unsupported show_values_as value: %(mode)s. "

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1925,6 +1925,21 @@ def test_pivot_df_show_values_as_zero_denominator_is_blank():
     assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
 
 
+def test_pivot_df_show_values_as_skips_empty_cells_in_denominators():
+    """A sparse pivot leaves NaN cells; they must not blank the whole table."""
+    df = show_values_as_df()
+    # drop UK/girl entirely, so that cell has no rows and pivots to NaN
+    sparse = df[~((df["nation"] == "UK") & (df["gender"] == "girl"))]
+    options = {**SHOW_VALUES_AS_OPTIONS, "show_rows_total": False}
+
+    pivoted = pivot_df(sparse, **options, show_values_as="percent_total")
+
+    # grand total is 10 + 30 + 20 = 60, the NaN cell contributing nothing
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == pytest.approx(10 / 60)
+    assert pivoted.loc[("UK",), ("SUM(num)", "boy")] == pytest.approx(20 / 60)
+    assert pd.isna(pivoted.loc[("UK",), ("SUM(num)", "girl")])
+
+
 def test_pivot_df_show_values_as_supersedes_legacy_fraction_aggfunc():
     """`showValuesAs` wins over a pre-SIP-216 fraction aggregate function."""
     pivoted = pivot_df(

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -523,11 +523,11 @@ def test_pivot_df_single_row_null_values():
     assert (
         pivoted.to_markdown()
         == """
-|                  |   ('SUM(num)',) |   ('MAX(num)',) | ('Total (Sum)',)   |
-|:-----------------|----------------:|----------------:|:-------------------|
-| ('boy',)         |             nan |             nan | nannan             |
-| ('girl',)        |          118065 |            2588 | 120653.0           |
-| ('Total (Sum)',) |          118065 |            2588 | 120653.0           |
+|                  |   ('SUM(num)',) |   ('MAX(num)',) |   ('Total (Sum)',) |
+|:-----------------|----------------:|----------------:|-------------------:|
+| ('boy',)         |             nan |             nan |                  0 |
+| ('girl',)        |          118065 |            2588 |             120653 |
+| ('Total (Sum)',) |          118065 |            2588 |             120653 |
     """.strip()
     )
 
@@ -547,15 +547,12 @@ def test_pivot_df_single_row_null_values():
     assert (
         pivoted.to_markdown()
         == f"""
-|                          |   ('{_("Total")} (Sum)',) |
-|:-------------------------|-------------------:|
-| ('SUM(num)', 'boy')      |                nan |
-| ('SUM(num)', 'girl')     |             118065 |
-| ('SUM(num)', 'Subtotal') |             118065 |
-| ('MAX(num)', 'boy')      |                nan |
-| ('MAX(num)', 'girl')     |               2588 |
-| ('MAX(num)', 'Subtotal') |               2588 |
-| ('{_("Total")} (Sum)', '')      |             120653 |
+|                      |   ('{_("Total")} (Sum)',) |
+|:---------------------|-------------------:|
+| ('SUM(num)', 'boy')  |                nan |
+| ('SUM(num)', 'girl') |             118065 |
+| ('MAX(num)', 'boy')  |                nan |
+| ('MAX(num)', 'girl') |               2588 |
     """.strip()
     )
 
@@ -693,11 +690,11 @@ def test_pivot_df_single_row_null_mix_values_strings():
     assert (
         pivoted.to_markdown()
         == """
-|                  | ('SUM(num)',)   |   ('MAX(num)',) | ('Total (Sum)',)   |
-|:-----------------|:----------------|----------------:|:-------------------|
-| ('boy',)         | NULL            |             nan | NULLnan            |
-| ('girl',)        | 118065          |            2588 | 120653.0           |
-| ('Total (Sum)',) | 118065.0        |            2588 | 120653.0           |
+|                  | ('SUM(num)',)   |   ('MAX(num)',) |   ('Total (Sum)',) |
+|:-----------------|:----------------|----------------:|-------------------:|
+| ('boy',)         | NULL            |             nan |                  0 |
+| ('girl',)        | 118065          |            2588 |             120653 |
+| ('Total (Sum)',) | 118065.0        |            2588 |             120653 |
     """.strip()
     )
 
@@ -721,8 +718,11 @@ def test_pivot_df_single_row_null_mix_values_strings():
 |:---------------------|:-------------------|
 | ('boy', 'SUM(num)')  | NULL               |
 | ('boy', 'MAX(num)')  | nan                |
+| ('boy', 'Subtotal')  | 0.0                |
 | ('girl', 'SUM(num)') | 118065             |
 | ('girl', 'MAX(num)') | 2588.0             |
+| ('girl', 'Subtotal') | 120653.0           |
+| ('Total (Sum)', '')  | 120653.0           |
     """.strip()
     )
 
@@ -854,12 +854,15 @@ def test_pivot_df_single_row_null_mix_values_numbers():
     assert (
         pivoted.to_markdown()
         == """
-|                      |   ('Total (Sum)',) |
-|:---------------------|-------------------:|
-| ('SUM(num)', 'boy')  |                 21 |
-| ('SUM(num)', 'girl') |             118065 |
-| ('MAX(num)', 'boy')  |                nan |
-| ('MAX(num)', 'girl') |               2588 |
+|                          |   ('Total (Sum)',) |
+|:-------------------------|-------------------:|
+| ('SUM(num)', 'boy')      |                 21 |
+| ('SUM(num)', 'girl')     |             118065 |
+| ('SUM(num)', 'Subtotal') |             118086 |
+| ('MAX(num)', 'boy')      |                nan |
+| ('MAX(num)', 'girl')     |               2588 |
+| ('MAX(num)', 'Subtotal') |               2588 |
+| ('Total (Sum)', '')      |             120674 |
     """.strip()
     )
 
@@ -883,8 +886,11 @@ def test_pivot_df_single_row_null_mix_values_numbers():
 |:---------------------|-------------------:|
 | ('boy', 'SUM(num)')  |                 21 |
 | ('boy', 'MAX(num)')  |                nan |
+| ('boy', 'Subtotal')  |                 21 |
 | ('girl', 'SUM(num)') |             118065 |
 | ('girl', 'MAX(num)') |               2588 |
+| ('girl', 'Subtotal') |             120653 |
+| ('{_("Total")} (Sum)', '')  |             120674 |
     """.strip()
     )
 

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1986,8 +1986,8 @@ def test_pivot_table_v2_show_values_as_formats_as_percent() -> None:
         },
     )
 
-    assert result.loc[("US",), ("SUM(num)", "boy")] == "12.500%"
-    assert result.loc[("US",), ("SUM(num)", "girl")] == "37.500%"
+    assert result.loc[("US",), ("SUM(num)", "boy")] == "12.5%"
+    assert result.loc[("US",), ("SUM(num)", "girl")] == "37.5%"
 
 
 def test_pivot_table_v2_show_values_as_actual_keeps_raw_values() -> None:

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2108,6 +2108,36 @@ def test_pivot_table_v2_divides_by_database_rollups(mode: str, expected: float):
     assert pivoted.loc[("UK",), ("AVG(num)", "boy")] == pytest.approx(expected)
 
 
+def _axis_has_total(axis) -> bool:
+    return any(
+        total_label() in (label if isinstance(label, tuple) else (label,))
+        for label in axis
+    )
+
+
+@pytest.mark.parametrize("layout", ["COLUMNS", "ROWS"])
+@pytest.mark.parametrize("toggle", ["rowTotals", "colTotals"])
+def test_pivot_table_v2_totals_land_on_the_displayed_axis(layout: str, toggle: str):
+    """`rowTotals` is always the right-hand column, whatever the metrics layout.
+
+    Moving metrics to rows transposes the frame on the way out, which would
+    otherwise flip the axis each total was inserted on.
+    """
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": "percent_row",
+        "metricsLayout": layout,
+        toggle: True,
+    }
+
+    pivoted = pivot_table_v2(grouping_sets_df(), form_data, apply_number_format=False)
+
+    assert _axis_has_total(pivoted.columns) is (toggle == "rowTotals")
+    assert _axis_has_total(pivoted.index) is (toggle == "colTotals")
+
+
 def test_pivot_table_v2_uses_database_rollups_with_metrics_on_rows():
     """The metrics layout moves the displayed axes but not the rollup levels."""
     form_data = {

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1900,6 +1900,101 @@ def test_pivot_df_show_values_as_keeps_metrics_separate():
     assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
     assert pivoted.loc[("UK",), ("MAX(num)", "boy")] == 0.375
     assert pivoted.loc[("UK",), ("MAX(num)", "girl")] == 0.625
+    # the cross-metric Total column divides by the denominator spanning every
+    # metric, so it still reads 100%
+    assert pivoted.loc[("US",), (total_label(), "")] == 1
+
+
+def test_pivot_df_show_values_as_with_combined_metrics():
+    """`combineMetric` moves the metric to the lowest column level."""
+    df = show_values_as_df()
+    df["MAX(num)"] = [1, 3, 6, 10]
+    pivoted = pivot_df(
+        df,
+        **{
+            **SHOW_VALUES_AS_OPTIONS,
+            "metrics": ["SUM(num)", "MAX(num)"],
+            "combine_metrics": True,
+            "show_rows_total": False,
+            "show_columns_total": False,
+        },
+        show_values_as="percent_row",
+    )
+
+    assert pivoted.loc[("US",), ("boy", "SUM(num)")] == 0.25
+    assert pivoted.loc[("US",), ("girl", "SUM(num)")] == 0.75
+    # each metric keeps its own denominator across the combined layout
+    assert pivoted.loc[("UK",), ("boy", "MAX(num)")] == 0.375
+    assert pivoted.loc[("UK",), ("girl", "MAX(num)")] == 0.625
+
+
+def test_pivot_table_v2_show_values_as_uses_min_max_rollups():
+    """A MIN/MAX metric divides by the row's extreme, not its sum.
+
+    Mirrors `additiveReducerFor` in the plugin's `plugin/utilities.ts`: the
+    chart rolls a MAX metric up with max, so a row of [6, 10] reads 60%/100%.
+    """
+    df = pd.DataFrame(
+        {
+            "nation": ["US", "US", "UK", "UK"],
+            "gender": ["boy", "girl", "boy", "girl"],
+            "MAX(num)": [1, 3, 6, 10],
+        }
+    )
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": [
+            {
+                "expressionType": "SIMPLE",
+                "aggregate": "MAX",
+                "column": {"column_name": "num"},
+                "label": "MAX(num)",
+            }
+        ],
+        "showValuesAs": "percent_row",
+        "rowTotals": True,
+    }
+
+    pivoted = pivot_table_v2(df, form_data, apply_number_format=False)
+
+    assert pivoted.loc[("UK",), ("MAX(num)", "boy")] == 0.6
+    assert pivoted.loc[("UK",), ("MAX(num)", "girl")] == 1
+    # the total divides by itself whatever the reducer
+    assert pivoted.loc[("UK",), (total_label(), "")] == 1
+
+
+def test_pivot_table_v2_drops_grouping_sets_rollup_rows():
+    """Rollup levels must not be pivoted as if they were leaf rows.
+
+    A non-additive metric makes `buildQuery` request every rollup level in one
+    frame, tagged with `GROUPING()` markers. Counting those rows as leaves both
+    inflates the denominators and adds a phantom row for the collapsed
+    dimensions.
+    """
+    df = pd.DataFrame(
+        {
+            "nation": ["US", "UK", None],
+            "gender": ["boy", "boy", None],
+            "nation__superset_grouping": [0, 0, 1],
+            "gender__superset_grouping": [0, 0, 1],
+            "AVG(num)": [10, 20, 30],
+        }
+    )
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": "percent_col",
+    }
+
+    pivoted = pivot_table_v2(df, form_data, apply_number_format=False)
+
+    # only the two leaf rows survive; the grand-total row would have added a
+    # third and pushed the column denominator from 30 to 60
+    assert len(pivoted.index) == 2
+    assert pivoted.loc[("US",), ("AVG(num)", "boy")] == pytest.approx(10 / 30)
+    assert pivoted.loc[("UK",), ("AVG(num)", "boy")] == pytest.approx(20 / 30)
 
 
 def test_pivot_df_show_values_as_metrics_on_rows():

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1804,6 +1804,200 @@ def test_pivot_df_complex_null_values():
     )
 
 
+# --- `showValuesAs` percent modes (#42809) -----------------------------------
+#
+# Exports and scheduled reports render server-side, so they have to reproduce
+# the client's `fractionOf` aggregator: each cell over its row, column, or grand
+# total, computed per metric, with totals dividing by their own rollup rather
+# than summing the fractions around them.
+
+SHOW_VALUES_AS_OPTIONS = {
+    "rows": ["nation"],
+    "columns": ["gender"],
+    "metrics": ["SUM(num)"],
+    "aggfunc": "Sum",
+    "transpose_pivot": False,
+    "combine_metrics": False,
+    "show_rows_total": True,
+    "show_columns_total": True,
+    "apply_metrics_on_rows": False,
+}
+
+
+def show_values_as_df() -> pd.DataFrame:
+    """A 2x2 pivot: row totals 40/40, column totals 30/50, grand total 80."""
+    return pd.DataFrame(
+        {
+            "nation": ["US", "US", "UK", "UK"],
+            "gender": ["boy", "girl", "boy", "girl"],
+            "SUM(num)": [10, 30, 20, 20],
+        }
+    )
+
+
+def total_label() -> str:
+    return f"{_('Total')} (Sum)"
+
+
+def test_pivot_df_show_values_as_percent_row():
+    pivoted = pivot_df(
+        show_values_as_df(), **SHOW_VALUES_AS_OPTIONS, show_values_as="percent_row"
+    )
+    total = total_label()
+
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
+    assert pivoted.loc[("US",), ("SUM(num)", "girl")] == 0.75
+    assert pivoted.loc[("UK",), ("SUM(num)", "boy")] == 0.5
+    # a row is always 100% of itself
+    assert pivoted.loc[("US",), (total, "")] == 1
+    # the totals row shows each column's share of the grand total (30/80 and
+    # 50/80), not the sum of the fractions above it
+    assert pivoted.loc[(total,), ("SUM(num)", "boy")] == 0.375
+    assert pivoted.loc[(total,), ("SUM(num)", "girl")] == 0.625
+    assert pivoted.loc[(total,), (total, "")] == 1
+
+
+def test_pivot_df_show_values_as_percent_col():
+    pivoted = pivot_df(
+        show_values_as_df(), **SHOW_VALUES_AS_OPTIONS, show_values_as="percent_col"
+    )
+    total = total_label()
+
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == pytest.approx(1 / 3)
+    assert pivoted.loc[("UK",), ("SUM(num)", "boy")] == pytest.approx(2 / 3)
+    assert pivoted.loc[("US",), ("SUM(num)", "girl")] == 0.6
+    # a column is always 100% of itself
+    assert pivoted.loc[(total,), ("SUM(num)", "boy")] == 1
+    # the totals column shows each row's share of the grand total
+    assert pivoted.loc[("US",), (total, "")] == 0.5
+
+
+def test_pivot_df_show_values_as_percent_total():
+    pivoted = pivot_df(
+        show_values_as_df(), **SHOW_VALUES_AS_OPTIONS, show_values_as="percent_total"
+    )
+    total = total_label()
+
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.125
+    assert pivoted.loc[("US",), ("SUM(num)", "girl")] == 0.375
+    assert pivoted.loc[("UK",), ("SUM(num)", "boy")] == 0.25
+    assert pivoted.loc[(total,), ("SUM(num)", "boy")] == 0.375
+    assert pivoted.loc[("US",), (total, "")] == 0.5
+    assert pivoted.loc[(total,), (total, "")] == 1
+
+
+def test_pivot_df_show_values_as_keeps_metrics_separate():
+    """One metric's cells are never divided by another metric's total."""
+    df = show_values_as_df()
+    df["MAX(num)"] = [1, 3, 6, 10]
+    pivoted = pivot_df(
+        df,
+        **{**SHOW_VALUES_AS_OPTIONS, "metrics": ["SUM(num)", "MAX(num)"]},
+        show_values_as="percent_row",
+    )
+
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
+    assert pivoted.loc[("UK",), ("MAX(num)", "boy")] == 0.375
+    assert pivoted.loc[("UK",), ("MAX(num)", "girl")] == 0.625
+
+
+def test_pivot_df_show_values_as_metrics_on_rows():
+    pivoted = pivot_df(
+        show_values_as_df(),
+        **{**SHOW_VALUES_AS_OPTIONS, "apply_metrics_on_rows": True},
+        show_values_as="percent_col",
+    )
+    total = total_label()
+
+    assert pivoted.loc[("SUM(num)", "US"), ("boy",)] == pytest.approx(1 / 3)
+    assert pivoted.loc[("SUM(num)", "US"), ("girl",)] == 0.6
+    assert pivoted.loc[("SUM(num)", "US"), (total,)] == 0.5
+    assert pivoted.loc[(total, ""), ("boy",)] == 1
+
+
+def test_pivot_df_show_values_as_zero_denominator_is_blank():
+    """A zero total renders blank rather than infinity."""
+    df = show_values_as_df()
+    df.loc[df["nation"] == "UK", "SUM(num)"] = 0
+    pivoted = pivot_df(df, **SHOW_VALUES_AS_OPTIONS, show_values_as="percent_row")
+
+    assert pd.isna(pivoted.loc[("UK",), ("SUM(num)", "boy")])
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
+
+
+def test_pivot_df_show_values_as_supersedes_legacy_fraction_aggfunc():
+    """`showValuesAs` wins over a pre-SIP-216 fraction aggregate function."""
+    pivoted = pivot_df(
+        show_values_as_df(),
+        **{**SHOW_VALUES_AS_OPTIONS, "aggfunc": "Sum as Fraction of Total"},
+        show_values_as="percent_row",
+    )
+
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
+
+
+def test_pivot_table_v2_show_values_as_formats_as_percent() -> None:
+    """A ratio ignores the configured value format and currency, as the chart does."""
+    result = pivot_table_v2(
+        show_values_as_df(),
+        {
+            "groupbyRows": ["nation"],
+            "groupbyColumns": ["gender"],
+            "metrics": ["SUM(num)"],
+            "showValuesAs": "percent_total",
+            "valueFormat": "$,.2f",
+            "currencyFormat": {"symbol": "USD", "symbolPosition": "prefix"},
+        },
+    )
+
+    assert result.loc[("US",), ("SUM(num)", "boy")] == "12.500%"
+    assert result.loc[("US",), ("SUM(num)", "girl")] == "37.500%"
+
+
+def test_pivot_table_v2_show_values_as_actual_keeps_raw_values() -> None:
+    result = pivot_table_v2(
+        show_values_as_df(),
+        {
+            "groupbyRows": ["nation"],
+            "groupbyColumns": ["gender"],
+            "metrics": ["SUM(num)"],
+            "showValuesAs": "actual",
+            "valueFormat": ",d",
+        },
+    )
+
+    assert result.loc[("US",), ("SUM(num)", "boy")] == "10"
+
+
+def test_apply_client_processing_csv_format_show_values_as():
+    """CSV exports carry the percentages the chart displays."""
+    result = {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.CSV,
+                "data": (
+                    "nation,gender,SUM(num)\n"
+                    "US,boy,10\nUS,girl,30\nUK,boy,20\nUK,girl,20\n"
+                ),
+            }
+        ]
+    }
+    form_data = {
+        "viz_type": "pivot_table_v2",
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["SUM(num)"],
+        "showValuesAs": "percent_row",
+        "metricsLayout": "COLUMNS",
+    }
+
+    processed = apply_client_processing(result, form_data)
+
+    assert processed["queries"][0]["data"] == (
+        ",SUM(num) boy,SUM(num) girl\nUK,0.5,0.5\nUS,0.25,0.75\n"
+    )
+
+
 def test_table():
     """
     Test that the table reports honor `d3NumberFormat`.

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1983,6 +1983,92 @@ def grouping_sets_df() -> pd.DataFrame:
     )
 
 
+def nested_grouping_sets_df() -> pd.DataFrame:
+    """Two row dimensions, so prefix subtotal rows appear beside the rollups.
+
+    Every level holds a value no leaf reduction would produce: the `{region}`
+    rollups are 17 and 24, `{region, nation}` are 18 and 25, `{gender}` are 26
+    and 24, and the grand total is 21.
+    """
+    records = [
+        # (region, nation, gender, rolled-up markers, value)
+        ("EU", "UK", "boy", (0, 0, 0), 10),
+        ("EU", "UK", "girl", (0, 0, 0), 30),
+        ("NA", "US", "boy", (0, 0, 0), 40),
+        ("NA", "US", "girl", (0, 0, 0), 20),
+        ("EU", "UK", None, (0, 0, 1), 18),
+        ("NA", "US", None, (0, 0, 1), 25),
+        ("EU", None, "boy", (0, 1, 0), 10),
+        ("EU", None, "girl", (0, 1, 0), 30),
+        ("NA", None, "boy", (0, 1, 0), 40),
+        ("NA", None, "girl", (0, 1, 0), 20),
+        ("EU", None, None, (0, 1, 1), 17),
+        ("NA", None, None, (0, 1, 1), 24),
+        (None, None, "boy", (1, 1, 0), 26),
+        (None, None, "girl", (1, 1, 0), 24),
+        (None, None, None, (1, 1, 1), 21),
+    ]
+    return pd.DataFrame(
+        [
+            {
+                "region": region,
+                "nation": nation,
+                "gender": gender,
+                "region__superset_grouping": markers[0],
+                "nation__superset_grouping": markers[1],
+                "gender__superset_grouping": markers[2],
+                "AVG(num)": value,
+            }
+            for region, nation, gender, markers, value in records
+        ]
+    )
+
+
+NESTED_FORM_DATA = {
+    "groupbyRows": ["region", "nation"],
+    "groupbyColumns": ["gender"],
+    "metrics": ["AVG(num)"],
+    "showValuesAs": "percent_row",
+    "rowTotals": True,
+    "colTotals": True,
+}
+
+
+def test_row_subtotal_keeps_its_total_column_cell():
+    """A subtotal row is not a whole-axis total; it must not be looked up as one."""
+    pivoted = pivot_table_v2(
+        nested_grouping_sets_df(), NESTED_FORM_DATA, apply_number_format=False
+    )
+
+    assert not pd.isna(pivoted.loc[("EU", "Subtotal"), (total_label(), "")])
+
+
+def test_row_subtotal_divides_by_its_own_rollup():
+    """An "EU" subtotal divides by the {region} rollup, not the grand total."""
+    pivoted = pivot_table_v2(
+        nested_grouping_sets_df(), NESTED_FORM_DATA, apply_number_format=False
+    )
+
+    assert pivoted.loc[("EU", "Subtotal"), ("AVG(num)", "boy")] == pytest.approx(
+        10 / 17
+    )
+    assert pivoted.loc[("NA", "Subtotal"), ("AVG(num)", "boy")] == pytest.approx(
+        40 / 24
+    )
+
+
+def test_nested_leaf_rows_still_divide_by_database_rollups():
+    """Regression guard: the leaf and whole-axis behaviour is unchanged."""
+    pivoted = pivot_table_v2(
+        nested_grouping_sets_df(), NESTED_FORM_DATA, apply_number_format=False
+    )
+
+    assert pivoted.loc[("EU", "UK"), ("AVG(num)", "boy")] == pytest.approx(10 / 18)
+    assert pivoted.loc[("NA", "US"), ("AVG(num)", "boy")] == pytest.approx(40 / 25)
+    assert pivoted.loc[("EU", "UK"), (total_label(), "")] == 1
+    assert pivoted.loc[(total_label(), ""), (total_label(), "")] == 1
+
+
 def test_pivot_table_v2_pivots_only_grouping_sets_leaf_rows():
     """Rollup levels must not be pivoted as if they were leaf rows."""
     form_data = {

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from io import BytesIO, StringIO
+from typing import Any
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -1811,7 +1812,7 @@ def test_pivot_df_complex_null_values():
 # total, computed per metric, with totals dividing by their own rollup rather
 # than summing the fractions around them.
 
-SHOW_VALUES_AS_OPTIONS = {
+SHOW_VALUES_AS_OPTIONS: dict[str, Any] = {
     "rows": ["nation"],
     "columns": ["gender"],
     "metrics": ["SUM(num)"],
@@ -1938,6 +1939,26 @@ def test_pivot_df_show_values_as_skips_empty_cells_in_denominators():
     assert pivoted.loc[("US",), ("SUM(num)", "boy")] == pytest.approx(10 / 60)
     assert pivoted.loc[("UK",), ("SUM(num)", "boy")] == pytest.approx(20 / 60)
     assert pd.isna(pivoted.loc[("UK",), ("SUM(num)", "girl")])
+
+
+@pytest.mark.parametrize("aggfunc", ["Sum", "Average", "Maximum"])
+def test_pivot_df_show_values_as_ignores_legacy_aggregate_function(aggfunc: str):
+    """A total always divides by itself, whatever `aggregateFunction` says.
+
+    The chart ignores `aggregateFunction` post-SIP-216, so a percent export must
+    too: computing totals with it while the denominators sum leaves the Total
+    row/column reading something other than 100%.
+    """
+    pivoted = pivot_df(
+        show_values_as_df(),
+        **{**SHOW_VALUES_AS_OPTIONS, "aggfunc": aggfunc},
+        show_values_as="percent_row",
+    )
+    total = total_label()
+
+    assert pivoted.loc[("US",), (total, "")] == 1
+    assert pivoted.loc[(total,), (total, "")] == 1
+    assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
 
 
 def test_pivot_df_show_values_as_supersedes_legacy_fraction_aggfunc():

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2108,6 +2108,40 @@ def test_pivot_table_v2_divides_by_database_rollups(mode: str, expected: float):
     assert pivoted.loc[("UK",), ("AVG(num)", "boy")] == pytest.approx(expected)
 
 
+def test_pivot_table_v2_uses_database_rollups_with_metrics_on_rows():
+    """The metrics layout moves the displayed axes but not the rollup levels."""
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": "percent_col",
+        "metricsLayout": "ROWS",
+    }
+
+    pivoted = pivot_table_v2(grouping_sets_df(), form_data, apply_number_format=False)
+
+    # 20/18 and 10/18 from the database rollup, not 20/30 from the leaf sum
+    assert pivoted.loc[("AVG(num)", "UK"), ("boy",)] == pytest.approx(20 / 18)
+    assert pivoted.loc[("AVG(num)", "US"), ("boy",)] == pytest.approx(10 / 18)
+
+
+def test_pivot_table_v2_keeps_a_null_rollup_blank():
+    """A NULL rollup is not a missing one: it blanks the cell, as the chart does."""
+    df = grouping_sets_df()
+    df.loc[df["nation"].isna() & df["gender"].notna(), "AVG(num)"] = None
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": "percent_col",
+    }
+
+    pivoted = pivot_table_v2(df, form_data, apply_number_format=False)
+
+    # falling back to the leaf-derived total would have produced 10/30 here
+    assert pd.isna(pivoted.loc[("US",), ("AVG(num)", "boy")])
+
+
 def test_pivot_table_v2_rollup_totals_divide_by_themselves():
     """A whole-axis total takes its value from the same level as its denominator."""
     form_data = {

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -1900,8 +1900,8 @@ def test_pivot_df_show_values_as_keeps_metrics_separate():
     assert pivoted.loc[("US",), ("SUM(num)", "boy")] == 0.25
     assert pivoted.loc[("UK",), ("MAX(num)", "boy")] == 0.375
     assert pivoted.loc[("UK",), ("MAX(num)", "girl")] == 0.625
-    # the cross-metric Total column divides by the denominator spanning every
-    # metric, so it still reads 100%
+    # a total collapsing the metric axis resolves to one metric, as the
+    # renderer does, so it still divides by itself
     assert pivoted.loc[("US",), (total_label(), "")] == 1
 
 
@@ -1964,23 +1964,27 @@ def test_pivot_table_v2_show_values_as_uses_min_max_rollups():
     assert pivoted.loc[("UK",), (total_label(), "")] == 1
 
 
-def test_pivot_table_v2_drops_grouping_sets_rollup_rows():
-    """Rollup levels must not be pivoted as if they were leaf rows.
+def grouping_sets_df() -> pd.DataFrame:
+    """A GROUPING SETS result whose rollups differ from any leaf reduction.
 
-    A non-additive metric makes `buildQuery` request every rollup level in one
-    frame, tagged with `GROUPING()` markers. Counting those rows as leaves both
-    inflates the denominators and adds a phantom row for the collapsed
-    dimensions.
+    Leaves are 10 and 20, so a leaf-derived total would be 30 (sum) or 15
+    (mean). The database rollups are deliberately none of those: 18 down the
+    column, 11/21 across the rows, 19 overall -- as a weighted average or a
+    distinct count would be.
     """
-    df = pd.DataFrame(
+    return pd.DataFrame(
         {
-            "nation": ["US", "UK", None],
-            "gender": ["boy", "boy", None],
-            "nation__superset_grouping": [0, 0, 1],
-            "gender__superset_grouping": [0, 0, 1],
-            "AVG(num)": [10, 20, 30],
+            "nation": ["US", "UK", None, "US", "UK", None],
+            "gender": ["boy", "boy", "boy", None, None, None],
+            "nation__superset_grouping": [0, 0, 1, 0, 0, 1],
+            "gender__superset_grouping": [0, 0, 0, 1, 1, 1],
+            "AVG(num)": [10, 20, 18, 11, 21, 19],
         }
     )
+
+
+def test_pivot_table_v2_pivots_only_grouping_sets_leaf_rows():
+    """Rollup levels must not be pivoted as if they were leaf rows."""
     form_data = {
         "groupbyRows": ["nation"],
         "groupbyColumns": ["gender"],
@@ -1988,13 +1992,50 @@ def test_pivot_table_v2_drops_grouping_sets_rollup_rows():
         "showValuesAs": "percent_col",
     }
 
-    pivoted = pivot_table_v2(df, form_data, apply_number_format=False)
+    pivoted = pivot_table_v2(grouping_sets_df(), form_data, apply_number_format=False)
 
-    # only the two leaf rows survive; the grand-total row would have added a
-    # third and pushed the column denominator from 30 to 60
+    # the rollup rows would otherwise add phantom rows for their NULL dimensions
     assert len(pivoted.index) == 2
-    assert pivoted.loc[("US",), ("AVG(num)", "boy")] == pytest.approx(10 / 30)
-    assert pivoted.loc[("UK",), ("AVG(num)", "boy")] == pytest.approx(20 / 30)
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        # each leaf divides by the rollup the database computed, never by a
+        # total re-derived from the leaves
+        ("percent_col", 20 / 18),
+        ("percent_row", 20 / 21),
+        ("percent_total", 20 / 19),
+    ],
+)
+def test_pivot_table_v2_divides_by_database_rollups(mode: str, expected: float):
+    """For a non-additive metric the DB rollup is the only correct total."""
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": mode,
+    }
+
+    pivoted = pivot_table_v2(grouping_sets_df(), form_data, apply_number_format=False)
+
+    assert pivoted.loc[("UK",), ("AVG(num)", "boy")] == pytest.approx(expected)
+
+
+def test_pivot_table_v2_rollup_totals_divide_by_themselves():
+    """A whole-axis total takes its value from the same level as its denominator."""
+    form_data = {
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["AVG(num)"],
+        "showValuesAs": "percent_row",
+        "rowTotals": True,
+    }
+
+    pivoted = pivot_table_v2(grouping_sets_df(), form_data, apply_number_format=False)
+
+    # 21/21, not the leaf sum over the database row rollup
+    assert pivoted.loc[("UK",), (total_label(), "")] == 1
 
 
 def test_pivot_df_show_values_as_metrics_on_rows():

--- a/tests/unit_tests/charts/test_client_processing.py
+++ b/tests/unit_tests/charts/test_client_processing.py
@@ -2261,6 +2261,43 @@ def test_pivot_table_v2_show_values_as_actual_keeps_raw_values() -> None:
     assert result.loc[("US",), ("SUM(num)", "boy")] == "10"
 
 
+def test_apply_client_processing_xlsx_formats_percentages_as_cells():
+    """The workbook shows percentages without giving up numeric cells.
+
+    A scheduled XLSX report and the browser's pivoted-Excel download have to
+    agree; writing formatted text would match the download but stop Excel from
+    summing the column.
+    """
+    import openpyxl  # noqa: PLC0415
+
+    source = pd.DataFrame(
+        {"nation": ["US", "US"], "gender": ["boy", "girl"], "SUM(num)": [1, 99]}
+    )
+    result = {
+        "queries": [
+            {
+                "result_format": ChartDataResultFormat.XLSX,
+                "data": excel.df_to_excel(source, index=False),
+            }
+        ]
+    }
+    form_data = {
+        "viz_type": "pivot_table_v2",
+        "groupbyRows": ["nation"],
+        "groupbyColumns": ["gender"],
+        "metrics": ["SUM(num)"],
+        "showValuesAs": "percent_row",
+        "metricsLayout": "COLUMNS",
+    }
+
+    processed = apply_client_processing(result, form_data)
+
+    workbook = openpyxl.load_workbook(BytesIO(processed["queries"][0]["data"]))
+    sheet = workbook.active
+    assert sheet.cell(row=2, column=2).value == pytest.approx(0.01)
+    assert sheet.cell(row=2, column=2).number_format == "0.0%"
+
+
 def test_apply_client_processing_csv_format_show_values_as():
     """CSV exports carry the percentages the chart displays."""
     result = {


### PR DESCRIPTION
### SUMMARY

A pivot table set to "Show values as" % of row/column/total showed percentages on screen but raw values in pivoted CSV/XLSX downloads and scheduled reports.

Those paths render server-side via `apply_client_processing` → `charts/client_processing.py::pivot_table_v2`, which reproduces the client pivot but only knew the pre-SIP-216 `"... as Fraction of ..."` aggregate functions. `showValuesAs` was already in the request form data and silently dropped — this reads it.

Mirrors the client's `fractionOf`:
- Applied **after** totals, so a "% of row" grand total row reads `columnTotal / grandTotal` instead of summing the fractions above it, and each subtotal divides by its own rollup.
- Denominators stay within one metric (handles `combineMetric` and the ROWS metrics layout); cross-metric totals divide by the all-metric denominator.
- Zero denominator → NaN, matching `pandas_postprocessing.pivot`.
- JSON output (report email tables) forces `,.3%` and drops currency, as the client ignores custom formatters for a ratio. CSV/XLSX keep raw fractions — that path never applies number formats to any metric.

### RELATION TO #42976

#42976 added an equivalent `show_values_as` to `superset/utils/pandas_postprocessing/pivot.py` as "the server-side half" of #42809, with a follow-up planned to wire it up from `buildQuery.ts`.

That operator isn't in the export path, so this PR implements the transform where exports actually run instead:

- Pivot exports/reports never invoke `QueryObject.post_processing` to pivot. They set `result_type=post_processed`, which routes to `apply_client_processing` (`charts/data/api.py:495`) and its separate pivot reimplementation.
- Emitting `pivot` postprocessing from `buildQuery.ts` couldn't be scoped to exports: `exec_post_processing` runs unconditionally in the query pipeline (`models/helpers.py:2530`), and `buildQuery` has no `result_type` — it runs before the request, which the export caller parameterizes. The chart itself would then receive a pre-pivoted frame it can't render.

So `show_values_as` in `pandas_postprocessing/pivot.py` has no callers today. It's additive and harmless; happy to remove it in a follow-up if maintainers prefer, but that's out of scope here.

To avoid two independent definitions of the same wire contract, the second commit lifts the mode strings into a `ShowValuesAs` StrEnum in `superset/constants.py` (next to `PandasAxis` and `PandasPostprocessingCompare`) and points both layers at it, dropping `_PERCENT_MODES`. The migration keeps its own copy on purpose - migrations are frozen snapshots and must not track live constants. That commit is standalone and can be dropped if you'd rather keep this PR to the fix alone.

To avoid two independent definitions of the same wire contract, the second commit lifts the mode strings into a `ShowValuesAs` StrEnum in `superset/constants.py` (next to `PandasAxis` and `PandasPostprocessingCompare`) and points both layers at it, dropping `_PERCENT_MODES`. The migration keeps its own copy on purpose — migrations are frozen snapshots and must not track live constants. That commit is standalone and can be dropped if you'd rather keep this PR to the fix alone.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

After:
resulting excel report has percentages instead of raw values
<img width="773" height="252" alt="image" src="https://github.com/user-attachments/assets/07460ae3-27c8-47d8-9cb2-65d3382b7269" />


### TESTING INSTRUCTIONS

1. Pivot table chart, "Show values as" = % of Total, Row totals on.
2. Download → **Export to Pivoted .CSV** (the plain "Export to .CSV" is the raw un-pivoted export and is unchanged). Cells are fractions of the grand total; the Total column reads `1`.
3. Schedule a report on the same chart with format XLSX or CSV → attachment matches. Format TEXT → emailed table shows `12.500%`.

Verified end-to-end through a scheduled XLSX report.

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #42809. Related: #42976 (merged), #42810 (client-side guards this mirrors), #42761 (reintroduced the control).
- [ ] Required feature flags: none
- [ ] Changes UI: no — backend-only
- [ ] Includes DB Migration: no
- [ ] Introduces new feature or API: no — existing form-data field now honored server-side
- [ ] Removes existing feature or API: no
