### PR TITLE
fix(dashboard): resolve metric Label in Chart Data (View as table) results grid

### DIFF
--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.test.tsx
@@ -35,20 +35,30 @@ jest.mock('src/utils/cachedSupersetGet');
 // only need a stand-in that lets us trigger onDrillBy with a distinguishable
 // config, so we can assert ChartContextMenu wires it into the modal.
 jest.mock('../DrillBy/DrillBySubmenu', () => ({
-  DrillBySubmenu: ({ onDrillBy }: any) => (
-    <button
-      type="button"
-      data-test="fake-drill-by-submenu"
-      onClick={() =>
-        onDrillBy(
-          { column_name: 'city', groupby: true },
-          { id: 1, columns: [], metrics: [] },
-          { filters: [{ col: 'selected_scope' }], groupbyFieldName: 'groupby' },
-        )
-      }
-    >
-      Fake Drill By
-    </button>
+  DrillBySubmenu: ({ onDrillBy, dataset }: any) => (
+    <>
+      <button
+        type="button"
+        data-test="fake-drill-by-submenu"
+        onClick={() =>
+          onDrillBy(
+            { column_name: 'city', groupby: true },
+            { id: 1, columns: [], metrics: [] },
+            {
+              filters: [{ col: 'selected_scope' }],
+              groupbyFieldName: 'groupby',
+            },
+          )
+        }
+      >
+        Fake Drill By
+      </button>
+      <div data-test="drillable-columns">
+        {(dataset?.drillable_columns ?? [])
+          .map((col: any) => col.column_name)
+          .join(',')}
+      </div>
+    </>
   ),
 }));
 
@@ -209,4 +219,36 @@ test('drill by modal uses the scope selected in the submenu over the raw context
     screen.getByTestId('drill-by-modal').textContent || '{}',
   );
   expect(modalConfig.filters).toEqual([{ col: 'selected_scope' }]);
+});
+
+test('drill by only offers dimension columns', async () => {
+  // drill_info returns every column so the results grid can label non-dimension
+  // ones; narrowing to dimensions is this component's job, not the API's.
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        columns: [
+          { column_name: 'city', verbose_name: 'City', groupby: true },
+          { column_name: 'revenue', verbose_name: 'Revenue', groupby: false },
+        ],
+        metrics: [],
+      },
+    },
+  } as any);
+  setup({
+    drillBy: {
+      filters: [{ col: 'raw_scope', op: '==', val: 'raw' }],
+      groupbyFieldName: 'groupby',
+    },
+  });
+
+  userEvent.click(screen.getByTestId('open-context-menu'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('drillable-columns')).toHaveTextContent('city');
+  });
+  expect(screen.getByTestId('drillable-columns')).not.toHaveTextContent(
+    'revenue',
+  );
 });

--- a/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
+++ b/superset-frontend/src/components/Chart/ChartContextMenu/ChartContextMenu.tsx
@@ -37,7 +37,6 @@ import {
   ensureIsArray,
   FeatureFlag,
   getChartMetadataRegistry,
-  getExtensionsRegistry,
   isFeatureEnabled,
   QueryFormData,
 } from '@superset-ui/core';
@@ -180,10 +179,6 @@ const ChartContextMenu = (
     [],
   );
 
-  const loadDrillByOptionsExtension = getExtensionsRegistry().get(
-    'load.drillby.options',
-  );
-
   const handleCloseDrillByModal = useCallback(() => {
     setShowDrillByModal(false);
   }, []);
@@ -234,8 +229,9 @@ const ChartContextMenu = (
 
     const filteredColumns = ensureIsArray(dataset.columns).filter(
       column =>
-        // If using an extension, also filter by column.groupby since the extension might not do this
-        (!loadDrillByOptionsExtension || column.groupby) &&
+        // Both the API and the extension return every column, since the same
+        // payload resolves display labels elsewhere. Only dimensions are drillable.
+        column.groupby &&
         !ensureIsArray(
           formData[filters?.drillBy?.groupbyFieldName ?? ''],
         ).includes(column.column_name) &&
@@ -257,7 +253,6 @@ const ChartContextMenu = (
     formData.x_axis,
     formData[enhancedFilters?.drillBy?.groupbyFieldName ?? ''],
     additionalConfig?.drillBy?.excludedColumns,
-    loadDrillByOptionsExtension,
   ]);
 
   const showCrossFilters = isDisplayed(ContextMenuItem.CrossFilter);

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/SliceHeaderControls.test.tsx
@@ -31,6 +31,17 @@ import downloadAsPdf from 'src/utils/downloadAsPdf';
 import SliceHeaderControls, { SliceHeaderControlsProps } from '.';
 
 jest.mock('src/utils/cachedSupersetGet');
+jest.mock('src/explore/components/DataTablesPane', () => ({
+  ResultsPaneOnDashboard: ({
+    columnDisplayNames,
+  }: {
+    columnDisplayNames?: Record<string, string>;
+  }) => (
+    <div data-test="results-pane">
+      {JSON.stringify(columnDisplayNames ?? {})}
+    </div>
+  ),
+}));
 jest.mock('src/utils/downloadAsImage', () =>
   jest.fn(() => jest.fn().mockResolvedValue(undefined)),
 );
@@ -707,6 +718,109 @@ test('Dataset drill info API call is not made when user lacks drill permissions'
   await new Promise(resolve => setTimeout(resolve, 0));
 
   expect(mockCachedSupersetGet).not.toHaveBeenCalled();
+});
+
+test('Dataset drill info API call is made when user can only view chart as table', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: false,
+  };
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  // "View as table" has its own permission, so label resolution must not be
+  // gated behind Drill to detail.
+  renderWrapper(props, {
+    Gamma: [
+      ['can_view_chart_as_table', 'Dashboard'],
+      ['can_get_drill_info', 'Dataset'],
+    ],
+  });
+
+  await waitFor(() =>
+    expect(mockCachedSupersetGet).toHaveBeenCalledWith({
+      endpoint: expect.stringContaining(
+        '/api/v1/dataset/58/drill_info/?q=(dashboard_id:26)',
+      ),
+    }),
+  );
+});
+
+test('Dataset drill info API call is made for an explore-only user', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: false,
+  };
+  // "View as table" is offered to `canExplore || canViewTable`, so the fetch that
+  // feeds its column headers has to cover the same set -- an explore user with
+  // neither `can_samples` nor `can_view_chart_as_table` opens the same modal.
+  renderWrapper(createProps(), {
+    Gamma: [['can_get_drill_info', 'Dataset']],
+  });
+
+  await waitFor(() =>
+    expect(mockCachedSupersetGet).toHaveBeenCalledWith({
+      endpoint: expect.stringContaining(
+        '/api/v1/dataset/58/drill_info/?q=(dashboard_id:26)',
+      ),
+    }),
+  );
+});
+
+test('Dataset drill info API call is not made without `can_get_drill_info`', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: false,
+  };
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  // The endpoint is guarded by `can_get_drill_info` on Dataset, so requesting
+  // it without that permission would only ever produce a 403.
+  renderWrapper(props, {
+    Gamma: [['can_view_chart_as_table', 'Dashboard']],
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(mockCachedSupersetGet).not.toHaveBeenCalled();
+});
+
+test('Results grid receives verbose names for a view-as-table-only user', async () => {
+  (global as any).featureFlags = {
+    [FeatureFlag.DrillToDetail]: false,
+  };
+  mockCachedSupersetGet.mockResolvedValue({
+    response: {} as Response,
+    json: {
+      result: {
+        columns: [{ column_name: 'region', verbose_name: 'Region' }],
+        metrics: [{ metric_name: 'sum__num', verbose_name: 'Yearly Total' }],
+      },
+    },
+  } as any);
+  const props = {
+    ...createProps(),
+    supersetCanExplore: false,
+  };
+  renderWrapper(props, {
+    Gamma: [
+      ['can_view_chart_as_table', 'Dashboard'],
+      ['can_get_drill_info', 'Dataset'],
+    ],
+  });
+  // Let the drill_info request settle the way it would while the dashboard loads.
+  await waitFor(() => expect(mockCachedSupersetGet).toHaveBeenCalled());
+  openMenu();
+  userEvent.click(screen.getByTestId('view-query-menu-item'));
+
+  await waitFor(() =>
+    expect(
+      JSON.parse(screen.getByTestId('results-pane').textContent as string),
+    ).toEqual({
+      region: 'Region',
+      sum__num: 'Yearly Total',
+    }),
+  );
 });
 
 test('Should show "Embed code" in Share menu when feature flag is enabled and chart has data', async () => {

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -196,13 +196,22 @@ const SliceHeaderControls = (
       .get(props.slice.viz_type)
       ?.behaviors?.includes(Behavior.InteractiveChart);
   const canExplore = props.supersetCanExplore;
-  const { canDrillToDetail, canViewQuery, canViewTable } = usePermissions();
+  const { canDrillToDetail, canGetDrillInfo, canViewQuery, canViewTable } =
+    usePermissions();
 
+  // Single predicate for the "View as table" entry, so the fetch that feeds its
+  // column headers cannot drift from the set of users who can open it.
+  const canViewResultsTable = canExplore || canViewTable;
+
+  // The dataset's verbose map resolves friendly Labels for both the drill-to-detail
+  // pane and the results grid, and those are separate permissions — so fetch it for
+  // either one, as long as the drill_info endpoint itself is readable (it is gated
+  // by `can_get_drill_info` on Dataset).
   const datasetResource = useDatasetDrillInfo(
     props.slice.datasource,
     props.dashboardId,
     props.formData,
-    !canDrillToDetail,
+    !canGetDrillInfo || !(canDrillToDetail || canViewResultsTable),
   );
 
   const datasetWithVerboseMap =
@@ -594,7 +603,7 @@ const SliceHeaderControls = (
     });
   }
 
-  if (canExplore || canViewTable) {
+  if (canViewResultsTable) {
     newMenuItems.push({
       key: MenuKeys.ViewResults,
       label: (

--- a/superset-frontend/src/hooks/apiResources/datasets.test.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { renderHook, waitFor } from '@testing-library/react';
+import { logging } from '@apache-superset/core/utils';
 import { Dataset } from 'src/components/Chart/types';
 import {
   cachedSupersetGet,
@@ -35,6 +36,11 @@ jest.mock('src/utils/cachedSupersetGet', () => ({
   },
 }));
 
+jest.mock('@apache-superset/core/utils', () => ({
+  ...jest.requireActual('@apache-superset/core/utils'),
+  logging: { error: jest.fn(), warn: jest.fn() },
+}));
+
 // Mock getExtensionsRegistry at module level - returns undefined by default
 const mockGetExtensionsRegistry = jest.fn(() => ({ get: () => undefined }));
 jest.mock('@superset-ui/core', () => ({
@@ -43,6 +49,7 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 const mockedCachedSupersetGet = jest.mocked(cachedSupersetGet);
+const mockedLoggingError = jest.mocked(logging.error);
 const mockedSupersetGetCacheDelete = jest.mocked(supersetGetCache.delete);
 const mockExtension = jest.fn();
 
@@ -139,6 +146,22 @@ test('createVerboseMap creates verbose_map from both columns and metrics', () =>
     col1: 'Column 1',
     metric1: 'Metric 1',
   });
+});
+
+test('createVerboseMap lets a column win a name collision with a metric', () => {
+  // A dataset can hold a column and a metric with the same name -- uniqueness is
+  // only enforced within each list. Both end up in one flat map, so one label has
+  // to win. Columns win, matching `SqlaTable.data_for_slices`, which builds the
+  // verbose_map the dashboard's own charts already render with. Otherwise an
+  // unused metric could relabel a column the chart actually selected.
+  const dataset = {
+    columns: [{ column_name: 'revenue', verbose_name: 'Revenue' }],
+    metrics: [{ metric_name: 'revenue', verbose_name: 'Revenue %' }],
+  } as Dataset;
+
+  const verboseMap = createVerboseMap(dataset);
+
+  expect(verboseMap).toEqual({ revenue: 'Revenue' });
 });
 
 test('createVerboseMap handles undefined dataset', () => {
@@ -317,6 +340,9 @@ test('useDatasetDrillInfo fetches dataset via extension when extension and formD
   mockExtension.mockResolvedValue({
     json: { result: mockDataset },
   } as any);
+  mockedCachedSupersetGet.mockResolvedValue({
+    json: { result: mockDataset },
+  } as any);
 
   const { result } = renderHook(() =>
     useDatasetDrillInfo(123, 456, mockFormData),
@@ -341,9 +367,94 @@ test('useDatasetDrillInfo fetches dataset via extension when extension and formD
     },
   });
   expect(result.current.error).toBeNull();
+});
 
-  // Verify cachedSupersetGet was NOT called (extension path bypasses REST API)
-  expect(mockedCachedSupersetGet).not.toHaveBeenCalled();
+test('useDatasetDrillInfo labels come from the API even when the extension supplies drill-by options', async () => {
+  setupExtensionMock();
+
+  const mockFormData = { viz_type: 'table', datasource: '123__table' };
+  // The extension contract only covers drill-by options, so a conforming
+  // implementation may return dimensions alone.
+  const extensionResult = {
+    id: 123,
+    columns: [{ column_name: 'city', verbose_name: 'City', groupby: true }],
+  };
+  // The API is the only source that promises the whole dataset.
+  const apiResult = {
+    id: 123,
+    columns: [
+      { column_name: 'city', verbose_name: 'City', groupby: true },
+      { column_name: 'revenue', verbose_name: 'Revenue', groupby: false },
+    ],
+    metrics: [{ metric_name: 'sum__num', verbose_name: 'Yearly Total' }],
+  };
+
+  mockExtension.mockResolvedValue({ json: { result: extensionResult } } as any);
+  mockedCachedSupersetGet.mockResolvedValue({
+    json: { result: apiResult },
+  } as any);
+
+  const { result } = renderHook(() =>
+    useDatasetDrillInfo(123, 456, mockFormData),
+  );
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('complete');
+  });
+
+  // Labels cover everything the chart may select...
+  expect(result.current.result?.verbose_map).toEqual({
+    city: 'City',
+    revenue: 'Revenue',
+    sum__num: 'Yearly Total',
+  });
+  // ...while drill-by options still come from the extension.
+  expect(result.current.result?.columns).toEqual(extensionResult.columns);
+});
+
+test('useDatasetDrillInfo keeps extension drill-by options when the label fetch fails', async () => {
+  setupExtensionMock();
+
+  const mockFormData = { viz_type: 'table', datasource: '123__table' };
+  const extensionResult = {
+    id: 123,
+    columns: [{ column_name: 'city', verbose_name: 'City', groupby: true }],
+  };
+
+  mockExtension.mockResolvedValue({ json: { result: extensionResult } } as any);
+  // A deployment may register the extension precisely because the REST endpoint
+  // is unavailable to it. Drill-by works there today and must keep working.
+  mockedCachedSupersetGet.mockRejectedValue(new Error('403'));
+
+  const { result } = renderHook(() =>
+    useDatasetDrillInfo(123, 456, mockFormData),
+  );
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('complete');
+  });
+
+  expect(mockedCachedSupersetGet).toHaveBeenCalled();
+  expect(result.current.result?.columns).toEqual(extensionResult.columns);
+  expect(result.current.result?.verbose_map).toEqual({ city: 'City' });
+  expect(result.current.error).toBeNull();
+  // The failure is expected and handled in these deployments, so it must not
+  // log an error on every dashboard load.
+  expect(mockedLoggingError).not.toHaveBeenCalled();
+});
+
+test('useDatasetDrillInfo logs when the API is the only source and it fails', async () => {
+  // Without an extension the failure is fatal rather than best-effort, so it
+  // still surfaces in the console.
+  mockedCachedSupersetGet.mockRejectedValue(new Error('500'));
+
+  const { result } = renderHook(() => useDatasetDrillInfo(123, 456));
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('error');
+  });
+
+  expect(mockedLoggingError).toHaveBeenCalled();
 });
 
 test('useDatasetDrillInfo handles extension throwing error', async () => {

--- a/superset-frontend/src/hooks/apiResources/datasets.ts
+++ b/superset-frontend/src/hooks/apiResources/datasets.ts
@@ -46,11 +46,16 @@ export const getDatasetId = (datasetId: string | number): number =>
  */
 export const createVerboseMap = (dataset?: Dataset): Record<string, string> => {
   const verbose_map: Record<string, string> = {};
-  ensureIsArray(dataset?.columns).forEach((column: Column) => {
-    verbose_map[column.column_name] = column.verbose_name || column.column_name;
-  });
+  // A name can appear in both lists -- uniqueness is only enforced within each
+  // one -- so metrics are written first and columns overwrite them. That matches
+  // `SqlaTable.data_for_slices`, which builds the verbose map the dashboard's own
+  // charts already render with, and keeps an unused metric from relabelling a
+  // column the chart actually selected.
   ensureIsArray(dataset?.metrics).forEach((metric: Metric) => {
     verbose_map[metric.metric_name] = metric.verbose_name || metric.metric_name;
+  });
+  ensureIsArray(dataset?.columns).forEach((column: Column) => {
+    verbose_map[column.column_name] = column.verbose_name || column.column_name;
   });
   return verbose_map;
 };
@@ -81,6 +86,23 @@ export const useDatasetDrillInfo = (
       });
       return;
     }
+    // `bestEffort` callers recover from a failure themselves, so it is not worth
+    // logging: a deployment that registers the drill-by extension because this
+    // endpoint is unreachable would otherwise log on every dashboard load.
+    const fetchDrillInfo = async ({ bestEffort = false } = {}) => {
+      const endpoint = `/api/v1/dataset/${getDatasetId(datasetId)}/drill_info/?q=(dashboard_id:${dashboardId})`;
+      try {
+        const { json } = await cachedSupersetGet({ endpoint });
+        return json.result;
+      } catch (error) {
+        if (!bestEffort) {
+          logging.error('Failed to load dataset: ', error);
+        }
+        supersetGetCache.delete(endpoint);
+        throw error;
+      }
+    };
+
     const fetchDataset = async () => {
       try {
         const numericDatasetId = getDatasetId(datasetId);
@@ -88,6 +110,7 @@ export const useDatasetDrillInfo = (
           'load.drillby.options',
         );
         let result;
+        let labelSource;
 
         if (loadDrillByOptionsExtension && formData) {
           const response = await loadDrillByOptionsExtension(
@@ -95,20 +118,23 @@ export const useDatasetDrillInfo = (
             formData,
           );
           result = response?.json?.result;
-        } else {
-          const endpoint = `/api/v1/dataset/${numericDatasetId}/drill_info/?q=(dashboard_id:${dashboardId})`;
+          // The extension contract only covers drill-by options, so a conforming
+          // implementation may omit metrics and non-dimension columns. Labels
+          // come from the API, which is the only source that promises the whole
+          // dataset. If it is unreachable -- a deployment may register the
+          // extension precisely because it is -- fall back to what the extension
+          // returned rather than breaking drill-by, which works there today.
           try {
-            const { json } = await cachedSupersetGet({ endpoint });
-            const { result: datasetResult } = json;
-            result = datasetResult;
-          } catch (error) {
-            logging.error('Failed to load dataset: ', error);
-            supersetGetCache.delete(endpoint);
-            throw error;
+            labelSource = await fetchDrillInfo({ bestEffort: true });
+          } catch {
+            labelSource = result;
           }
+        } else {
+          result = await fetchDrillInfo();
+          labelSource = result;
         }
 
-        const verbose_map = createVerboseMap(result);
+        const verbose_map = createVerboseMap(labelSource);
 
         setResource({
           status: ResourceStatus.Complete,

--- a/superset-frontend/src/hooks/usePermissions.ts
+++ b/superset-frontend/src/hooks/usePermissions.ts
@@ -90,6 +90,7 @@ export const usePermissions = () => {
     canDrill,
     canDrillBy,
     canDrillToDetail,
+    canGetDrillInfo,
     canViewQuery,
     canViewTable,
   };

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1834,6 +1834,8 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
             "columns.column_name",
             "columns.verbose_name",
             "columns.groupby",
+            "metrics.metric_name",
+            "metrics.verbose_name",
         ]
         dataset_schema = DatasetDrillInfoSchema()
 

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -31,7 +31,6 @@ from marshmallow import (
 from marshmallow.validate import Length, OneOf
 
 from superset import security_manager
-from superset.connectors.sqla.models import SqlaTable
 from superset.exceptions import SupersetMarshmallowValidationError
 from superset.models.sql_types import parse_currency_string
 from superset.utils import json
@@ -476,6 +475,14 @@ class DatasetCacheWarmUpResponseSchema(Schema):
 class DatasetColumnDrillInfoSchema(Schema):
     column_name = fields.String(required=True)
     verbose_name = fields.String(required=False)
+    # Consumers need every column to resolve display labels, but only dimensions
+    # belong in the drill-by picker, so ship the flag and let them narrow.
+    groupby = fields.Boolean(required=False)
+
+
+class DatasetMetricDrillInfoSchema(Schema):
+    metric_name = fields.String(required=True)
+    verbose_name = fields.String(required=False)
 
 
 class UserSchema(Schema):
@@ -503,6 +510,7 @@ class DrillInfoEditorSchema(Schema):
 class DatasetDrillInfoSchema(Schema):
     id = fields.Integer()
     columns = fields.List(fields.Nested(DatasetColumnDrillInfoSchema))
+    metrics = fields.List(fields.Nested(DatasetMetricDrillInfoSchema))
     table_name = fields.String()
     editors = fields.List(fields.Nested(DrillInfoEditorSchema))
     created_by = fields.Nested(UserSchema)
@@ -511,25 +519,29 @@ class DatasetDrillInfoSchema(Schema):
     changed_on_humanized = fields.String()
 
     # pylint: disable=unused-argument
-    @post_dump(pass_original=True)
-    def post_dump(
-        self, serialized: dict[str, Any], obj: SqlaTable, **kwargs: Any
-    ) -> dict[str, Any]:
+    @post_dump
+    def post_dump(self, serialized: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         """
-        Clear API response to avoid exposing sensitive information for embedded users,
-        and filter columns to only include those with groupby=True for drill operations.
-        """
-        dimensions = {
-            col.column_name
-            for col in getattr(obj, "columns", [])
-            if getattr(col, "groupby", False)
-        }
-        serialized["columns"] = [
-            col
-            for col in serialized.get("columns", [])
-            if col["column_name"] in dimensions
-        ]
+        Clear API response to avoid exposing sensitive information for embedded users.
 
+        Both ``columns`` and ``metrics`` are returned whole. Besides feeding the
+        drill-by dimension picker, this response is the source of the verbose map
+        that labels the dashboard "View as table" results grid, and a chart can
+        select any column or metric -- a raw-records table routinely selects
+        non-dimension columns. Narrowing to ``groupby=True`` here left those
+        columns, and every metric, showing their raw technical names. Each column
+        carries its ``groupby`` flag instead, so the drill-by picker can narrow to
+        dimensions client-side, which is the only consumer that needs it.
+
+        Guests get the same lists. They reach this endpoint only through the
+        dashboard fallback, which first verifies dashboard access to a dashboard
+        built on this dataset, and they already see these labels rendered in that
+        dashboard's charts. The branch stays minimal in every other respect.
+        """
         if security_manager.is_guest_user():
-            return {"id": serialized["id"], "columns": serialized["columns"]}
+            return {
+                "id": serialized["id"],
+                "columns": serialized["columns"],
+                "metrics": serialized.get("metrics", []),
+            }
         return serialized

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3402,6 +3402,25 @@ class TestDatasetApi(SupersetTestCase):
                     groupby=False,
                 ),
             ],
+            metrics=[
+                SqlMetric(
+                    metric_name="sum__value",
+                    expression="SUM(value)",
+                    verbose_name="Yearly Total",
+                ),
+                # Shares its name with the non-dimension "value" column above, so
+                # applying the column filter to metrics would drop this one. It is
+                # asserted as present below to pin the deliberate asymmetry.
+                SqlMetric(
+                    metric_name="value",
+                    expression="MAX(value)",
+                    verbose_name="Raw Value Metric",
+                ),
+                SqlMetric(
+                    metric_name="count",
+                    expression="COUNT(*)",
+                ),
+            ],
             fetch_metadata=False,
         )
 
@@ -3421,10 +3440,27 @@ class TestDatasetApi(SupersetTestCase):
         assert result["id"] == dataset.id
         assert result["table_name"] == "test_drill_dataset"
         assert result["editors"] == []
-        assert len(result["columns"]) == 2
+        # Every column is returned, including the non-dimension ones: this payload
+        # also resolves display labels for the dashboard "View as table" results
+        # grid, and a raw-records table can select any of them. `groupby` rides
+        # along so the drill-by picker can narrow to dimensions client-side.
         assert result["columns"] == [
-            {"column_name": "category", "verbose_name": "Category Column"},
-            {"column_name": "region", "verbose_name": None},
+            {
+                "column_name": "category",
+                "verbose_name": "Category Column",
+                "groupby": True,
+            },
+            {"column_name": "region", "verbose_name": None, "groupby": True},
+            {"column_name": "value", "verbose_name": None, "groupby": False},
+            {"column_name": "description", "verbose_name": None, "groupby": False},
+        ]
+        # Metrics carry their verbose_name for the same reason. "value" is asserted
+        # here precisely because it would be dropped if a dimension filter were ever
+        # applied to metrics -- no metric name is a member of the dimension set.
+        assert result["metrics"] == [
+            {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
+            {"metric_name": "value", "verbose_name": "Raw Value Metric"},
+            {"metric_name": "count", "verbose_name": None},
         ]
 
         self.items_to_delete = [dataset]
@@ -3603,6 +3639,13 @@ class TestDatasetApi(SupersetTestCase):
                     groupby=True,
                 ),
             ],
+            metrics=[
+                SqlMetric(
+                    metric_name="sum__value",
+                    expression="SUM(value)",
+                    verbose_name="Yearly Total",
+                ),
+            ],
             fetch_metadata=False,
         )
         chart = self.insert_chart("Test Embedded Chart", dataset.id)
@@ -3626,8 +3669,15 @@ class TestDatasetApi(SupersetTestCase):
             assert result == {
                 "id": dataset.id,
                 "columns": [
-                    {"column_name": "category", "verbose_name": "Category Column"},
-                    {"column_name": "region", "verbose_name": None},
+                    {
+                        "column_name": "category",
+                        "verbose_name": "Category Column",
+                        "groupby": True,
+                    },
+                    {"column_name": "region", "verbose_name": None, "groupby": True},
+                ],
+                "metrics": [
+                    {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
                 ],
             }
 

--- a/tests/unit_tests/datasets/schema_tests.py
+++ b/tests/unit_tests/datasets/schema_tests.py
@@ -16,8 +16,11 @@
 # under the License.
 
 # pylint: disable=import-outside-toplevel, invalid-name, unused-argument, redefined-outer-name
+from typing import Any
+
 import pytest
 from marshmallow import ValidationError
+from pytest_mock import MockerFixture
 
 from superset.datasets.schemas import validate_python_date_format
 
@@ -91,6 +94,98 @@ def test_drill_info_editor_schema_does_not_expose_secondary_label() -> None:
     dumped = DrillInfoEditorSchema().dump(_FakeEditorSubject())
     assert "secondary_label" not in dumped
     assert dumped == {"id": 1, "label": "Jane Doe", "img": "avatar.png", "type": 1}
+
+
+class _FakeDrillInfoColumn:
+    def __init__(self, column_name: str, groupby: bool, verbose_name: str | None):
+        self.column_name = column_name
+        self.groupby = groupby
+        self.verbose_name = verbose_name
+
+
+class _FakeDrillInfoMetric:
+    def __init__(self, metric_name: str, verbose_name: str | None):
+        self.metric_name = metric_name
+        self.verbose_name = verbose_name
+
+
+class _FakeDrillInfoDataset:
+    id = 1
+    table_name = "test_dataset"
+    editors: list[Any] = []
+    created_by = None
+    changed_by = None
+    created_on_humanized = "now"
+    changed_on_humanized = "now"
+    # "value" is a non-dimension column: a raw-records table can select it, so the
+    # results grid needs its label, but the drill-by picker must not offer it. The
+    # metric also named "value" exists because uniqueness is only enforced within
+    # each list, so both lists have to survive serialization independently.
+    columns = [
+        _FakeDrillInfoColumn("category", groupby=True, verbose_name="Category Column"),
+        _FakeDrillInfoColumn("value", groupby=False, verbose_name="Raw Value"),
+    ]
+    metrics = [
+        _FakeDrillInfoMetric("sum__value", verbose_name="Yearly Total"),
+        _FakeDrillInfoMetric("value", verbose_name="Raw Value Metric"),
+        _FakeDrillInfoMetric("count", verbose_name=None),
+    ]
+
+
+def _dump_drill_info(mocker: MockerFixture, *, is_guest: bool) -> dict[str, Any]:
+    from superset.datasets.schemas import DatasetDrillInfoSchema
+
+    mocker.patch(
+        "superset.datasets.schemas.security_manager.is_guest_user",
+        return_value=is_guest,
+    )
+    return DatasetDrillInfoSchema().dump(_FakeDrillInfoDataset())
+
+
+def test_drill_info_returns_columns_and_metrics_unfiltered(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Both lists are returned whole, because this response resolves display labels
+    for the dashboard "View as table" results grid and a chart may select any
+    column or metric -- a raw-records table routinely selects non-dimension
+    columns. ``groupby`` rides along so the drill-by picker can narrow to
+    dimensions client-side, which is where that concern belongs; narrowing here
+    would strip the labels the grid needs.
+    """
+    dumped = _dump_drill_info(mocker, is_guest=False)
+
+    assert dumped["columns"] == [
+        {
+            "column_name": "category",
+            "verbose_name": "Category Column",
+            "groupby": True,
+        },
+        {"column_name": "value", "verbose_name": "Raw Value", "groupby": False},
+    ]
+    assert dumped["metrics"] == [
+        {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
+        {"metric_name": "value", "verbose_name": "Raw Value Metric"},
+        {"metric_name": "count", "verbose_name": None},
+    ]
+
+
+def test_drill_info_guest_payload_keeps_labels(mocker: MockerFixture) -> None:
+    """
+    Guests reach this endpoint only through the dashboard fallback, which first
+    verifies they can access a dashboard built on the dataset, and they see the
+    same labels rendered in that dashboard's charts. The branch stays minimal in
+    every other respect -- no table name, editors, or audit fields.
+    """
+    dumped = _dump_drill_info(mocker, is_guest=True)
+
+    assert set(dumped) == {"id", "columns", "metrics"}
+    assert [col["column_name"] for col in dumped["columns"]] == ["category", "value"]
+    assert dumped["metrics"] == [
+        {"metric_name": "sum__value", "verbose_name": "Yearly Total"},
+        {"metric_name": "value", "verbose_name": "Raw Value Metric"},
+        {"metric_name": "count", "verbose_name": None},
+    ]
 
 
 def test_dataset_post_schema_has_all_put_scalar_fields() -> None:


### PR DESCRIPTION
### SUMMARY
On a dashboard, opening a chart's context menu → "View as table" (the Chart Data modal, `ResultsPaneOnDashboard`) showed raw technical names (e.g. `sum__num`) as results-grid column headers instead of the friendly Labels (verbose_name), even though the chart itself rendered the Labels correctly and even for a full-permission Admin user.

There were two independent causes, one on each side.

**Backend.** The results-grid header comes from `columnDisplayNames?.[key] ?? key` in `useGridResultTable`, fed by `datasetWithVerboseMap?.verbose_map` in `SliceHeaderControls`, which `createVerboseMap` builds from `GET /api/v1/dataset/<pk>/drill_info/`. That endpoint was purpose-built for the Drill-to-Detail "drill by" dimension picker, so it selected only `columns` and narrowed them to `groupby=True`, and `DatasetDrillInfoSchema` had no `metrics` field at all. Once it was also used as the source of the results grid's verbose map, everything it dropped for the picker's benefit lost its label: every metric, and every non-dimension column — which a raw-records table routinely selects.

Fix: return both lists whole. `metrics.metric_name`/`metrics.verbose_name` are added to the select columns and a `metrics` field (via a new `DatasetMetricDrillInfoSchema`) to the schema; the `post_dump` narrowing of `columns` is removed and each column carries its `groupby` flag instead, so the drill-by picker can narrow to dimensions client-side — the only consumer that needs it. `ChartContextMenu` now filters on `column.groupby`, which it already did on the extension path.

**Frontend.** `SliceHeaderControls` passed `!canDrillToDetail` as the `skip` argument to `useDatasetDrillInfo`, which short-circuits to an empty dataset. "View as table" is offered to a different set of users (`canExplore || canViewTable`), so anyone in that set without Drill to detail — including the default Gamma role — never fetched `drill_info` at all and still saw raw names, no matter what the API returned. The menu entry and the fetch that feeds its headers now share one predicate so they cannot drift, guarded by `can_get_drill_info` so a role without dataset read access does not fire a request that can only 403:

```ts
const canViewResultsTable = canExplore || canViewTable;

useDatasetDrillInfo(
  props.slice.datasource,
  props.dashboardId,
  props.formData,
  !canGetDrillInfo || !(canDrillToDetail || canViewResultsTable),
);
```

`createVerboseMap` also writes metrics before columns, so a column wins a name collision — uniqueness is only enforced within each list, and without this an unused metric could relabel a column the chart actually selected. This matches `SqlaTable.data_for_slices`, which builds the verbose map the dashboard's own charts already render with.

### Behaviour changes worth noting

**Payload.** `drill_info` now returns every column rather than only `groupby=True` ones, for all callers including embedded guests. Guests reach this endpoint only through the dashboard fallback, which first verifies dashboard access to a dashboard built on the dataset, and the response already carried dataset-level dimension names and analyst-authored labels; this widens that to non-dimension columns and metrics. The drill-by picker is unchanged from a user's perspective — the narrowing simply moved client-side.

**Cost.** One additional `SELECT` per request (measured: 12 → 13 during the request), the eager load of `sql_metrics`. That query is unavoidable given the feature — without it in `select_columns` the schema would lazy-load the same rows at dump time. Request counts are unchanged for default roles, since `ChartContextMenu` already fetched `drill_info` via `canDrillBy` and both call sites share `cachedSupersetGet`'s endpoint key.

**Extensions.** Where `load.drillby.options` is registered, the hook now also calls the REST endpoint for labels, because the extension contract only covers drill-by options and a conforming implementation may omit metrics and non-dimension columns. That is one extra request per dataset per dashboard load in those deployments only; if the endpoint is unreachable there, the verbose map falls back to the extension payload rather than failing drill-by.

## Video evidence

### Before fix

https://github.com/user-attachments/assets/37b80318-3105-4644-9668-bcd77313deef

### After fix

https://github.com/user-attachments/assets/442e4549-6890-4995-9447-5de823bc928c


### TESTING INSTRUCTIONS
- Create a dataset with a metric that has a Label (verbose_name) set, e.g. `sum__num` → "Yearly Total", and a column with a Label that is **not** marked as a dimension (`groupby` off).
- Build a chart from it and add it to a dashboard. Confirm the chart itself shows the Labels.
- Open the chart's context menu → "View as table" and confirm the results-grid headers show the Labels rather than the technical names, for both the metric and the non-dimension column.
- Repeat as a user who has `can_view_chart_as_table` on Dashboard but not Drill to detail (e.g. default Gamma) and confirm the Labels resolve there too.
- Confirm the "Drill by" submenu still offers only dimension columns.
- `pytest tests/integration_tests/datasets/api_tests.py -k drill_info`
- `pytest tests/unit_tests/datasets/schema_tests.py -k drill_info`
- `npm run test -- SliceHeaderControls.test.tsx ChartContextMenu.test.tsx datasets.test.ts`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

