### PR TITLE
feat(dataset): warn about dependent charts and dashboards before purging an archived dataset

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -24,6 +24,21 @@ assists people when migrating to a new version.
 
 ## Next
 
+### Archived dataset purge requires impact confirmation
+
+`GET /api/v1/dataset/<uuid>/purge-impact` returns the charts and distinct
+dashboards affected by permanently deleting an archived dataset, together with
+an opaque `impact_token`. The dataset purge endpoint now requires that token in
+the JSON body as `confirmed_impact_token`. API clients that call
+`POST /api/v1/dataset/<uuid>/purge` must fetch and display the impact first;
+requests with a missing or malformed token are rejected with 400.
+
+The server rechecks the dependency identities immediately before mutation. If
+they changed, purge performs no deletion and returns 409 with a refreshed impact
+payload. Clients must display the new impact and obtain renewed confirmation
+before retrying. Preview or recheck failures fail closed rather than treating
+unknown impact as zero. Chart and dashboard purge endpoints are unchanged.
+
 - `SAMPLES_ROW_LIMIT` is now the default for `/datasource/samples` requests without a valid explicit `per_page`, rather than a hard per-request ceiling; explicit limits are honored up to the existing global row-limit ceiling, matching `/chart/data` SAMPLES requests.
 - The `cockroachdb` extra (`pip install apache-superset[cockroachdb]`) now installs `sqlalchemy-cockroachdb` instead of the abandoned `cockroachdb` package, whose SQLAlchemy dialect could not be imported under SQLAlchemy 2.0. Existing environments with the old package installed should `pip uninstall cockroachdb && pip install sqlalchemy-cockroachdb` (or simply reinstall the extra) to restore CockroachDB connectivity.
 

--- a/docs/docs/using-superset/recently-archived.mdx
+++ b/docs/docs/using-superset/recently-archived.mdx
@@ -70,5 +70,24 @@ alert or report is removed, and the reason is shown. Charts that belong to
 dashboards are removed from those dashboards as part of the deletion; the
 dashboards themselves are left in place.
 
+Before an archived dataset is deleted permanently, Superset checks which
+charts still use it and which dashboards contain those charts. The confirmation
+shows the total number of affected charts and dashboards, identifies the ones
+you are allowed to access, and reports the remaining objects only as restricted
+counts. Restricted names, identifiers, and links are not displayed. Archived
+dependents are included because they can still be recovered after the dataset
+is gone.
+
+Deleting the dataset does not delete those charts or dashboards. They remain
+in place without a usable dataset and may therefore be broken. If there are no
+dependents, the confirmation explicitly reports zero affected charts and
+dashboards.
+
+The dependency check fails closed. While it is loading, or if its result is
+unavailable, permanent deletion is disabled; cancel or retry the check. Superset
+checks again when you submit. If dependencies changed while the confirmation
+was open, the refreshed impact replaces the previous result and you must type
+DELETE again before proceeding.
+
 Objects are also deleted permanently on their own once they have been in the
 archive longer than the retention window, without anyone acting.

--- a/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/DeleteModal.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/DeleteModal.test.tsx
@@ -146,3 +146,61 @@ test('Calling "onConfirm" only after typing "delete" in the input', async () => 
   // confirm input has been cleared
   expect(screen.getByTestId('delete-modal-input')).toHaveValue('');
 });
+
+test('external disable keeps the destructive action unavailable after confirmation', async () => {
+  const onConfirm = jest.fn();
+  render(
+    <DeleteModal
+      title="Delete permanently?"
+      description="This cannot be undone."
+      onConfirm={onConfirm}
+      onHide={jest.fn()}
+      open
+      disablePrimaryButton
+    />,
+  );
+
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+  expect(onConfirm).not.toHaveBeenCalled();
+});
+
+test('loading disables the destructive action and exposes busy state', async () => {
+  render(
+    <DeleteModal
+      title="Delete permanently?"
+      description="Checking dependencies"
+      onConfirm={jest.fn()}
+      onHide={jest.fn()}
+      open
+      loading
+    />,
+  );
+
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+
+  expect(screen.getByTestId('modal-confirm-button')).toBeDisabled();
+  expect(screen.getByTestId('antd-modal')).toHaveAttribute('aria-busy', 'true');
+});
+
+test('confirmation reset key clears and re-arms type-to-confirm', async () => {
+  const props = {
+    title: 'Delete permanently?',
+    description: 'This cannot be undone.',
+    onConfirm: jest.fn(),
+    onHide: jest.fn(),
+    open: true,
+  };
+  const { rerender } = render(
+    <DeleteModal {...props} confirmationResetKey="initial" />,
+  );
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+
+  rerender(<DeleteModal {...props} confirmationResetKey="impact-changed" />);
+
+  expect(screen.getByTestId('delete-modal-input')).toHaveValue('');
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+});

--- a/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/index.tsx
@@ -40,6 +40,9 @@ export function DeleteModal({
   title,
   name,
   recoverable = false,
+  disablePrimaryButton = false,
+  loading = false,
+  confirmationResetKey,
 }: DeleteModalProps) {
   // Recoverable (archive) deletes drop the "type DELETE to confirm" step;
   // a permanent delete keeps it.
@@ -53,6 +56,11 @@ export function DeleteModal({
       inputRef.current.focus();
     }
   }, [open]);
+
+  useEffect(() => {
+    setConfirmation('');
+    setDisableChange(true);
+  }, [confirmationResetKey]);
 
   // Re-arm the gate alongside clearing the text: resetting only the string
   // leaves disableChange=false behind, so a user who typed DELETE, cancelled,
@@ -76,14 +84,19 @@ export function DeleteModal({
   };
 
   const onPressEnter = () => {
-    if (!disableChange) {
+    if (!disableChange && !disablePrimaryButton && !loading) {
       confirm();
     }
   };
 
   return (
     <Modal
-      disablePrimaryButton={showConfirmationInput ? disableChange : false}
+      disablePrimaryButton={
+        disablePrimaryButton ||
+        loading ||
+        (showConfirmationInput ? disableChange : false)
+      }
+      primaryButtonLoading={loading}
       onHide={hide}
       onHandledPrimaryAction={confirm}
       primaryButtonName={recoverable ? t('Archive') : t('Delete')}
@@ -91,6 +104,7 @@ export function DeleteModal({
       show={open}
       name={name}
       title={title}
+      wrapProps={{ 'aria-busy': loading }}
       centered
     >
       {description}

--- a/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/DeleteModal/types.ts
@@ -32,4 +32,10 @@ export interface DeleteModalProps {
    * friction and uses a primary (non-danger) confirm button.
    */
   recoverable?: boolean;
+  /** Disable confirmation independently of the typed-text gate. */
+  disablePrimaryButton?: boolean;
+  /** Show progress on the primary action and prevent duplicate submission. */
+  loading?: boolean;
+  /** Clear and re-arm the typed-text gate when the reviewed data changes. */
+  confirmationResetKey?: string | number;
 }

--- a/superset-frontend/src/pages/ArchivedList/ArchivedDatasetPurgeModal.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedDatasetPurgeModal.tsx
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState } from 'react';
+import { t } from '@apache-superset/core/translation';
+import { styled } from '@apache-superset/core/theme';
+import { Button, DeleteModal } from '@superset-ui/core/components';
+import type {
+  ArchivedDatasetPurgeModalState,
+  PurgeImpactCollection,
+  PurgeImpactItem,
+} from './types';
+
+const ImpactSection = styled.section`
+  ${({ theme }) => `
+    margin-top: ${theme.sizeUnit * 4}px;
+  `}
+`;
+
+const ImpactHeading = styled.h4`
+  margin-bottom: ${({ theme }) => theme.sizeUnit * 2}px;
+`;
+
+const ImpactList = styled.ul`
+  margin-bottom: ${({ theme }) => theme.sizeUnit * 2}px;
+  padding-left: ${({ theme }) => theme.sizeUnit * 5}px;
+`;
+
+const ArchivedMarker = styled.span`
+  ${({ theme }) => `
+    color: ${theme.colorTextSecondary};
+    margin-left: ${theme.sizeUnit}px;
+  `}
+`;
+
+const Message = styled.p`
+  margin-top: ${({ theme }) => theme.sizeUnit * 3}px;
+`;
+
+const DEFAULT_VISIBLE_ITEMS = 5;
+
+function ImpactItem({ item }: { item: PurgeImpactItem }) {
+  const label =
+    item.url && !item.archived ? <a href={item.url}>{item.name}</a> : item.name;
+
+  return (
+    <li>
+      {label}
+      {item.archived && (
+        <ArchivedMarker aria-label={t('Archived')}>
+          {t('(archived)')}
+        </ArchivedMarker>
+      )}
+    </li>
+  );
+}
+
+function ImpactCollection({
+  collection,
+  singular,
+  plural,
+}: {
+  collection: PurgeImpactCollection;
+  singular: string;
+  plural: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleItems = expanded
+    ? collection.result
+    : collection.result.slice(0, DEFAULT_VISIBLE_ITEMS);
+  const hasMore = collection.result.length > DEFAULT_VISIBLE_ITEMS;
+
+  return (
+    <ImpactSection>
+      <ImpactHeading>
+        {t('%(count)s %(label)s', {
+          count: collection.count,
+          label: collection.count === 1 ? singular : plural,
+        })}
+      </ImpactHeading>
+      {collection.count === 0 ? (
+        <p>{t('No affected %(label)s.', { label: plural.toLowerCase() })}</p>
+      ) : (
+        <>
+          {visibleItems.length > 0 && (
+            <ImpactList>
+              {visibleItems.map(item => (
+                <ImpactItem key={item.uuid} item={item} />
+              ))}
+            </ImpactList>
+          )}
+          {collection.restricted_count > 0 && (
+            <p>
+              {t('%(count)s additional restricted %(label)s', {
+                count: collection.restricted_count,
+                label: collection.restricted_count === 1 ? singular : plural,
+              })}
+            </p>
+          )}
+          {hasMore && (
+            <Button
+              buttonStyle="link"
+              onClick={() => setExpanded(value => !value)}
+            >
+              {expanded ? t('Show fewer') : t('Show all')}
+            </Button>
+          )}
+        </>
+      )}
+    </ImpactSection>
+  );
+}
+
+export interface ArchivedDatasetPurgeModalProps {
+  state: Exclude<ArchivedDatasetPurgeModalState, { status: 'closed' }>;
+  onConfirm: () => void;
+  onHide: () => void;
+  onRetry: () => void;
+}
+
+export function ArchivedDatasetPurgeModal({
+  state,
+  onConfirm,
+  onHide,
+  onRetry,
+}: ArchivedDatasetPurgeModalProps) {
+  const name = String(state.item.table_name ?? '');
+  const hasImpact =
+    state.status === 'ready' ||
+    state.status === 'submitting' ||
+    state.status === 'changed';
+  const impact = hasImpact ? state.impact : undefined;
+  const unavailable = state.status === 'error';
+
+  return (
+    <DeleteModal
+      open
+      name="archived-dataset-purge"
+      title={t('Delete permanently %(name)s?', { name })}
+      description={
+        <div aria-live="polite">
+          {state.status === 'loading' && (
+            <p>{t('Checking charts and dashboards that use this dataset…')}</p>
+          )}
+          {state.status === 'changed' && (
+            <Message role="alert">
+              {t(
+                'The affected charts or dashboards changed. Review the updated impact and type DELETE again to continue.',
+              )}
+            </Message>
+          )}
+          {unavailable && (
+            <>
+              <Message role="alert">
+                {t(
+                  'The deletion impact could not be determined. This dataset cannot be permanently deleted until the check succeeds.',
+                )}
+              </Message>
+              <Button onClick={onRetry}>{t('Retry')}</Button>
+            </>
+          )}
+          {impact && (
+            <>
+              <p>
+                {t(
+                  'Deleting this dataset is permanent. The affected charts and dashboards will remain, but they may no longer work.',
+                )}
+              </p>
+              <ImpactCollection
+                collection={impact.charts}
+                singular={t('Chart')}
+                plural={t('Charts')}
+              />
+              <ImpactCollection
+                collection={impact.dashboards}
+                singular={t('Dashboard')}
+                plural={t('Dashboards')}
+              />
+            </>
+          )}
+        </div>
+      }
+      disablePrimaryButton={state.status === 'loading' || unavailable}
+      loading={state.status === 'submitting'}
+      confirmationResetKey={
+        impact ? `${state.status}:${impact.impact_token}` : state.status
+      }
+      onConfirm={onConfirm}
+      onHide={onHide}
+    />
+  );
+}

--- a/superset-frontend/src/pages/ArchivedList/ArchivedDatasetPurgeModal.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedDatasetPurgeModal.tsx
@@ -55,8 +55,17 @@ const Message = styled.p`
 const DEFAULT_VISIBLE_ITEMS = 5;
 
 function ImpactItem({ item }: { item: PurgeImpactItem }) {
+  // Only link server-issued application paths; anything else (absolute or
+  // scheme-relative URLs, javascript: and data: schemes) renders as text.
+  const isSafeAppPath = Boolean(
+    item.url && item.url.startsWith('/') && !item.url.startsWith('//'),
+  );
   const label =
-    item.url && !item.archived ? <a href={item.url}>{item.name}</a> : item.name;
+    item.url && isSafeAppPath && !item.archived ? (
+      <a href={item.url}>{item.name}</a>
+    ) : (
+      item.name
+    );
 
   return (
     <li>

--- a/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
@@ -56,6 +56,43 @@ const dashboardInfoEndpoint = 'glob:*/api/v1/dashboard/_info*';
 const dashboardListEndpoint = 'glob:*/api/v1/dashboard/?*';
 const datasetInfoEndpoint = 'glob:*/api/v1/dataset/_info*';
 const datasetListEndpoint = 'glob:*/api/v1/dataset/?*';
+const datasetImpactEndpoint = 'glob:*/api/v1/dataset/*/purge-impact';
+const datasetPurgeEndpoint = 'glob:*/api/v1/dataset/*/purge';
+
+const buildImpact = (overrides: Record<string, unknown> = {}) => ({
+  impact_token: 'v1:reviewed-impact',
+  charts: { count: 0, restricted_count: 0, result: [] },
+  dashboards: { count: 0, restricted_count: 0, result: [] },
+  ...overrides,
+});
+
+const buildPositiveImpact = () =>
+  buildImpact({
+    charts: {
+      count: 2,
+      restricted_count: 1,
+      result: [
+        {
+          uuid: 'accessible-chart',
+          name: 'Revenue chart',
+          archived: true,
+          url: null,
+        },
+      ],
+    },
+    dashboards: {
+      count: 1,
+      restricted_count: 0,
+      result: [
+        {
+          uuid: 'accessible-dashboard',
+          name: 'Executive dashboard',
+          archived: false,
+          url: '/superset/dashboard/accessible-dashboard/',
+        },
+      ],
+    },
+  });
 
 const mockDashboards = [
   { id: 10, uuid: 'dash-uuid-1', dashboard_title: 'Deleted Dashboard One' },
@@ -118,6 +155,7 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
 const mockRoutes = (
   restoreStatus = 200,
   purgeResponse: Parameters<typeof fetchMock.post>[1] = {},
+  impactResponse: Parameters<typeof fetchMock.get>[1] = buildPositiveImpact(),
 ) => {
   fetchMock.get(infoEndpoint, { permissions: ['can_read', 'can_write'] });
   fetchMock.get(listEndpoint, { result: mockCharts, count: mockCharts.length });
@@ -137,6 +175,8 @@ const mockRoutes = (
     result: mockDatasets,
     count: mockDatasets.length,
   });
+  fetchMock.get(datasetImpactEndpoint, impactResponse);
+  fetchMock.post(datasetPurgeEndpoint, purgeResponse);
 };
 
 const renderArchivedList = (withStore = store) =>
@@ -644,4 +684,85 @@ test('labels the dataset type "Dataset" when semantic layers is disabled', async
   expect(
     within(datasetRow as HTMLElement).getByText('Dataset'),
   ).toBeInTheDocument();
+});
+
+const openDatasetPurgeModal = async () => {
+  await selectOption('Dataset', 'Type');
+  await screen.findByText('deleted_table_one');
+  fireEvent.click((await screen.findAllByTestId('archived-row-purge'))[0]);
+};
+
+test('dataset purge shows positive, archived, and restricted impact', async () => {
+  mockRoutes();
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+
+  await openDatasetPurgeModal();
+
+  expect(await screen.findByText('2 Charts')).toBeInTheDocument();
+  expect(screen.getByText('Revenue chart')).toBeInTheDocument();
+  expect(
+    within(screen.getByRole('dialog')).getByLabelText('Archived'),
+  ).toBeInTheDocument();
+  expect(screen.getByText('1 additional restricted Chart')).toBeInTheDocument();
+  expect(screen.getByText('Executive dashboard').closest('a')).not.toBeNull();
+});
+
+test('dataset purge renders an explicit zero only after impact loads', async () => {
+  mockRoutes(200, {}, buildImpact());
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+
+  await openDatasetPurgeModal();
+
+  expect(await screen.findByText('No affected charts.')).toBeInTheDocument();
+  expect(screen.getByText('No affected dashboards.')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+});
+
+test('dataset purge fails closed when impact is unavailable', async () => {
+  mockRoutes(200, {}, 500);
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+
+  await openDatasetPurgeModal();
+
+  expect(
+    await screen.findByText(/deletion impact could not be determined/i),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled();
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  expect(screen.queryByText('No affected charts.')).not.toBeInTheDocument();
+  expect(fetchMock.callHistory.calls(datasetPurgeEndpoint)).toHaveLength(0);
+});
+
+test('a 409 replaces impact and re-arms DELETE confirmation', async () => {
+  const changedImpact = buildImpact({
+    impact_token: 'v1:changed-impact',
+    charts: { count: 1, restricted_count: 0, result: [] },
+  });
+  mockRoutes(200, {
+    status: 409,
+    body: {
+      message: 'Impact changed',
+      reason: 'purge_impact_changed',
+      impact: changedImpact,
+    },
+  });
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+  await openDatasetPurgeModal();
+  await screen.findByText('2 Charts');
+
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+  await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(
+    /affected charts or dashboards changed/i,
+  );
+  expect(screen.getByText('1 Chart')).toBeInTheDocument();
+  expect(screen.getByTestId('delete-modal-input')).toHaveValue('');
+  expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
 });

--- a/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
@@ -137,6 +137,7 @@ jest.mock('@superset-ui/core', () => ({
 }));
 
 const mockAddDangerToast = jest.fn();
+const mockAddSuccessToast = jest.fn();
 jest.mock('src/components/MessageToasts/withToasts', () => ({
   __esModule: true,
   default:
@@ -145,7 +146,7 @@ jest.mock('src/components/MessageToasts/withToasts', () => ({
       <Component
         {...props}
         addDangerToast={mockAddDangerToast}
-        addSuccessToast={jest.fn()}
+        addSuccessToast={mockAddSuccessToast}
         addInfoToast={jest.fn()}
         addWarningToast={jest.fn()}
       />
@@ -193,6 +194,7 @@ beforeEach(() => {
   fetchMock.removeRoutes();
   fetchMock.clearHistory();
   mockAddDangerToast.mockClear();
+  mockAddSuccessToast.mockClear();
 });
 
 afterEach(() => {
@@ -736,6 +738,81 @@ test('dataset purge fails closed when impact is unavailable', async () => {
   expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   expect(screen.queryByText('No affected charts.')).not.toBeInTheDocument();
   expect(fetchMock.callHistory.calls(datasetPurgeEndpoint)).toHaveLength(0);
+});
+
+test('a purge that succeeds after the modal closes still toasts and refetches', async () => {
+  let resolvePurge: (value: {
+    status: number;
+    body: object;
+  }) => void = () => {};
+  const deferredPurge = new Promise<{ status: number; body: object }>(
+    resolve => {
+      resolvePurge = resolve;
+    },
+  );
+  mockRoutes(200, deferredPurge);
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+  await openDatasetPurgeModal();
+  await screen.findByText('2 Charts');
+
+  await userEvent.type(screen.getByTestId('delete-modal-input'), 'DELETE');
+  await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+  const listCallsBefore =
+    fetchMock.callHistory.calls(datasetListEndpoint).length;
+
+  // The user closes the modal while the purge request is still in flight;
+  // the deletion still happens server-side.
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+  resolvePurge({ status: 200, body: { message: 'OK' } });
+
+  await waitFor(() =>
+    expect(mockAddSuccessToast).toHaveBeenCalledWith(
+      expect.stringContaining('deleted successfully'),
+    ),
+  );
+  await waitFor(() =>
+    expect(
+      fetchMock.callHistory.calls(datasetListEndpoint).length,
+    ).toBeGreaterThan(listCallsBefore),
+  );
+});
+
+test('impact entries with non-application URLs render as text, not links', async () => {
+  mockRoutes(
+    200,
+    {},
+    buildImpact({
+      dashboards: {
+        count: 2,
+        restricted_count: 0,
+        result: [
+          {
+            uuid: 'external-dashboard',
+            name: 'External dashboard',
+            archived: false,
+            url: 'https://evil.example/dashboard',
+          },
+          {
+            uuid: 'schemeless-dashboard',
+            name: 'Schemeless dashboard',
+            archived: false,
+            url: '//evil.example/dashboard',
+          },
+        ],
+      },
+    }),
+  );
+  renderArchivedList();
+  await screen.findByTestId('archived-list-view');
+
+  await openDatasetPurgeModal();
+
+  expect(await screen.findByText('External dashboard')).toBeInTheDocument();
+  expect(screen.getByText('External dashboard').closest('a')).toBeNull();
+  expect(screen.getByText('Schemeless dashboard').closest('a')).toBeNull();
 });
 
 test('a 409 replaces impact and re-arms DELETE confirmation', async () => {

--- a/superset-frontend/src/pages/ArchivedList/index.tsx
+++ b/superset-frontend/src/pages/ArchivedList/index.tsx
@@ -368,12 +368,14 @@ function ArchivedListBody({
         }),
         headers: { 'Content-Type': 'application/json' },
       });
-      if (impactRequestGeneration.current !== generation) {
-        return;
-      }
+      // The purge succeeded even if the modal was closed while the request
+      // was in flight, so the toast and refresh must not be gated on the
+      // request generation — only the modal state is.
       const name = String(item[config.nameField] ?? '');
       addSuccessToast(t('%(name)s deleted successfully', { name }));
-      setDatasetPurgeModal({ status: 'closed' });
+      if (impactRequestGeneration.current === generation) {
+        setDatasetPurgeModal({ status: 'closed' });
+      }
       await refreshData();
     } catch (error) {
       if (impactRequestGeneration.current !== generation) {

--- a/superset-frontend/src/pages/ArchivedList/index.tsx
+++ b/superset-frontend/src/pages/ArchivedList/index.tsx
@@ -46,8 +46,12 @@ import {
   ARCHIVED_TYPES,
   ARCHIVED_TYPE_CONFIG,
   type ArchivedItem,
+  type ArchivedDatasetPurgeModalState,
   type ArchivedType,
+  type PurgeImpactChangedResponse,
+  type PurgeImpactResponse,
 } from './types';
+import { ArchivedDatasetPurgeModal } from './ArchivedDatasetPurgeModal';
 
 /** Cell props shape shared by the column renderers below. */
 type ArchivedCell = { row: { original: ArchivedItem } };
@@ -102,15 +106,29 @@ function ArchivedRowActions({
   name,
   onRestore,
   onPurge,
+  previewBeforePurge = false,
   busy = false,
 }: {
   item: ArchivedItem;
   name: string;
   onRestore: (item: ArchivedItem) => void;
   onPurge: (item: ArchivedItem) => void;
+  previewBeforePurge?: boolean;
   /** A request for this row is in flight; both actions stand down. */
   busy?: boolean;
 }) {
+  const permanentDeleteButton = (onClick: () => void) => (
+    <ActionButton
+      label={t('Delete permanently')}
+      tooltip={t('Delete permanently')}
+      placement="bottom"
+      icon={<Icons.DeleteOutlined iconSize="l" />}
+      dataTest="archived-row-purge"
+      disabled={busy}
+      onClick={onClick}
+    />
+  );
+
   return (
     <StyledActions className="actions">
       <ActionButton
@@ -122,25 +140,19 @@ function ArchivedRowActions({
         disabled={busy}
         onClick={() => onRestore(item)}
       />
-      <ConfirmStatusChange
-        title={t('Delete permanently %(name)s?', { name })}
-        description={t(
-          "If you delete this item, you won't be able to recover it.",
-        )}
-        onConfirm={() => onPurge(item)}
-      >
-        {confirmDelete => (
-          <ActionButton
-            label={t('Delete permanently')}
-            tooltip={t('Delete permanently')}
-            placement="bottom"
-            icon={<Icons.DeleteOutlined iconSize="l" />}
-            dataTest="archived-row-purge"
-            disabled={busy}
-            onClick={confirmDelete}
-          />
-        )}
-      </ConfirmStatusChange>
+      {previewBeforePurge ? (
+        permanentDeleteButton(() => onPurge(item))
+      ) : (
+        <ConfirmStatusChange
+          title={t('Delete permanently %(name)s?', { name })}
+          description={t(
+            "If you delete this item, you won't be able to recover it.",
+          )}
+          onConfirm={() => onPurge(item)}
+        >
+          {confirmDelete => permanentDeleteButton(confirmDelete)}
+        </ConfirmStatusChange>
+      )}
     </StyledActions>
   );
 }
@@ -188,6 +200,9 @@ function ArchivedListBody({
   // so the buttons can render disabled meanwhile.
   const inFlightRef = useRef<Set<string>>(new Set());
   const [inFlight, setInFlight] = useState<readonly string[]>([]);
+  const [datasetPurgeModal, setDatasetPurgeModal] =
+    useState<ArchivedDatasetPurgeModalState>({ status: 'closed' });
+  const impactRequestGeneration = useRef(0);
 
   const beginAction = useCallback((uuid: string): boolean => {
     if (inFlightRef.current.has(uuid)) {
@@ -286,6 +301,123 @@ function ArchivedListBody({
     [performRowAction, addSuccessToast],
   );
 
+  const loadDatasetPurgeImpact = useCallback(async (item: ArchivedItem) => {
+    const generation = impactRequestGeneration.current + 1;
+    impactRequestGeneration.current = generation;
+    setDatasetPurgeModal({ status: 'loading', item });
+
+    try {
+      const { json } = await SupersetClient.get({
+        endpoint: `/api/v1/dataset/${item.uuid}/purge-impact`,
+      });
+      if (impactRequestGeneration.current !== generation) {
+        return;
+      }
+      setDatasetPurgeModal({
+        status: 'ready',
+        item,
+        impact: json as PurgeImpactResponse,
+      });
+    } catch (error) {
+      if (impactRequestGeneration.current !== generation) {
+        return;
+      }
+      const { error: message } = await getClientErrorObject(error);
+      if (impactRequestGeneration.current === generation) {
+        setDatasetPurgeModal({
+          status: 'error',
+          item,
+          message,
+        });
+      }
+    }
+  }, []);
+
+  const closeDatasetPurgeModal = useCallback(() => {
+    impactRequestGeneration.current += 1;
+    setDatasetPurgeModal({ status: 'closed' });
+  }, []);
+
+  const retryDatasetPurgeImpact = useCallback(() => {
+    if (datasetPurgeModal.status !== 'closed') {
+      loadDatasetPurgeImpact(datasetPurgeModal.item);
+    }
+  }, [datasetPurgeModal, loadDatasetPurgeImpact]);
+
+  const confirmDatasetPurge = useCallback(async () => {
+    if (
+      datasetPurgeModal.status !== 'ready' &&
+      datasetPurgeModal.status !== 'changed'
+    ) {
+      return;
+    }
+
+    const { item, impact } = datasetPurgeModal;
+    if (!beginAction(item.uuid)) {
+      return;
+    }
+    const generation = impactRequestGeneration.current + 1;
+    impactRequestGeneration.current = generation;
+    setDatasetPurgeModal({ status: 'submitting', item, impact });
+
+    try {
+      await SupersetClient.post({
+        endpoint: `/api/v1/dataset/${item.uuid}/purge`,
+        body: JSON.stringify({
+          confirmed_impact_token: impact.impact_token,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (impactRequestGeneration.current !== generation) {
+        return;
+      }
+      const name = String(item[config.nameField] ?? '');
+      addSuccessToast(t('%(name)s deleted successfully', { name }));
+      setDatasetPurgeModal({ status: 'closed' });
+      await refreshData();
+    } catch (error) {
+      if (impactRequestGeneration.current !== generation) {
+        return;
+      }
+      const parsedError = (await getClientErrorObject(error)) as Awaited<
+        ReturnType<typeof getClientErrorObject>
+      > &
+        Partial<PurgeImpactChangedResponse> & { status?: number };
+      if (
+        parsedError.status === 409 &&
+        parsedError.reason === 'purge_impact_changed' &&
+        parsedError.impact
+      ) {
+        setDatasetPurgeModal({
+          status: 'changed',
+          item,
+          impact: parsedError.impact,
+          message: parsedError.message ?? parsedError.error,
+        });
+      } else if (parsedError.status === 404) {
+        setDatasetPurgeModal({ status: 'closed' });
+        addDangerToast(parsedError.error);
+        await refreshData();
+      } else {
+        setDatasetPurgeModal({
+          status: 'error',
+          item,
+          message: parsedError.error,
+        });
+      }
+    } finally {
+      endAction(item.uuid);
+    }
+  }, [
+    datasetPurgeModal,
+    beginAction,
+    endAction,
+    config.nameField,
+    addSuccessToast,
+    addDangerToast,
+    refreshData,
+  ]);
+
   const columns = useMemo<ListViewProps['columns']>(
     () => [
       {
@@ -349,7 +481,8 @@ function ArchivedListBody({
             item={original}
             name={String(original[config.nameField] ?? '')}
             onRestore={handleRestore}
-            onPurge={handlePurge}
+            onPurge={type === 'dataset' ? loadDatasetPurgeImpact : handlePurge}
+            previewBeforePurge={type === 'dataset'}
             busy={inFlight.includes(original.uuid)}
           />
         ),
@@ -359,7 +492,14 @@ function ArchivedListBody({
         size: 'sm',
       },
     ],
-    [config.nameField, type, handleRestore, handlePurge, inFlight],
+    [
+      config.nameField,
+      type,
+      handleRestore,
+      handlePurge,
+      loadDatasetPurgeImpact,
+      inFlight,
+    ],
   );
 
   // Default to most-recently-archived first. `deleted_at` is orderable on all
@@ -421,24 +561,34 @@ function ArchivedListBody({
   );
 
   return (
-    <ListView<ArchivedItem>
-      className="archived-list-view"
-      columns={columns}
-      filters={filters}
-      data={resourceCollection}
-      count={resourceCount}
-      pageSize={PAGE_SIZE}
-      fetchData={fetchData}
-      refreshData={refreshData}
-      addSuccessToast={addSuccessToast}
-      addDangerToast={addDangerToast}
-      loading={loading}
-      initialSort={initialSort}
-      emptyState={{
-        title: t('No archived items'),
-        image: 'empty.svg',
-      }}
-    />
+    <>
+      <ListView<ArchivedItem>
+        className="archived-list-view"
+        columns={columns}
+        filters={filters}
+        data={resourceCollection}
+        count={resourceCount}
+        pageSize={PAGE_SIZE}
+        fetchData={fetchData}
+        refreshData={refreshData}
+        addSuccessToast={addSuccessToast}
+        addDangerToast={addDangerToast}
+        loading={loading}
+        initialSort={initialSort}
+        emptyState={{
+          title: t('No archived items'),
+          image: 'empty.svg',
+        }}
+      />
+      {datasetPurgeModal.status !== 'closed' && (
+        <ArchivedDatasetPurgeModal
+          state={datasetPurgeModal}
+          onConfirm={confirmDatasetPurge}
+          onHide={closeDatasetPurgeModal}
+          onRetry={retryDatasetPurgeImpact}
+        />
+      )}
+    </>
   );
 }
 

--- a/superset-frontend/src/pages/ArchivedList/types.ts
+++ b/superset-frontend/src/pages/ArchivedList/types.ts
@@ -103,3 +103,41 @@ export interface ArchivedItem {
   // dynamically via the type config, so the index signature remains.
   [key: string]: unknown;
 }
+
+export interface PurgeImpactItem {
+  uuid: string;
+  name: string;
+  archived: boolean;
+  url?: string | null;
+}
+
+export interface PurgeImpactCollection {
+  count: number;
+  restricted_count: number;
+  result: PurgeImpactItem[];
+}
+
+export interface PurgeImpactResponse {
+  impact_token: string;
+  charts: PurgeImpactCollection;
+  dashboards: PurgeImpactCollection;
+}
+
+export interface PurgeImpactChangedResponse {
+  message: string;
+  reason: 'purge_impact_changed';
+  impact: PurgeImpactResponse;
+}
+
+export type ArchivedDatasetPurgeModalState =
+  | { status: 'closed' }
+  | { status: 'loading'; item: ArchivedItem }
+  | { status: 'ready'; item: ArchivedItem; impact: PurgeImpactResponse }
+  | { status: 'submitting'; item: ArchivedItem; impact: PurgeImpactResponse }
+  | {
+      status: 'changed';
+      item: ArchivedItem;
+      impact: PurgeImpactResponse;
+      message: string;
+    }
+  | { status: 'error'; item: ArchivedItem; message: string };

--- a/superset/commands/deletion_retention/force_purge.py
+++ b/superset/commands/deletion_retention/force_purge.py
@@ -74,12 +74,14 @@ class ForcePurgeCommand:
         model_cls: type[SoftDeleteMixin] | None = None,
         require_archived: bool = False,
         require_audit: bool = False,
+        confirmed_impact_token: str | None = None,
     ) -> None:
         self._uuid: str = uuid
         self._actor: str = actor
         self._model_cls = model_cls
         self._require_archived = require_archived
         self._require_audit = require_audit
+        self._confirmed_impact_token: str | None = confirmed_impact_token
 
     def _resolve(self) -> SoftDeleteMixin | None:
         """Find the entity by UUID, visibility-filter bypassed.
@@ -164,6 +166,7 @@ class ForcePurgeCommand:
                     entity,
                     enforce_window=False,
                     require_archived=self._require_archived,
+                    confirmed_impact_token=self._confirmed_impact_token,
                 )
             # Commit AFTER the suppression block: Continuum executes its
             # pending association statements during flush/commit, so the

--- a/superset/commands/deletion_retention/purge_cascade.py
+++ b/superset/commands/deletion_retention/purge_cascade.py
@@ -52,6 +52,11 @@ import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from superset.commands.deletion_retention.purge_impact import (
+    collect_dataset_purge_impact,
+    DatasetPurgeImpact,
+    PurgeImpactChangedError,
+)
 from superset.commands.deletion_retention.purge_policy import (
     BlockerReason,
     get_purge_policy,
@@ -192,6 +197,7 @@ def cascade_hard_delete(
     enforce_window: bool,
     cutoff: datetime | None = None,
     require_archived: bool = False,
+    confirmed_impact_token: str | None = None,
 ) -> CascadeResult:
     """Remove *entity* and everything that depends on it in one transaction.
 
@@ -224,6 +230,7 @@ def cascade_hard_delete(
     removed_dashboard_slices = 0
     version_rows = 0
     permission_name: str | None = None
+    confirmed_impact: DatasetPurgeImpact | None = None
 
     try:
         with session.begin_nested():
@@ -241,6 +248,11 @@ def cascade_hard_delete(
             if session.execute(claim.with_for_update()).scalar_one_or_none() is None:
                 raise PurgeRaceLostError
 
+            if entity_type == "dataset" and confirmed_impact_token is not None:
+                confirmed_impact = collect_dataset_purge_impact(session, entity_id)
+                if confirmed_impact.impact_token != confirmed_impact_token:
+                    raise PurgeImpactChangedError(confirmed_impact)
+
             policy.validate(session, policy, entity_id)
             # Captured under the lock: the row is claimed, so the identity
             # the permission name is built from can no longer change.
@@ -248,8 +260,10 @@ def cascade_hard_delete(
             removed_dashboard_slices = policy.count_dashboard_slices(
                 session, policy, entity_id
             )
-            dangling_chart_uuids = policy.collect_dangling_chart_uuids(
-                session, policy, entity_id
+            dangling_chart_uuids = (
+                [chart.uuid for chart in confirmed_impact.charts]
+                if confirmed_impact is not None
+                else policy.collect_dangling_chart_uuids(session, policy, entity_id)
             )
 
             policy.delete_associations(session, policy, entity_id)

--- a/superset/commands/deletion_retention/purge_impact.py
+++ b/superset/commands/deletion_retention/purge_impact.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Authoritative dependency snapshots for archived dataset purges."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from superset.models.dashboard import Dashboard, dashboard_slices
+from superset.models.helpers import skip_visibility_filter
+from superset.models.slice import Slice
+
+
+@dataclass(frozen=True)
+class DatasetImpactObject:
+    """Scalar identity and display data for one dependent object."""
+
+    id: int
+    uuid: str
+    name: str | None
+    archived: bool
+
+
+@dataclass(frozen=True)
+class DatasetPurgeImpact:
+    """Complete dependent identities at one point in time."""
+
+    impact_token: str
+    charts: tuple[DatasetImpactObject, ...]
+    dashboards: tuple[DatasetImpactObject, ...]
+
+
+class PurgeImpactChangedError(Exception):
+    """Raised when a dataset's dependencies differ from those confirmed."""
+
+    def __init__(self, impact: DatasetPurgeImpact) -> None:
+        super().__init__("Dataset dependencies changed; review them before deleting")
+        self.impact: DatasetPurgeImpact = impact
+
+
+def _impact_token(
+    charts: tuple[DatasetImpactObject, ...],
+    dashboards: tuple[DatasetImpactObject, ...],
+) -> str:
+    """Return a deterministic, versioned fingerprint of dependent identities."""
+    canonical: str = "\n".join(
+        sorted(f"chart:{chart.uuid}" for chart in charts)
+        + sorted(f"dashboard:{dashboard.uuid}" for dashboard in dashboards)
+    )
+    digest: str = hashlib.sha256(canonical.encode()).hexdigest()
+    return f"v1:{digest}"
+
+
+def collect_dataset_purge_impact(
+    session: Session, dataset_id: int
+) -> DatasetPurgeImpact:
+    """Collect live and archived charts and distinct dashboards for a dataset."""
+    with skip_visibility_filter(session, Slice, Dashboard):
+        chart_rows: list[tuple[int, object, str | None, object | None]] = list(
+            session.execute(
+                sa.select(Slice.id, Slice.uuid, Slice.slice_name, Slice.deleted_at)
+                .where(Slice.datasource_type == "table")
+                .where(Slice.datasource_id == dataset_id)
+                .order_by(Slice.uuid)
+            ).tuples()
+        )
+        dashboard_rows: list[tuple[int, object, str | None, object | None]] = list(
+            session.execute(
+                sa.select(
+                    Dashboard.id,
+                    Dashboard.uuid,
+                    Dashboard.dashboard_title,
+                    Dashboard.deleted_at,
+                )
+                .join(
+                    dashboard_slices,
+                    dashboard_slices.c.dashboard_id == Dashboard.id,
+                )
+                .join(Slice, Slice.id == dashboard_slices.c.slice_id)
+                .where(Slice.datasource_type == "table")
+                .where(Slice.datasource_id == dataset_id)
+                .distinct()
+                .order_by(Dashboard.uuid)
+            ).tuples()
+        )
+
+    charts: tuple[DatasetImpactObject, ...] = tuple(
+        DatasetImpactObject(
+            id=chart_id,
+            uuid=str(chart_uuid),
+            name=chart_name,
+            archived=deleted_at is not None,
+        )
+        for chart_id, chart_uuid, chart_name, deleted_at in chart_rows
+    )
+    dashboard_by_uuid: dict[str, DatasetImpactObject] = {
+        str(dashboard_uuid): DatasetImpactObject(
+            id=dashboard_id,
+            uuid=str(dashboard_uuid),
+            name=dashboard_name,
+            archived=deleted_at is not None,
+        )
+        for dashboard_id, dashboard_uuid, dashboard_name, deleted_at in dashboard_rows
+    }
+    dashboards: tuple[DatasetImpactObject, ...] = tuple(dashboard_by_uuid.values())
+    return DatasetPurgeImpact(
+        impact_token=_impact_token(charts, dashboards),
+        charts=charts,
+        dashboards=dashboards,
+    )

--- a/superset/commands/deletion_retention/purge_policy.py
+++ b/superset/commands/deletion_retention/purge_policy.py
@@ -988,17 +988,13 @@ def dangling_chart_uuids(
     """Return chart UUIDs left by the dataset preservation policy."""
     if policy.entity_type != "dataset":
         return []
-    # avoid circular import: the chart model participates in registry assembly
-    from superset.models.slice import Slice
+    from superset.commands.deletion_retention.purge_impact import (
+        collect_dataset_purge_impact,
+        DatasetPurgeImpact,
+    )
 
-    return [
-        str(chart_uuid)
-        for (chart_uuid,) in session.execute(
-            sa.select(Slice.uuid)
-            .where(Slice.datasource_id == entity_id)
-            .where(Slice.datasource_type == "table")
-        )
-    ]
+    impact: DatasetPurgeImpact = collect_dataset_purge_impact(session, entity_id)
+    return [chart.uuid for chart in impact.charts]
 
 
 def delete_associations(

--- a/superset/commands/purge.py
+++ b/superset/commands/purge.py
@@ -25,21 +25,34 @@ items the user already sees in the archive.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
-from superset import is_feature_enabled, security_manager
+from superset import db, is_feature_enabled, security_manager
 from superset.commands.base import BaseCommand
 from superset.commands.deletion_retention.force_purge import ForcePurgeCommand
+from superset.commands.deletion_retention.purge_impact import (
+    collect_dataset_purge_impact,
+    DatasetImpactObject,
+    DatasetPurgeImpact,
+    PurgeImpactChangedError,
+)
+from superset.connectors.sqla.models import SqlaTable
 from superset.daos.base import BaseDAO
 from superset.daos.exceptions import DAODeleteFailedError
 from superset.exceptions import SupersetSecurityException
-from superset.models.helpers import SoftDeleteMixin
+from superset.models.dashboard import Dashboard
+from superset.models.helpers import skip_visibility_filter, SoftDeleteMixin
+from superset.models.slice import Slice
 from superset.tasks.utils import get_current_user
 
 logger = logging.getLogger(__name__)
+
+ImpactCollector: TypeAlias = Callable[[Session, SoftDeleteMixin], DatasetPurgeImpact]
 
 #: Recorded when the audit trail cannot name the acting user. The purge routes
 #: are ``@protect()``-ed, so this should be unreachable; it exists so an
@@ -60,14 +73,21 @@ class SoftDeleteBinding:
     not_found: type[Exception]
     forbidden: type[Exception]
     delete_failed: type[Exception]
+    impact_collector: ImpactCollector | None = None
 
 
 class PurgeArchivedCommand(BaseCommand):
     """Permanently delete a single soft-deleted entity, by UUID."""
 
-    def __init__(self, model_uuid: str, binding: SoftDeleteBinding) -> None:
+    def __init__(
+        self,
+        model_uuid: str,
+        binding: SoftDeleteBinding,
+        confirmed_impact_token: str | None = None,
+    ) -> None:
         self._model_uuid = model_uuid
         self._binding = binding
+        self._confirmed_impact_token: str | None = confirmed_impact_token
         #: The authorized entity, resolved by ``validate()``. ``BaseCommand``
         #: fixes ``validate()``'s return type as ``None``, so the model is
         #: handed to ``run()`` here rather than returned.
@@ -78,6 +98,13 @@ class PurgeArchivedCommand(BaseCommand):
         model = self._model
         if model is None:  # pragma: no cover — validate() raises or sets it
             raise self._binding.not_found(f"No row with uuid={self._model_uuid!r}")
+        if self._binding.impact_collector is not None:
+            impact: DatasetPurgeImpact = self._binding.impact_collector(
+                db.session, model
+            )
+            if impact.impact_token != self._confirmed_impact_token:
+                raise PurgeImpactChangedError(impact)
+
         try:
             # ForcePurgeCommand owns the cascade + commit + audit.
             #
@@ -98,6 +125,7 @@ class PurgeArchivedCommand(BaseCommand):
                 # the CLI's fail-open default is an operator-trust decision
                 # that does not extend to REST principals.
                 require_audit=True,
+                confirmed_impact_token=self._confirmed_impact_token,
             ).run()
         except (SQLAlchemyError, DAODeleteFailedError) as ex:
             # Deliberately narrow: a database or DAO failure is a real
@@ -175,3 +203,82 @@ class PurgeArchivedCommand(BaseCommand):
         except SupersetSecurityException as ex:
             raise self._binding.forbidden() from ex
         self._model = model
+
+    def preview_dataset_impact(self) -> DatasetPurgeImpact:
+        """Return the authorized impact snapshot for an archived dataset."""
+        self.validate()
+        model: SoftDeleteMixin | None = self._model
+        collector: ImpactCollector | None = self._binding.impact_collector
+        if model is None or collector is None:
+            raise self._binding.not_found("The purge target is not a dataset")
+        return collector(db.session, model)
+
+
+def collect_dataset_impact(
+    session: Session, model: SoftDeleteMixin
+) -> DatasetPurgeImpact:
+    """Collect purge impact for a dataset binding."""
+    if not isinstance(model, SqlaTable):
+        raise TypeError("Dataset purge binding resolved a non-dataset model")
+    return collect_dataset_purge_impact(session, model.id)
+
+
+def serialize_dataset_purge_impact(impact: DatasetPurgeImpact) -> dict[str, Any]:
+    """Apply object access control and serialize a complete impact snapshot."""
+    chart_ids: list[int] = [item.id for item in impact.charts]
+    dashboard_ids: list[int] = [item.id for item in impact.dashboards]
+    with skip_visibility_filter(db.session, Slice, Dashboard):
+        charts: dict[int, Slice] = {
+            chart.id: chart
+            for chart in db.session.query(Slice).filter(Slice.id.in_(chart_ids)).all()
+        }
+        dashboards: dict[int, Dashboard] = {
+            dashboard.id: dashboard
+            for dashboard in db.session.query(Dashboard)
+            .filter(Dashboard.id.in_(dashboard_ids))
+            .all()
+        }
+
+    chart_result: list[dict[str, Any]] = []
+    for item in impact.charts:
+        chart: Slice | None = charts.get(item.id)
+        if chart is not None and security_manager.can_access_chart(chart):
+            chart_result.append(
+                _serialize_impact_object(item, chart.url, fallback="Untitled chart")
+            )
+
+    dashboard_result: list[dict[str, Any]] = []
+    for item in impact.dashboards:
+        dashboard: Dashboard | None = dashboards.get(item.id)
+        if dashboard is not None and security_manager.can_access_dashboard(dashboard):
+            dashboard_result.append(
+                _serialize_impact_object(
+                    item, dashboard.url, fallback="Untitled dashboard"
+                )
+            )
+
+    return {
+        "impact_token": impact.impact_token,
+        "charts": {
+            "count": len(impact.charts),
+            "restricted_count": len(impact.charts) - len(chart_result),
+            "result": chart_result,
+        },
+        "dashboards": {
+            "count": len(impact.dashboards),
+            "restricted_count": len(impact.dashboards) - len(dashboard_result),
+            "result": dashboard_result,
+        },
+    }
+
+
+def _serialize_impact_object(
+    item: DatasetImpactObject, live_url: str, *, fallback: str
+) -> dict[str, Any]:
+    """Serialize one authorized object without linking an archived target."""
+    return {
+        "uuid": item.uuid,
+        "name": item.name or fallback,
+        "archived": item.archived,
+        "url": None if item.archived else live_url,
+    }

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -56,10 +56,19 @@ from superset.commands.dataset.refresh import RefreshDatasetCommand
 from superset.commands.dataset.restore import RestoreDatasetCommand
 from superset.commands.dataset.update import UpdateDatasetCommand
 from superset.commands.dataset.warm_up_cache import DatasetWarmUpCacheCommand
+from superset.commands.deletion_retention.purge_impact import (
+    DatasetPurgeImpact,
+    PurgeImpactChangedError,
+)
 from superset.commands.exceptions import CommandException
 from superset.commands.importers.exceptions import NoValidFilesFoundError
 from superset.commands.importers.v1.utils import get_contents_from_bundle
-from superset.commands.purge import PurgeArchivedCommand, SoftDeleteBinding
+from superset.commands.purge import (
+    collect_dataset_impact,
+    PurgeArchivedCommand,
+    serialize_dataset_purge_impact,
+    SoftDeleteBinding,
+)
 from superset.connectors.sqla.models import SqlaTable
 from superset.constants import MODEL_API_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.daos.dashboard import DashboardDAO
@@ -78,6 +87,8 @@ from superset.datasets.schemas import (
     DatasetDrillInfoSchema,
     DatasetDuplicateSchema,
     DatasetPostSchema,
+    DatasetPurgeImpactSchema,
+    DatasetPurgeRequestSchema,
     DatasetPutSchema,
     DatasetRelatedObjectsResponse,
     get_delete_ids_schema,
@@ -132,6 +143,7 @@ _DATASET_PURGE_BINDING = SoftDeleteBinding(
     not_found=DatasetNotFoundError,
     forbidden=DatasetForbiddenError,
     delete_failed=DatasetDeleteFailedError,
+    impact_collector=collect_dataset_impact,
 )
 
 
@@ -154,6 +166,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         "restore": "write",
         "restore_version": "write",
         "purge": "write",
+        "purge_impact": "write",
     }
     include_route_methods = RouteMethod.REST_MODEL_VIEW_CRUD_SET | {
         RouteMethod.EXPORT,
@@ -163,6 +176,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         "bulk_delete",
         "restore",
         "purge",
+        "purge_impact",
         "refresh",
         "related_objects",
         "duplicate",
@@ -400,6 +414,8 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         DatasetCacheWarmUpRequestSchema,
         DatasetCacheWarmUpResponseSchema,
         DatasetRelatedObjectsResponse,
+        DatasetPurgeImpactSchema,
+        DatasetPurgeRequestSchema,
         DatasetDuplicateSchema,
         GetOrCreateDatasetSchema,
         VersionListItemSchema,
@@ -1275,6 +1291,33 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
             )
             return self.response_422(message=str(ex))
 
+    @expose("/<uuid>/purge-impact", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.purge_impact"
+        ),
+        log_to_statsd=False,
+    )
+    def purge_impact(self, uuid: str) -> Response:
+        """Preview the dependency impact of purging an archived dataset."""
+        try:
+            impact: DatasetPurgeImpact = PurgeArchivedCommand(
+                uuid, _DATASET_PURGE_BINDING
+            ).preview_dataset_impact()
+            return self.response(200, **serialize_dataset_purge_impact(impact))
+        except DatasetNotFoundError:
+            return self.response_404()
+        except DatasetForbiddenError:
+            return self.response_403()
+        except Exception:  # noqa: BLE001
+            logger.exception("Unable to collect dataset purge impact")
+            return self.response_500(
+                message="The dependency impact could not be determined"
+            )
+
     @expose("/<uuid>/purge", methods=("POST",))
     @protect()
     @safe
@@ -1283,6 +1326,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.purge",
         log_to_statsd=False,
     )
+    @requires_json
     def purge(self, uuid: str) -> Response:
         """Permanently delete a soft-deleted (archived) dataset.
         ---
@@ -1297,6 +1341,13 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
               type: string
               format: uuid
             name: uuid
+          requestBody:
+            description: Confirmed dependency impact
+            required: true
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DatasetPurgeRequestSchema'
           responses:
             200:
               description: Dataset permanently deleted
@@ -1307,20 +1358,52 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
                     properties:
                       message:
                         type: string
+            400:
+              $ref: '#/components/responses/400'
             401:
               $ref: '#/components/responses/401'
             403:
               $ref: '#/components/responses/403'
             404:
               $ref: '#/components/responses/404'
+            409:
+              description: Dataset dependency impact changed
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    required: [message, reason, impact]
+                    properties:
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                        enum: [purge_impact_changed]
+                      impact:
+                        $ref: '#/components/schemas/DatasetPurgeImpactSchema'
             422:
               $ref: '#/components/responses/422'
             500:
               $ref: '#/components/responses/500'
         """
         try:
-            PurgeArchivedCommand(uuid, _DATASET_PURGE_BINDING).run()
+            body: dict[str, Any] = DatasetPurgeRequestSchema().load(request.json)
+            confirmed_impact_token: str = body["confirmed_impact_token"]
+            PurgeArchivedCommand(
+                uuid,
+                _DATASET_PURGE_BINDING,
+                confirmed_impact_token=confirmed_impact_token,
+            ).run()
             return self.response(200, message="OK")
+        except ValidationError as ex:
+            return self.response_400(message=ex.messages)
+        except PurgeImpactChangedError as ex:
+            return self.response(
+                409,
+                message=str(ex),
+                reason="purge_impact_changed",
+                impact=serialize_dataset_purge_impact(ex.impact),
+            )
         except DatasetNotFoundError:
             return self.response_404()
         except DatasetForbiddenError:

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1302,7 +1302,37 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         log_to_statsd=False,
     )
     def purge_impact(self, uuid: str) -> Response:
-        """Preview the dependency impact of purging an archived dataset."""
+        """Preview the dependency impact of purging an archived dataset.
+        ---
+        get:
+          summary: Preview the dependency impact of purging an archived dataset
+          description: >-
+            Report the charts and dashboards that depend on an archived
+            dataset, with an impact token that must be echoed back on the
+            purge request. Limited to owners and admins (same audience as
+            restore).
+          parameters:
+          - in: path
+            schema:
+              type: string
+              format: uuid
+            name: uuid
+          responses:
+            200:
+              description: Dependency impact of purging the dataset
+              content:
+                application/json:
+                  schema:
+                    $ref: '#/components/schemas/DatasetPurgeImpactSchema'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
         try:
             impact: DatasetPurgeImpact = PurgeArchivedCommand(
                 uuid, _DATASET_PURGE_BINDING

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -28,7 +28,7 @@ from marshmallow import (
     validates_schema,
     ValidationError,
 )
-from marshmallow.validate import Length, OneOf
+from marshmallow.validate import Length, OneOf, Range
 
 from superset import security_manager
 from superset.connectors.sqla.models import SqlaTable
@@ -257,6 +257,58 @@ class DatasetRelatedDashboards(Schema):
 class DatasetRelatedObjectsResponse(Schema):
     charts = fields.Nested(DatasetRelatedCharts)
     dashboards = fields.Nested(DatasetRelatedDashboards)
+
+
+class DatasetPurgeRequestSchema(Schema):
+    """Validate a dataset purge confirmation payload."""
+
+    confirmed_impact_token: fields.String = fields.String(
+        required=True,
+        allow_none=False,
+        validate=Length(min=1),
+    )
+
+
+class DatasetPurgeImpactObjectSchema(Schema):
+    """Describe one dependent object visible to the caller."""
+
+    uuid: fields.UUID = fields.UUID(required=True)
+    name: fields.String = fields.String(required=True)
+    archived: fields.Boolean = fields.Boolean(required=True)
+    url: fields.String = fields.String(required=True, allow_none=True)
+
+
+class DatasetPurgeImpactCollectionSchema(Schema):
+    """Validate totals and visible results for one dependent object type."""
+
+    count: fields.Integer = fields.Integer(required=True, validate=Range(min=0))
+    restricted_count: fields.Integer = fields.Integer(
+        required=True, validate=Range(min=0)
+    )
+    result: fields.List = fields.List(
+        fields.Nested(DatasetPurgeImpactObjectSchema), required=True
+    )
+
+    @validates_schema
+    def validate_totals(self, data: dict[str, Any], **kwargs: Any) -> None:
+        """Require visible and restricted records to equal the total."""
+        count: int = data["count"]
+        restricted_count: int = data["restricted_count"]
+        result: list[dict[str, Any]] = data["result"]
+        if restricted_count > count or len(result) + restricted_count != count:
+            raise ValidationError("Impact totals do not match the result")
+
+
+class DatasetPurgeImpactSchema(Schema):
+    """Describe the authoritative, access-filtered dataset purge impact."""
+
+    impact_token: fields.String = fields.String(required=True)
+    charts: fields.Nested = fields.Nested(
+        DatasetPurgeImpactCollectionSchema, required=True
+    )
+    dashboards: fields.Nested = fields.Nested(
+        DatasetPurgeImpactCollectionSchema, required=True
+    )
 
 
 class ImportV1ColumnSchema(Schema):

--- a/superset/migrations/versions/2026-08-25_18-00_8f31c5d726ab_index_dataset_dependency_lookups.py
+++ b/superset/migrations/versions/2026-08-25_18-00_8f31c5d726ab_index_dataset_dependency_lookups.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Index dataset dependency lookups.
+
+Revision ID: 8f31c5d726ab
+Revises: 39097d124752
+Create Date: 2026-08-25 18:00:00.000000
+
+"""
+
+from superset.migrations.shared.utils import create_index, drop_index
+
+revision: str = "8f31c5d726ab"
+down_revision: str = "39097d124752"
+
+_SLICE_DATASOURCE_INDEX: str = "ix_slices_datasource_type_datasource_id"
+_DASHBOARD_SLICE_INDEX: str = "ix_dashboard_slices_slice_id"
+
+
+def upgrade() -> None:
+    """Add indexes supporting dataset impact collection."""
+    create_index(
+        "slices",
+        _SLICE_DATASOURCE_INDEX,
+        ["datasource_type", "datasource_id"],
+    )
+    create_index(
+        "dashboard_slices",
+        _DASHBOARD_SLICE_INDEX,
+        ["slice_id"],
+    )
+
+
+def downgrade() -> None:
+    """Remove dataset impact lookup indexes."""
+    drop_index("dashboard_slices", _DASHBOARD_SLICE_INDEX)
+    drop_index("slices", _SLICE_DATASOURCE_INDEX)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -128,6 +128,7 @@ dashboard_slices = Table(
         ForeignKey("slices.id", ondelete="CASCADE"),
         primary_key=True,
     ),
+    sqla.Index("ix_dashboard_slices_slice_id", "slice_id"),
 )
 
 

--- a/superset/models/slice.py
+++ b/superset/models/slice.py
@@ -71,6 +71,13 @@ class Slice(  # pylint: disable=too-many-public-methods
     query_context_factory: QueryContextFactory | None = None
 
     __tablename__ = "slices"
+    __table_args__: tuple[sqla.Index, ...] = (
+        sqla.Index(
+            "ix_slices_datasource_type_datasource_id",
+            "datasource_type",
+            "datasource_id",
+        ),
+    )
     # query_context is excluded: it is a cached/regenerated field, not user-authored.
     # deleted_at is deletion-state metadata (SoftDeleteMixin), tracked by soft
     # delete, not content versioning; it is also absent from the slices_version

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -17246,3 +17246,36 @@ msgstr ""
 
 msgid "№"
 msgstr ""
+
+msgid "(archived)"
+msgstr ""
+
+#, python-format
+msgid "%(count)s %(label)s"
+msgstr ""
+
+#, python-format
+msgid "%(count)s additional restricted %(label)s"
+msgstr ""
+
+msgid "Checking charts and dashboards that use this dataset…"
+msgstr ""
+
+msgid "Deleting this dataset is permanent. The affected charts and dashboards will remain, but they may no longer work."
+msgstr ""
+
+msgid "The affected charts or dashboards changed. Review the updated impact and type DELETE again to continue."
+msgstr ""
+
+msgid "The deletion impact could not be determined. This dataset cannot be permanently deleted until the check succeeds."
+msgstr ""
+
+#, python-format
+msgid "No affected %(label)s."
+msgstr ""
+
+msgid "Show fewer"
+msgstr ""
+
+msgid "Show all"
+msgstr ""

--- a/tests/integration_tests/datasets/soft_delete_tests.py
+++ b/tests/integration_tests/datasets/soft_delete_tests.py
@@ -17,7 +17,10 @@
 """Integration tests for dataset soft-delete and restore."""
 
 from datetime import datetime
+from typing import cast
+from unittest.mock import patch
 
+from flask import Response
 from flask_appbuilder.security.sqla.models import User
 
 from superset import security_manager
@@ -755,7 +758,28 @@ class TestDatasetArchiveListing(SupersetTestCase):
         db.session.commit()
 
         self.login(ADMIN_USERNAME)
-        rv = self.client.post(f"/api/v1/dataset/{dataset_uuid}/purge")
+        impact_rv: Response = self.client.get(
+            f"/api/v1/dataset/{dataset_uuid}/purge-impact"
+        )
+        assert impact_rv.status_code == 200, impact_rv.data
+        impact: dict[str, object] = json.loads(impact_rv.data)
+        assert impact["charts"] == {
+            "count": 0,
+            "restricted_count": 0,
+            "result": [],
+        }
+        assert impact["dashboards"] == {
+            "count": 0,
+            "restricted_count": 0,
+            "result": [],
+        }
+        impact_token: str = str(impact["impact_token"])
+        assert impact_token.startswith("v1:")
+
+        rv: Response = self.client.post(
+            f"/api/v1/dataset/{dataset_uuid}/purge",
+            json={"confirmed_impact_token": impact_token},
+        )
         assert rv.status_code == 200, rv.data
 
         row = (
@@ -769,6 +793,141 @@ class TestDatasetArchiveListing(SupersetTestCase):
         # The dataset is purged; clean up its database row.
         db.session.delete(database)
         db.session.commit()
+
+    @with_feature_flags(SOFT_DELETE=True)
+    def test_dataset_purge_rejects_missing_confirmation_token(self) -> None:
+        """A malformed client request cannot bypass impact confirmation."""
+        created: tuple[SqlaTable, Database] = self._make("arch_purge_missing_token")
+        dataset: SqlaTable = created[0]
+        database: Database = created[1]
+        dataset_id: int = dataset.id
+        dataset_uuid: str = str(dataset.uuid)
+        dataset.deleted_at = datetime(2026, 1, 1, 12, 0, 0)
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        rv: Response = self.client.post(
+            f"/api/v1/dataset/{dataset_uuid}/purge", json={}
+        )
+
+        assert rv.status_code == 400, rv.data
+        assert (
+            db.session.query(SqlaTable)
+            .execution_options(**{SKIP_VISIBILITY_FILTER_CLASSES: {SqlaTable}})
+            .filter(SqlaTable.id == dataset_id)
+            .one_or_none()
+            is not None
+        )
+        self._cleanup(dataset_id, database)
+
+    @with_feature_flags(SOFT_DELETE=True)
+    def test_dataset_purge_requires_reconfirmation_when_impact_changes(self) -> None:
+        """A stale token returns refreshed impact without mutating the dataset."""
+        created: tuple[SqlaTable, Database] = self._make("arch_purge_stale_token")
+        dataset: SqlaTable = created[0]
+        database: Database = created[1]
+        dataset_id: int = dataset.id
+        dataset_uuid: str = str(dataset.uuid)
+        dataset.deleted_at = datetime(2026, 1, 1, 12, 0, 0)
+        db.session.commit()
+
+        self.login(ADMIN_USERNAME)
+        preview_rv: Response = self.client.get(
+            f"/api/v1/dataset/{dataset_uuid}/purge-impact"
+        )
+        preview: dict[str, object] = json.loads(preview_rv.data)
+        stale_token: str = str(preview["impact_token"])
+
+        chart: Slice = Slice(
+            slice_name="new impact chart",
+            datasource_id=dataset_id,
+            datasource_type="table",
+            viz_type="table",
+        )
+        db.session.add(chart)
+        db.session.commit()
+
+        stale_rv: Response = self.client.post(
+            f"/api/v1/dataset/{dataset_uuid}/purge",
+            json={"confirmed_impact_token": stale_token},
+        )
+        stale_payload: dict[str, object] = json.loads(stale_rv.data)
+
+        assert stale_rv.status_code == 409, stale_rv.data
+        assert stale_payload["reason"] == "purge_impact_changed"
+        refreshed: dict[str, object] = cast(dict[str, object], stale_payload["impact"])
+        refreshed_charts: dict[str, object] = cast(
+            dict[str, object], refreshed["charts"]
+        )
+        assert refreshed_charts["count"] == 1
+        assert db.session.get(SqlaTable, dataset_id) is not None
+        assert db.session.get(Slice, chart.id) is not None
+
+        refreshed_token: str = str(refreshed["impact_token"])
+        confirmed_rv: Response = self.client.post(
+            f"/api/v1/dataset/{dataset_uuid}/purge",
+            json={"confirmed_impact_token": refreshed_token},
+        )
+        assert confirmed_rv.status_code == 200, confirmed_rv.data
+        assert db.session.get(SqlaTable, dataset_id) is None
+
+        db.session.delete(chart)
+        db.session.delete(database)
+        db.session.commit()
+
+    @with_feature_flags(SOFT_DELETE=True)
+    def test_purge_impact_redacts_restricted_chart_for_non_admin_editor(
+        self,
+    ) -> None:
+        """Dataset editorship exposes impact cardinality, not object details."""
+        alpha: User = self.get_user(ALPHA_USERNAME)
+        database: Database = Database(
+            database_name="db_arch_impact_redaction", sqlalchemy_uri="sqlite://"
+        )
+        db.session.add(database)
+        db.session.flush()
+        dataset: SqlaTable = SqlaTable(
+            table_name="arch_impact_redaction",
+            database=database,
+            editors=[_user_subject(alpha)],
+        )
+        db.session.add(dataset)
+        db.session.flush()
+        chart: Slice = Slice(
+            slice_name="restricted impact chart",
+            datasource_id=dataset.id,
+            datasource_type="table",
+            viz_type="table",
+        )
+        db.session.add(chart)
+        db.session.commit()
+        dataset_id: int = dataset.id
+        dataset_uuid: str = str(dataset.uuid)
+        chart_uuid: str = str(chart.uuid)
+        dataset.deleted_at = datetime(2026, 1, 1, 12, 0, 0)
+        db.session.commit()
+
+        try:
+            self.login(ALPHA_USERNAME)
+            with patch.object(security_manager, "can_access_chart", return_value=False):
+                rv: Response = self.client.get(
+                    f"/api/v1/dataset/{dataset_uuid}/purge-impact"
+                )
+
+            assert rv.status_code == 200, rv.data
+            payload: dict[str, object] = json.loads(rv.data)
+            assert payload["charts"] == {
+                "count": 1,
+                "restricted_count": 1,
+                "result": [],
+            }
+            serialized_payload: str = rv.data.decode()
+            assert chart_uuid not in serialized_payload
+            assert "restricted impact chart" not in serialized_payload
+        finally:
+            db.session.delete(chart)
+            db.session.commit()
+            self._cleanup(dataset_id, database)
 
     @with_feature_flags(SOFT_DELETE=True)
     def test_purge_blocked_for_non_owner(self) -> None:

--- a/tests/integration_tests/deletion_retention/force_purge_tests.py
+++ b/tests/integration_tests/deletion_retention/force_purge_tests.py
@@ -30,6 +30,10 @@ from superset.commands.deletion_retention.force_purge import (
     AmbiguousPurgeTargetError,
     ForcePurgeCommand,
 )
+from superset.commands.deletion_retention.purge_impact import (
+    collect_dataset_purge_impact,
+    PurgeImpactChangedError,
+)
 from superset.connectors.sqla.models import SqlaTable
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
@@ -101,6 +105,35 @@ class TestForcePurge(DeletionRetentionTestBase):
         audit = db.session.query(PurgeAuditLog).filter_by(entity_uuid=ds_uuid).one()
         assert audit.affected_referrers
         assert chart_uuid in audit.affected_referrers
+
+    def test_dataset_impact_drift_fails_audit_without_mutation(self) -> None:
+        """The locked recheck records a failed no-op when impact changed."""
+        reviewed_chart: Slice = self.make_chart("impact_reviewed", dataset=self.dataset)
+        dataset_id: int = self.dataset.id
+        dataset_uuid: str = str(self.dataset.uuid)
+        reviewed_token: str = collect_dataset_purge_impact(
+            db.session, dataset_id
+        ).impact_token
+        changed_chart: Slice = self.make_chart("impact_changed", dataset=self.dataset)
+        reviewed_chart_id: int = reviewed_chart.id
+        changed_chart_id: int = changed_chart.id
+
+        with pytest.raises(PurgeImpactChangedError):
+            ForcePurgeCommand(
+                dataset_uuid,
+                model_cls=SqlaTable,
+                confirmed_impact_token=reviewed_token,
+            ).run()
+
+        assert self.exists(SqlaTable, dataset_id)
+        assert self.exists(Slice, reviewed_chart_id)
+        assert self.exists(Slice, changed_chart_id)
+        audit_row: PurgeAuditLog = (
+            db.session.query(PurgeAuditLog).filter_by(entity_uuid=dataset_uuid).one()
+        )
+        assert audit_row.status == audit.STATUS_FAILED
+        assert audit_row.removed_dashboard_slices == 0
+        assert audit_row.affected_referrers is None
 
     def test_force_purge_counts_removed_dashboard_slices_before_db_cascade(
         self,

--- a/tests/unit_tests/commands/deletion_retention/test_purge_impact.py
+++ b/tests/unit_tests/commands/deletion_retention/test_purge_impact.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for authoritative dataset purge-impact snapshots."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from superset.commands.deletion_retention.purge_impact import (
+    _impact_token,
+    collect_dataset_purge_impact,
+    DatasetImpactObject,
+    DatasetPurgeImpact,
+)
+
+
+def _object(kind_id: int, uuid: str, *, archived: bool = False) -> DatasetImpactObject:
+    return DatasetImpactObject(
+        id=kind_id,
+        uuid=uuid,
+        name=f"object-{kind_id}",
+        archived=archived,
+    )
+
+
+def test_impact_token_canonicalizes_uuid_order() -> None:
+    """Database ordering must not be part of the confirmation contract."""
+    first: DatasetImpactObject = _object(1, "00000000-0000-0000-0000-000000000001")
+    second: DatasetImpactObject = _object(2, "00000000-0000-0000-0000-000000000002")
+
+    forward: str = _impact_token((first, second), ())
+    reverse: str = _impact_token((second, first), ())
+
+    assert forward == reverse
+    assert forward.startswith("v1:")
+
+
+def test_impact_token_namespaces_chart_and_dashboard_identities() -> None:
+    """Moving the same UUID between object kinds changes the reviewed impact."""
+    shared: DatasetImpactObject = _object(1, "00000000-0000-0000-0000-000000000001")
+
+    assert _impact_token((shared,), ()) != _impact_token((), (shared,))
+
+
+def test_impact_token_detects_same_count_identity_substitution() -> None:
+    original: DatasetImpactObject = _object(1, "00000000-0000-0000-0000-000000000001")
+    replacement: DatasetImpactObject = _object(
+        2, "00000000-0000-0000-0000-000000000002"
+    )
+
+    assert _impact_token((original,), ()) != _impact_token((replacement,), ())
+
+
+def test_collector_includes_archived_objects_and_deduplicates_dashboards() -> None:
+    archived_at: datetime = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    chart_uuid: UUID = UUID("00000000-0000-0000-0000-000000000001")
+    dashboard_uuid: UUID = UUID("00000000-0000-0000-0000-000000000002")
+    chart_result: MagicMock = MagicMock()
+    chart_result.tuples.return_value = [(10, chart_uuid, "Archived chart", archived_at)]
+    dashboard_result: MagicMock = MagicMock()
+    # A dashboard containing two affected charts is one impacted dashboard.
+    dashboard_result.tuples.return_value = [
+        (20, dashboard_uuid, "Archived dashboard", archived_at),
+        (20, dashboard_uuid, "Archived dashboard", archived_at),
+    ]
+    session: MagicMock = MagicMock(spec=Session)
+    session.execute.side_effect = [chart_result, dashboard_result]
+
+    with patch(
+        "superset.commands.deletion_retention.purge_impact.skip_visibility_filter",
+        return_value=nullcontext(),
+    ):
+        impact: DatasetPurgeImpact = collect_dataset_purge_impact(session, dataset_id=7)
+
+    assert [(item.uuid, item.archived) for item in impact.charts] == [
+        (str(chart_uuid), True)
+    ]
+    assert [(item.uuid, item.archived) for item in impact.dashboards] == [
+        (str(dashboard_uuid), True)
+    ]


### PR DESCRIPTION
### SUMMARY

With `SOFT_DELETE` enabled, archiving a dataset warns about the charts and dashboards that depend on it — but permanently deleting that same dataset from **Settings → Recently archived** showed only a generic type-DELETE confirmation. The irreversible action carried less warning than the recoverable one, and confirming it silently orphaned every dependent chart (the non-cascade itself is intended behaviour: `ForcePurgeCommand` preserves independently owned entities).

This PR makes the permanent-delete confirmation for an **archived dataset** show the full dependency impact before the user can confirm:

- A new protected endpoint, `GET /api/v1/dataset/<uuid>/purge-impact`, returns the authoritative dependent-object counts (live **and** recoverable-archived charts and dashboards), the names/links the caller may see, an aggregate `restricted_count` for objects the caller cannot access (no names, UUIDs, or links leak), and a versioned SHA-256 `impact_token` fingerprinting the exact affected set.
- The modal names and links the affected charts and dashboards (archived ones badged), shows explicit zero-states, keeps the type-DELETE gate, and disables **Delete** until the impact is known — if impact cannot be determined, permanent deletion is unavailable (Cancel/Retry only, fail closed).
- The purge request must carry the confirmed `impact_token`. The purge re-collects impact at submit time and again under the dataset row lock inside the cascade; if the affected set changed since the user read the warning, the request mutates nothing and returns **409** with the refreshed impact, and the modal asks for a renewed confirmation (same TOCTOU shape as the version-restore guard). A post-write-ahead mismatch finalises its force-purge audit row as `failed` with zero removals.
- Chart and dashboard purges keep the existing generic confirmation — the impact preview is dataset-only, where the orphaning harm is.
- A reversible migration (`8f31c5d726ab`) adds two small indexes used by the impact queries: `slices(datasource_type, datasource_id)` and `dashboard_slices(slice_id)`.

Design notes: dependents are deliberately **not** globally serialised — the guarantee is two submit-time rechecks, not an immutable set after the final snapshot (documented in the spec; a 7-lens review's serialisation finding was evaluated and rejected by design). Inaccessible dependents are counted but never named.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Archived dataset `purge_demo` with two live dependent charts.

**Before** — no mention of the two charts this purge will orphan:

![Before: bare type-DELETE confirmation](https://raw.githubusercontent.com/mikebridge/superset/sc-118271-screenshots/purge-modal-before-light.png)

**After** — authoritative counts, named and linked charts, explicit zero-state for dashboards, Delete gated on the typed confirmation:

![After: impact-aware confirmation, light](https://raw.githubusercontent.com/mikebridge/superset/sc-118271-screenshots/purge-modal-light.png)

![After: impact-aware confirmation, dark](https://raw.githubusercontent.com/mikebridge/superset/sc-118271-screenshots/purge-modal-dark.png)

### TESTING INSTRUCTIONS

1. Enable `SOFT_DELETE`. Create a dataset and build two charts on it.
2. Archive the dataset from the Datasets list, then open **Settings → Recently archived**, set Type to Dataset, and click **Delete permanently** on the row.
3. The modal lists "2 Charts" with links (and "0 Dashboards" explicitly); **Delete** stays disabled until the impact has loaded and DELETE is typed.
4. Stale-impact path: with the modal open, create another chart on the dataset in a second tab, then confirm — the purge is refused, nothing is deleted, and the modal shows the refreshed impact and asks to confirm again.
5. Failure path: block `/purge-impact` in devtools and open the modal — an error state with Retry/Cancel appears and **Delete** cannot be reached.
6. Confirm with a matching token: the dataset is purged; the charts remain (intended) and the force-purge audit row records the dangling chart UUIDs from the confirmed snapshot.
7. Chart/dashboard rows in Recently archived keep the previous generic confirmation.

Automated: `test_purge_impact.py` (canonical ordering, fingerprint stability, dashboard dedup, archived inclusion), `soft_delete_tests.py` (authorization incl. a caller with a restricted dependent; contract fields), `force_purge_tests.py` / `purge_tests.py` (matching/mismatched/same-count tokens, locked recheck, failed audit finalisation, token-free scheduled retention), `ArchivedList.test.tsx` (27 tests: loading, counts, badges, restricted aggregates, bounded lists, 409 renewal, error/retry, unchanged chart/dashboard flows), `DeleteModal.test.tsx` (external disable/loading/reset). Migration verified by upgrade→downgrade→re-upgrade on a fresh metadata DB, re-run after re-chaining onto `39097d124752`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `SOFT_DELETE`
- [x] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible
  - [x] Confirm DB migration upgrade and downgrade tested
  - [x] Runtime estimates and downtime expectations provided: two `CREATE INDEX` statements on `slices` and `dashboard_slices`; seconds on typical metadata volumes, no table rewrites, no downtime expected
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

_This description was drafted with Claude (AI) assistance on behalf of @mikebridge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
