### PR TITLE
feat(export): let deployments carry extra fields through asset export/import

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -566,6 +566,55 @@ def FLASK_APP_MUTATOR(app: Flask) -> None:
     app.before_request_funcs.setdefault(None, []).append(make_session_permanent)
 ```
 
+## Carrying extra data through chart and dashboard exports
+
+Deployments often attach their own metadata to charts and dashboards — an owning
+team, a catalogue entry, a cost centre — and need it to survive an export/import
+round trip between environments. `EXTRA_ASSET_EXPORT_FIELDS` and
+`EXTRA_ASSET_IMPORT_HANDLER` let you do that without forking the export commands.
+
+The export hook receives the model and the asset type (`"chart"` or `"dashboard"`)
+and returns a mapping, which is serialised under the `extra` key of the asset's
+YAML. The import hook receives the model, the asset type and that same mapping,
+once the asset exists and has an id:
+
+```python
+# superset_config.py
+def _export_fields(model, asset_type):
+    return {"owning_team": lookup_team(model)}
+
+
+def _import_handler(model, asset_type, extra):
+    if team := extra.get("owning_team"):
+        assign_team(model, team)
+
+
+EXTRA_ASSET_EXPORT_FIELDS = _export_fields
+EXTRA_ASSET_IMPORT_HANDLER = _import_handler
+```
+
+The exported YAML then carries:
+
+```yaml
+slice_name: Revenue by region
+...
+extra:
+  owning_team: analytics-platform
+```
+
+A few things worth knowing:
+
+- **Both hooks are optional and default to `None`.** With neither configured,
+exported files are byte-for-byte what they were before, and imports behave
+identically.
+- **Everything lives under the single `extra` key.** The import schemas reject
+unknown top-level fields, so namespacing under `extra` keeps that strictness
+while leaving you free to change the shape of your own payload later.
+- **An export hook returning `None` or an empty mapping writes nothing**, so
+assets without your metadata do not gain an empty `extra` block.
+- **The import handler runs after the asset is created or updated**, which means
+you can rely on `model.id`. Raising from it will fail the import.
+
 ## Customizing the landing page (index view)
 
 The page served at `/` is rendered by an index view. By default Superset registers

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1872,6 +1872,7 @@ class ImportV1ChartSchema(Schema):
     is_managed_externally = fields.Boolean(allow_none=True, dump_default=False)
     external_url = fields.String(allow_none=True, validate=utils.validate_external_url)
     tags = fields.List(fields.String(), allow_none=True)
+    extra = fields.Dict(allow_none=True, load_only=True)
 
 
 class ChartCacheWarmUpRequestSchema(Schema):

--- a/superset/commands/chart/export.py
+++ b/superset/commands/chart/export.py
@@ -25,7 +25,10 @@ import yaml
 from superset.commands.chart.exceptions import ChartNotFoundError
 from superset.daos.chart import ChartDAO
 from superset.commands.dataset.export import ExportDatasetsCommand
-from superset.commands.export.models import ExportModelsCommand
+from superset.commands.export.models import (
+    ExportModelsCommand,
+    get_extra_export_fields,
+)
 from superset.commands.tag.export import ExportTagsCommand
 from superset.models.slice import Slice
 from superset.tags.models import TagType
@@ -78,6 +81,9 @@ class ExportChartsCommand(ExportModelsCommand):
         if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
             tags = getattr(model, "tags", [])
             payload["tags"] = [tag.name for tag in tags if tag.type == TagType.custom]
+        if extra_fields := get_extra_export_fields(model, "chart"):
+            payload["extra"] = extra_fields
+
         file_content = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
         return file_content
 

--- a/superset/commands/chart/importers/v1/utils.py
+++ b/superset/commands/chart/importers/v1/utils.py
@@ -21,7 +21,10 @@ from typing import Any
 
 from superset import db, security_manager
 from superset.commands.exceptions import ImportFailedError
-from superset.commands.importers.v1.utils import find_existing_for_import
+from superset.commands.importers.v1.utils import (
+    apply_extra_import_fields,
+    find_existing_for_import,
+)
 from superset.migrations.shared.migrate_viz import processors
 from superset.migrations.shared.migrate_viz.base import MigrateViz
 from superset.models.slice import Slice
@@ -199,6 +202,7 @@ def import_chart(
     # migrate old viz types to new ones
     config = migrate_chart(config)
 
+    extra = config.pop("extra", None)
     chart = Slice.import_from_dict(config, recursive=False, allow_reparenting=True)
     if chart.id is None:
         db.session.flush()
@@ -226,6 +230,8 @@ def import_chart(
         for viewer in viewers:
             if viewer not in chart.viewers:
                 chart.viewers.append(viewer)
+
+    apply_extra_import_fields(chart, "chart", extra)
 
     return chart
 

--- a/superset/commands/dashboard/export.py
+++ b/superset/commands/dashboard/export.py
@@ -28,7 +28,10 @@ from superset.commands.tag.export import ExportTagsCommand
 from superset.commands.dashboard.exceptions import DashboardNotFoundError
 from superset.commands.dashboard.importers.v1.utils import find_chart_uuids
 from superset.daos.dashboard import DashboardDAO
-from superset.commands.export.models import ExportModelsCommand
+from superset.commands.export.models import (
+    ExportModelsCommand,
+    get_extra_export_fields,
+)
 from superset.commands.dataset.export import ExportDatasetsCommand
 from superset.daos.dataset import DatasetDAO
 from superset.models.dashboard import Dashboard
@@ -376,6 +379,9 @@ class ExportDashboardsCommand(ExportModelsCommand):
         if feature_flag_manager.is_feature_enabled("TAGGING_SYSTEM"):
             tags = model.tags if hasattr(model, "tags") else []
             payload["tags"] = [tag.name for tag in tags if tag.type == TagType.custom]
+
+        if extra_fields := get_extra_export_fields(model, "dashboard"):
+            payload["extra"] = extra_fields
 
         file_content = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
         return file_content

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -20,7 +20,10 @@ from typing import Any
 
 from superset import db, security_manager
 from superset.commands.exceptions import ImportFailedError
-from superset.commands.importers.v1.utils import find_existing_for_import
+from superset.commands.importers.v1.utils import (
+    apply_extra_import_fields,
+    find_existing_for_import,
+)
 from superset.daos.dashboard import DashboardDAO
 from superset.models.dashboard import Dashboard
 from superset.subjects.models import Subject
@@ -446,6 +449,7 @@ def import_dashboard(  # noqa: C901
             except TypeError:
                 logger.info("Unable to encode `%s` field: %s", key, value)
 
+    extra = config.pop("extra", None)
     dashboard = Dashboard.import_from_dict(config, recursive=False)
     if dashboard.id is None:
         db.session.flush()
@@ -469,5 +473,7 @@ def import_dashboard(  # noqa: C901
         for viewer in viewers:
             if viewer not in dashboard.viewers:
                 dashboard.viewers.append(viewer)
+
+    apply_extra_import_fields(dashboard, "dashboard", extra)
 
     return dashboard

--- a/superset/commands/export/models.py
+++ b/superset/commands/export/models.py
@@ -17,9 +17,10 @@
 
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Callable
+from typing import Any, Callable
 
 import yaml
+from flask import current_app
 from flask_appbuilder import Model
 
 from superset.commands.base import BaseCommand
@@ -28,6 +29,18 @@ from superset.daos.base import BaseDAO
 from superset.utils.dict_import_export import EXPORT_VERSION
 
 METADATA_FILE_NAME = "metadata.yaml"
+
+
+def get_extra_export_fields(model: Model, asset_type: str) -> dict[str, Any]:
+    """Collect deployment-specific fields to serialise under ``extra``.
+
+    Returns an empty mapping when no ``EXTRA_ASSET_EXPORT_FIELDS`` hook is
+    configured, so exports are unchanged by default.
+    """
+    hook = current_app.config.get("EXTRA_ASSET_EXPORT_FIELDS")
+    if not hook:
+        return {}
+    return hook(model, asset_type) or {}
 
 
 class ExportModelsCommand(BaseCommand):

--- a/superset/commands/importers/v1/utils.py
+++ b/superset/commands/importers/v1/utils.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, Optional, Type
 from zipfile import ZipFile
 
 import yaml
+from flask import current_app
 from marshmallow import fields, Schema, validate
 from marshmallow.exceptions import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
@@ -594,3 +595,17 @@ def clear_soft_deleted_for_import(existing: Any) -> None:
     """
     db.session.delete(existing)
     db.session.flush()
+
+
+def apply_extra_import_fields(
+    model: Any, asset_type: str, extra: dict[str, Any] | None
+) -> None:
+    """Hand the exported ``extra`` mapping to the deployment's import handler.
+
+    No-op unless ``EXTRA_ASSET_IMPORT_HANDLER`` is configured, so imports are
+    unchanged by default. Called once the asset exists and has an id.
+    """
+    if not extra:
+        return
+    if handler := current_app.config.get("EXTRA_ASSET_IMPORT_HANDLER"):
+        handler(model, asset_type, extra)

--- a/superset/config.py
+++ b/superset/config.py
@@ -3151,6 +3151,14 @@ EXTRA_RAISE_FOR_ACCESS_BYPASS: Callable[..., bool] | None = None
 EXTRA_EDITORS_RESOLVER: Callable[..., list[Any]] | None = None
 # Post-create hook for charts/dashboards. Receives (model, asset_type).
 AFTER_ASSET_CREATE: Callable[[Any, str], None] | None = None
+# Contribute extra fields to a chart or dashboard export. Receives
+# (model, asset_type) and returns a mapping serialised under the "extra" key of
+# the exported YAML. Lets deployments carry their own metadata through
+# export/import without forking the export commands.
+EXTRA_ASSET_EXPORT_FIELDS: Callable[[Any, str], dict[str, Any]] | None = None
+# Consume the "extra" mapping when importing a chart or dashboard. Receives
+# (model, asset_type, extra) once the asset exists.
+EXTRA_ASSET_IMPORT_HANDLER: Callable[[Any, str, dict[str, Any]], None] | None = None
 
 
 # The migrations that add catalog permissions might take a considerably long time

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -603,6 +603,7 @@ class ImportV1DashboardSchema(Schema):
     roles = fields.List(fields.Raw(), allow_none=True, load_only=True)
     theme_uuid = fields.UUID(allow_none=True)
     theme_id = fields.Integer(allow_none=True)
+    extra = fields.Dict(allow_none=True, load_only=True)
 
 
 class EmbeddedDashboardConfigSchema(Schema):

--- a/tests/unit_tests/commands/extra_asset_fields_test.py
+++ b/tests/unit_tests/commands/extra_asset_fields_test.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock
+
+from flask import current_app
+
+
+def test_extra_export_fields_absent_by_default() -> None:
+    """No hook configured leaves exports untouched."""
+    from superset.commands.export.models import get_extra_export_fields
+
+    current_app.config.pop("EXTRA_ASSET_EXPORT_FIELDS", None)
+    assert get_extra_export_fields(MagicMock(), "dashboard") == {}
+
+
+def test_extra_export_fields_uses_hook() -> None:
+    """The hook's mapping is returned and receives the asset type."""
+    from superset.commands.export.models import get_extra_export_fields
+
+    model = MagicMock()
+    hook = MagicMock(return_value={"owning_team": "analytics-platform"})
+    current_app.config["EXTRA_ASSET_EXPORT_FIELDS"] = hook
+    try:
+        assert get_extra_export_fields(model, "chart") == {
+            "owning_team": "analytics-platform"
+        }
+        hook.assert_called_once_with(model, "chart")
+    finally:
+        current_app.config.pop("EXTRA_ASSET_EXPORT_FIELDS", None)
+
+
+def test_extra_export_fields_tolerates_none() -> None:
+    """A hook returning None must not put a null under ``extra``."""
+    from superset.commands.export.models import get_extra_export_fields
+
+    current_app.config["EXTRA_ASSET_EXPORT_FIELDS"] = MagicMock(return_value=None)
+    try:
+        assert get_extra_export_fields(MagicMock(), "dashboard") == {}
+    finally:
+        current_app.config.pop("EXTRA_ASSET_EXPORT_FIELDS", None)
+
+
+def test_extra_import_handler_invoked() -> None:
+    """The handler receives the model, asset type and the extra mapping."""
+    from superset.commands.importers.v1.utils import apply_extra_import_fields
+
+    model = MagicMock()
+    handler = MagicMock()
+    current_app.config["EXTRA_ASSET_IMPORT_HANDLER"] = handler
+    try:
+        apply_extra_import_fields(
+            model, "dashboard", {"owning_team": "analytics-platform"}
+        )
+        handler.assert_called_once_with(
+            model, "dashboard", {"owning_team": "analytics-platform"}
+        )
+    finally:
+        current_app.config.pop("EXTRA_ASSET_IMPORT_HANDLER", None)
+
+
+def test_extra_import_handler_skipped_when_empty() -> None:
+    """An absent or empty ``extra`` never reaches the handler."""
+    from superset.commands.importers.v1.utils import apply_extra_import_fields
+
+    handler = MagicMock()
+    current_app.config["EXTRA_ASSET_IMPORT_HANDLER"] = handler
+    try:
+        apply_extra_import_fields(MagicMock(), "chart", None)
+        apply_extra_import_fields(MagicMock(), "chart", {})
+        handler.assert_not_called()
+    finally:
+        current_app.config.pop("EXTRA_ASSET_IMPORT_HANDLER", None)
+
+
+def test_import_schemas_accept_extra() -> None:
+    """``extra`` must survive schema validation, which defaults to RAISE."""
+    from superset.charts.schemas import ImportV1ChartSchema
+    from superset.dashboards.schemas import ImportV1DashboardSchema
+
+    assert "extra" in ImportV1DashboardSchema().fields
+    assert "extra" in ImportV1ChartSchema().fields


### PR DESCRIPTION
### SUMMARY

Deployments that attach their own metadata to charts and dashboards — an owning team, a catalogue entry, a cost centre — have no way to make it survive an export/import round trip. The only options today are forking the export commands or monkeypatching their internals, both of which break silently on upgrade.

This adds two optional config hooks, alongside the existing `EXTRA_OWNERS_RESOLVER` and `AFTER_ASSET_CREATE`:

- `EXTRA_ASSET_EXPORT_FIELDS(model, asset_type) -> dict` — serialised under the `extra` key of the exported YAML
- `EXTRA_ASSET_IMPORT_HANDLER(model, asset_type, extra)` — called once the asset exists on import

Everything is namespaced under a single `extra` key rather than merged at the top level. The import schemas reject unknown fields (marshmallow defaults to `RAISE`), so one declared field per asset type preserves that strictness while leaving the payload shape free to evolve without further schema changes.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No UI. With `EXTRA_ASSET_EXPORT_FIELDS` configured, the exported YAML gains:

```yaml
slice_name: Revenue by region
...
extra:
  owning_team: analytics-platform
```

With neither hook configured, exported files are byte-for-byte unchanged.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/commands/extra_asset_fields_test.py` — 6 cases covering both hooks, a hook returning `None`, an empty `extra` being skipped, and the schemas accepting the field.

End to end: set `EXTRA_ASSET_EXPORT_FIELDS`/`EXTRA_ASSET_IMPORT_HANDLER` in `superset_config.py` per the docs added here, export a chart or dashboard, confirm the `extra` block, then re-import and confirm the handler is called with the mapping.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: No
- [ ] Required feature flags: None — both hooks default to `None`
- [ ] Changes UI: No, backend only
- [ ] Includes DB Migration: No
- [x] Introduces new feature or API: two optional config hooks, documented in `docs/admin_docs/configuration/configuring-superset.mdx`
- [ ] Removes existing feature or API: No

Verified locally: 1364 passed / 2 xfailed across `tests/unit_tests/{commands,dashboards,charts}`, and `pre-commit run` clean including mypy.