### PR TITLE
fix(datasets): catch MultipleResultsFound in get_or_create's schema-scoped lookup

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1536,7 +1536,10 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         # physical Postgres/MySQL table stored with a non-NULL schema).
         # If two datasets share the ``table_name`` across schemas and the
         # caller omits ``schema``, surface a 400 with an actionable message
-        # instead of the original 500 ``MultipleResultsFound``.
+        # instead of the original 500 ``MultipleResultsFound``. The same guard
+        # applies when the caller supplies ``schema`` but two legacy rows still
+        # match with ``catalog=None`` (the composite unique constraint treats
+        # NULL catalogs as distinct), so both branches catch the exception.
         # Catalog follows the same literal-pass rule: existing datasets
         # created before multi-catalog support landed are stored with
         # ``catalog=None``, so applying ``database.get_default_catalog()``
@@ -1544,9 +1547,20 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         schema = body.get("schema") or None
         catalog = body.get("catalog") or None
         if schema:
-            table = DatasetDAO.get_table_by_catalog_schema_and_name(
-                database_id, schema, table_name, catalog=catalog
-            )
+            try:
+                table = DatasetDAO.get_table_by_catalog_schema_and_name(
+                    database_id, schema, table_name, catalog=catalog
+                )
+            except MultipleResultsFound:
+                return self.response_400(
+                    message=(
+                        f"Multiple datasets named '{table_name}' exist in "
+                        f"schema '{schema}' of this database, differing only "
+                        "by catalog. Specify the 'catalog' field to "
+                        "disambiguate, or contact an admin about removing "
+                        "duplicate legacy datasets."
+                    )
+                )
         else:
             try:
                 table = DatasetDAO.get_table_by_name(database_id, table_name)

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -3269,6 +3269,61 @@ class TestDatasetApi(SupersetTestCase):
         assert rv.status_code == 400
         assert "Specify the 'schema' field" in rv.data.decode("utf-8")
 
+    def test_get_or_create_dataset_with_schema_returns_400_when_ambiguous(self):
+        """
+        Dataset API: regression for the ``if schema:`` branch of
+        ``get_or_create``.
+
+        Two legacy datasets can share ``(database_id, schema, table_name)``
+        while both carry ``catalog=None``: the composite unique constraint
+        treats NULL catalogs as distinct, so it does not prevent this. When
+        the caller supplies ``schema`` and two such rows match,
+        ``one_or_none()`` raises ``MultipleResultsFound``. The API must return
+        a 400 with an actionable message rather than 500-ing — mirroring the
+        no-schema guard.
+        """
+        if get_main_database().backend == "sqlite":
+            pytest.skip(
+                "SQLite has a legacy single-column unique constraint on "
+                "table_name that prevents seeding two same-name datasets in "
+                "the same schema"
+            )
+
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        examples_db = get_example_database()
+        table_name = "test_get_or_create_ambiguous_catalog"
+        schema = "same_schema"
+
+        # Both rows share database_id + schema + table_name with catalog=None
+        # (the default), so they match the ``if schema:`` lookup ambiguously.
+        ds_a = self.insert_dataset(
+            table_name,
+            [admin_id],
+            examples_db,
+            schema=schema,
+            fetch_metadata=False,
+        )
+        ds_b = self.insert_dataset(
+            table_name,
+            [admin_id],
+            examples_db,
+            schema=schema,
+            fetch_metadata=False,
+        )
+        self.items_to_delete = [ds_a, ds_b]
+
+        rv = self.client.post(
+            "api/v1/dataset/get_or_create/",
+            json={
+                "table_name": table_name,
+                "schema": schema,
+                "database_id": examples_db.id,
+            },
+        )
+        assert rv.status_code == 400
+        assert "catalog" in rv.data.decode("utf-8")
+
     @pytest.mark.usefixtures(
         "load_energy_table_with_slice", "load_birth_names_dashboard_with_slices"
     )


### PR DESCRIPTION
### SUMMARY

`DatasetRestApi.get_or_create_dataset()` (`POST /api/v1/dataset/get_or_create/`) has two lookup branches. When the caller omits `schema`, `DatasetDAO.get_table_by_name()`'s `.one_or_none()` call is wrapped in `try/except MultipleResultsFound`, returning a clean 400 if more than one dataset matches (added in commit cb1694575c6, fixing #30377). When the caller *does* supply `schema`, the parallel call to `DatasetDAO.get_table_by_catalog_schema_and_name()` — added in that same commit — has no such guard, so a raw `sqlalchemy.exc.MultipleResultsFound` propagates uncaught as an opaque 500 instead of a 400.

This is reachable in practice, not just theoretical: `SqlaTable` has `UniqueConstraint("database_id", "catalog", "schema", "table_name")`, but standard SQL uniqueness semantics (Postgres, MySQL) treat NULL as distinct from NULL, so two rows sharing `(database_id, schema, table_name)` with `catalog=NULL` on both do not violate that constraint. Since multi-catalog support is recent, plenty of existing datasets have `catalog=None` — see the method's own comment acknowledging this. If such a duplicate pair exists and a caller specifies `schema` explicitly, the endpoint 500s instead of returning an actionable error.

This PR applies the exact same guard the sibling branch already uses, mirroring it into the schema-scoped path.

This follows the same cleanup pattern as prior PRs in this series, e.g. https://github.com/apache/superset/pull/42401 and https://github.com/apache/superset/pull/43433 — a raw exception from a library call is replaced with the Superset-idiomatic caught-and-classified error, matching a sibling call site's existing pattern in the same file.

### TESTING INSTRUCTIONS

Added `test_get_or_create_dataset_with_schema_returns_400_when_ambiguous` in `tests/integration_tests/datasets/api_tests.py`, next to the existing sibling tests for this endpoint (`test_get_or_create_dataset_disambiguates_by_schema`, `test_get_or_create_dataset_no_schema_returns_400_when_ambiguous`). It seeds two datasets sharing `database_id`/`schema`/`table_name` (both `catalog=None`), then POSTs to `get_or_create/` with that `schema` explicitly set, and asserts a 400 with an actionable message instead of an unhandled 500. Skipped on SQLite for the same pre-existing reason the sibling tests are (legacy single-column `table_name` unique constraint in the SQLite test schema). Verified locally against a fresh SQLite DB using the composite constraint only: confirmed `MultipleResultsFound` propagates unhandled pre-fix, and the endpoint returns a clean 400 post-fix.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
