### PR TITLE
fix(echarts-timeseries): convert xAxisLabelInterval string '0' to number 0

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -767,7 +767,7 @@ export default function transformProps(
     showMaxLabel,
     xAxisType,
     xAxisLabelRotation,
-    xAxisLabelInterval,
+    xAxisLabelInterval === '0' ? 0 : xAxisLabelInterval,
     deduplicatedFormatter,
     false,
     zoomable,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -1254,7 +1254,7 @@ export default function transformProps(
     showMaxLabel,
     xAxisType,
     xAxisLabelRotation,
-    xAxisLabelInterval,
+    xAxisLabelInterval === '0' ? 0 : xAxisLabelInterval,
     deduplicatedFormatter,
     isHorizontal,
     zoomable,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -1115,17 +1115,26 @@ export function getTemporalAxisTickConfig(
     ? capTickMarks(temporalTickValues)
     : undefined;
   const labelCustomValues = zoomable ? temporalTickValues : cappedTickValues;
+  // When the user picks "All" (interval === 0), they want every label shown.
+  // Disable hideOverlap so ECharts never drops a label, and pin customValues
+  // to the full tick set so each label lands on a real gridline.
+  const showAllLabels = xAxisLabelInterval === 0;
+
   return {
     axisLabel: {
       // Pinned ticks label every bucket, which does crowd, so thinning
-      // always wins there.
+      // wins there unless the user asked for every label.
       hideOverlap:
-        !!temporalTickValues ||
-        (showMaxLabel
-          ? false
-          : !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0)),
+        !showAllLabels &&
+        (!!temporalTickValues ||
+          (showMaxLabel
+            ? false
+            : !(xAxisType === AxisType.Time && xAxisLabelRotation !== 0))),
       formatter,
       rotate: xAxisLabelRotation,
+      // ECharts only honors axisLabel.interval on category axes. A time axis
+      // ignores it, so the "All" setting relies on showAllLabels disabling
+      // hideOverlap above rather than on interval: 0 here.
       interval: xAxisLabelInterval,
       // Force the boundary labels so the first and last dates stay visible:
       // hideOverlap can hide the last label, and a min date that falls

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -1114,11 +1114,15 @@ export function getTemporalAxisTickConfig(
   const cappedTickValues = temporalTickValues
     ? capTickMarks(temporalTickValues)
     : undefined;
-  const labelCustomValues = zoomable ? temporalTickValues : cappedTickValues;
   // When the user picks "All" (interval === 0), they want every label shown.
   // Disable hideOverlap so ECharts never drops a label, and pin customValues
   // to the full tick set so each label lands on a real gridline.
   const showAllLabels = xAxisLabelInterval === 0;
+  // On a zoomable axis the full set is already used; for "All" we also bypass
+  // the cap so every tick gets a label rather than the 60-mark subset.
+  const labelCustomValues = zoomable || showAllLabels
+    ? temporalTickValues
+    : cappedTickValues;
 
   return {
     axisLabel: {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1767,4 +1767,6 @@ test('hides the ticks on the x axis and both y axes', () => {
 test('converts xAxisLabelInterval string "0" to number 0', () => {
   const { xAxis } = transformWithChrome({ xAxisLabelInterval: '0' });
   expect(xAxis.axisLabel.interval).toBe(0);
+  // "All" must also disable hideOverlap so ECharts never drops a label.
+  expect(xAxis.axisLabel.hideOverlap).toBe(false);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/transformProps.test.ts
@@ -1763,3 +1763,8 @@ test('hides the ticks on the x axis and both y axes', () => {
   expect(yAxis[0].axisTick.show).toBe(false);
   expect(yAxis[1].axisTick.show).toBe(false);
 });
+
+test('converts xAxisLabelInterval string "0" to number 0', () => {
+  const { xAxis } = transformWithChrome({ xAxisLabelInterval: '0' });
+  expect(xAxis.axisLabel.interval).toBe(0);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -3288,4 +3288,3 @@ describe('xAxisLabelInterval string "0" is converted to number 0', () => {
     expect(xAxisRaw.interval).toBe(3);
   });
 });
-});

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -3207,8 +3207,18 @@ test('boundary label alignment is dropped when the orientation moves the time ax
   expect(horizontal.axisLabel.alignMaxLabel).toBeUndefined();
 
   // The boundary labels themselves stay forced in both orientations.
+  expect(vertical.axisLabel.showMinLabel).toBe(true);
+  expect(vertical.axisLabel.showMaxLabel).toBe(true);
+  expect(horizontal.axisLabel.showMinLabel).toBe(true);
+  expect(horizontal.axisLabel.showMaxLabel).toBe(true);
+});
 
 describe('xAxisLabelInterval string "0" is converted to number 0', () => {
+  const monthData = [
+    { __timestamp: Date.UTC(2003, 4, 1), sales: 100 },
+    { __timestamp: Date.UTC(2003, 5, 1), sales: 200 },
+  ];
+
   test('converts string "0" to number 0 so ECharts shows all labels', () => {
     const result = transformProps(
       createTestChartProps({
@@ -3278,8 +3288,4 @@ describe('xAxisLabelInterval string "0" is converted to number 0', () => {
     expect(xAxisRaw.interval).toBe(3);
   });
 });
-  expect(vertical.axisLabel.showMinLabel).toBe(true);
-  expect(vertical.axisLabel.showMaxLabel).toBe(true);
-  expect(horizontal.axisLabel.showMinLabel).toBe(true);
-  expect(horizontal.axisLabel.showMaxLabel).toBe(true);
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -3207,6 +3207,77 @@ test('boundary label alignment is dropped when the orientation moves the time ax
   expect(horizontal.axisLabel.alignMaxLabel).toBeUndefined();
 
   // The boundary labels themselves stay forced in both orientations.
+
+describe('xAxisLabelInterval string "0" is converted to number 0', () => {
+  test('converts string "0" to number 0 so ECharts shows all labels', () => {
+    const result = transformProps(
+      createTestChartProps({
+        formData: {
+          granularity_sqla: 'ds',
+          timeGrainSqla: TimeGranularity.MONTH,
+          xAxisTimeFormat: 'smart_date',
+          seriesType: EchartsTimeseriesSeriesType.Line,
+          xAxisLabelInterval: '0',
+        },
+        queriesData: [
+          createTestQueryData(monthData, {
+            colnames: ['__timestamp', 'sales'],
+            coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+          }),
+        ],
+      }),
+    ).echartOptions;
+
+    const xAxisRaw = (result.xAxis as any).axisLabel;
+    expect(xAxisRaw.interval).toBe(0);
+  });
+
+  test('passes "auto" through unchanged', () => {
+    const result = transformProps(
+      createTestChartProps({
+        formData: {
+          granularity_sqla: 'ds',
+          timeGrainSqla: TimeGranularity.MONTH,
+          xAxisTimeFormat: 'smart_date',
+          seriesType: EchartsTimeseriesSeriesType.Line,
+          xAxisLabelInterval: 'auto',
+        },
+        queriesData: [
+          createTestQueryData(monthData, {
+            colnames: ['__timestamp', 'sales'],
+            coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+          }),
+        ],
+      }),
+    ).echartOptions;
+
+    const xAxisRaw = (result.xAxis as any).axisLabel;
+    expect(xAxisRaw.interval).toBe('auto');
+  });
+
+  test('passes numeric interval unchanged', () => {
+    const result = transformProps(
+      createTestChartProps({
+        formData: {
+          granularity_sqla: 'ds',
+          timeGrainSqla: TimeGranularity.MONTH,
+          xAxisTimeFormat: 'smart_date',
+          seriesType: EchartsTimeseriesSeriesType.Line,
+          xAxisLabelInterval: 3,
+        },
+        queriesData: [
+          createTestQueryData(monthData, {
+            colnames: ['__timestamp', 'sales'],
+            coltypes: [GenericDataType.Temporal, GenericDataType.Numeric],
+          }),
+        ],
+      }),
+    ).echartOptions;
+
+    const xAxisRaw = (result.xAxis as any).axisLabel;
+    expect(xAxisRaw.interval).toBe(3);
+  });
+});
   expect(vertical.axisLabel.showMinLabel).toBe(true);
   expect(vertical.axisLabel.showMaxLabel).toBe(true);
   expect(horizontal.axisLabel.showMinLabel).toBe(true);

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -3240,6 +3240,9 @@ describe('xAxisLabelInterval string "0" is converted to number 0', () => {
 
     const xAxisRaw = (result.xAxis as any).axisLabel;
     expect(xAxisRaw.interval).toBe(0);
+    // "All" must also disable hideOverlap, otherwise ECharts still drops
+    // crowded labels even after interval is numeric 0.
+    expect(xAxisRaw.hideOverlap).toBe(false);
   });
 
   test('passes "auto" through unchanged', () => {


### PR DESCRIPTION
## What
When the X Axis Label Interval control is set to "All" in area/line/time-series charts, Superset stores the value as the string `'0'` (from `SelectControl` choices). ECharts interprets string `'0'` as a truthy value and skips every label, showing only n, n+4, n+8 instead of all labels.

This change converts `xAxisLabelInterval === '0'` to numeric `0` before passing to ECharts' `axisLabel.interval`, which correctly renders all labels.

## Test plan
Added tests in both `transformProps.test.ts` (Timeseries) and `transformProps.test.ts` (MixedTimeseries) covering:
- String `'0'` → numeric `0`
- `'auto'` passed through unchanged
- Numeric values passed through unchanged

Fixes #36325