### PR TITLE
fix(partition): normalize ancestor-path array names to leaf values

### DIFF
--- a/superset-frontend/plugins/plugin-chart-partition/src/Partition.ts
+++ b/superset-frontend/plugins/plugin-chart-partition/src/Partition.ts
@@ -31,7 +31,12 @@ import {
 } from '@superset-ui/core';
 
 interface PartitionDataNode {
-  name: string;
+  // A plain string for the metric row and the first grouping level;
+  // an array of the full ancestor path (e.g. ["a", "a.1", "a.1.1"])
+  // for any node below that, per PartitionViz.nest_values /
+  // transformData. Consumers should read PartitionNode.name instead,
+  // which is normalized to a plain leaf string in `init`.
+  name: string | string[];
   val: number;
   children?: PartitionDataNode[];
 }
@@ -99,11 +104,21 @@ const lazyFunction = (f: () => Record<string, unknown>) =>
     return f().apply(this, args);
   };
 const leafType = PropTypes.shape({
-  name: PropTypes.string,
+  // A plain string at the first grouping level, or an array of the
+  // full ancestor path at any level below that.
+  name: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   val: PropTypes.number.isRequired,
 });
 const parentShape = {
-  name: PropTypes.string,
+  // A plain string at the first grouping level, or an array of the
+  // full ancestor path at any level below that.
+  name: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   val: PropTypes.number.isRequired,
   children: PropTypes.arrayOf(
     PropTypes.oneOfType([
@@ -228,7 +243,13 @@ function Icicle(element: HTMLElement, props: IcicleProps): void {
       n.disp = n.data.val;
       n.value = n.disp < 0 ? -n.disp : n.disp;
       n.weight = n.value;
-      n.name = n.data.name;
+      // n.data.name is an array of the full ancestor path for any node
+      // below the first grouping level; normalize to this node's own
+      // leaf value so sorting, tooltips, on-chart labels, and the
+      // categorical color key all key off a plain string.
+      n.name = Array.isArray(n.data.name)
+        ? n.data.name[n.data.name.length - 1]
+        : n.data.name;
       // If the parent is a metric and we still have
       // the time column, perform a date-time format
       if (n.parent && hasDateNode(n.parent)) {


### PR DESCRIPTION
### SUMMARY

Fixes #43728.

`PartitionViz.nest_values` (and `transformData.ts`'s equivalent frontend re-implementation for the v1 chart data API) return `name` as an array of the full ancestor path (e.g. `["a", "a.1", "a.1.1"]`) for any node below the first grouping level, instead of a plain leaf string. `Partition.ts`'s renderer was never updated to expect this, so every consumer of `node.name` -- the sort comparator, tooltip cell, on-chart segment label, and categorical color key -- treated it as a plain string. JS silently stringifies an array via `Array.prototype.toString()` wherever it's interpolated into a template literal, so a 3rd-level segment rendered as e.g. `"a,a.1,a.1.1"` instead of just `"a.1.1"`.

This fix normalizes `name` to its own leaf value right where it's read from `data`, before any of those consumers run -- a single-point fix. It also widens the `PartitionDataNode` type and the `PropTypes` declarations to reflect the real `string | string[]` contract, instead of leaving them declared (and asserted) as `string` while actually receiving arrays.

Verified against a real 4-dimension Partition chart with 12,907 nodes: 0 arrays remained after the fix, and every node's displayed name matched the correct leaf value from the original payload. See #43728 for the full analysis, screenshots, and repro SQL.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

See #43728 for before/after screenshots from a real Superset instance using the exact repro SQL below.

### TESTING INSTRUCTIONS

Minimal repro (from #43728) -- register as a virtual dataset, build a Partition Chart with metric `SUM(val)` and Levels = `category`, `subcategory`, `sub_subcategory`:

```sql
SELECT 'B' AS category, 'B1' AS subcategory, NULL AS sub_subcategory, 2 AS val
UNION ALL
SELECT 'A' AS category, 'A1' AS subcategory, 'A1a' AS sub_subcategory, 1 AS val
UNION ALL
SELECT 'A' AS category, 'A1' AS subcategory, 'A1b' AS sub_subcategory, 1 AS val
```

Before this fix, the 3rd-level segments are labeled `A,A1,A1a` / `A,A1,A1b`. After, they read `A1a` / `A1b`.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43728
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
