### PR TITLE
feat(dashboard): add column allowlist to Group By native filter

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx
@@ -21,15 +21,22 @@ import {
   type ChartCustomization,
 } from '@superset-ui/core';
 import { LabeledValue } from '@superset-ui/core/components';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, userEvent } from 'spec/helpers/testing-library';
+import { cachedSupersetGet } from 'src/utils/cachedSupersetGet';
 import GroupByFilterCard, {
+  applyColumnAllowlist,
   createLabelSortComparator,
 } from './GroupByFilterCard';
 
 jest.mock('src/utils/cachedSupersetGet', () => ({
-  // Never resolves, pinning the card in its column-loading state.
+  // Never resolves by default, pinning the card in its column-loading state.
+  // Individual tests override this with `mockImplementationOnce`.
   cachedSupersetGet: jest.fn(() => new Promise(() => {})),
 }));
+
+const mockedCachedSupersetGet = cachedSupersetGet as jest.MockedFunction<
+  typeof cachedSupersetGet
+>;
 
 const apple: LabeledValue = { value: 'a', label: 'Apple' };
 const banana: LabeledValue = { value: 'b', label: 'Banana' };
@@ -52,6 +59,33 @@ test('preserves source order when sortAscending is unset', () => {
   expect(compare(banana, apple)).toBe(0);
 });
 
+const columnOptions = [
+  { label: 'Country', value: 'country' },
+  { label: 'State', value: 'state' },
+  { label: 'City', value: 'city' },
+];
+
+test('returns all options when the allowlist is unset (backwards compatible)', () => {
+  expect(applyColumnAllowlist(columnOptions, undefined)).toEqual(columnOptions);
+});
+
+test('returns all options when the allowlist is empty (no restriction)', () => {
+  expect(applyColumnAllowlist(columnOptions, [])).toEqual(columnOptions);
+});
+
+test('keeps only allowlisted columns and preserves their order', () => {
+  expect(applyColumnAllowlist(columnOptions, ['city', 'country'])).toEqual([
+    { label: 'Country', value: 'country' },
+    { label: 'City', value: 'city' },
+  ]);
+});
+
+test('ignores allowlist entries that are not real columns', () => {
+  expect(
+    applyColumnAllowlist(columnOptions, ['state', 'does_not_exist']),
+  ).toEqual([{ label: 'State', value: 'state' }]);
+});
+
 const groupByCustomization: ChartCustomization = {
   id: 'groupby-1',
   name: 'Group By',
@@ -62,6 +96,73 @@ const groupByCustomization: ChartCustomization = {
   controlValues: {},
   defaultDataMask: {},
 };
+
+const datasetResponse = {
+  json: {
+    result: {
+      table_name: 'cleaned_sales_data',
+      columns: [
+        { column_name: 'country', verbose_name: 'Country', filterable: true },
+        { column_name: 'state', verbose_name: 'State', filterable: true },
+        { column_name: 'city', verbose_name: 'City', filterable: true },
+      ],
+    },
+  },
+};
+
+test('only offers allowlisted columns to viewers', async () => {
+  mockedCachedSupersetGet.mockImplementationOnce(
+    () =>
+      Promise.resolve(datasetResponse) as unknown as ReturnType<
+        typeof cachedSupersetGet
+      >,
+  );
+
+  render(
+    <GroupByFilterCard
+      customizationItem={{
+        ...groupByCustomization,
+        controlValues: { columnsAllowlist: ['country', 'city'] },
+      }}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        dataMask: {},
+        nativeFilters: { filters: {} },
+      },
+    },
+  );
+
+  userEvent.click(await screen.findByRole('combobox'));
+
+  expect(await screen.findByText('Country')).toBeInTheDocument();
+  expect(screen.getByText('City')).toBeInTheDocument();
+  expect(screen.queryByText('State')).not.toBeInTheDocument();
+});
+
+test('offers every groupable column when no allowlist is configured', async () => {
+  mockedCachedSupersetGet.mockImplementationOnce(
+    () =>
+      Promise.resolve(datasetResponse) as unknown as ReturnType<
+        typeof cachedSupersetGet
+      >,
+  );
+
+  render(<GroupByFilterCard customizationItem={groupByCustomization} />, {
+    useRedux: true,
+    initialState: {
+      dataMask: {},
+      nativeFilters: { filters: {} },
+    },
+  });
+
+  userEvent.click(await screen.findByRole('combobox'));
+
+  expect(await screen.findByText('Country')).toBeInTheDocument();
+  expect(screen.getByText('State')).toBeInTheDocument();
+  expect(screen.getByText('City')).toBeInTheDocument();
+});
 
 test('renders the column-loading spinner small and muted', async () => {
   render(<GroupByFilterCard customizationItem={groupByCustomization} />, {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -217,6 +217,21 @@ const DescriptionTooltip = ({ description }: { description: string }) => (
   </ToolTipContainer>
 );
 
+// Restrict the groupable column options to the builder-configured allowlist.
+// An unset or empty allowlist means "no restriction" so existing Group By
+// customizations (which never stored an allowlist) keep offering every
+// groupable column, preserving backwards compatibility.
+export const applyColumnAllowlist = <T extends { value: string }>(
+  options: T[],
+  allowlist?: string[] | null,
+): T[] => {
+  if (!Array.isArray(allowlist) || allowlist.length === 0) {
+    return options;
+  }
+  const allowed = new Set(allowlist);
+  return options.filter(option => allowed.has(option.value));
+};
+
 // Sort display values by label: ascending when sortAscending is true, descending
 // when false, and source order (no sort) when it is unset.
 export const createLabelSortComparator =
@@ -353,6 +368,16 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
   const sortComparator = useMemo(
     () => createLabelSortComparator(sortAscending),
     [sortAscending],
+  );
+
+  // Builder-configured allowlist of columns viewers are allowed to group by.
+  const columnsAllowlist = customizationItem.controlValues?.columnsAllowlist as
+    | string[]
+    | undefined;
+
+  const allowedColumnOptions = useMemo(
+    () => applyColumnAllowlist(columnOptions, columnsAllowlist),
+    [columnOptions, columnsAllowlist],
   );
 
   const columnDisplayName = useMemo(() => {
@@ -599,7 +624,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
               placeholder={t('Search columns...')}
               value={currentValue}
               onChange={handleColumnChange}
-              options={columnOptions}
+              options={allowedColumnOptions}
               showSearch
               mode={canSelectMultiple ? 'multiple' : undefined}
               filterOption={(input, option) =>
@@ -629,7 +654,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
             placeholder={t('Search columns...')}
             value={currentValue}
             onChange={handleColumnChange}
-            options={columnOptions}
+            options={allowedColumnOptions}
             showSearch
             mode={canSelectMultiple ? 'multiple' : undefined}
             filterOption={(input, option) =>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/ColumnSelect.tsx
@@ -45,6 +45,10 @@ interface ColumnSelectProps {
   value?: string | string[];
   onChange?: (value: string) => void;
   mode?: 'multiple';
+  // Called with the names of the columns that back the rendered options
+  // (already narrowed by `filterValues`) whenever a dataset's columns load.
+  // Lets a parent seed a default selection that matches the options exactly.
+  onColumnsLoaded?: (columnNames: string[]) => void;
 }
 
 /** Special purpose AsyncSelect that selects a column from a dataset */
@@ -60,6 +64,7 @@ export function ColumnSelect({
   value,
   onChange,
   mode,
+  onColumnsLoaded,
 }: ColumnSelectProps) {
   const [columns, setColumns] = useState<Column[]>();
   const [loading, setLoading] = useState(false);
@@ -70,13 +75,24 @@ export function ColumnSelect({
     ]);
   }, [form, filterId, formField]);
 
+  // The names backing the rendered options: the loaded columns narrowed by
+  // `filterValues`. Shared by both the option list and the onColumnsLoaded
+  // callback so a seeded default matches the available options exactly.
+  const filterColumnNames = useCallback(
+    (cols: Column[]) =>
+      ensureIsArray(cols)
+        .filter(filterValues)
+        .map((col: Column) => col.column_name),
+    [filterValues],
+  );
+
   const options = useMemo(
     () =>
-      ensureIsArray(columns)
-        .filter(filterValues)
-        .map((col: Column) => col.column_name)
-        .map((column: string) => ({ label: column, value: column })),
-    [columns, filterValues],
+      filterColumnNames(ensureIsArray(columns)).map((column: string) => ({
+        label: column,
+        value: column,
+      })),
+    [columns, filterColumnNames],
   );
 
   const currentFilterType =
@@ -141,6 +157,7 @@ export function ColumnSelect({
               resetColumnField();
             }
             setColumns(cols);
+            onColumnsLoaded?.(filterColumnNames(cols));
           }, handleError)
           .finally(() => setLoading(false));
       } else {
@@ -163,6 +180,7 @@ export function ColumnSelect({
               resetColumnField();
             }
             setColumns(result.columns);
+            onColumnsLoaded?.(filterColumnNames(result.columns));
           }, handleError)
           .finally(() => setLoading(false));
       }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -614,6 +614,37 @@ const FiltersConfigForm = (
     [filterId, form, formChanged],
   );
 
+  // Seed a NEW Dynamic Group By control's allowlist with every groupable
+  // column so it defaults to "all selected" (builders can then deselect to
+  // restrict). Only seeds when no allowlist is set yet — a freshly created
+  // control, or one whose dataset just changed (which clears the allowlist).
+  // An existing selection, including a deliberately narrowed or emptied one,
+  // is never overwritten. The column names come from the same source that
+  // populates the multi-select options, so the default matches exactly what
+  // the builder can choose from. Seeding does not mark the form as changed, so
+  // editing a legacy control that never stored an allowlist stays a no-op
+  // unless the builder actually narrows the selection.
+  const seedGroupByAllowlist = useCallback(
+    (columnNames: string[]) => {
+      if (!isDynamicGroupBy || columnNames.length === 0) {
+        return;
+      }
+      const currentControlValues =
+        form.getFieldValue(['filters', filterId, 'controlValues']) || {};
+      if (currentControlValues.columnsAllowlist !== undefined) {
+        return;
+      }
+      setNativeFilterFieldValues(form, filterId, {
+        controlValues: {
+          ...currentControlValues,
+          columnsAllowlist: columnNames,
+        },
+      });
+      forceUpdate();
+    },
+    [isDynamicGroupBy, form, filterId, forceUpdate],
+  );
+
   const hasPreFilter =
     !!formFilter?.adhoc_filters ||
     !!formFilter?.time_range ||
@@ -1199,9 +1230,12 @@ const FiltersConfigForm = (
                                 datasourceType: newDatasourceType,
                                 defaultDataMask: null,
                                 column: null,
-                                // Columns are dataset-specific, so drop any
-                                // configured Group By allowlist when the
-                                // dataset changes to avoid stale entries.
+                                // Columns are dataset-specific, so clear the
+                                // Group By allowlist when the dataset changes to
+                                // avoid stale entries. Clearing it to undefined
+                                // lets seedGroupByAllowlist re-seed the default
+                                // (all groupable columns) once the new dataset's
+                                // columns load.
                                 ...(isDynamicGroupBy
                                   ? {
                                       controlValues: {
@@ -1267,6 +1301,7 @@ const FiltersConfigForm = (
                         datasetId={datasetId}
                         datasourceType={datasourceType}
                         filterValues={(column: Column) => !!column?.filterable}
+                        onColumnsLoaded={seedGroupByAllowlist}
                         onChange={() => {
                           forceUpdate();
                           formChanged();

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1233,45 +1233,47 @@ const FiltersConfigForm = (
                   </StyledRowContainer>
                 )}
                 {isDynamicGroupBy && hasDataset && showDataset && (
-                  <StyledRowFormItem
-                    expanded={expanded}
-                    name={[
-                      'filters',
-                      filterId,
-                      'controlValues',
-                      'columnsAllowlist',
-                    ]}
-                    initialValue={
-                      customizationToEdit?.controlValues?.columnsAllowlist
-                    }
-                    label={
-                      <>
-                        <StyledLabel>{t('Groupable columns')}</StyledLabel>
-                        &nbsp;
-                        <InfoTooltip
-                          placement="top"
-                          tooltip={t(
-                            'Columns viewers are allowed to group by. Leave empty to allow all groupable columns.',
-                          )}
-                        />
-                      </>
-                    }
-                    data-test="groupby-columns-allowlist"
-                  >
-                    <ColumnSelect
-                      mode="multiple"
-                      allowClear
-                      form={form}
-                      filterId={filterId}
-                      datasetId={datasetId}
-                      datasourceType={datasourceType}
-                      filterValues={(column: Column) => !!column?.filterable}
-                      onChange={() => {
-                        forceUpdate();
-                        formChanged();
-                      }}
-                    />
-                  </StyledRowFormItem>
+                  <StyledRowContainer justify="space-between">
+                    <StyledRowFormItem
+                      expanded={expanded}
+                      name={[
+                        'filters',
+                        filterId,
+                        'controlValues',
+                        'columnsAllowlist',
+                      ]}
+                      initialValue={
+                        customizationToEdit?.controlValues?.columnsAllowlist
+                      }
+                      label={
+                        <>
+                          <StyledLabel>{t('Groupable columns')}</StyledLabel>
+                          &nbsp;
+                          <InfoTooltip
+                            placement="top"
+                            tooltip={t(
+                              'Columns viewers are allowed to group by. Leave empty to allow all groupable columns.',
+                            )}
+                          />
+                        </>
+                      }
+                      data-test="groupby-columns-allowlist"
+                    >
+                      <ColumnSelect
+                        mode="multiple"
+                        allowClear
+                        form={form}
+                        filterId={filterId}
+                        datasetId={datasetId}
+                        datasourceType={datasourceType}
+                        filterValues={(column: Column) => !!column?.filterable}
+                        onChange={() => {
+                          forceUpdate();
+                          formChanged();
+                        }}
+                      />
+                    </StyledRowFormItem>
+                  </StyledRowContainer>
                 )}
                 <Collapse
                   modalMode

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1266,50 +1266,6 @@ const FiltersConfigForm = (
                       )}
                   </StyledRowContainer>
                 )}
-                {isDynamicGroupBy && hasDataset && showDataset && (
-                  <StyledRowContainer justify="space-between">
-                    <StyledRowFormItem
-                      expanded={expanded}
-                      name={[
-                        'filters',
-                        filterId,
-                        'controlValues',
-                        'columnsAllowlist',
-                      ]}
-                      initialValue={
-                        customizationToEdit?.controlValues?.columnsAllowlist
-                      }
-                      label={
-                        <>
-                          <StyledLabel>{t('Groupable columns')}</StyledLabel>
-                          &nbsp;
-                          <InfoTooltip
-                            placement="top"
-                            tooltip={t(
-                              'Columns viewers are allowed to group by. Leave empty to allow all groupable columns.',
-                            )}
-                          />
-                        </>
-                      }
-                      data-test="groupby-columns-allowlist"
-                    >
-                      <ColumnSelect
-                        mode="multiple"
-                        allowClear
-                        form={form}
-                        filterId={filterId}
-                        datasetId={datasetId}
-                        datasourceType={datasourceType}
-                        filterValues={(column: Column) => !!column?.filterable}
-                        onColumnsLoaded={seedGroupByAllowlist}
-                        onChange={() => {
-                          forceUpdate();
-                          formChanged();
-                        }}
-                      />
-                    </StyledRowFormItem>
-                  </StyledRowContainer>
-                )}
                 <Collapse
                   modalMode
                   defaultActiveKey={activeFilterPanelKeys}
@@ -1329,6 +1285,55 @@ const FiltersConfigForm = (
                               : FilterPanels.configuration.name,
                             children: (
                               <>
+                                {isDynamicGroupBy &&
+                                  hasDataset &&
+                                  showDataset && (
+                                    <StyledRowFormItem
+                                      expanded={expanded}
+                                      name={[
+                                        'filters',
+                                        filterId,
+                                        'controlValues',
+                                        'columnsAllowlist',
+                                      ]}
+                                      initialValue={
+                                        customizationToEdit?.controlValues
+                                          ?.columnsAllowlist
+                                      }
+                                      label={
+                                        <>
+                                          <StyledLabel>
+                                            {t('Groupable columns')}
+                                          </StyledLabel>
+                                          &nbsp;
+                                          <InfoTooltip
+                                            placement="top"
+                                            tooltip={t(
+                                              'Columns viewers are allowed to group by. Leave empty to allow all groupable columns.',
+                                            )}
+                                          />
+                                        </>
+                                      }
+                                      data-test="groupby-columns-allowlist"
+                                    >
+                                      <ColumnSelect
+                                        mode="multiple"
+                                        allowClear
+                                        form={form}
+                                        filterId={filterId}
+                                        datasetId={datasetId}
+                                        datasourceType={datasourceType}
+                                        filterValues={(column: Column) =>
+                                          !!column?.filterable
+                                        }
+                                        onColumnsLoaded={seedGroupByAllowlist}
+                                        onChange={() => {
+                                          forceUpdate();
+                                          formChanged();
+                                        }}
+                                      />
+                                    </StyledRowFormItem>
+                                  )}
                                 {canDependOnOtherFilters &&
                                   (hasAvailableFilters ||
                                     dependencies.length > 0) && (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -93,6 +93,7 @@ import {
   mergeExtraFormData,
 } from 'src/dashboard/components/nativeFilters/utils';
 import { DatasetSelectLabel } from 'src/features/datasets/DatasetSelectLabel';
+import { ChartCustomizationPlugins } from 'src/constants';
 import {
   ALLOW_DEPENDENCIES as TYPES_SUPPORT_DEPENDENCIES,
   getFiltersConfigModalTestId,
@@ -389,6 +390,12 @@ const FiltersConfigForm = (
   const hasDataset =
     // @ts-expect-error
     !!nativeFilterAndCustomizationItems[itemTypeField]?.value?.datasourceCount;
+
+  // The Dynamic Group By customization lets builders curate which columns
+  // viewers may group by via a column allowlist (stored in controlValues).
+  const isDynamicGroupBy =
+    isChartCustomization &&
+    itemTypeField === ChartCustomizationPlugins.DynamicGroupBy;
 
   const getDatasetId = () => {
     if (isChartCustomization) {
@@ -1192,6 +1199,17 @@ const FiltersConfigForm = (
                                 datasourceType: newDatasourceType,
                                 defaultDataMask: null,
                                 column: null,
+                                // Columns are dataset-specific, so drop any
+                                // configured Group By allowlist when the
+                                // dataset changes to avoid stale entries.
+                                ...(isDynamicGroupBy
+                                  ? {
+                                      controlValues: {
+                                        ...formFilter?.controlValues,
+                                        columnsAllowlist: undefined,
+                                      },
+                                    }
+                                  : {}),
                               });
                             }
                             forceUpdate();
@@ -1213,6 +1231,47 @@ const FiltersConfigForm = (
                         key => mainControlItems[key].element,
                       )}
                   </StyledRowContainer>
+                )}
+                {isDynamicGroupBy && hasDataset && showDataset && (
+                  <StyledRowFormItem
+                    expanded={expanded}
+                    name={[
+                      'filters',
+                      filterId,
+                      'controlValues',
+                      'columnsAllowlist',
+                    ]}
+                    initialValue={
+                      customizationToEdit?.controlValues?.columnsAllowlist
+                    }
+                    label={
+                      <>
+                        <StyledLabel>{t('Groupable columns')}</StyledLabel>
+                        &nbsp;
+                        <InfoTooltip
+                          placement="top"
+                          tooltip={t(
+                            'Columns viewers are allowed to group by. Leave empty to allow all groupable columns.',
+                          )}
+                        />
+                      </>
+                    }
+                    data-test="groupby-columns-allowlist"
+                  >
+                    <ColumnSelect
+                      mode="multiple"
+                      allowClear
+                      form={form}
+                      filterId={filterId}
+                      datasetId={datasetId}
+                      datasourceType={datasourceType}
+                      filterValues={(column: Column) => !!column?.filterable}
+                      onChange={() => {
+                        forceUpdate();
+                        formChanged();
+                      }}
+                    />
+                  </StyledRowFormItem>
                 )}
                 <Collapse
                   modalMode

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/GroupByColumnAllowlist.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/GroupByColumnAllowlist.test.tsx
@@ -25,7 +25,7 @@ import {
 } from '@superset-ui/core';
 import { Form } from '@superset-ui/core/components';
 import fetchMock from 'fetch-mock';
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import { ChartCustomizationPlugins } from 'src/constants';
 import FiltersConfigForm from './FiltersConfigForm';
 
@@ -52,7 +52,73 @@ fetchMock.get('glob:*/api/v1/dataset/1?*', {
 
 const FILTER_ID = 'CHART_CUSTOMIZATION-groupby';
 
-const customizationToEdit: ChartCustomization = {
+const noop = () => {};
+
+function renderForm({
+  customizationToEdit,
+  initialControlValues,
+}: {
+  customizationToEdit?: ChartCustomization;
+  initialControlValues?: Record<string, unknown>;
+} = {}) {
+  function Harness() {
+    const [form] = Form.useForm();
+    return (
+      <Form
+        form={form}
+        initialValues={{
+          filters: {
+            [FILTER_ID]: {
+              filterType: ChartCustomizationPlugins.DynamicGroupBy,
+              dataset: { value: 1, label: 'sales' },
+              ...(initialControlValues
+                ? { controlValues: initialControlValues }
+                : {}),
+            },
+          },
+        }}
+      >
+        <FiltersConfigForm
+          filterId={FILTER_ID}
+          itemType="chartCustomization"
+          form={form}
+          customizationToEdit={customizationToEdit}
+          expanded
+          removedFilters={{}}
+          restoreFilter={noop}
+          onModifyFilter={noop}
+          getAvailableFilters={() => []}
+          handleActiveFilterPanelChange={noop}
+          activeFilterPanelKeys={[]}
+          isActive
+          setErroredFilters={() => []}
+          validateDependencies={noop}
+          getDependencySuggestion={() => ''}
+        />
+      </Form>
+    );
+  }
+
+  return render(<Harness />, {
+    useRedux: true,
+    initialState: {
+      dashboardInfo: { id: 1 },
+      datasources: {},
+      charts: {},
+    },
+  });
+}
+
+// Scopes queries to the Groupable columns multi-select. antd only renders
+// picked values (not the closed dropdown options) as selection items, so text
+// found inside this Form.Item reflects the current allowlist selection.
+async function getAllowlistScope() {
+  const label = await screen.findByText('Groupable columns');
+  const formItem = label.closest('.ant-form-item') as HTMLElement;
+  return within(formItem);
+}
+
+const customizationWithNarrowedAllowlist: ChartCustomization = {
   id: FILTER_ID,
   name: 'Group By',
   filterType: ChartCustomizationPlugins.DynamicGroupBy,
@@ -63,56 +129,12 @@ const customizationToEdit: ChartCustomization = {
   defaultDataMask: {},
 };
 
-const noop = () => {};
-
-function Harness() {
-  const [form] = Form.useForm();
-  return (
-    <Form
-      form={form}
-      initialValues={{
-        filters: {
-          [FILTER_ID]: {
-            filterType: ChartCustomizationPlugins.DynamicGroupBy,
-            dataset: { value: 1, label: 'sales' },
-          },
-        },
-      }}
-    >
-      <FiltersConfigForm
-        filterId={FILTER_ID}
-        itemType="chartCustomization"
-        form={form}
-        customizationToEdit={customizationToEdit}
-        expanded
-        removedFilters={{}}
-        restoreFilter={noop}
-        onModifyFilter={noop}
-        getAvailableFilters={() => []}
-        handleActiveFilterPanelChange={noop}
-        activeFilterPanelKeys={[]}
-        isActive
-        setErroredFilters={() => []}
-        validateDependencies={noop}
-        getDependencySuggestion={() => ''}
-      />
-    </Form>
-  );
-}
-
 afterAll(() => {
   fetchMock.clearHistory().removeRoutes();
 });
 
 test('shows the Groupable columns allowlist control for the Group By customization', async () => {
-  render(<Harness />, {
-    useRedux: true,
-    initialState: {
-      dashboardInfo: { id: 1 },
-      datasources: {},
-      charts: {},
-    },
-  });
+  renderForm({ customizationToEdit: customizationWithNarrowedAllowlist });
 
   await waitFor(() =>
     expect(screen.getByText('Groupable columns')).toBeInTheDocument(),
@@ -120,5 +142,34 @@ test('shows the Groupable columns allowlist control for the Group By customizati
 
   // The previously-configured allowlist column is rendered as a selected value,
   // proving the control reads back its persisted controlValues.columnsAllowlist.
-  expect(await screen.findByText('country')).toBeInTheDocument();
+  const allowlist = await getAllowlistScope();
+  expect(await allowlist.findByText('country')).toBeInTheDocument();
+});
+
+test('seeds a new control with every groupable column selected by default', async () => {
+  // No customizationToEdit and no configured allowlist: a freshly created
+  // control. Once the dataset's columns load, the allowlist should default to
+  // ALL groupable columns so builders start from "all selected".
+  renderForm();
+
+  const allowlist = await getAllowlistScope();
+  expect(await allowlist.findByText('country')).toBeInTheDocument();
+  expect(await allowlist.findByText('state')).toBeInTheDocument();
+});
+
+test('does not overwrite an existing narrowed allowlist when editing', async () => {
+  // Editing a control that already narrowed the allowlist to a single column
+  // must keep that selection; the seeding default only applies to new controls.
+  renderForm({
+    customizationToEdit: customizationWithNarrowedAllowlist,
+    initialControlValues: { columnsAllowlist: ['country'] },
+  });
+
+  const allowlist = await getAllowlistScope();
+  expect(await allowlist.findByText('country')).toBeInTheDocument();
+  // 'state' is a valid option but was deliberately excluded, so it must not be
+  // seeded back in as a selected value.
+  await waitFor(() =>
+    expect(allowlist.queryByText('state')).not.toBeInTheDocument(),
+  );
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/GroupByColumnAllowlist.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/GroupByColumnAllowlist.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  Behavior,
+  ChartMetadata,
+  ChartCustomization,
+  ChartCustomizationType,
+  getChartMetadataRegistry,
+} from '@superset-ui/core';
+import { Form } from '@superset-ui/core/components';
+import fetchMock from 'fetch-mock';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { ChartCustomizationPlugins } from 'src/constants';
+import FiltersConfigForm from './FiltersConfigForm';
+
+// Register a minimal Group By customization so the config form treats it as a
+// dataset-backed chart customization (datasourceCount > 0 -> hasDataset).
+getChartMetadataRegistry().registerValue(
+  ChartCustomizationPlugins.DynamicGroupBy,
+  new ChartMetadata({
+    name: 'Group By',
+    datasourceCount: 1,
+    behaviors: [Behavior.ChartCustomization],
+    thumbnail: '',
+  }),
+);
+
+fetchMock.get('glob:*/api/v1/dataset/1?*', {
+  result: {
+    columns: [
+      { column_name: 'country', is_dttm: false, filterable: true },
+      { column_name: 'state', is_dttm: false, filterable: true },
+    ],
+  },
+});
+
+const FILTER_ID = 'CHART_CUSTOMIZATION-groupby';
+
+const customizationToEdit: ChartCustomization = {
+  id: FILTER_ID,
+  name: 'Group By',
+  filterType: ChartCustomizationPlugins.DynamicGroupBy,
+  type: ChartCustomizationType.ChartCustomization,
+  targets: [{ datasetId: 1 }],
+  scope: { rootPath: ['ROOT_ID'], excluded: [] },
+  controlValues: { columnsAllowlist: ['country'] },
+  defaultDataMask: {},
+};
+
+const noop = () => {};
+
+function Harness() {
+  const [form] = Form.useForm();
+  return (
+    <Form
+      form={form}
+      initialValues={{
+        filters: {
+          [FILTER_ID]: {
+            filterType: ChartCustomizationPlugins.DynamicGroupBy,
+            dataset: { value: 1, label: 'sales' },
+          },
+        },
+      }}
+    >
+      <FiltersConfigForm
+        filterId={FILTER_ID}
+        itemType="chartCustomization"
+        form={form}
+        customizationToEdit={customizationToEdit}
+        expanded
+        removedFilters={{}}
+        restoreFilter={noop}
+        onModifyFilter={noop}
+        getAvailableFilters={() => []}
+        handleActiveFilterPanelChange={noop}
+        activeFilterPanelKeys={[]}
+        isActive
+        setErroredFilters={() => []}
+        validateDependencies={noop}
+        getDependencySuggestion={() => ''}
+      />
+    </Form>
+  );
+}
+
+afterAll(() => {
+  fetchMock.clearHistory().removeRoutes();
+});
+
+test('shows the Groupable columns allowlist control for the Group By customization', async () => {
+  render(<Harness />, {
+    useRedux: true,
+    initialState: {
+      dashboardInfo: { id: 1 },
+      datasources: {},
+      charts: {},
+    },
+  });
+
+  await waitFor(() =>
+    expect(screen.getByText('Groupable columns')).toBeInTheDocument(),
+  );
+
+  // The previously-configured allowlist column is rendered as a selected value,
+  // proving the control reads back its persisted controlValues.columnsAllowlist.
+  expect(await screen.findByText('country')).toBeInTheDocument();
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/customizationTransformer.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/customizationTransformer.test.ts
@@ -73,6 +73,31 @@ test('serializes a dataset-backed customization into a full ChartCustomization',
   expect(result).not.toHaveProperty('defaultValueQueriesData');
 });
 
+test('persists the Group By column allowlist from controlValues on save', () => {
+  const formItem = {
+    ...baseFormItem,
+    name: 'Group by',
+    filterType: 'chart_customization_dynamic_groupby',
+    dataset: { value: 42, label: 'sales' },
+    controlValues: {
+      canSelectMultiple: true,
+      columnsAllowlist: ['region', 'country'],
+    },
+  } as unknown as ChartCustomizationsFormItem;
+
+  const result = transformCustomizationForSave(
+    'CHART_CUSTOMIZATION-allowlist',
+    formItem,
+  ) as ChartCustomization;
+
+  // The allowlist rides along in controlValues so it survives save/reload and
+  // dashboard export/import with no extra plumbing.
+  expect(result.controlValues).toEqual({
+    canSelectMultiple: true,
+    columnsAllowlist: ['region', 'country'],
+  });
+});
+
 test('passes an already-saved ChartCustomization through untouched', () => {
   const saved: ChartCustomization = {
     id: 'CHART_CUSTOMIZATION-ghi',


### PR DESCRIPTION
### SUMMARY

Dashboard builders can configure a **Group By** native filter (the Dynamic Group By chart customization, `chart_customization_dynamic_groupby`), but until now viewers could group by **any** groupable column of the underlying dataset. This PR lets the builder curate an **allowlist** of columns that viewers are allowed to group by.

Tracking: [Shortcut sc-119327](https://app.shortcut.com/preset/story/119327)

**What changed**

- **Builder config panel** (`FiltersConfigForm.tsx`): adds a multi-select **"Groupable columns"** control for the Group By filter, reusing the existing `ColumnSelect` in `mode="multiple"`. The selection is the allowlist. It renders only for the Dynamic Group By customization and only once a dataset is chosen. Changing the dataset clears the allowlist so it can't hold stale, dataset-specific column names.
- **Persistence**: the selection is stored in the customization's `controlValues.columnsAllowlist`. `controlValues` is already serialized with the customization, so the allowlist survives **save/reload** and **dashboard export/import** with **no backend changes**.
- **Viewer** (`GroupByFilterCard.tsx`): filters the offered column options through the allowlist via a small pure helper `applyColumnAllowlist`.
- **Backwards compatible**: an **unset or empty** allowlist means **no restriction**. Existing Group By filters (which never stored an allowlist) keep offering every groupable column exactly as before.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

[sc-119327-groupby-allowlist-demo.webm](https://github.com/user-attachments/assets/b6fea30d-cc18-4fed-8648-decfb3ad9808)


### TESTING INSTRUCTIONS

Automated (frontend):

```
cd superset-frontend
npm test -- \
  src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.test.tsx \
  src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/GroupByColumnAllowlist.test.tsx \
  src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/customizationTransformer.test.ts
```

Covers: the filtering helper (allowlist unset/empty → all columns; non-empty → only allowlisted, ignoring non-existent entries), the viewer only rendering allowlisted options (and all options when unconfigured), the config-form control rendering and reading back its persisted value, and `controlValues.columnsAllowlist` surviving the save transform.

Manual:
1. On a dashboard, add a **Group By** native filter and pick a dataset.
2. In its config, set **"Groupable columns"** to a subset of columns; save.
3. As a viewer, confirm the Group By filter only offers that subset.
4. Clear the selection (empty) and confirm all groupable columns are offered again (backwards-compatible default).
5. Export the dashboard and re-import it; confirm the allowlist is preserved.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

