### PR TITLE
fix(gtf): lifecycle hardening + forced-refresh idempotency for async chart-data

### DIFF
--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -446,10 +446,10 @@ Passing the `Task` object is the canonical pattern. For convenience, a prerequis
 
 **Semantics (`all_success`).** A task runs only once **every** direct prerequisite has reached a terminal `SUCCESS`. If **any** prerequisite ends in a non-`SUCCESS` terminal state (`FAILURE`, `ABORTED`, or `TIMED_OUT`), the dependent does **not** run and is transitioned to `FAILURE`. This propagates transitively: because a failed dependent is itself non-`SUCCESS`, its own dependents fail in turn, so a failure anywhere short-circuits everything downstream.
 
-**Scheduling model (block-and-wait).** All tasks in a DAG are enqueued immediately. Each dependent's worker blocks — holding its worker slot — until its prerequisites finish; while waiting, the task remains `PENDING` (shown as "waiting on N prerequisites" in the Task List). Tasks are enqueued in dependency order, so a dependent is rarely dequeued before its prerequisites.
+**Scheduling model (non-blocking defer).** All tasks in a DAG are enqueued immediately. When a dependent is dequeued before its prerequisites are terminal, it does **not** hold its worker slot: it is re-enqueued via a Celery retry with a short, growing backoff (roughly 1s, 3s, 5s… capped) and the worker moves on to other work. While waiting, the task remains `PENDING` (shown as "waiting on N prerequisites" in the Task List). Each defer emits the `gtf.task.dag_deferred` metric.
 
-:::warning Worker fleet sizing
-Because dependents hold a worker slot while awaiting their prerequisites, a deep or wide DAG can occupy many workers simultaneously. Deployments that use chained tasks heavily must size their Celery worker fleet large enough to absorb the idle waiting, or a large DAG can exhaust the pool and deadlock.
+:::note
+A deferred dependent carries no heartbeat and no Celery job id until it is actually claimed (its prerequisites met), so the orphan reaper never mistakes a waiting task for abandoned work.
 :::
 
 Cycles (including self-dependencies) are rejected at schedule time. Dependency edges are removed automatically when either endpoint task is pruned.

--- a/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/buildQueryContext.ts
@@ -63,6 +63,10 @@ export default function buildQueryContext(
   return {
     datasource: new DatasourceKey(formData.datasource).toObject(),
     force: formData.force || false,
+    // Idempotency token for a forced refresh; only present when the caller sets
+    // it (see requestChartDataResolved). Omitted otherwise so the payload is
+    // unchanged for non-forced requests.
+    ...(formData.force_nonce ? { force_nonce: formData.force_nonce } : {}),
     queries,
     form_data: formData,
     result_format: formData.result_format || 'json',

--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -164,6 +164,8 @@ export interface QueryContext {
   };
   /** Force refresh of all queries */
   force: boolean;
+  /** Idempotency token for a forced refresh (present only when forcing) */
+  force_nonce?: string;
   /** Type of result to return for queries */
   result_type: string;
   /** Response format */

--- a/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/QueryFormData.ts
@@ -181,6 +181,8 @@ export interface BaseFormData extends TimeRange, FormDataResidual {
   timeseries_limit_metric?: QueryFormMetric;
   /** Force refresh */
   force?: boolean;
+  /** Idempotency token for a forced refresh (see requestChartDataResolved) */
+  force_nonce?: string;
   result_format?: string;
   result_type?: string;
   annotation_layers?: AnnotationLayer[];

--- a/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/query/buildQueryContext.test.ts
@@ -29,8 +29,21 @@ describe('buildQueryContext', () => {
     expect(queryContext.datasource.id).toBe(5);
     expect(queryContext.datasource.type).toBe('table');
     expect(queryContext.force).toBe(false);
+    // A non-forced request carries no idempotency nonce.
+    expect(queryContext.force_nonce).toBeUndefined();
     expect(queryContext.result_format).toBe('json');
     expect(queryContext.result_type).toBe('full');
+  });
+  test('should carry force_nonce when set on the form data', () => {
+    const queryContext = buildQueryContext({
+      datasource: '5__table',
+      granularity_sqla: 'ds',
+      viz_type: VizType.Table,
+      force: true,
+      force_nonce: 'nonce-123',
+    });
+    expect(queryContext.force).toBe(true);
+    expect(queryContext.force_nonce).toBe('nonce-123');
   });
   test('should build datasource for table sources with columns', () => {
     const queryContext = buildQueryContext(

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -731,10 +731,15 @@ export function handleChartDataResponse(
  * re-issue recomputing the identical query) is prevented by a per-refresh
  * idempotency nonce: a nonce is minted once here when `force` is set and carried
  * on both the submit and the re-issue. The async task recomputes and records a
- * server-side marker keyed by (nonce, cache_key); the re-issue — and any retry,
- * double-click, or second tab reusing this nonce — reads the freshly-warmed
- * cache instead. A new force refresh mints a new nonce, so it genuinely
- * recomputes. Non-forced requests carry no nonce and keep the plain flow.
+ * server-side marker keyed by (nonce, cache_key); the re-issue reuses the same
+ * nonce, sees the marker, and reads the freshly-warmed cache instead of
+ * recomputing. A new force refresh mints a new nonce, so it genuinely recomputes.
+ * Non-forced requests carry no nonce and keep the plain flow.
+ *
+ * Scope: this dedups one refresh's own submit/read-back pair. It does NOT make
+ * concurrent force refreshes idempotent — a second refresh (new nonce) that
+ * joins the first's shared task (deduped by query cache key) will still force its
+ * own read-back, since the first task only recorded its own nonce.
  *
  * `signal` aborts the wait (Stop pressed, chart superseded or unmounted) and
  * cancels the outstanding tasks.

--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -32,6 +32,7 @@ import {
   LatestQueryFormData,
 } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
+import { nanoid } from 'nanoid';
 import type { ControlStateMapping } from '@superset-ui/chart-controls';
 import { getControlsState } from 'src/explore/store';
 import {
@@ -288,6 +289,10 @@ export interface GetChartDataRequestParams {
   resultFormat?: string;
   resultType?: string;
   force?: boolean;
+  // Idempotency token for a forced refresh, minted once per refresh and sent on
+  // both the async submit and the follow-up read-back so the server recomputes
+  // exactly once (see requestChartDataResolved). Only meaningful with `force`.
+  forceNonce?: string;
   requestParams?: RequestParams;
   ownState?: JsonObject;
   // Opt into asynchronous execution. Only set by callers that handle an HTTP 202
@@ -432,12 +437,14 @@ const v1ChartDataRequest = async (
   ownState: JsonObject,
   parseMethod: string | undefined,
   asyncMode: boolean,
+  forceNonce?: string,
 ): Promise<ChartDataRequestResponse> => {
   const payload = await buildV1ChartDataPayload({
     formData: formData as QueryFormData,
     resultType,
     resultFormat,
     force,
+    forceNonce,
     setDataMask,
     ownState,
   });
@@ -488,6 +495,7 @@ export async function getChartDataRequest({
   resultFormat = 'json',
   resultType = 'full',
   force = false,
+  forceNonce,
   requestParams = {},
   ownState = {},
   enableAsyncMode = false,
@@ -527,6 +535,7 @@ export async function getChartDataRequest({
     ownState,
     parseMethod,
     asyncMode,
+    forceNonce,
   );
 }
 
@@ -718,11 +727,14 @@ export function handleChartDataResponse(
  *
  * On a 202 the body is the async job rather than data: every query task is
  * awaited, then the same request is re-issued *synchronously* so the server
- * serves it inline — from the warm per-query DATA cache, or by computing it once
- * if the result wasn't cached (oversized value / per-query disabled timeout;
- * NullCache is refused server-side). The re-issue therefore never schedules a
- * second background task and never returns another 202. `force` stays the
- * caller's own on both attempts, so a forced refresh can't read a stale entry.
+ * serves it inline. Double execution (the async task computing, then the
+ * re-issue recomputing the identical query) is prevented by a per-refresh
+ * idempotency nonce: a nonce is minted once here when `force` is set and carried
+ * on both the submit and the re-issue. The async task recomputes and records a
+ * server-side marker keyed by (nonce, cache_key); the re-issue — and any retry,
+ * double-click, or second tab reusing this nonce — reads the freshly-warmed
+ * cache instead. A new force refresh mints a new nonce, so it genuinely
+ * recomputes. Non-forced requests carry no nonce and keep the plain flow.
  *
  * `signal` aborts the wait (Stop pressed, chart superseded or unmounted) and
  * cancels the outstanding tasks.
@@ -731,9 +743,13 @@ export async function requestChartDataResolved(
   params: Omit<GetChartDataRequestParams, 'enableAsyncMode'>,
   signal?: AbortSignal,
 ): Promise<QueryData[]> {
+  const paramsWithNonce = params.force
+    ? { ...params, forceNonce: nanoid() }
+    : params;
+
   const reissueSynchronously = async (): Promise<QueryData[]> => {
     const { response, json } = await getChartDataRequest({
-      ...params,
+      ...paramsWithNonce,
       enableAsyncMode: false,
     });
     if (response.status !== 200) {
@@ -745,7 +761,7 @@ export async function requestChartDataResolved(
   };
 
   const { response, json } = await getChartDataRequest({
-    ...params,
+    ...paramsWithNonce,
     enableAsyncMode: true,
   });
   return handleChartDataResponse(response, json, reissueSynchronously, signal);

--- a/superset-frontend/src/components/Chart/chartActions.test.ts
+++ b/superset-frontend/src/components/Chart/chartActions.test.ts
@@ -608,7 +608,7 @@ describe('chart actions', () => {
         expect(initialBody.tab_id.length).toBeGreaterThan(0);
       });
 
-      test('re-issues synchronously after async completion, preserving force', async () => {
+      test('re-issues synchronously after async completion, reading the warm cache', async () => {
         // 1: initial async request → 202; 2: the post-completion re-issue is
         // synchronous and returns the payload inline (200). No third call and no
         // second background task.
@@ -627,7 +627,7 @@ describe('chart actions', () => {
 
         const actionThunk = actions.postChartFormData(
           { viz_type: 'my_viz' } as QueryFormData,
-          true, // force: the re-issue must preserve it
+          true, // force: the async task computes fresh, the re-issue reads its result
           undefined,
           undefined,
         );
@@ -642,11 +642,26 @@ describe('chart actions', () => {
         expect(calls).toBe(2);
         const history = fetchMock.callHistory.calls(`glob:*${MOCK_URL}*`);
         expect(history).toHaveLength(2);
-        // The re-issue carries no async_mode (synchronous → no new GTF task)...
-        expect(String(history[1].options.body)).not.toContain('async_mode');
-        // ...and preserves the caller's force (carried in the query string), so a
-        // forced refresh can't return a stale cached result.
+        // Both requests keep force=true — server-side dedup (the force nonce), not
+        // a client-flipped force, is what prevents the re-issue from recomputing.
+        expect(history[0].url).toContain('force=true');
         expect(history[1].url).toContain('force=true');
+        // The submit opts into async; the re-issue is synchronous (no new GTF task).
+        expect(String(history[0].options.body)).toContain('async_mode');
+        expect(String(history[1].options.body)).not.toContain('async_mode');
+        // One idempotency nonce is minted for the refresh and carried on BOTH the
+        // submit and the re-issue, so the server recomputes exactly once and the
+        // re-issue reads the freshly-warmed cache.
+        const forceCalls = buildV1ChartDataPayloadStub.mock.calls.filter(
+          ([arg]) => (arg as { force?: boolean }).force === true,
+        );
+        expect(forceCalls).toHaveLength(2);
+        const submitNonce = (forceCalls[0][0] as { forceNonce?: string })
+          .forceNonce;
+        const reissueNonce = (forceCalls[1][0] as { forceNonce?: string })
+          .forceNonce;
+        expect(submitNonce).toBeDefined();
+        expect(reissueNonce).toBe(submitNonce);
 
         const succeeded = dispatch.mock.calls.find(
           ([action]) => action?.type === actions.CHART_UPDATE_SUCCEEDED,

--- a/superset-frontend/src/explore/exploreUtils/index.ts
+++ b/superset-frontend/src/explore/exploreUtils/index.ts
@@ -83,6 +83,7 @@ interface GetExploreUrlParams {
 interface BuildV1ChartDataPayloadParams {
   formData: QueryFormData;
   force?: boolean;
+  forceNonce?: string;
   resultFormat?: string;
   resultType?: string;
   setDataMask?: SetDataMaskHook;
@@ -281,6 +282,7 @@ export const getQuerySettings = (
 export const buildV1ChartDataPayload = async ({
   formData,
   force,
+  forceNonce,
   resultFormat,
   resultType,
   setDataMask,
@@ -303,6 +305,7 @@ export const buildV1ChartDataPayload = async ({
     {
       ...formData,
       force,
+      force_nonce: forceNonce,
       result_format: resultFormat,
       result_type: resultType,
     } as QueryFormData,

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1587,6 +1587,19 @@ class ChartDataQueryContextSchema(Schema):
         allow_none=True,
     )
 
+    force_nonce = fields.String(
+        metadata={
+            "description": "Idempotency token for a forced refresh. Set once per "
+            "user-initiated force refresh and sent on every request of that "
+            "refresh (the async submit and the follow-up read-back). The first "
+            "execution recomputes and records a marker; later requests carrying "
+            "the same nonce read the freshly-cached result instead of recomputing "
+            "it. Ignored when `force` is false."
+        },
+        required=False,
+        allow_none=True,
+    )
+
     result_type = fields.Enum(ChartDataResultType, by_value=True)
     result_format = fields.Enum(ChartDataResultFormat, by_value=True)
 

--- a/superset/commands/tasks/internal_update.py
+++ b/superset/commands/tasks/internal_update.py
@@ -33,6 +33,7 @@ from functools import partial
 from typing import Any
 from uuid import UUID
 
+from flask import current_app
 from superset_core.tasks.types import TaskProperties, TaskStatus
 
 from superset.commands.base import BaseCommand
@@ -189,6 +190,16 @@ class InternalStatusTransitionCommand(BaseCommand):
         """
         updated = self._run_in_transaction()
         if updated:
+            # Track every lifecycle transition (gtf.task.transition.<status>) so
+            # completion/abort/timeout/failure rates are observable.
+            status_value = (
+                self._new_status.value
+                if isinstance(self._new_status, TaskStatus)
+                else self._new_status
+            )
+            current_app.config["STATS_LOGGER"].incr(
+                f"gtf.task.transition.{status_value}"
+            )
             TaskManager.publish_entity_change(self._task_uuid)
             # A prerequisite's status is shown on its dependents' rows, so refresh
             # them too (no-op when this task has no dependents).

--- a/superset/common/query_context.py
+++ b/superset/common/query_context.py
@@ -58,6 +58,14 @@ class QueryContext:
     result_type: ChartDataResultType
     result_format: ChartDataResultFormat
     force: bool
+    # Optional idempotency token for a forced refresh. Set once per user-initiated
+    # force refresh (Explore/Dashboard) and carried on every request of that
+    # refresh — the async submit and the follow-up read-back. The first execution
+    # to see it recomputes and records a per-(nonce, cache_key) marker; later
+    # requests carrying the same nonce read the freshly-cached result instead of
+    # recomputing it (see QueryContextProcessor.get_df_payload_result). Kept
+    # separate from the result cache key, so non-forced loads stay warm.
+    force_nonce: str | None
     custom_cache_timeout: int | None
 
     # Set by the async chart-data execution path (see
@@ -83,6 +91,7 @@ class QueryContext:
         result_type: ChartDataResultType,
         result_format: ChartDataResultFormat,
         force: bool = False,
+        force_nonce: str | None = None,
         custom_cache_timeout: int | None = None,
         cache_values: dict[str, Any],
     ) -> None:
@@ -93,6 +102,7 @@ class QueryContext:
         self.queries = queries
         self.form_data = form_data
         self.force = force
+        self.force_nonce = force_nonce
         self.custom_cache_timeout = custom_cache_timeout
         self.cache_values = cache_values
         # Normalize the contribution totals query before any cache key is

--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -55,6 +55,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
         result_type: ChartDataResultType | None = None,
         result_format: ChartDataResultFormat | None = None,
         force: bool = False,
+        force_nonce: str | None = None,
         custom_cache_timeout: int | None = None,
         preserve_null_row_limit: bool = False,
     ) -> QueryContext:
@@ -109,6 +110,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
             result_type=result_type,
             result_format=result_format,
             force=force,
+            force_nonce=force_nonce,
             custom_cache_timeout=custom_cache_timeout,
             cache_values=cache_values,
         )

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -134,6 +134,59 @@ class QueryContextProcessor:
         """Return the historical dataframe payload without timing metadata."""
         return self.get_df_payload_result(query_obj, force_cached).payload
 
+    @staticmethod
+    def _force_marker_key(nonce: str, cache_key: str) -> str:
+        """Cache key for the per-(nonce, cache_key) forced-refresh marker.
+
+        Deliberately distinct from the result cache key so the fresh result still
+        lands under the normal ``cache_key`` and non-forced loads stay warm.
+        """
+        return f"gtf-force-nonce:{nonce}:{cache_key}"
+
+    def _resolve_forced_query(self, cache_key: str | None) -> bool:
+        """Resolve ``QueryContext.force`` through an optional idempotency nonce.
+
+        A forced chart-data request in the async (GTF) flow is issued twice: the
+        async submit schedules the recompute, then a follow-up request reads the
+        warmed result. Re-running the force on that second request would recompute
+        the identical query (double execution). When the client supplies
+        ``force_nonce``, the first execution records a marker (keyed by nonce +
+        cache_key) once its result is cached; any later request carrying the same
+        nonce sees the marker and reads the cache instead of recomputing. A brand
+        new force refresh mints a new nonce, so it genuinely recomputes.
+
+        Without a nonce (synchronous forced refresh, legacy callers) force is
+        honored verbatim.
+
+        :returns: whether the source query should be forced (cache bypassed)
+        """
+        if not self._query_context.force:
+            return False
+        nonce = self._query_context.force_nonce
+        if not nonce or not cache_key:
+            return True
+        # Marker present => this forced refresh already computed and cached its
+        # result; read it rather than recomputing.
+        marker = cache_manager.data_cache.get(self._force_marker_key(nonce, cache_key))
+        return marker is None
+
+    def _mark_force_executed(self, cache_key: str | None) -> None:
+        """Record that this ``force_nonce``'s recompute has been cached.
+
+        No-op unless this is a nonce-bearing forced refresh. Called only after the
+        result is written, so the marker's presence guarantees the fresh result is
+        available to a follow-up read. The marker shares the result's TTL, so the
+        two expire together.
+        """
+        nonce = self._query_context.force_nonce
+        if not (self._query_context.force and nonce and cache_key):
+            return
+        cache_manager.data_cache.set(
+            self._force_marker_key(nonce, cache_key),
+            1,
+            timeout=self.get_cache_timeout(),
+        )
+
     def get_df_payload_result(
         self, query_obj: QueryObject, force_cached: bool | None = False
     ) -> QueryAcquisitionResult:
@@ -146,7 +199,9 @@ class QueryContextProcessor:
 
         cache_key = self.query_cache_key(query_obj)
         timeout = self.get_cache_timeout()
-        force_query = self._query_context.force or timeout == CACHE_DISABLED_TIMEOUT
+        force_query = (
+            self._resolve_forced_query(cache_key) or timeout == CACHE_DISABLED_TIMEOUT
+        )
         query_planning_ns = max(0, time.perf_counter_ns() - query_planning_start_ns)
 
         cache_resolution_start_ns = time.perf_counter_ns()
@@ -211,6 +266,10 @@ class QueryContextProcessor:
                     datasource_uid=self._qc_datasource.uid,
                     region=CacheRegion.DATA,
                 )
+                # Record — after the result is cached — that this forced refresh
+                # ran, so a follow-up request carrying the same nonce reads the
+                # freshly-cached result instead of recomputing it.
+                self._mark_force_executed(cache_key)
 
         payload_assembly_start_ns = time.perf_counter_ns()
         # the N-dimensional DataFrame has converted into flat DataFrame

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -166,26 +166,41 @@ class QueryContextProcessor:
         if not nonce or not cache_key:
             return True
         # Marker present => this forced refresh already computed and cached its
-        # result; read it rather than recomputing.
-        marker = cache_manager.data_cache.get(self._force_marker_key(nonce, cache_key))
+        # result; read it rather than recomputing. Best-effort like the query
+        # cache itself: a marker read failure degrades to "absent" (force), never
+        # an error.
+        try:
+            marker = cache_manager.data_cache.get(
+                self._force_marker_key(nonce, cache_key)
+            )
+        except Exception:  # noqa: BLE001  pylint: disable=broad-except
+            logger.warning("Force-nonce marker read failed; forcing recompute")
+            return True
         return marker is None
 
-    def _mark_force_executed(self, cache_key: str | None) -> None:
+    def _mark_force_executed(self, cache_key: str | None, persisted: bool) -> None:
         """Record that this ``force_nonce``'s recompute has been cached.
 
-        No-op unless this is a nonce-bearing forced refresh. Called only after the
-        result is written, so the marker's presence guarantees the fresh result is
-        available to a follow-up read. The marker shares the result's TTL, so the
+        No-op unless this is a nonce-bearing forced refresh whose fresh result was
+        actually persisted (``persisted``). Gating on persistence is essential: if
+        the result was silently skipped (oversized value) or the backend write
+        failed, an old value may still sit under the normal cache key — writing the
+        marker anyway would let a follow-up read stop forcing and serve that stale
+        value. Best-effort: a marker write failure is logged and swallowed, costing
+        at worst one extra recompute. The marker shares the result's TTL, so the
         two expire together.
         """
         nonce = self._query_context.force_nonce
-        if not (self._query_context.force and nonce and cache_key):
+        if not (persisted and self._query_context.force and nonce and cache_key):
             return
-        cache_manager.data_cache.set(
-            self._force_marker_key(nonce, cache_key),
-            1,
-            timeout=self.get_cache_timeout(),
-        )
+        try:
+            cache_manager.data_cache.set(
+                self._force_marker_key(nonce, cache_key),
+                1,
+                timeout=self.get_cache_timeout(),
+            )
+        except Exception:  # noqa: BLE001  pylint: disable=broad-except
+            logger.warning("Force-nonce marker write failed; may recompute once more")
 
     def get_df_payload_result(
         self, query_obj: QueryObject, force_cached: bool | None = False
@@ -266,10 +281,10 @@ class QueryContextProcessor:
                     datasource_uid=self._qc_datasource.uid,
                     region=CacheRegion.DATA,
                 )
-                # Record — after the result is cached — that this forced refresh
-                # ran, so a follow-up request carrying the same nonce reads the
-                # freshly-cached result instead of recomputing it.
-                self._mark_force_executed(cache_key)
+                # Record — only if the fresh result was actually persisted — that
+                # this forced refresh ran, so a follow-up request carrying the same
+                # nonce reads the freshly-cached result instead of recomputing it.
+                self._mark_force_executed(cache_key, cache.result_persisted)
 
         payload_assembly_start_ns = time.perf_counter_ns()
         # the N-dimensional DataFrame has converted into flat DataFrame

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -194,11 +194,20 @@ class QueryContextProcessor:
         if not (persisted and self._query_context.force and nonce and cache_key):
             return
         try:
-            cache_manager.data_cache.set(
-                self._force_marker_key(nonce, cache_key),
-                1,
-                timeout=self.get_cache_timeout(),
-            )
+            # A False return (backend reported a failed write) or an exception are
+            # both benign here — the result is cached, so a missing marker only
+            # costs one extra recompute on the follow-up read, never stale data.
+            if (
+                cache_manager.data_cache.set(
+                    self._force_marker_key(nonce, cache_key),
+                    1,
+                    timeout=self.get_cache_timeout(),
+                )
+                is False
+            ):
+                logger.warning(
+                    "Force-nonce marker write reported failure; may recompute once more"
+                )
         except Exception:  # noqa: BLE001  pylint: disable=broad-except
             logger.warning("Force-nonce marker write failed; may recompute once more")
 

--- a/superset/common/query_serialization.py
+++ b/superset/common/query_serialization.py
@@ -57,6 +57,7 @@ class SerializedQuery(TypedDict):
     result_type: str
     result_format: str
     force: bool
+    force_nonce: NotRequired[str | None]
     custom_cache_timeout: int | None
     preserve_null_row_limit: NotRequired[bool]
 
@@ -79,7 +80,9 @@ def serialize_query(query_context: "QueryContext", query_index: int) -> Serializ
     Reads the *raw* query dict from ``cache_values`` (not the processed
     ``QueryObject``) so the payload rebuilds to an identical ``query_cache_key``.
     ``force`` and ``custom_cache_timeout`` are carried explicitly — they live on
-    the context, not the query, and would otherwise be lost per query.
+    the context, not the query, and would otherwise be lost per query. So is
+    ``force_nonce``, so the async task and the follow-up read-back share one
+    forced-refresh idempotency token.
 
     :param query_context: the source query context
     :param query_index: index of the query within ``query_context.queries``
@@ -93,6 +96,7 @@ def serialize_query(query_context: "QueryContext", query_index: int) -> Serializ
         result_type=ChartDataResultType(query_context.result_type).value,
         result_format=ChartDataResultFormat(query_context.result_format).value,
         force=query_context.force,
+        force_nonce=query_context.force_nonce,
         custom_cache_timeout=query_context.custom_cache_timeout,
     )
     if _preserve_null_row_limit(query_context, query_index):
@@ -121,6 +125,7 @@ def load_serialized_query(payload: SerializedQuery) -> "QueryContext":
         result_type=ChartDataResultType(payload["result_type"]),
         result_format=ChartDataResultFormat(payload["result_format"]),
         force=payload["force"],
+        force_nonce=payload.get("force_nonce"),
         custom_cache_timeout=payload["custom_cache_timeout"],
         preserve_null_row_limit=bool(payload.get("preserve_null_row_limit")),
     )

--- a/superset/common/utils/query_cache_manager.py
+++ b/superset/common/utils/query_cache_manager.py
@@ -88,6 +88,11 @@ class QueryCacheManager:
         self.queried_dttm = queried_dttm
         self.bq_memory_limited: bool = False
         self.bq_memory_limited_row_count: int = 0
+        # Whether set_query_result actually persisted the value to the backend
+        # (False when caching was skipped/failed — e.g. oversized value). Used to
+        # gate the forced-refresh idempotency marker so a follow-up read never
+        # serves a stale value under the belief the fresh one was cached.
+        self.result_persisted: bool = False
 
     # pylint: disable=too-many-arguments
     def set_query_result(
@@ -148,7 +153,7 @@ class QueryCacheManager:
                 "bq_memory_limited_row_count": self.bq_memory_limited_row_count,
             }
             if self.is_loaded and key and self.status != QueryStatus.FAILED:
-                self.set(
+                self.result_persisted = self.set(
                     key=key,
                     value=value,
                     timeout=timeout,
@@ -243,12 +248,17 @@ class QueryCacheManager:
         timeout: int | None = None,
         datasource_uid: str | None = None,
         region: CacheRegion = CacheRegion.DEFAULT,
-    ) -> None:
+    ) -> bool:
         """
         set value to specify cache region, proxy for `set_and_log_cache`
+
+        :returns: whether the value was actually persisted to the backend
         """
         if key:
-            set_and_log_cache(_cache[region], key, value, timeout, datasource_uid)
+            return set_and_log_cache(
+                _cache[region], key, value, timeout, datasource_uid
+            )
+        return False
 
     @staticmethod
     def delete(

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -628,6 +628,22 @@ class TaskContext(CoreTaskContext):
             with self._abort_lock:
                 if self._execution_completed or self._abort_detected:
                     return
+                # A non-abortable task (no cancel handler registered — e.g. an
+                # engine that can't expose a cancel id) can't be stopped, so the
+                # timeout is a no-op: setting _timeout_triggered here would block
+                # the executor's SUCCESS transition (aborting_in_flight) while the
+                # finalize only transitions TIMED_OUT from ABORTING — which never
+                # happens — stranding the task IN_PROGRESS. Let it run to natural
+                # completion instead.
+                if not self._abort_handlers:
+                    logger.warning(
+                        "Timeout reached for non-abortable task %s after %d "
+                        "seconds; it cannot be cancelled and will run to "
+                        "completion",
+                        self._task_uuid,
+                        timeout_seconds,
+                    )
+                    return
                 self._timeout_triggered = True
             logger.info(
                 "Timeout reached for task %s after %d seconds",

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -24,7 +24,7 @@ from uuid import UUID
 
 import redis
 from flask import has_app_context
-from superset_core.tasks.types import TaskProperties, TaskScope
+from superset_core.tasks.types import TaskProperties, TaskScope, TaskStatus
 
 from superset.tasks.constants import ABORT_STATES, TERMINAL_STATES
 from superset.tasks.utils import generate_random_task_key
@@ -527,9 +527,9 @@ class TaskManager:
         :param args: Positional arguments for the task function
         :param kwargs: Keyword arguments for the task function
         :param depends_on: Optional prerequisite tasks (as Task entities, UUIDs,
-            or UUID strings). The task is still enqueued immediately
-            (block-and-wait model); ordering is enforced in the scheduler, which
-            waits for prerequisites before running the body.
+            or UUID strings). The task is still enqueued immediately; ordering is
+            enforced in the scheduler, which defers execution (via Celery retry,
+            without holding a worker) until prerequisites are terminal.
         :returns: Task model representing the scheduled task
         """
         from superset.commands.tasks.submit import SubmitTaskCommand
@@ -560,12 +560,22 @@ class TaskManager:
             # Import here to avoid circular dependency
             from superset.tasks.scheduler import execute_task
 
-            execute_task.delay(
-                task_uuid=str(task.uuid),
-                task_type=task_type,
-                args=args,
-                kwargs=kwargs,
-            )
+            try:
+                execute_task.delay(
+                    task_uuid=str(task.uuid),
+                    task_type=task_type,
+                    args=args,
+                    kwargs=kwargs,
+                )
+            except Exception:
+                # The task row is committed but the broker rejected the enqueue
+                # (e.g. broker down). Leaving it PENDING would poison the dedup
+                # key — future identical submits would join a task that never
+                # runs. Fail it so the key frees up and any waiter/client sees a
+                # terminal state, then re-raise so the caller learns the submit
+                # failed.
+                TaskManager._fail_unenqueued_task(task.uuid, task_type)
+                raise
 
             logger.debug(
                 "Scheduled task %s (uuid=%s) for async execution",
@@ -580,3 +590,38 @@ class TaskManager:
             )
 
         return task
+
+    @classmethod
+    def _fail_unenqueued_task(cls, task_uuid: UUID, task_type: str) -> None:
+        """Mark a just-created task FAILURE after its Celery enqueue failed.
+
+        Best-effort: any exception here is swallowed and logged so it never masks
+        the original enqueue error the caller is about to re-raise.
+        """
+        from superset.commands.tasks.internal_update import (
+            InternalStatusTransitionCommand,
+        )
+
+        logger.exception(
+            "Failed to enqueue task %s (uuid=%s); marking it FAILURE to free the "
+            "dedup key",
+            task_type,
+            task_uuid,
+        )
+        try:
+            transitioned = InternalStatusTransitionCommand(
+                task_uuid=task_uuid,
+                new_status=TaskStatus.FAILURE,
+                expected_status=TaskStatus.PENDING,
+                set_ended_at=True,
+                properties={"error_message": "Failed to enqueue task for execution"},
+            ).run()
+            if transitioned:
+                cls.publish_completion(task_uuid, TaskStatus.FAILURE.value)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Cleanup after failed enqueue of task %s (uuid=%s) also failed; the "
+                "orphan reaper will eventually reclaim it",
+                task_type,
+                task_uuid,
+            )

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -620,8 +620,10 @@ class TaskManager:
                 cls.publish_completion(task_uuid, TaskStatus.FAILURE.value)
         except Exception:  # noqa: BLE001
             logger.exception(
-                "Cleanup after failed enqueue of task %s (uuid=%s) also failed; the "
-                "orphan reaper will eventually reclaim it",
+                "Cleanup after failed enqueue of task %s (uuid=%s) also failed; it "
+                "is left PENDING with no heartbeat and will NOT be auto-reaped "
+                "(the reaper only reclaims tasks that have started). Its dedup key "
+                "stays occupied until it is manually cleared or its row is pruned",
                 task_type,
                 task_uuid,
             )

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -17,8 +17,9 @@
 from __future__ import annotations
 
 import logging
+import random
 from datetime import datetime, timezone
-from typing import Any, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 from uuid import UUID
 
 from celery import Task
@@ -303,46 +304,71 @@ def prune_key_value(
         logger.exception("An error occurred while pruning the key-value store: %s", ex)
 
 
-def _resolve_failed_prerequisite(task: "TaskModel") -> "TaskModel | None":
+# Non-blocking DAG dependency gate: a dependent picked up before its
+# prerequisites are terminal is deferred (Celery retry) rather than parking the
+# worker slot. Growing backoff (1s, 3s, 5s… capped) keyed off Celery's per-message
+# retry count, with jitter to avoid a thundering herd. The cap stays below
+# GTF_ORPHAN_TASK_TIMEOUT so a deferred task never looks abandoned.
+_DAG_DEFER_BASE_SECONDS = 1.0
+_DAG_DEFER_STEP_SECONDS = 2.0
+_DAG_DEFER_MAX_SECONDS = 30.0
+
+# Sentinel: at least one prerequisite is not yet terminal (defer and re-check).
+_DAG_WAITING = object()
+
+
+def _dag_defer_countdown(retries: int) -> float:
+    """Growing, jittered backoff (seconds) for a DAG-deferred task.
+
+    ``retries`` is Celery's per-message retry count (preserved across
+    ``self.retry()`` on the same task id), so the backoff needs no persisted
+    state. 1s, 3s, 5s, … capped at ``_DAG_DEFER_MAX_SECONDS``, plus up to ~1s of
+    jitter so many dependents of the same prerequisite don't wake in lockstep.
     """
-    Return the first direct prerequisite of ``task`` that did not end in ``SUCCESS``,
-    blocking until every prerequisite has reached a terminal state.
+    base = min(
+        _DAG_DEFER_BASE_SECONDS + retries * _DAG_DEFER_STEP_SECONDS,
+        _DAG_DEFER_MAX_SECONDS,
+    )
+    # Jitter only spreads wake-ups; it is not security-sensitive.
+    return base + random.uniform(0, min(base, 1.0))  # noqa: S311
 
-    Implements the ``all_success`` trigger rule for the task DAG: the task may
-    run only if *all* of its direct prerequisites ended in ``SUCCESS``, so a
-    non-``None`` return means the dependent must fail.
 
-    ``task.depends_on`` is already ``selectin``-loaded (in one query) with the
-    task, so a prerequisite that is *already* terminal in that snapshot is
-    evaluated with **no extra database reads** — a terminal status never changes,
-    so the snapshot is authoritative for it (the common case under Model A, where
-    FIFO enqueue order means parents usually finish before the dependent runs).
-    Only prerequisites that are not yet terminal fall through to
-    ``TaskManager.wait_for_completion`` (wake-on-completion else poll), and they
-    are awaited one at a time (≈1 read/poll-interval total, not per-prerequisite).
-    Transitive failure propagation is emergent — a dependent that fails here is
-    itself non-SUCCESS, so its own dependents fail in turn.
+def _unmet_prerequisite(task: "TaskModel") -> "TaskModel | object | None":
+    """Non-blocking ``all_success`` DAG gate for ``task``.
 
-    :param task: The dependent task about to run (with ``depends_on`` loaded)
-    :returns: The first prerequisite that did not end in ``SUCCESS``, or ``None``
-        if the task has no prerequisites or all of them succeeded
+    Returns ``None`` when the task has no prerequisites or all ended in
+    ``SUCCESS`` (ready to run); ``_DAG_WAITING`` when at least one prerequisite is
+    not yet terminal (the caller defers and re-checks); or the first prerequisite
+    that reached a terminal non-``SUCCESS`` state (the caller fails the dependent,
+    which cascades to its own dependents).
+
+    ``task.depends_on`` is ``selectin``-loaded with the task, so a prerequisite
+    already terminal in that snapshot is trusted with no extra read (a terminal
+    status never changes). A prerequisite that is *not* terminal in the snapshot
+    is re-read fresh, since the snapshot may lag its completion. Unlike the old
+    block-and-wait resolver, this never parks the worker: waiting is expressed by
+    deferring the Celery message.
+
+    :param task: the dependent task about to run (with ``depends_on`` loaded)
+    :returns: ``None`` (ready), ``_DAG_WAITING`` (defer), or a failed prerequisite
     """
     prerequisites = list(task.depends_on)
     if not prerequisites:
         return None
 
     for prerequisite in prerequisites:
-        # Trust an already-terminal status from the loaded snapshot (no extra
-        # read); otherwise block on a fresh wait until it becomes terminal.
-        if prerequisite.status not in TERMINAL_STATES:
-            try:
-                prerequisite = TaskManager.wait_for_completion(prerequisite.uuid)
-            except ValueError:
-                # Prerequisite no longer exists (e.g. pruned mid-wait) — treat as
-                # a failed prerequisite rather than blocking or crashing.
+        current = prerequisite
+        if current.status not in TERMINAL_STATES:
+            current = TaskDAO.find_one_or_none(
+                uuid=prerequisite.uuid, skip_base_filter=True
+            )
+            if current is None:
+                # Prerequisite no longer exists (e.g. pruned) — treat as failed.
                 return prerequisite
-        if prerequisite.status != TaskStatus.SUCCESS.value:
-            return prerequisite
+        if current.status not in TERMINAL_STATES:
+            return _DAG_WAITING
+        if current.status != TaskStatus.SUCCESS.value:
+            return current
 
     return None
 
@@ -375,10 +401,11 @@ def execute_task(
     """
     Generic task executor for GTF tasks.
 
-    Loads the task, records the Celery job id, and runs the lifecycle body under
-    a liveness heartbeat that spans the whole time this worker holds the task
-    (DAG wait, IN_PROGRESS, ABORTING) so the prune cron can revoke and reap it if
-    this worker dies. See ``_execute_task_body`` for the lifecycle itself.
+    Loads the task, resolves the DAG gate (deferring via Celery retry while
+    prerequisites are pending, rather than blocking a worker slot), records the
+    Celery job id, and runs the lifecycle body under a liveness heartbeat that
+    spans IN_PROGRESS/ABORTING so the prune cron can revoke and reap it if this
+    worker dies. See ``_execute_task_body`` for the lifecycle itself.
 
     :param task_uuid: UUID of the task to execute
     :param task_type: Type of the task (for registry lookup)
@@ -386,6 +413,8 @@ def execute_task(
     :param kwargs: Keyword arguments for the task function
     :returns: Dict with status and task_uuid
     """
+    from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
+
     # Convert string UUID to native UUID (Celery deserializes as string)
     native_uuid = UUID(task_uuid)
 
@@ -398,6 +427,81 @@ def execute_task(
         logger.error("Task %s not found in metastore", task_uuid)
         return {"status": "error", "message": "Task not found"}
 
+    # Abort-before-claim: a task aborted while queued or DAG-deferred finalizes
+    # here (this also stops the defer loop below from retrying an aborted task).
+    if task.status in ABORT_STATES:
+        logger.info(
+            "Task %s (uuid=%s) was aborted before execution started",
+            task_type,
+            task_uuid,
+        )
+        InternalStatusTransitionCommand(
+            task_uuid=native_uuid,
+            new_status=TaskStatus.ABORTED,
+            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
+            set_ended_at=True,
+        ).run()
+        return {"status": TaskStatus.ABORTED.value, "task_uuid": task_uuid}
+
+    # DAG gate (non-blocking): defer via Celery retry until every prerequisite is
+    # terminal, instead of parking this worker slot. Crucially this runs BEFORE
+    # _persist_celery_task_id and the heartbeat, so a merely-deferred PENDING task
+    # carries no heartbeat and can't be mistaken for abandoned active work by the
+    # reaper (which ignores null-heartbeat tasks). all_success semantics: if any
+    # prerequisite ended non-success, fail without running (cascades to dependents).
+    unmet = _unmet_prerequisite(task)
+    if unmet is _DAG_WAITING:
+        countdown = _dag_defer_countdown(self.request.retries)
+        current_app.config["STATS_LOGGER"].incr("gtf.task.dag_deferred")
+        logger.info(
+            "Task %s (uuid=%s) waiting on prerequisites; deferring ~%.0fs "
+            "(retry %d) without holding the worker",
+            task_type,
+            task_uuid,
+            countdown,
+            self.request.retries,
+        )
+        # Re-sends the same task id/args/kwargs; max_retries=None because a
+        # prerequisite is guaranteed to become terminal (its own timeout/reaper),
+        # so the defer loop always ends.
+        raise self.retry(countdown=countdown, max_retries=None)
+    if unmet is not None:
+        # A prerequisite ended non-success (unmet is that Task): fail without
+        # running the body. Its failure then cascades to this task's dependents.
+        # The _DAG_WAITING sentinel was handled above, so this is a Task.
+        unmet = cast("TaskModel", unmet)
+        logger.info(
+            "Task %s (uuid=%s) failing: prerequisite %s did not succeed (status=%s)",
+            task_type,
+            task_uuid,
+            unmet.uuid,
+            unmet.status,
+        )
+        failed_transition = InternalStatusTransitionCommand(
+            task_uuid=native_uuid,
+            new_status=TaskStatus.FAILURE,
+            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
+            set_ended_at=True,
+            properties={
+                "error_message": (
+                    f"Prerequisite task {unmet.uuid} did not "
+                    f"succeed (status={unmet.status})"
+                )
+            },
+        ).run()
+        if failed_transition:
+            TaskManager.publish_completion(native_uuid, TaskStatus.FAILURE.value)
+            return {"status": TaskStatus.FAILURE.value, "task_uuid": task_uuid}
+        # The dependent moved to a terminal state concurrently (e.g. aborted while
+        # deferred), so the FAILURE transition was a no-op — report the committed
+        # status instead of publishing a contradictory FAILURE completion.
+        refreshed = TaskDAO.find_one_or_none(uuid=native_uuid, skip_base_filter=True)
+        return {
+            "status": refreshed.status if refreshed else "unknown",
+            "task_uuid": task_uuid,
+        }
+
+    # Prerequisites satisfied → claim the task and run it under the heartbeat.
     _persist_celery_task_id(task, self.request.id)
     app = current_app._get_current_object()  # noqa: SLF001
     with task_heartbeat(task.id, app) as heartbeat:
@@ -416,74 +520,21 @@ def _execute_task_body(  # noqa: C901
     Run a claimed GTF task through its lifecycle.
 
     This body:
-    1. Checks if task was aborted before execution starts
-    2. Builds context (task + user) and sets ambient context via contextvars
-    3. Executes the task function (which accesses context via get_context())
-    4. Updates task status throughout lifecycle using atomic conditional updates
-    5. Runs cleanup handlers on task end (success/failure/abortion)
-    6. Resets context after execution
+    1. Builds context (task + user) and sets ambient context via contextvars
+    2. Executes the task function (which accesses context via get_context())
+    3. Updates task status throughout lifecycle using atomic conditional updates
+    4. Runs cleanup handlers on task end (success/failure/abortion)
+    5. Resets context after execution
 
-    Uses atomic conditional status updates to prevent race conditions with
-    concurrent abort operations.
+    The pre-claim abort check and the DAG dependency gate run in ``execute_task``
+    before the task is claimed (heartbeat + Celery id), so by here the task is
+    ready to run; a concurrent abort in the claim window is still caught by the
+    PENDING → IN_PROGRESS transition below. Uses atomic conditional status updates
+    to prevent race conditions with concurrent abort operations.
     """
     from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
 
     task_uuid = str(native_uuid)
-
-    # AUTOMATIC PRE-EXECUTION CHECK: Don't execute if already aborted/aborting
-    if task.status in ABORT_STATES:
-        logger.info(
-            "Task %s (uuid=%s) was aborted before execution started",
-            task_type,
-            task_uuid,
-        )
-        # Atomic transition to ABORTED (if not already)
-        InternalStatusTransitionCommand(
-            task_uuid=native_uuid,
-            new_status=TaskStatus.ABORTED,
-            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
-            set_ended_at=True,
-        ).run()
-        return {"status": TaskStatus.ABORTED.value, "task_uuid": task_uuid}
-
-    # DAG gate: wait for prerequisites before claiming the task. The task stays
-    # PENDING while waiting, so the "waiting on prerequisites" indicator applies
-    # and an abort mid-wait is caught by the PENDING → IN_PROGRESS transition
-    # below. If any prerequisite did not succeed, fail without running the body
-    # (all_success semantics); the failure then cascades to this task's own
-    # dependents.
-    if (failed_prerequisite := _resolve_failed_prerequisite(task)) is not None:
-        logger.info(
-            "Task %s (uuid=%s) failing: prerequisite %s did not succeed (status=%s)",
-            task_type,
-            task_uuid,
-            failed_prerequisite.uuid,
-            failed_prerequisite.status,
-        )
-        failed_transition = InternalStatusTransitionCommand(
-            task_uuid=native_uuid,
-            new_status=TaskStatus.FAILURE,
-            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
-            set_ended_at=True,
-            properties={
-                "error_message": (
-                    f"Prerequisite task {failed_prerequisite.uuid} did not "
-                    f"succeed (status={failed_prerequisite.status})"
-                )
-            },
-        ).run()
-        if failed_transition:
-            TaskManager.publish_completion(native_uuid, TaskStatus.FAILURE.value)
-            return {"status": TaskStatus.FAILURE.value, "task_uuid": task_uuid}
-        # The dependent was moved to a terminal state concurrently (e.g. aborted
-        # while waiting on prerequisites), so the FAILURE transition was a no-op.
-        # Report the status that actually committed rather than publishing a
-        # FAILURE completion that contradicts the DB.
-        refreshed = TaskDAO.find_one_or_none(uuid=native_uuid, skip_base_filter=True)
-        return {
-            "status": refreshed.status if refreshed else "unknown",
-            "task_uuid": task_uuid,
-        }
 
     # Atomic transition: PENDING → IN_PROGRESS (set started_at for duration tracking)
     if not InternalStatusTransitionCommand(

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -23,7 +23,7 @@ from typing import Any, cast, TYPE_CHECKING
 from uuid import UUID
 
 from celery import Task
-from celery.exceptions import SoftTimeLimitExceeded
+from celery.exceptions import Retry, SoftTimeLimitExceeded
 from celery.signals import task_failure
 from flask import current_app
 from superset_core.tasks.types import TaskStatus
@@ -377,11 +377,13 @@ def _persist_celery_task_id(task: "TaskModel", celery_task_id: str | None) -> No
     """Record the Celery job id on the task so the reaper can revoke it.
 
     Mutates the in-memory task (so the ``TaskContext`` built later carries the id
-    through its property writes) and commits. Written once at pickup, before the
-    DAG gate and the status transition, so the reaper can revoke even a task
-    still waiting on prerequisites. The id is dropped on the terminal transition
-    along with the rest of ``properties``, which is fine — only ACTIVE tasks are
-    ever reaped.
+    through its property writes) and commits. Written once when the task is
+    claimed — after the DAG gate has confirmed the prerequisites are met and
+    immediately before the heartbeat/status transition — so the reaper can revoke
+    the running job. A task still deferred on prerequisites carries no Celery id
+    or heartbeat and is simply re-enqueued rather than reaped. The id is dropped
+    on the terminal transition along with the rest of ``properties``, which is
+    fine — only ACTIVE tasks are ever reaped.
     """
     if not celery_task_id:
         return
@@ -390,7 +392,13 @@ def _persist_celery_task_id(task: "TaskModel", celery_task_id: str | None) -> No
     db.session.commit()  # pylint: disable=consider-using-transaction
 
 
-@celery_app.task(name="tasks.execute", bind=True)
+# max_retries=None makes the DAG-defer retries truly unlimited. Celery's
+# self.retry(max_retries=None) falls back to the *task's* max_retries attribute
+# (default 3), not infinity — so the ceiling has to be lifted here, on the task,
+# or a parent that runs longer than a few defer intervals would exhaust retries
+# and leave the dependent stuck PENDING. Only the DAG defer path retries; real
+# failures go through the FAILURE transition instead.
+@celery_app.task(name="tasks.execute", bind=True, max_retries=None)
 def execute_task(
     self: Any,  # Celery task instance
     task_uuid: str,
@@ -461,10 +469,32 @@ def execute_task(
             countdown,
             self.request.retries,
         )
-        # Re-sends the same task id/args/kwargs; max_retries=None because a
-        # prerequisite is guaranteed to become terminal (its own timeout/reaper),
-        # so the defer loop always ends.
-        raise self.retry(countdown=countdown, max_retries=None)
+        # Re-sends the same task id/args/kwargs. self.retry raises the Retry
+        # sentinel Celery expects; if it instead fails to publish the replacement
+        # message (broker down), that would escape as a non-Retry exception and
+        # leave this task PENDING with no heartbeat — unreapable, the same shape as
+        # a failed enqueue. So only the Retry sentinel is allowed to propagate;
+        # any other error fails the task terminally.
+        try:
+            raise self.retry(countdown=countdown, max_retries=None)
+        except Retry:
+            raise
+        except Exception:  # noqa: BLE001  pylint: disable=broad-except
+            logger.exception(
+                "Failed to defer task %s (uuid=%s); failing it so it is not "
+                "stranded PENDING",
+                task_type,
+                task_uuid,
+            )
+            if InternalStatusTransitionCommand(
+                task_uuid=native_uuid,
+                new_status=TaskStatus.FAILURE,
+                expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
+                set_ended_at=True,
+                properties={"error_message": "Failed to defer task for execution"},
+            ).run():
+                TaskManager.publish_completion(native_uuid, TaskStatus.FAILURE.value)
+            return {"status": TaskStatus.FAILURE.value, "task_uuid": task_uuid}
     if unmet is not None:
         # A prerequisite ended non-success (unmet is that Task): fail without
         # running the body. Its failure then cascades to this task's dependents.

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -107,7 +107,14 @@ def set_and_log_cache(
                 app.config["STATS_LOGGER"].incr("skip_cache_value_too_large")
                 return False
 
-        cache_instance.set(cache_key, value, timeout=timeout)
+        # Flask-Caching's set() returns bool | None: cachelib backends can report
+        # a failed write by returning False without raising, while some backends
+        # return None (no status). Treat an explicit False as failure so callers
+        # that gate on persistence (the forced-refresh marker) don't claim a write
+        # that never landed; treat None as success.
+        if cache_instance.set(cache_key, value, timeout=timeout) is False:
+            logger.warning("Cache backend reported a failed set for key %s", cache_key)
+            return False
         stats_logger = app.config["STATS_LOGGER"]
         stats_logger.incr("set_cache_key")
 

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -60,9 +60,18 @@ def set_and_log_cache(
     cache_value: dict[str, Any],
     cache_timeout: int | None = None,
     datasource_uid: str | None = None,
-) -> None:
+) -> bool:
+    """Write a value to the cache, logging outcomes.
+
+    :returns: ``True`` only when the value was actually persisted to the backend;
+        ``False`` when caching was skipped (null cache, disabled timeout, value
+        too large) or the backend write failed. Callers that need to know the
+        value is really cached (e.g. the forced-refresh idempotency marker) must
+        gate on this, since a silent skip would otherwise let a follow-up read
+        serve a stale value.
+    """
     if isinstance(cache_instance.cache, NullCache):
-        return
+        return False
 
     timeout = (
         cache_timeout
@@ -72,7 +81,7 @@ def set_and_log_cache(
 
     # Skip caching if timeout is CACHE_DISABLED_TIMEOUT (no caching requested)
     if timeout == CACHE_DISABLED_TIMEOUT:
-        return
+        return False
     try:
         dttm: str = (
             datetime.now(timezone.utc).replace(tzinfo=None).isoformat().split(".")[0]
@@ -96,7 +105,7 @@ def set_and_log_cache(
                     max_value_size,
                 )
                 app.config["STATS_LOGGER"].incr("skip_cache_value_too_large")
-                return
+                return False
 
         cache_instance.set(cache_key, value, timeout=timeout)
         stats_logger = app.config["STATS_LOGGER"]
@@ -117,11 +126,13 @@ def set_and_log_cache(
                 datasource_uid=datasource_uid,
             )
             db.session.add(ck)
+        return True
     except Exception as ex:  # pylint: disable=broad-except
         # cache.set call can fail if the backend is down or if
         # the key is too large or whatever other reasons
         logger.warning("Could not cache key %s", cache_key)
         logger.exception(ex)
+        return False
 
 
 # If a user sets `max_age` to 0, for long the browser should cache the

--- a/tests/unit_tests/commands/tasks/__init__.py
+++ b/tests/unit_tests/commands/tasks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/unit_tests/commands/tasks/test_internal_update.py
+++ b/tests/unit_tests/commands/tasks/test_internal_update.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for GTF internal status-transition observability."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from superset_core.tasks.types import TaskStatus
+
+from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
+
+
+def _run_transition(new_status, *, committed: bool):
+    """Run a transition with the DB write forced to ``committed`` and capture the
+    STATS_LOGGER the command emitted to. Returns the stats logger mock."""
+    stats_logger = MagicMock()
+    app = MagicMock()
+    app.config = {"STATS_LOGGER": stats_logger}
+    cmd = InternalStatusTransitionCommand(
+        task_uuid=uuid4(),
+        new_status=new_status,
+        expected_status=TaskStatus.PENDING,
+    )
+    with (
+        patch.object(cmd, "_run_in_transaction", return_value=committed),
+        patch("superset.commands.tasks.internal_update.current_app", app),
+        patch(
+            "superset.commands.tasks.internal_update.TaskManager"
+        ),  # silence realtime nudges
+    ):
+        cmd.run()
+    return stats_logger
+
+
+def test_transition_emits_status_scoped_metric_on_commit():
+    """A committed transition emits gtf.task.transition.<status> so completion/
+    abort/timeout/failure rates are observable."""
+    stats_logger = _run_transition(TaskStatus.SUCCESS, committed=True)
+    stats_logger.incr.assert_called_once_with("gtf.task.transition.success")
+
+
+def test_transition_accepts_raw_string_status():
+    """new_status may be a raw string (not the enum) — metric still resolves."""
+    stats_logger = _run_transition("failure", committed=True)
+    stats_logger.incr.assert_called_once_with("gtf.task.transition.failure")
+
+
+def test_no_metric_when_transition_is_noop():
+    """A no-op transition (expected status didn't match) emits no metric."""
+    stats_logger = _run_transition(TaskStatus.SUCCESS, committed=False)
+    stats_logger.incr.assert_not_called()

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -2047,6 +2047,7 @@ def test_get_df_payload_invalidates_cache_missing_applied_filter_columns():
             self.annotation_data = {}
             self.bq_memory_limited = False
             self.bq_memory_limited_row_count = 0
+            self.result_persisted = False
             self.set_query_result = MagicMock()
 
     mock_cache = MockCache()
@@ -2513,10 +2514,25 @@ def test_mark_force_executed_sets_marker_for_nonce_refresh(
         patch("superset.common.query_context_processor.cache_manager") as cache_manager,
         patch.object(processor, "get_cache_timeout", return_value=123),
     ):
-        processor._mark_force_executed("ck")
+        processor._mark_force_executed("ck", persisted=True)
     cache_manager.data_cache.set.assert_called_once_with(
         "gtf-force-nonce:nonce-1:ck", 1, timeout=123
     )
+
+
+def test_mark_force_executed_noop_when_result_not_persisted(
+    processor, mock_query_context
+):
+    """If the fresh result wasn't actually cached (oversized/backend error), the
+    marker must NOT be written — otherwise a follow-up read stops forcing and can
+    serve a stale pre-refresh value."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        processor._mark_force_executed("ck", persisted=False)
+    cache_manager.data_cache.set.assert_not_called()
 
 
 def test_mark_force_executed_noop_without_nonce(processor, mock_query_context):
@@ -2525,5 +2541,30 @@ def test_mark_force_executed_noop_without_nonce(processor, mock_query_context):
     with patch(
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
-        processor._mark_force_executed("ck")
+        processor._mark_force_executed("ck", persisted=True)
     cache_manager.data_cache.set.assert_not_called()
+
+
+def test_mark_force_executed_swallows_marker_write_error(processor, mock_query_context):
+    """A marker write failure is best-effort — logged and swallowed."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with (
+        patch("superset.common.query_context_processor.cache_manager") as cache_manager,
+        patch.object(processor, "get_cache_timeout", return_value=123),
+    ):
+        cache_manager.data_cache.set.side_effect = RuntimeError("backend down")
+        processor._mark_force_executed("ck", persisted=True)  # must not raise
+
+
+def test_resolve_forced_query_forces_when_marker_read_errors(
+    processor, mock_query_context
+):
+    """A marker read failure degrades to 'absent' (force), never an error."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        cache_manager.data_cache.get.side_effect = RuntimeError("backend down")
+        assert processor._resolve_forced_query("ck") is True

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -2448,3 +2448,82 @@ def test_get_native_annotation_data_requires_annotation_read_access():
             QueryContextProcessor.get_native_annotation_data(query_obj)
     security_manager_mock.can_access.assert_called_once_with("can_read", "Annotation")
     find_by_ids_mock.assert_not_called()
+
+
+# =============================================================================
+# Forced-refresh idempotency nonce (GTF async double-execution guard)
+# =============================================================================
+
+
+def test_resolve_forced_query_false_when_not_forced(processor, mock_query_context):
+    mock_query_context.force = False
+    assert processor._resolve_forced_query("ck") is False
+
+
+def test_resolve_forced_query_true_when_forced_without_nonce(
+    processor, mock_query_context
+):
+    """A forced refresh with no nonce (sync/legacy) forces verbatim."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = None
+    assert processor._resolve_forced_query("ck") is True
+
+
+def test_resolve_forced_query_true_when_forced_without_cache_key(
+    processor, mock_query_context
+):
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    assert processor._resolve_forced_query(None) is True
+
+
+def test_resolve_forced_query_reads_cache_when_marker_present(
+    processor, mock_query_context
+):
+    """Marker present => this forced refresh already cached its result; read it."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        cache_manager.data_cache.get.return_value = 1  # marker exists
+        assert processor._resolve_forced_query("ck") is False
+    cache_manager.data_cache.get.assert_called_once_with("gtf-force-nonce:nonce-1:ck")
+
+
+def test_resolve_forced_query_forces_when_marker_absent(processor, mock_query_context):
+    """No marker for THIS (nonce, cache_key) — including a cache_key that shifted
+    since the forced compute (templated/time-relative keys) — forces a recompute
+    rather than mis-reading another key's result."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        cache_manager.data_cache.get.return_value = None  # no marker
+        assert processor._resolve_forced_query("ck") is True
+
+
+def test_mark_force_executed_sets_marker_for_nonce_refresh(
+    processor, mock_query_context
+):
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "nonce-1"
+    with (
+        patch("superset.common.query_context_processor.cache_manager") as cache_manager,
+        patch.object(processor, "get_cache_timeout", return_value=123),
+    ):
+        processor._mark_force_executed("ck")
+    cache_manager.data_cache.set.assert_called_once_with(
+        "gtf-force-nonce:nonce-1:ck", 1, timeout=123
+    )
+
+
+def test_mark_force_executed_noop_without_nonce(processor, mock_query_context):
+    mock_query_context.force = True
+    mock_query_context.force_nonce = None
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        processor._mark_force_executed("ck")
+    cache_manager.data_cache.set.assert_not_called()

--- a/tests/unit_tests/common/test_query_serialization.py
+++ b/tests/unit_tests/common/test_query_serialization.py
@@ -35,6 +35,7 @@ def _payload() -> SerializedQuery:
         result_type="full",
         result_format="json",
         force=True,
+        force_nonce="nonce-abc",
         custom_cache_timeout=42,
     )
 
@@ -51,10 +52,13 @@ def test_serialize_query_extracts_raw_query_and_context_params(
     ctx.result_type = ChartDataResultType.FULL
     ctx.result_format = ChartDataResultFormat.JSON
     ctx.force = True
+    ctx.force_nonce = "nonce-abc"
     ctx.custom_cache_timeout = 42
 
     # Serializes the *raw* query dict (not the processed QueryObject) plus the
-    # context-level params (force/custom_cache_timeout live on the context).
+    # context-level params (force/force_nonce/custom_cache_timeout live on the
+    # context). force_nonce is carried so the async task and the follow-up
+    # read-back share one forced-refresh idempotency token.
     assert serialize_query(ctx, 1) == {
         "datasource": {"id": 1, "type": "table"},
         "query": {"b": 2},
@@ -62,6 +66,7 @@ def test_serialize_query_extracts_raw_query_and_context_params(
         "result_type": "full",
         "result_format": "json",
         "force": True,
+        "force_nonce": "nonce-abc",
         "custom_cache_timeout": 42,
     }
 
@@ -113,6 +118,7 @@ def test_load_serialized_query_rebuilds_via_factory(mocker: MockerFixture) -> No
         result_type=ChartDataResultType.FULL,
         result_format=ChartDataResultFormat.JSON,
         force=True,
+        force_nonce="nonce-abc",
         custom_cache_timeout=42,
         preserve_null_row_limit=False,
     )

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -34,134 +34,220 @@ def _task(status: str = TaskStatus.PENDING.value, **kwargs):
     return SimpleNamespace(uuid=uuid4(), status=status, task_name=None, **kwargs)
 
 
-class TestResolveFailedPrerequisite:
-    """Tests for the scheduler's all_success prerequisite gate."""
+class TestUnmetPrerequisite:
+    """Tests for the scheduler's non-blocking ``all_success`` DAG gate."""
 
     def test_no_dependencies_returns_none(self):
-        from superset.tasks.scheduler import _resolve_failed_prerequisite
+        from superset.tasks.scheduler import _unmet_prerequisite
 
-        assert _resolve_failed_prerequisite(SimpleNamespace(depends_on=[])) is None
+        assert _unmet_prerequisite(SimpleNamespace(depends_on=[])) is None
 
-    @patch("superset.tasks.scheduler.TaskManager.wait_for_completion")
-    def test_all_success_returns_none(self, mock_wait):
-        from superset.tasks.scheduler import _resolve_failed_prerequisite
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_all_terminal_success_snapshot_needs_no_read(self, mock_find):
+        """Prerequisites already SUCCESS in the loaded snapshot skip any DB read."""
+        from superset.tasks.scheduler import _unmet_prerequisite
 
-        task = SimpleNamespace(depends_on=[_task(), _task()])
-        mock_wait.return_value = SimpleNamespace(status=TaskStatus.SUCCESS.value)
+        task = SimpleNamespace(
+            depends_on=[
+                _task(status=TaskStatus.SUCCESS.value),
+                _task(status=TaskStatus.SUCCESS.value),
+            ]
+        )
+        assert _unmet_prerequisite(task) is None
+        # A terminal status never changes, so no fresh read is issued.
+        mock_find.assert_not_called()
 
-        assert _resolve_failed_prerequisite(task) is None
-        assert mock_wait.call_count == 2
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_failed_prerequisite_in_snapshot_is_returned(self, mock_find):
+        from superset.tasks.scheduler import _unmet_prerequisite
 
-    @patch("superset.tasks.scheduler.TaskManager.wait_for_completion")
-    def test_already_terminal_prerequisites_skip_wait(self, mock_wait):
-        """Prerequisites already terminal in the loaded snapshot need no DB wait."""
-        from superset.tasks.scheduler import _resolve_failed_prerequisite
-
-        # One already succeeded, one already failed → decided from the snapshot
         succeeded = _task(status=TaskStatus.SUCCESS.value)
         failed = _task(status=TaskStatus.FAILURE.value)
         assert (
-            _resolve_failed_prerequisite(
-                SimpleNamespace(depends_on=[succeeded, failed])
-            )
+            _unmet_prerequisite(SimpleNamespace(depends_on=[succeeded, failed]))
             is failed
         )
-        # All-terminal snapshot → wait_for_completion is never called
+        mock_find.assert_not_called()
+
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_non_terminal_snapshot_reread_still_pending_defers(self, mock_find):
+        """A prerequisite still non-terminal after a fresh read → defer signal."""
+        from superset.tasks.scheduler import _DAG_WAITING, _unmet_prerequisite
+
+        pending = _task(status=TaskStatus.PENDING.value)
+        mock_find.return_value = _task(status=TaskStatus.IN_PROGRESS.value)
+
         assert (
-            _resolve_failed_prerequisite(SimpleNamespace(depends_on=[succeeded]))
-            is None
+            _unmet_prerequisite(SimpleNamespace(depends_on=[pending])) is _DAG_WAITING
         )
-        mock_wait.assert_not_called()
+        mock_find.assert_called_once()
 
-    @patch("superset.tasks.scheduler.TaskManager.wait_for_completion")
-    def test_first_non_success_is_returned(self, mock_wait):
-        from superset.tasks.scheduler import _resolve_failed_prerequisite
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_non_terminal_snapshot_reread_succeeded_is_ready(self, mock_find):
+        """A stale non-terminal snapshot that actually finished SUCCESS → ready."""
+        from superset.tasks.scheduler import _unmet_prerequisite
 
-        task = SimpleNamespace(depends_on=[_task(), _task()])
-        failed = SimpleNamespace(uuid=uuid4(), status=TaskStatus.FAILURE.value)
-        mock_wait.side_effect = [
-            SimpleNamespace(status=TaskStatus.SUCCESS.value),
-            failed,
-        ]
+        stale = _task(status=TaskStatus.IN_PROGRESS.value)
+        mock_find.return_value = _task(status=TaskStatus.SUCCESS.value)
 
-        assert _resolve_failed_prerequisite(task) is failed
+        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is None
 
-    @patch("superset.tasks.scheduler.TaskManager.wait_for_completion")
-    def test_missing_prerequisite_treated_as_failed(self, mock_wait):
-        from superset.tasks.scheduler import _resolve_failed_prerequisite
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_non_terminal_snapshot_reread_failed_is_returned(self, mock_find):
+        from superset.tasks.scheduler import _unmet_prerequisite
 
-        prerequisite = _task()
-        task = SimpleNamespace(depends_on=[prerequisite])
-        mock_wait.side_effect = ValueError("gone")
+        stale = _task(status=TaskStatus.PENDING.value)
+        failed = _task(status=TaskStatus.FAILURE.value)
+        mock_find.return_value = failed
 
-        # The (stale) prerequisite is returned rather than blocking/raising.
-        assert _resolve_failed_prerequisite(task) is prerequisite
+        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is failed
+
+    @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
+    def test_missing_prerequisite_treated_as_failed(self, mock_find):
+        from superset.tasks.scheduler import _unmet_prerequisite
+
+        stale = _task(status=TaskStatus.PENDING.value)
+        mock_find.return_value = None  # prerequisite pruned/gone
+
+        # The (stale) prerequisite is returned as failed rather than deferring.
+        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is stale
 
 
-class TestExecuteTaskFailedPrerequisite:
-    """execute_task's handling when a prerequisite did not succeed."""
+class TestDagDeferCountdown:
+    """The DAG defer backoff grows monotonically and is capped."""
+
+    def test_backoff_grows_then_caps(self):
+        from superset.tasks.scheduler import (
+            _dag_defer_countdown,
+            _DAG_DEFER_MAX_SECONDS,
+        )
+
+        # 1s, 3s, 5s, … before jitter; jitter adds at most ~1s.
+        assert 1.0 <= _dag_defer_countdown(0) <= 2.0
+        assert 3.0 <= _dag_defer_countdown(1) <= 4.0
+        assert 5.0 <= _dag_defer_countdown(2) <= 6.0
+        # Monotonic non-decreasing base across retries.
+        bases = [_dag_defer_countdown(r) for r in range(0, 40)]
+        assert all(b <= a + 1.0 for b, a in zip(bases, bases[1:], strict=False)) or True
+        # Capped: even a huge retry count stays at the ceiling (+ jitter).
+        capped = _dag_defer_countdown(1000)
+        assert _DAG_DEFER_MAX_SECONDS <= capped <= _DAG_DEFER_MAX_SECONDS + 1.0
+
+
+class TestExecuteTaskDagGate:
+    """execute_task's non-blocking gate: defer while waiting, fail on non-success."""
 
     @staticmethod
-    def _run_with_transition(*, transitioned: bool, refreshed_status: str):
-        """Drive the task body through the failed-prerequisite branch.
+    def _call(
+        fake_self, task, *, unmet_return, find_side_effect=None, stats_logger=None
+    ):
+        """Invoke the raw execute_task function with a controllable ``self``.
 
-        Returns ``(result, publish_completion_mock)`` with the status transition
-        forced to ``transitioned`` and the post-transition re-read reporting
-        ``refreshed_status``.
+        Returns ``(result_or_None, stats_logger, task_manager)``. Raises whatever
+        the body raises (e.g. the Retry from ``self.retry``). Pass ``stats_logger``
+        to retain a reference across a raising call (e.g. to assert a metric fired
+        before ``self.retry`` raised).
         """
-        native = uuid4()
-        pending = SimpleNamespace(uuid=native, status=TaskStatus.PENDING.value)
-        refreshed = SimpleNamespace(uuid=native, status=refreshed_status)
-        failed_prereq = _task(status=TaskStatus.FAILURE.value)
+        from superset.tasks import scheduler
 
-        transition = MagicMock()
-        transition.return_value.run.return_value = transitioned
+        # execute_task is a bound Celery Task method; reach the plain function so
+        # we control self.request.retries and self.retry.
+        raw = scheduler.execute_task.run.__func__
 
+        stats_logger = stats_logger or MagicMock()
+        app = MagicMock()
+        app.config = {"STATS_LOGGER": stats_logger}
+        find = (
+            MagicMock(side_effect=find_side_effect)
+            if find_side_effect is not None
+            else MagicMock(return_value=task)
+        )
         with (
+            patch("superset.tasks.scheduler.TaskDAO.find_one_or_none", find),
             patch(
-                "superset.tasks.scheduler.TaskDAO.find_one_or_none",
-                side_effect=[refreshed],
-            ),
-            patch(
-                "superset.tasks.scheduler._resolve_failed_prerequisite",
-                return_value=failed_prereq,
+                "superset.tasks.scheduler._unmet_prerequisite",
+                return_value=unmet_return,
             ),
             patch("superset.tasks.scheduler.TaskManager") as task_manager,
-            patch(
-                "superset.commands.tasks.internal_update."
-                "InternalStatusTransitionCommand",
-                transition,
-            ),
+            patch("superset.tasks.scheduler.current_app", app),
+            patch("superset.commands.tasks.internal_update.current_app", app),
         ):
-            from superset.tasks.scheduler import _execute_task_body
+            result = raw(fake_self, str(task.uuid), "some.task", (), {})
+            return result, stats_logger, task_manager
 
-            # Call the lifecycle body directly with the already-loaded task; the
-            # heartbeat/celery-id wrapper (execute_task) is covered separately.
-            result = _execute_task_body(
-                pending,  # type: ignore[arg-type]
-                native,
-                "some.task",
-                (),
-                {},
-                MagicMock(),
+    def test_waiting_defers_via_retry_and_emits_metric(self):
+        from superset.tasks.scheduler import _DAG_WAITING
+
+        native = uuid4()
+        task = SimpleNamespace(
+            id=1, uuid=native, status=TaskStatus.PENDING.value, depends_on=[]
+        )
+        fake_self = MagicMock()
+        fake_self.request.retries = 2
+        fake_self.retry.side_effect = RuntimeError("retry raised")
+        stats_logger = MagicMock()
+
+        with pytest.raises(RuntimeError, match="retry raised"):
+            self._call(
+                fake_self, task, unmet_return=_DAG_WAITING, stats_logger=stats_logger
             )
-            return result, task_manager.publish_completion
 
-    def test_failure_published_when_transition_commits(self):
-        result, publish_completion = self._run_with_transition(
-            transitioned=True, refreshed_status=TaskStatus.PENDING.value
+        # A defer metric fired before the retry raised…
+        stats_logger.incr.assert_any_call("gtf.task.dag_deferred")
+        # …and the task was deferred via a countdown'd retry that never gives up.
+        _, kwargs = fake_self.retry.call_args
+        assert kwargs["max_retries"] is None
+        assert kwargs["countdown"] >= 1.0
+
+    def test_failed_prerequisite_publishes_failure(self):
+        native = uuid4()
+        task = SimpleNamespace(
+            id=1, uuid=native, status=TaskStatus.PENDING.value, depends_on=[]
         )
+        failed_prereq = _task(status=TaskStatus.FAILURE.value)
+        transition = MagicMock()
+        transition.return_value.run.return_value = True
+        fake_self = MagicMock()
+        fake_self.request.retries = 0
+
+        with patch(
+            "superset.commands.tasks.internal_update.InternalStatusTransitionCommand",
+            transition,
+        ):
+            result, _, task_manager = self._call(
+                fake_self, task, unmet_return=failed_prereq
+            )
+
         assert result["status"] == TaskStatus.FAILURE.value
-        publish_completion.assert_called_once()
+        task_manager.publish_completion.assert_called_once()
 
-    def test_no_failure_published_when_task_already_terminal(self):
-        # The task was aborted while waiting on prerequisites, so the FAILURE
-        # transition is a no-op — report the committed status, publish no FAILURE.
-        result, publish_completion = self._run_with_transition(
-            transitioned=False, refreshed_status=TaskStatus.ABORTED.value
+    def test_failed_prerequisite_no_publish_when_already_terminal(self):
+        native = uuid4()
+        task = SimpleNamespace(
+            id=1, uuid=native, status=TaskStatus.PENDING.value, depends_on=[]
         )
+        aborted = SimpleNamespace(uuid=native, status=TaskStatus.ABORTED.value)
+        failed_prereq = _task(status=TaskStatus.FAILURE.value)
+        transition = MagicMock()
+        transition.return_value.run.return_value = False  # no-op: task already terminal
+        fake_self = MagicMock()
+        fake_self.request.retries = 0
+
+        with patch(
+            "superset.commands.tasks.internal_update.InternalStatusTransitionCommand",
+            transition,
+        ):
+            # First find_one_or_none loads the task; the second (post no-op) re-reads
+            # the committed terminal status.
+            result, _, task_manager = self._call(
+                fake_self,
+                task,
+                unmet_return=failed_prereq,
+                find_side_effect=[task, aborted],
+            )
+
         assert result["status"] == TaskStatus.ABORTED.value
-        publish_completion.assert_not_called()
+        task_manager.publish_completion.assert_not_called()
 
 
 class TestPersistDependencies:

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -126,9 +126,11 @@ class TestDagDeferCountdown:
         assert 1.0 <= _dag_defer_countdown(0) <= 2.0
         assert 3.0 <= _dag_defer_countdown(1) <= 4.0
         assert 5.0 <= _dag_defer_countdown(2) <= 6.0
-        # Monotonic non-decreasing base across retries.
-        bases = [_dag_defer_countdown(r) for r in range(0, 40)]
-        assert all(b <= a + 1.0 for b, a in zip(bases, bases[1:], strict=False)) or True
+        # Strictly increasing before the cap: the base grows by 2s each retry and
+        # the jitter is bounded by 1s, so consecutive values can't overlap.
+        vals = [_dag_defer_countdown(r) for r in range(0, 14)]
+        pairs = zip(vals, vals[1:], strict=False)
+        assert all(earlier < later for earlier, later in pairs)
         # Capped: even a huge retry count stays at the ceiling (+ jitter).
         capped = _dag_defer_countdown(1000)
         assert _DAG_DEFER_MAX_SECONDS <= capped <= _DAG_DEFER_MAX_SECONDS + 1.0
@@ -176,6 +178,8 @@ class TestExecuteTaskDagGate:
             return result, stats_logger, task_manager
 
     def test_waiting_defers_via_retry_and_emits_metric(self):
+        from celery.exceptions import Retry
+
         from superset.tasks.scheduler import _DAG_WAITING
 
         native = uuid4()
@@ -184,10 +188,12 @@ class TestExecuteTaskDagGate:
         )
         fake_self = MagicMock()
         fake_self.request.retries = 2
-        fake_self.retry.side_effect = RuntimeError("retry raised")
+        # The normal defer path: self.retry raises Celery's Retry sentinel, which
+        # must propagate so Celery reschedules the message.
+        fake_self.retry.side_effect = Retry()
         stats_logger = MagicMock()
 
-        with pytest.raises(RuntimeError, match="retry raised"):
+        with pytest.raises(Retry):
             self._call(
                 fake_self, task, unmet_return=_DAG_WAITING, stats_logger=stats_logger
             )
@@ -198,6 +204,34 @@ class TestExecuteTaskDagGate:
         _, kwargs = fake_self.retry.call_args
         assert kwargs["max_retries"] is None
         assert kwargs["countdown"] >= 1.0
+
+    def test_defer_publish_failure_fails_task(self):
+        """If self.retry can't publish the replacement message (broker down), the
+        task must be failed rather than left stranded PENDING with no heartbeat."""
+        from superset.tasks.scheduler import _DAG_WAITING
+
+        native = uuid4()
+        task = SimpleNamespace(
+            id=1, uuid=native, status=TaskStatus.PENDING.value, depends_on=[]
+        )
+        fake_self = MagicMock()
+        fake_self.request.retries = 0
+        # A non-Retry error from self.retry models a publish failure.
+        fake_self.retry.side_effect = RuntimeError("broker down")
+
+        transition = MagicMock()
+        transition.return_value.run.return_value = True
+
+        with patch(
+            "superset.commands.tasks.internal_update.InternalStatusTransitionCommand",
+            transition,
+        ):
+            result, _, task_manager = self._call(
+                fake_self, task, unmet_return=_DAG_WAITING
+            )
+
+        assert result["status"] == TaskStatus.FAILURE.value
+        task_manager.publish_completion.assert_called_once()
 
     def test_failed_prerequisite_publishes_failure(self):
         native = uuid4()

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -531,3 +531,113 @@ class TestTaskManagerWaitForCompletion:
         assert result.status == "success"
         backend.stream_last_id.assert_called_once_with("gtf:complete:test-uuid")
         backend.xread.assert_called_once()
+
+
+class TestSubmitTaskEnqueueFailure:
+    """submit_task must not leave a task PENDING if the Celery enqueue fails.
+
+    A committed-but-unenqueued PENDING task would poison the dedup key: future
+    identical submits would join a task that never runs. So an enqueue failure
+    fails the task (freeing the key) and re-raises to the caller.
+    """
+
+    SUBMIT = "superset.commands.tasks.submit.SubmitTaskCommand"
+    EXECUTE = "superset.tasks.scheduler.execute_task"
+    TRANSITION = (
+        "superset.commands.tasks.internal_update.InternalStatusTransitionCommand"
+    )
+    PUBLISH = "superset.tasks.manager.TaskManager.publish_completion"
+
+    def test_enqueue_failure_fails_task_and_reraises(self):
+        from superset_core.tasks.types import TaskScope, TaskStatus
+
+        task = MagicMock()
+        task.uuid = uuid.uuid4()
+
+        transition = MagicMock()
+        transition.return_value.run.return_value = True
+
+        with (
+            patch(self.SUBMIT) as submit_cmd,
+            patch(self.EXECUTE) as execute_task,
+            patch(self.TRANSITION, transition),
+            patch(self.PUBLISH) as publish_completion,
+        ):
+            submit_cmd.return_value.run_with_info.return_value = (task, True)
+            execute_task.delay.side_effect = redis.exceptions.ConnectionError("down")
+
+            with pytest.raises(redis.exceptions.ConnectionError):
+                TaskManager.submit_task(
+                    task_type="test.task",
+                    task_key="k",
+                    task_name="n",
+                    scope=TaskScope.SHARED,
+                    timeout=None,
+                    args=(),
+                    kwargs={},
+                )
+
+        # Failed PENDING→FAILURE to free the dedup key, and told waiters/clients.
+        _, kwargs = transition.call_args
+        assert kwargs["new_status"] == TaskStatus.FAILURE
+        assert kwargs["expected_status"] == TaskStatus.PENDING
+        publish_completion.assert_called_once_with(task.uuid, TaskStatus.FAILURE.value)
+
+    def test_cleanup_failure_is_swallowed_and_original_error_reraised(self):
+        """If the FAILURE cleanup itself throws, the original enqueue error still
+        surfaces (the reaper reclaims the orphan later)."""
+        from superset_core.tasks.types import TaskScope
+
+        task = MagicMock()
+        task.uuid = uuid.uuid4()
+
+        transition = MagicMock()
+        transition.return_value.run.side_effect = RuntimeError("metastore down")
+
+        with (
+            patch(self.SUBMIT) as submit_cmd,
+            patch(self.EXECUTE) as execute_task,
+            patch(self.TRANSITION, transition),
+            patch(self.PUBLISH) as publish_completion,
+        ):
+            submit_cmd.return_value.run_with_info.return_value = (task, True)
+            execute_task.delay.side_effect = redis.exceptions.ConnectionError("down")
+
+            with pytest.raises(redis.exceptions.ConnectionError):
+                TaskManager.submit_task(
+                    task_type="test.task",
+                    task_key="k",
+                    task_name="n",
+                    scope=TaskScope.SHARED,
+                    timeout=None,
+                    args=(),
+                    kwargs={},
+                )
+
+        publish_completion.assert_not_called()
+
+    def test_joined_task_is_not_enqueued(self):
+        """A deduped (joined) task must not be enqueued a second time."""
+        from superset_core.tasks.types import TaskScope
+
+        task = MagicMock()
+        task.uuid = uuid.uuid4()
+
+        with (
+            patch(self.SUBMIT) as submit_cmd,
+            patch(self.EXECUTE) as execute_task,
+        ):
+            submit_cmd.return_value.run_with_info.return_value = (task, False)
+
+            result = TaskManager.submit_task(
+                task_type="test.task",
+                task_key="k",
+                task_name="n",
+                scope=TaskScope.SHARED,
+                timeout=None,
+                args=(),
+                kwargs={},
+            )
+
+        assert result is task
+        execute_task.delay.assert_not_called()

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -585,7 +585,9 @@ class TestSubmitTaskEnqueueFailure:
 
     def test_cleanup_failure_is_swallowed_and_original_error_reraised(self):
         """If the FAILURE cleanup itself throws, the original enqueue error still
-        surfaces (the reaper reclaims the orphan later)."""
+        surfaces. The task is left PENDING with no heartbeat and is NOT auto-reaped
+        (the reaper only reclaims started tasks); its dedup key stays occupied
+        until manually cleared or pruned."""
         from superset_core.tasks.types import TaskScope
 
         task = MagicMock()

--- a/tests/unit_tests/tasks/test_scheduler_executor.py
+++ b/tests/unit_tests/tasks/test_scheduler_executor.py
@@ -73,9 +73,6 @@ def _run_body_with_raising_executor(
         patch(
             "superset.tasks.scheduler.TaskDAO.find_one_or_none", return_value=refreshed
         ),
-        patch(
-            "superset.tasks.scheduler._resolve_failed_prerequisite", return_value=None
-        ),
         patch("superset.tasks.scheduler.TaskContext", return_value=ctx),
         patch(
             "superset.tasks.scheduler.TaskRegistry.get_executor", return_value=_raise

--- a/tests/unit_tests/tasks/test_timeout.py
+++ b/tests/unit_tests/tasks/test_timeout.py
@@ -317,7 +317,15 @@ class TestTimeoutTrigger:
     def test_timeout_logs_warning_when_not_abortable(
         self, mock_flask_app, mock_task_not_abortable
     ):
-        """Test that timeout logs warning when task has no abort handler."""
+        """A non-abortable task's timeout is a no-op: it logs a warning and does
+        NOT set _timeout_triggered.
+
+        Setting the flag would block the executor's IN_PROGRESS→SUCCESS transition
+        (which is gated on no abort being in flight), while the finalize only moves
+        TIMED_OUT from ABORTING — a transition that never happens for a task with no
+        abort handlers — stranding it IN_PROGRESS. So the task must run to natural
+        completion instead.
+        """
         with (
             patch("superset.tasks.context.current_app") as mock_current_app,
             patch("superset.daos.tasks.TaskDAO") as mock_dao,
@@ -342,11 +350,12 @@ class TestTimeoutTrigger:
             # Wait for timeout to fire
             time.sleep(1.5)
 
-            # Should have logged warning
+            # Should have logged a warning that the task can't be cancelled…
             mock_logger.warning.assert_called()
             warning_call = mock_logger.warning.call_args
-            assert "no abort handler" in warning_call[0][0].lower()
-            assert ctx._timeout_triggered
+            assert "cannot be cancelled" in warning_call[0][0].lower()
+            # …and crucially left the task un-triggered so SUCCESS can still commit.
+            assert ctx._timeout_triggered is False
             assert not ctx._abort_detected  # No abort since no handler
 
             # Cleanup

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -213,6 +213,20 @@ def test_set_and_log_cache_returns_persistence_outcome(mocker: MockerFixture) ->
     failing.set.side_effect = RuntimeError("backend down")
     assert set_and_log_cache(failing, "k", {"df": "small"}) is False
 
+    # Backend reports a failed write by returning False (no exception) → False.
+    # cachelib backends do this; ignoring it would let the marker claim a write
+    # that never landed.
+    _patch_config(mocker, DATA_CACHE_MAX_VALUE_SIZE=10 * 1024 * 1024)
+    reports_false = _make_cache_instance(mocker)
+    reports_false.set.return_value = False
+    assert set_and_log_cache(reports_false, "k", {"df": "small"}) is False
+
+    # Backend returns None (no status reported) → treated as success.
+    _patch_config(mocker, DATA_CACHE_MAX_VALUE_SIZE=10 * 1024 * 1024)
+    reports_none = _make_cache_instance(mocker)
+    reports_none.set.return_value = None
+    assert set_and_log_cache(reports_none, "k", {"df": "small"}) is True
+
 
 def test_set_and_log_cache_over_threshold(mocker: MockerFixture) -> None:
     """A value exceeding DATA_CACHE_MAX_VALUE_SIZE is not cached."""

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -183,6 +183,37 @@ def test_set_and_log_cache_under_threshold(mocker: MockerFixture) -> None:
     )
 
 
+def test_set_and_log_cache_returns_persistence_outcome(mocker: MockerFixture) -> None:
+    """set_and_log_cache reports whether the value was actually persisted so the
+    forced-refresh idempotency marker only claims a real cache write."""
+    from flask_caching.backends import NullCache
+
+    from superset.utils.cache import set_and_log_cache
+
+    # Persisted normally → True
+    _patch_config(mocker, DATA_CACHE_MAX_VALUE_SIZE=10 * 1024 * 1024)
+    assert set_and_log_cache(_make_cache_instance(mocker), "k", {"df": "small"}) is True
+
+    # Skipped for exceeding the size limit → False
+    _patch_config(mocker, DATA_CACHE_MAX_VALUE_SIZE=10)
+    assert (
+        set_and_log_cache(_make_cache_instance(mocker), "k", {"df": "x" * 1000})
+        is False
+    )
+
+    # NullCache backend → False
+    _patch_config(mocker)
+    null_instance = mocker.MagicMock()
+    null_instance.cache = NullCache()
+    assert set_and_log_cache(null_instance, "k", {"df": "small"}) is False
+
+    # Backend write raises → False (best-effort, swallowed)
+    _patch_config(mocker, DATA_CACHE_MAX_VALUE_SIZE=10 * 1024 * 1024)
+    failing = _make_cache_instance(mocker)
+    failing.set.side_effect = RuntimeError("backend down")
+    assert set_and_log_cache(failing, "k", {"df": "small"}) is False
+
+
 def test_set_and_log_cache_over_threshold(mocker: MockerFixture) -> None:
     """A value exceeding DATA_CACHE_MAX_VALUE_SIZE is not cached."""
     from superset.utils.cache import set_and_log_cache


### PR DESCRIPTION
### SUMMARY

Addresses the latest review of the GTF async chart-data work (findings
P1a/P1b/P1c and the DAG-scheduling concern P2a), and adds transition/deferral
metrics. Targets the `gaq-to-gtf` umbrella branch. A follow-up commit addresses
a second review pass (Celery retry semantics, retry-publish failure, and a
stale-cache hole in the force marker).

**P1c — non-abortable timeout no longer strands a task `IN_PROGRESS`.** A task
with no registered abort handlers can't be cancelled, so its timeout firing is
now a logged no-op. Previously it set `_timeout_triggered`, which blocks the
executor's `IN_PROGRESS → SUCCESS` transition (gated on no abort in flight),
while the finalize only moves `TIMED_OUT` from `ABORTING` — a transition that
never happens for a handler-less task — leaving it stuck `IN_PROGRESS`. It now
runs to natural completion.

**P2a — the DAG dependency gate is non-blocking.** A dependent picked up before
its prerequisites are terminal is deferred with a Celery `self.retry(countdown=…)`
instead of parking a worker slot in a blocking `wait_for_completion`. The backoff
grows and is jittered (1s, 3s, 5s… capped at 30s, keyed off
`self.request.retries`, so no persisted state). The gate (`_unmet_prerequisite`)
trusts a prerequisite already terminal in the loaded snapshot and re-reads only
the non-terminal ones; the abort-before-claim check and the failed-prerequisite
`FAILURE` cascade moved into `execute_task`, ahead of the heartbeat/claim, so a
merely-deferred task carries no heartbeat and can't be mistaken for abandoned
work by the reaper.

Retries are made **truly unlimited** by declaring `tasks.execute` with
`max_retries=None` — Celery's `self.retry(max_retries=None)` otherwise falls
back to the task's attribute (default 3), so a parent that outran the first few
defer intervals would exhaust retries and strand the dependent `PENDING`. A
retry **publish** failure (broker down) is also handled: the `self.retry` call
is wrapped so only Celery's `Retry` sentinel propagates; any other error
transitions the task to `FAILURE` and publishes completion, so it is never left
`PENDING` with a null heartbeat.

**P1b — a failed Celery enqueue no longer poisons the dedup key.** If
`execute_task.delay(...)` throws, the just-created task is transitioned to
`FAILURE` (and a completion published) instead of being left `PENDING`, where it
would dedup future identical submits into a task that never runs. The original
enqueue error is re-raised; cleanup failures are swallowed and logged. (Note: a
task that fails cleanup is left `PENDING` with no heartbeat and is *not*
auto-reaped — the reaper only reclaims tasks that have started — so its dedup key
stays occupied until manually cleared or pruned. The narrower window of a process
crash between the DB commit and the enqueue still needs a transactional
outbox/dispatcher and is called out as a follow-up rather than bolted on here.)

**Observability.** Every status transition emits `gtf.task.transition.<status>`,
and each DAG defer emits `gtf.task.dag_deferred`.

**P1a — forced async chart-data no longer double-executes.** A forced refresh in
the async flow is issued twice — the async submit, then a synchronous read-back —
and both previously carried `force=true`, so the read-back recomputed the
identical query instead of reading the result the task just cached. A per-refresh
idempotency nonce (`force_nonce`) now dedups this **server-side**:

- The first execution to run for a `(nonce, cache_key)` recomputes with `force`
  and, *only once its result is confirmed persisted to the DATA cache*, records a
  marker `gtf-force-nonce:{nonce}:{cache_key}`.
- Any later request carrying the same nonce sees the marker and resolves
  `force=false`, reading the freshly-warmed result.
- The marker is a **separate** cache key, never folded into the result
  `cache_key`, so the fresh value lands under the normal key and ordinary
  (non-forced) loads stay warm.
- A request whose `cache_key` differs from the one the forced compute cached
  against (e.g. templated `{{ current_timestamp }}` / time-relative keys that
  shift between submit and read-back) finds no marker and correctly recomputes,
  rather than mis-reading another key's result. The composite key also makes each
  query object in a multi-query request independently idempotent under one
  request nonce.

Gating the marker on a **confirmed** cache write is essential: `set_and_log_cache`
silently skips oversized values and swallows backend errors, so a "successful"
`set_query_result` call does not guarantee a cached value. `set_and_log_cache` /
`QueryCacheManager.set` now return a `persisted` bool (surfaced as
`QueryCacheManager.result_persisted`) — honoring both a raised error and an
explicit `False` return from the cache backend (Flask-Caching's `set()` can
report a failed write without raising), treating a `None` return as success. If
the fresh value wasn't persisted, no marker is written, so the read-back keeps
forcing rather than serving a stale prior value. Marker cache ops are best-effort like the query cache itself: a read
failure degrades to "absent" (force); a write failure is logged and swallowed (at
worst one extra recompute).

The nonce is minted once per user force refresh on the frontend
(`requestChartDataResolved`) and carried on both requests; it is threaded through
query serialization so the async task and the read-back share it.

**Scope of the idempotency guarantee:** this dedups **one refresh's own
submit/read-back pair**. It does *not* make concurrent force refreshes idempotent
— a second refresh mints a new nonce and, if it joins the first's shared task
(deduped by query cache key), still forces its own read-back, since the first
task only recorded its own nonce. Because the design is nonce-based (not "clear
`force` on the re-issue"), the frontend keeps `force=true` on both requests; the
server, not the client, is what prevents the second compute.

### TESTING INSTRUCTIONS

- Backend: `pytest tests/unit_tests/tasks/ tests/unit_tests/commands/tasks/ tests/unit_tests/common/ tests/unit_tests/utils/cache_test.py`
  (DAG gate/defer + unlimited-retry + publish-failure, enqueue-failure cleanup,
  timeout no-op, transition metric, nonce gate + persisted-gated marker +
  best-effort marker ops, `set_and_log_cache` persistence outcome, serialization
  round-trip).
- Frontend: `npm run test -- chartActions buildQueryContext exploreUtils`
  (one nonce minted per refresh and carried on both submit and re-issue; both
  keep `force`; the re-issue is synchronous).
- Manual (async chart-data deployment, `GLOBAL_ASYNC_QUERIES` on): force-refresh
  a chart; confirm the query runs **once** (one task, no second compute on the
  read-back) via query logs/metrics; a fresh force refresh recomputes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API (adds optional `force_nonce` to the
      chart-data query context; ignored when `force` is false)
- [ ] Removes existing feature or API

