### PR TITLE
fix(gtf): review-driven correctness & resilience hardening (12 findings)

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.ts
+++ b/superset-frontend/src/components/Chart/chartAction.ts
@@ -32,7 +32,6 @@ import {
   LatestQueryFormData,
 } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
-import { nanoid } from 'nanoid';
 import type { ControlStateMapping } from '@superset-ui/chart-controls';
 import { getControlsState } from 'src/explore/store';
 import {
@@ -289,10 +288,11 @@ export interface GetChartDataRequestParams {
   resultFormat?: string;
   resultType?: string;
   force?: boolean;
-  // Idempotency token for a forced refresh, minted once per refresh and sent on
-  // both the async submit and the follow-up read-back so the server recomputes
-  // exactly once (see requestChartDataResolved). Only meaningful with `force`.
-  forceNonce?: string;
+  // Forced-refresh idempotency tokens for the synchronous read-back: each is the
+  // async task's UUID for the query at the same index (from the 202 `task_ids`),
+  // so a forced refresh reads the result its task warmed instead of recomputing
+  // (see requestChartDataResolved). Only meaningful with `force`.
+  queryForceNonces?: string[];
   requestParams?: RequestParams;
   ownState?: JsonObject;
   // Opt into asynchronous execution. Only set by callers that handle an HTTP 202
@@ -437,14 +437,14 @@ const v1ChartDataRequest = async (
   ownState: JsonObject,
   parseMethod: string | undefined,
   asyncMode: boolean,
-  forceNonce?: string,
+  queryForceNonces?: string[],
 ): Promise<ChartDataRequestResponse> => {
   const payload = await buildV1ChartDataPayload({
     formData: formData as QueryFormData,
     resultType,
     resultFormat,
     force,
-    forceNonce,
+    queryForceNonces,
     setDataMask,
     ownState,
   });
@@ -495,7 +495,7 @@ export async function getChartDataRequest({
   resultFormat = 'json',
   resultType = 'full',
   force = false,
-  forceNonce,
+  queryForceNonces,
   requestParams = {},
   ownState = {},
   enableAsyncMode = false,
@@ -535,7 +535,7 @@ export async function getChartDataRequest({
     ownState,
     parseMethod,
     asyncMode,
-    forceNonce,
+    queryForceNonces,
   );
 }
 
@@ -697,7 +697,7 @@ const extractResult = (json: ChartDataRequestResponse['json']): QueryData[] =>
 export function handleChartDataResponse(
   response: Response,
   json: ChartDataRequestResponse['json'],
-  refetch: () => Promise<QueryData[]>,
+  refetch: (queryForceNonces?: string[]) => Promise<QueryData[]>,
   signal?: AbortSignal,
 ): Promise<QueryData[]> | QueryData[] {
   if (isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) {
@@ -728,18 +728,16 @@ export function handleChartDataResponse(
  * On a 202 the body is the async job rather than data: every query task is
  * awaited, then the same request is re-issued *synchronously* so the server
  * serves it inline. Double execution (the async task computing, then the
- * re-issue recomputing the identical query) is prevented by a per-refresh
- * idempotency nonce: a nonce is minted once here when `force` is set and carried
- * on both the submit and the re-issue. The async task recomputes and records a
- * server-side marker keyed by (nonce, cache_key); the re-issue reuses the same
- * nonce, sees the marker, and reads the freshly-warmed cache instead of
- * recomputing. A new force refresh mints a new nonce, so it genuinely recomputes.
- * Non-forced requests carry no nonce and keep the plain flow.
- *
- * Scope: this dedups one refresh's own submit/read-back pair. It does NOT make
- * concurrent force refreshes idempotent — a second refresh (new nonce) that
- * joins the first's shared task (deduped by query cache key) will still force its
- * own read-back, since the first task only recorded its own nonce.
+ * re-issue recomputing the identical query) is prevented by a forced-refresh
+ * idempotency nonce that IS the async task's UUID: the async submit carries no
+ * nonce (the worker stamps each query with its own task UUID and records a marker
+ * keyed by (task_uuid, cache_key) once cached), and the synchronous read-back
+ * carries each query's task id — returned in the 202 `task_ids`, in query order —
+ * as that query's `force_nonce`, so it reads the freshly-warmed cache instead of
+ * recomputing. Because the token is the task's identity, a concurrent force
+ * refresh that joins the same shared task (deduped by query cache key) reads back
+ * under the same id — so it does NOT double-execute either. Non-forced requests
+ * carry no nonce and keep the plain flow.
  *
  * `signal` aborts the wait (Stop pressed, chart superseded or unmounted) and
  * cancels the outstanding tasks.
@@ -748,13 +746,14 @@ export async function requestChartDataResolved(
   params: Omit<GetChartDataRequestParams, 'enableAsyncMode'>,
   signal?: AbortSignal,
 ): Promise<QueryData[]> {
-  const paramsWithNonce = params.force
-    ? { ...params, forceNonce: nanoid() }
-    : params;
-
-  const reissueSynchronously = async (): Promise<QueryData[]> => {
+  // The synchronous read-back of a forced refresh stamps each query with its
+  // task id (from the 202, index-aligned to queries) as the forced-refresh nonce.
+  const reissueSynchronously = async (
+    queryForceNonces?: string[],
+  ): Promise<QueryData[]> => {
     const { response, json } = await getChartDataRequest({
-      ...paramsWithNonce,
+      ...params,
+      queryForceNonces: params.force ? queryForceNonces : undefined,
       enableAsyncMode: false,
     });
     if (response.status !== 200) {
@@ -766,7 +765,7 @@ export async function requestChartDataResolved(
   };
 
   const { response, json } = await getChartDataRequest({
-    ...paramsWithNonce,
+    ...params,
     enableAsyncMode: true,
   });
   return handleChartDataResponse(response, json, reissueSynchronously, signal);

--- a/superset-frontend/src/components/Chart/chartActions.test.ts
+++ b/superset-frontend/src/components/Chart/chartActions.test.ts
@@ -158,9 +158,11 @@ describe('chart actions', () => {
     );
     waitForAsyncDataStub = jest
       .spyOn(asyncEvent, 'waitForAsyncData')
-      // New contract: resolve by invoking the caller-provided refetch thunk.
-      .mockImplementation((_job: unknown, refetch: () => Promise<unknown>) =>
-        refetch(),
+      // New contract: resolve by invoking the caller-provided refetch thunk,
+      // forwarding the job's task_ids as the per-query forced-refresh nonces.
+      .mockImplementation(
+        (job: unknown, refetch: (nonces?: string[]) => Promise<unknown>) =>
+          refetch((job as asyncEvent.AsyncJob)?.task_ids),
       );
   });
 
@@ -649,19 +651,22 @@ describe('chart actions', () => {
         // The submit opts into async; the re-issue is synchronous (no new GTF task).
         expect(String(history[0].options.body)).toContain('async_mode');
         expect(String(history[1].options.body)).not.toContain('async_mode');
-        // One idempotency nonce is minted for the refresh and carried on BOTH the
-        // submit and the re-issue, so the server recomputes exactly once and the
-        // re-issue reads the freshly-warmed cache.
+        // The forced-refresh nonce IS the async task's UUID: the submit carries
+        // none (the worker stamps each query with its own task id and records the
+        // marker), and the synchronous re-issue carries the 202's task_ids as the
+        // per-query force nonces, so the server reads back instead of recomputing.
         const forceCalls = buildV1ChartDataPayloadStub.mock.calls.filter(
           ([arg]) => (arg as { force?: boolean }).force === true,
         );
         expect(forceCalls).toHaveLength(2);
-        const submitNonce = (forceCalls[0][0] as { forceNonce?: string })
-          .forceNonce;
-        const reissueNonce = (forceCalls[1][0] as { forceNonce?: string })
-          .forceNonce;
-        expect(submitNonce).toBeDefined();
-        expect(reissueNonce).toBe(submitNonce);
+        const submitNonces = (
+          forceCalls[0][0] as { queryForceNonces?: string[] }
+        ).queryForceNonces;
+        const reissueNonces = (
+          forceCalls[1][0] as { queryForceNonces?: string[] }
+        ).queryForceNonces;
+        expect(submitNonces).toBeUndefined();
+        expect(reissueNonces).toEqual(['task-1']);
 
         const succeeded = dispatch.mock.calls.find(
           ([action]) => action?.type === actions.CHART_UPDATE_SUCCEEDED,

--- a/superset-frontend/src/explore/exploreUtils/index.ts
+++ b/superset-frontend/src/explore/exploreUtils/index.ts
@@ -83,7 +83,9 @@ interface GetExploreUrlParams {
 interface BuildV1ChartDataPayloadParams {
   formData: QueryFormData;
   force?: boolean;
-  forceNonce?: string;
+  // Per-query forced-refresh nonces (the async tasks' UUIDs), assigned to each
+  // built query by index for the synchronous read-back of a forced refresh.
+  queryForceNonces?: string[];
   resultFormat?: string;
   resultType?: string;
   setDataMask?: SetDataMaskHook;
@@ -282,7 +284,7 @@ export const getQuerySettings = (
 export const buildV1ChartDataPayload = async ({
   formData,
   force,
-  forceNonce,
+  queryForceNonces,
   resultFormat,
   resultType,
   setDataMask,
@@ -301,11 +303,10 @@ export const buildV1ChartDataPayload = async ({
     : undefined;
   const buildQuery =
     (registryResult ? await registryResult : undefined) ?? defaultBuildQuery;
-  return buildQuery(
+  const payload = await buildQuery(
     {
       ...formData,
       force,
-      force_nonce: forceNonce,
       result_format: resultFormat,
       result_type: resultType,
     } as QueryFormData,
@@ -317,6 +318,18 @@ export const buildV1ChartDataPayload = async ({
       },
     },
   );
+  // Stamp each query with its forced-refresh nonce (its async task's UUID, from
+  // the 202 `task_ids`, index-aligned to queries) for the synchronous read-back.
+  if (queryForceNonces?.length && Array.isArray(payload.queries)) {
+    payload.queries.forEach((query, index) => {
+      if (queryForceNonces[index]) {
+        // eslint-disable-next-line no-param-reassign
+        (query as { force_nonce?: string }).force_nonce =
+          queryForceNonces[index];
+      }
+    });
+  }
+  return payload;
 };
 
 export const exportChart = async ({

--- a/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
@@ -62,7 +62,7 @@ const InfoIconWrapper = styled.span`
 `;
 
 interface TaskPayloadPopoverProps {
-  payload: Record<string, any>;
+  payload: Record<string, unknown>;
   // Internal, debug-only state (present only in debug mode). Rendered as a
   // separate section below the results payload; kept distinct because the
   // payload may get custom renderers while `private` stays a raw dump.

--- a/superset-frontend/src/features/tasks/types.ts
+++ b/superset-frontend/src/features/tasks/types.ts
@@ -120,7 +120,7 @@ export interface Task {
     last_name: string;
   } | null;
   user_id: number | null;
-  payload: Record<string, any>;
+  payload: Record<string, unknown>;
   properties: TaskProperties;
   duration_seconds: number | null;
   subscriber_count: number;

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -42,6 +42,7 @@ jest.mock('src/hooks/useTabId', () => {
 // the "socket (re)connected" event that triggers the WS-mode catch-up.
 /* eslint-disable no-var, vars-on-top */
 var mockRealtimeOpenListener: (() => void) | undefined;
+var mockRealtimeStateListener: ((state: string) => void) | undefined;
 /* eslint-enable no-var, vars-on-top */
 jest.mock('src/middleware/realtime', () => ({
   connectRealtime: jest.fn(),
@@ -50,6 +51,12 @@ jest.mock('src/middleware/realtime', () => ({
     mockRealtimeOpenListener = listener;
     return () => {
       mockRealtimeOpenListener = undefined;
+    };
+  },
+  subscribeRealtimeState: (listener: (state: string) => void) => {
+    mockRealtimeStateListener = listener;
+    return () => {
+      mockRealtimeStateListener = undefined;
     };
   },
 }));
@@ -623,6 +630,51 @@ test('WS mode: a reconnect runs one catch-up that reconciles the gap', async () 
 
   expect(await promise).toEqual([{ rows: 3 }]);
   expect(refetch).toHaveBeenCalledTimes(1);
+});
+
+test('WS mode: a reconnecting transition runs a catch-up that reconciles the gap', async () => {
+  queueStatuses({ 'task-1': { status: 'success' } });
+  asyncEvent.init(wsConfig);
+
+  const refetch = jest.fn().mockResolvedValue([{ rows: 4 }]);
+  const promise = asyncEvent.waitForAsyncData(
+    { task_ids: ['task-1'] },
+    refetch,
+  );
+
+  // Let the registration catch-up consume the empty baseline first.
+  await new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+
+  // The socket dropped: reconcile via the socket-independent status_changes fetch.
+  mockRealtimeStateListener?.('reconnecting');
+
+  expect(await promise).toEqual([{ rows: 4 }]);
+  expect(refetch).toHaveBeenCalledTimes(1);
+});
+
+test('WS mode: an unhealthy socket settles pending waiters with a bounded error', async () => {
+  queueStatuses(); // no completion is ever delivered
+  asyncEvent.init(wsConfig);
+
+  const refetch = jest.fn();
+  const promise = asyncEvent.waitForAsyncData(
+    { task_ids: ['task-1'] },
+    refetch,
+  );
+
+  // Let the registration catch-up run (finding nothing) so the waiter is pending.
+  await new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+
+  // The socket has failed to reconnect enough times to be considered down: rather
+  // than hang until the long give-up, the waiter is settled with a clear error.
+  mockRealtimeStateListener?.('unhealthy');
+
+  await expect(promise).rejects.toThrow('Realtime connection unavailable');
+  expect(refetch).not.toHaveBeenCalled();
 });
 
 test('WS mode: coalesces many same-tick registrations into one catch-up', async () => {

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -538,9 +538,26 @@ test('a realtime message is a no-op when async queries are disabled', () => {
 
 const wsConfig = {
   WEBSOCKET_ENABLE: true,
+  WEBSOCKET_URL: 'ws://localhost:8080/',
   GLOBAL_ASYNC_QUERIES_POLLING_DELAY: 20,
   GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT: 600_000,
 };
+
+test('WEBSOCKET_ENABLE without a URL keeps polling (never disables the poll)', async () => {
+  // A socket can never open without a URL, so the transport must not be treated
+  // as enabled — otherwise the poll is disabled and completion never arrives.
+  queueStatuses({ 'task-1': { status: 'success' } });
+  asyncEvent.init({
+    WEBSOCKET_ENABLE: true,
+    GLOBAL_ASYNC_QUERIES_POLLING_DELAY: 20,
+  });
+
+  const refetch = jest.fn().mockResolvedValue([{ rows: 1 }]);
+  // Resolves via the interval poll (no socket message is delivered).
+  expect(
+    await asyncEvent.waitForAsyncData({ task_ids: ['task-1'] }, refetch),
+  ).toEqual([{ rows: 1 }]);
+});
 
 test('WS mode: settles via the socket without any status_changes polling', async () => {
   queueStatuses(); // registration catch-up sees no change

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -546,7 +546,10 @@ export const init = (appConfig?: AppConfig) => {
   // registration/reconnect. With it disabled, the interval poll below is the only
   // mechanism. (`config` can be undefined when bootstrap carries no conf — e.g.
   // under test — so read it defensively; this runs before the feature gate.)
-  wsEnabled = Boolean(config?.WEBSOCKET_ENABLE);
+  // Require a usable URL too: WEBSOCKET_ENABLE without WEBSOCKET_URL can never open
+  // a socket (openSocket no-ops), so treating it as the transport would disable the
+  // poll AND never deliver completion — keep polling as the safe fallback instead.
+  wsEnabled = Boolean(config?.WEBSOCKET_ENABLE && config?.WEBSOCKET_URL);
 
   // (Re)connect the shared realtime socket whenever the websocket transport is
   // enabled — independent of GLOBAL_ASYNC_QUERIES, since realtime list views

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -422,7 +422,7 @@ subscribeRealtime(TASK_STATUS_TOPIC, handleTaskStatus);
  */
 export const waitForAsyncData = async <T = unknown[]>(
   asyncJob: AsyncJob,
-  refetch: () => Promise<T>,
+  refetch: (queryForceNonces?: string[]) => Promise<T>,
   signal?: AbortSignal,
 ): Promise<T> => {
   const taskIds = asyncJob.task_ids ?? [];
@@ -502,7 +502,10 @@ export const waitForAsyncData = async <T = unknown[]>(
     if (wsEnabled) scheduleCatchUp();
   });
 
-  return refetch();
+  // Read the warmed results back synchronously. The per-query task ids double as
+  // forced-refresh idempotency nonces (see chartAction.requestChartDataResolved),
+  // so a forced refresh reads the result its task cached instead of recomputing.
+  return refetch(taskIds);
 };
 
 export const init = (appConfig?: AppConfig) => {

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -45,6 +45,7 @@ import {
   connectRealtime,
   subscribeRealtime,
   subscribeRealtimeOpen,
+  subscribeRealtimeState,
 } from 'src/middleware/realtime';
 
 // The GTF task type chart-data queries run under (see
@@ -237,6 +238,17 @@ const abandonPolling = () => {
   );
 };
 
+// Settle every still-pending waiter when the realtime socket is unhealthy (the
+// sole transport is down with no poll fallback), so charts surface a prompt,
+// bounded error rather than hanging until the give-up timeout.
+const abandonRealtimeWaiters = () => {
+  const stranded = new Set<Waiter>();
+  waitersByTaskId.forEach(waiters => waiters.forEach(w => stranded.add(w)));
+  stranded.forEach(waiter =>
+    settle(waiter, new Error('Realtime connection unavailable')),
+  );
+};
+
 const applyStatus = (taskId: string, status: string) => {
   const waiters = waitersByTaskId.get(taskId);
   if (!waiters || !TERMINAL_STATUSES.has(status)) return;
@@ -387,6 +399,21 @@ const scheduleCatchUp = () => {
 };
 
 subscribeRealtimeOpen(scheduleCatchUp);
+
+// The websocket is the sole completion transport when enabled, so a genuinely-down
+// server must not hang waiters until the long give-up. On each `reconnecting`
+// transition, reconcile via the socket-independent status_changes catch-up (so a
+// task that completed while disconnected is still observed); once the socket is
+// `unhealthy` (enough consecutive failed reconnects), settle the still-pending
+// waiters with a clear error instead of waiting out `pollStaleTimeoutMs`.
+subscribeRealtimeState(state => {
+  if (!wsEnabled || !waitersByTaskId.size) return;
+  if (state === 'reconnecting') {
+    scheduleCatchUp();
+  } else if (state === 'unhealthy') {
+    abandonRealtimeWaiters();
+  }
+});
 
 /**
  * Handle a `task.status` message from the shared realtime client.

--- a/superset-frontend/src/middleware/realtime.test.ts
+++ b/superset-frontend/src/middleware/realtime.test.ts
@@ -23,6 +23,7 @@ import {
   resetRealtimeForTests,
   subscribeRealtime,
   subscribeRealtimeOpen,
+  subscribeRealtimeState,
 } from 'src/middleware/realtime';
 
 // Controllable useTabId mock (overrides the global shim for this file) so we can
@@ -254,6 +255,42 @@ test('reconnects after the socket closes', () => {
   jest.advanceTimersByTime(5000);
 
   expect(FakeWebSocket.instances).toHaveLength(2);
+  jest.useRealTimers();
+});
+
+test('reports reconnecting then unhealthy after repeated failures, and open resets it', () => {
+  jest.useFakeTimers();
+  const states: string[] = [];
+  subscribeRealtimeState(s => states.push(s));
+  connectRealtime(ENABLED);
+
+  // Three consecutive closes with no successful OPEN in between.
+  for (let i = 0; i < 3; i += 1) {
+    FakeWebSocket.instances[FakeWebSocket.instances.length - 1].onclose?.();
+    // Advance past the max backoff so the scheduled reconnect fires.
+    jest.advanceTimersByTime(30000);
+  }
+  expect(states).toContain('reconnecting');
+  expect(states).toContain('unhealthy');
+
+  // A successful OPEN clears the failure state back to healthy.
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1].onopen?.();
+  expect(states[states.length - 1]).toBe('open');
+  jest.useRealTimers();
+});
+
+test('a synchronous WebSocket constructor failure still schedules a reconnect', () => {
+  jest.useFakeTimers();
+  const Broken = jest.fn(() => {
+    throw new Error('construct failed');
+  });
+  global.WebSocket = Broken as unknown as typeof WebSocket;
+
+  connectRealtime(ENABLED);
+  // The throw is caught; a reconnect is scheduled rather than dead-ending, so the
+  // constructor is retried (repeatedly, with backoff) instead of only once.
+  jest.advanceTimersByTime(30000);
+  expect(Broken.mock.calls.length).toBeGreaterThan(1);
   jest.useRealTimers();
 });
 

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -377,6 +377,9 @@ export const connectRealtime = (config?: RealtimeConfig): void => {
 
   teardownSocket();
   generation += 1;
+  // Fresh (re)configuration: start the failure counter clean so a prior outage's
+  // count can't make the first new attempt look unhealthy.
+  reconnectAttempts = 0;
   started = true;
   enabled = nextEnabled;
   url = nextUrl;
@@ -387,6 +390,7 @@ export const connectRealtime = (config?: RealtimeConfig): void => {
 /** Tear down the socket and stop reconnecting. */
 export const disconnectRealtime = (): void => {
   generation += 1;
+  reconnectAttempts = 0;
   teardownSocket();
 };
 
@@ -444,11 +448,4 @@ export const emitRealtimeOpenForTests = (
   reason: RealtimeOpenReason = 'reconnect',
 ): void => {
   openListeners.forEach(listener => listener(reason));
-};
-
-// Test-only: simulate a connection-state transition firing the state-listeners.
-export const emitRealtimeStateForTests = (
-  state: RealtimeConnectionState,
-): void => {
-  emitState(state);
 };

--- a/superset-frontend/src/middleware/realtime.ts
+++ b/superset-frontend/src/middleware/realtime.ts
@@ -53,10 +53,16 @@ type RealtimeConfig = {
   WEBSOCKET_JWT_EXPIRATION_SECONDS?: number;
 };
 
-// Backoff before reconnecting after the socket closes (mirrors the Node
-// server's own subscribe retry). The socket is best-effort, so a generous
-// delay is fine — each feature's poll/fetch covers the gap.
-const RECONNECT_DELAY_MS = 5000;
+// Reconnect backoff after the socket closes. The socket is a first-class
+// transport when enabled, so it reconnects indefinitely; the delay grows
+// exponentially (with jitter) up to a cap so a persistently-down server is not
+// hammered every few seconds while a transient blip still recovers fast.
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30000;
+// After this many consecutive closes with no intervening OPEN, the connection is
+// reported `unhealthy` so waiters can stop waiting on it (bounded, rather than a
+// silent multi-minute hang) instead of assuming a message is merely in flight.
+const UNHEALTHY_AFTER_ATTEMPTS = 3;
 const WS_CONNECTING = 0;
 const WS_OPEN = 1;
 
@@ -98,6 +104,76 @@ type RealtimeOpenListener = (reason: RealtimeOpenReason) => void;
 // Fired every time a socket transitions to OPEN, with the reason (see above), so
 // a feature can reconcile state it may have missed while the socket was down.
 const openListeners = new Set<RealtimeOpenListener>();
+
+// Connection health, surfaced so a feature can reconcile via its authorized REST
+// API on a reconnect and, crucially, stop waiting on a genuinely-down socket
+// (`unhealthy`) instead of hanging until a long give-up timeout.
+export type RealtimeConnectionState =
+  | 'connecting'
+  | 'open'
+  | 'reconnecting'
+  | 'unhealthy';
+
+type RealtimeStateListener = (state: RealtimeConnectionState) => void;
+
+const stateListeners = new Set<RealtimeStateListener>();
+
+// Consecutive socket closes (or connect failures) with no intervening OPEN. Reset
+// to 0 on OPEN. Drives the reconnect backoff and the `unhealthy` transition.
+let reconnectAttempts = 0;
+
+/**
+ * Register a listener fired on every connection-state transition
+ * (`connecting`/`open`/`reconnecting`/`unhealthy`); returns an unsubscribe
+ * function. Use it to reconcile on reconnect and to give up promptly when the
+ * socket is `unhealthy` rather than waiting out a long timeout.
+ */
+export const subscribeRealtimeState = (
+  listener: RealtimeStateListener,
+): (() => void) => {
+  stateListeners.add(listener);
+  return () => {
+    stateListeners.delete(listener);
+  };
+};
+
+const emitState = (state: RealtimeConnectionState): void => {
+  stateListeners.forEach(listener => {
+    try {
+      listener(state);
+    } catch (err) {
+      logging.warn('Realtime state-listener error', err);
+    }
+  });
+};
+
+// Exponential backoff with jitter, capped. `attempts` is the count of consecutive
+// failed connects (>= 1 when scheduling a reconnect).
+const reconnectDelayMs = (attempts: number): number => {
+  const base = Math.min(
+    RECONNECT_BASE_MS * 2 ** Math.max(0, attempts - 1),
+    RECONNECT_MAX_MS,
+  );
+  // Jitter only spreads reconnects; it is not security-sensitive.
+  return base + Math.random() * Math.min(base, RECONNECT_BASE_MS);
+};
+
+// Record a close/connect failure: bump the attempt counter, report `reconnecting`
+// (or `unhealthy` once the socket has failed enough times), and schedule the next
+// reconnect with backoff.
+const scheduleReconnect = (thisGeneration: number): void => {
+  reconnectAttempts += 1;
+  emitState(
+    reconnectAttempts >= UNHEALTHY_AFTER_ATTEMPTS
+      ? 'unhealthy'
+      : 'reconnecting',
+  );
+  reconnectTimeoutId = window.setTimeout(
+    // eslint-disable-next-line no-use-before-define -- mutual reconnect recursion
+    () => openSocket(thisGeneration, 'reconnect'),
+    reconnectDelayMs(reconnectAttempts),
+  );
+};
 
 /**
  * Register a listener fired when the socket (re)connects (transitions to OPEN);
@@ -191,18 +267,23 @@ const teardownSocket = (): void => {
   }
 };
 
-const openSocket = (
-  thisGeneration: number,
-  reason: RealtimeOpenReason,
-): void => {
+// Declared as a hoisted function so scheduleReconnect (above) can reference it
+// for the mutual reconnect recursion without a use-before-define cycle.
+function openSocket(thisGeneration: number, reason: RealtimeOpenReason): void {
   if (thisGeneration !== generation) return;
   if (!enabled || !url || typeof WebSocket === 'undefined') return;
   const connectUrl = buildConnectUrl(url);
+  emitState('connecting');
   let ws: WebSocket;
   try {
     ws = new WebSocket(connectUrl);
   } catch (err) {
     logging.warn('Failed to open realtime WebSocket', err);
+    // A synchronous constructor throw would otherwise dead-end this generation
+    // (no onclose fires). Treat it as a failed attempt and keep retrying with
+    // backoff so a first-class socket recovers and a persistent failure surfaces
+    // as `unhealthy`.
+    scheduleReconnect(thisGeneration);
     return;
   }
   socket = ws;
@@ -250,6 +331,9 @@ const openSocket = (
 
   ws.onopen = () => {
     if (thisGeneration !== generation) return;
+    // Recovered: reset the failure counter and report a healthy connection.
+    reconnectAttempts = 0;
+    emitState('open');
     openListeners.forEach(listener => {
       try {
         listener(reason);
@@ -264,15 +348,12 @@ const openSocket = (
   };
   ws.onclose = () => {
     if (thisGeneration !== generation) return;
-    reconnectTimeoutId = window.setTimeout(
-      () => openSocket(thisGeneration, 'reconnect'),
-      RECONNECT_DELAY_MS,
-    );
+    scheduleReconnect(thisGeneration);
   };
   // Errors surface as a subsequent close; let onclose own the reconnect and
   // avoid logging the (payload-free) error event on every transient blip.
   ws.onerror = () => {};
-};
+}
 
 /**
  * (Re)configure and (re)connect the shared socket. Idempotent and safe to call
@@ -351,6 +432,8 @@ export const resetRealtimeForTests = (): void => {
   disconnectRealtime();
   handlersByTopic.clear();
   openListeners.clear();
+  stateListeners.clear();
+  reconnectAttempts = 0;
   started = false;
   enabled = false;
   url = undefined;
@@ -361,4 +444,11 @@ export const emitRealtimeOpenForTests = (
   reason: RealtimeOpenReason = 'reconnect',
 ): void => {
   openListeners.forEach(listener => listener(reason));
+};
+
+// Test-only: simulate a connection-state transition firing the state-listeners.
+export const emitRealtimeStateForTests = (
+  state: RealtimeConnectionState,
+): void => {
+  emitState(state);
 };

--- a/superset-frontend/src/pages/TaskList/index.tsx
+++ b/superset-frontend/src/pages/TaskList/index.tsx
@@ -584,7 +584,7 @@ function TaskList({ addDangerToast, addSuccessToast, user }: TaskListProps) {
 
           const isSharedTask = original.scope === TaskScope.Shared;
           const userIsSubscribed = original.subscribers?.some(
-            (sub: any) => sub.user_id === user.userId,
+            (sub: TaskSubscriber) => sub.user_id === user.userId,
           );
 
           // Check if task is in a non-active state (completed or aborting)

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1568,6 +1568,19 @@ class ChartDataQueryObjectSchema(Schema):
                 data[new] = value
         return data
 
+    force_nonce = fields.String(
+        metadata={
+            "description": "Per-query forced-refresh idempotency token: the async "
+            "task's UUID (as returned in the 202 `task_ids`, in query order). Sent "
+            "on the synchronous read-back of a forced refresh so it reads the "
+            "result the task warmed instead of recomputing. Because the token is "
+            "the task's identity, concurrent refreshes joining the same shared task "
+            "read back under the same token. Ignored when `force` is false."
+        },
+        required=False,
+        allow_none=True,
+    )
+
 
 class ChartDataQueryContextSchema(Schema):
     query_context_factory: QueryContextFactory | None = None

--- a/superset/commands/distributed_lock/release.py
+++ b/superset/commands/distributed_lock/release.py
@@ -28,6 +28,7 @@ from superset.commands.distributed_lock.base import BaseDistributedLockCommand
 from superset.coordination.base import CoordinationService
 from superset.daos.key_value import KeyValueDAO
 from superset.exceptions import ReleaseDistributedLockFailedException
+from superset.extensions import db
 from superset.key_value.exceptions import KeyValueDeleteFailedError
 from superset.utils.decorators import on_error, transaction
 
@@ -102,14 +103,21 @@ class ReleaseDistributedLock(BaseDistributedLockCommand):
     def _release_kv(self) -> None:
         """Release the KV lock only if we still own it (ownership-checked).
 
-        The read and the delete are separate statements, so this is not atomic the
-        way the Redis path's compare-and-delete is; the enclosing transaction plus
-        the lock's TTL keep the residual window harmless.
+        Row-locks the entry (``SELECT ... FOR UPDATE``) before the token check so
+        the check and the delete are atomic against a concurrent expire+re-acquire:
+        without the lock, another holder could re-acquire between a plain read and
+        the delete, and this delete would then remove *their* lock. This is the KV
+        equivalent of the Redis path's compare-and-delete.
         """
+        entry = KeyValueDAO.get_entry(self.resource, self.key, for_update=True)
+        if entry is None or entry.is_expired():
+            # Nothing to release (already gone or expired). A later holder that
+            # re-created the row holds its own (locked) entry, untouched here.
+            return
         if self.token is not None:
-            stored = KeyValueDAO.get_value(self.resource, self.key, self.codec)
+            stored = self.codec.decode(entry.value)
             if not isinstance(stored, dict) or stored.get("token") != self.token:
-                # Missing/expired, or re-acquired by another holder — leave it.
+                # Re-acquired by another holder — leave their lock in place.
                 logger.warning(
                     "Not releasing KV lock namespace=%s key=%s: not owned by "
                     "this acquisition",
@@ -117,7 +125,7 @@ class ReleaseDistributedLock(BaseDistributedLockCommand):
                     self.key,
                 )
                 return
-        KeyValueDAO.delete_entry(self.resource, self.key)
+        db.session.delete(entry)
         logger.debug(
             "Released KV lock: namespace=%s key=%s",
             self.namespace,

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -143,17 +143,28 @@ class QueryContextProcessor:
         """
         return f"gtf-force-nonce:{nonce}:{cache_key}"
 
-    def _resolve_forced_query(self, cache_key: str | None) -> bool:
+    def _force_nonce(self, query_obj: QueryObject) -> str | None:
+        """The forced-refresh nonce for a query: its per-query token (the async
+        task's UUID, set on the read-back) if present, else the context-level token
+        (legacy/single-query fallback)."""
+        return (
+            getattr(query_obj, "force_nonce", None) or self._query_context.force_nonce
+        )
+
+    def _resolve_forced_query(
+        self, query_obj: QueryObject, cache_key: str | None
+    ) -> bool:
         """Resolve ``QueryContext.force`` through an optional idempotency nonce.
 
         A forced chart-data request in the async (GTF) flow is issued twice: the
         async submit schedules the recompute, then a follow-up request reads the
         warmed result. Re-running the force on that second request would recompute
-        the identical query (double execution). When the client supplies
-        ``force_nonce``, the first execution records a marker (keyed by nonce +
-        cache_key) once its result is cached; any later request carrying the same
-        nonce sees the marker and reads the cache instead of recomputing. A brand
-        new force refresh mints a new nonce, so it genuinely recomputes.
+        the identical query (double execution). When a nonce is present (the async
+        task's UUID, carried per-query on the read-back — see :meth:`_force_nonce`),
+        the first execution records a marker (keyed by nonce + cache_key) once its
+        result is cached; any later request carrying the same nonce sees the marker
+        and reads the cache instead of recomputing. A brand new force refresh uses a
+        new task (new nonce), so it genuinely recomputes.
 
         Without a nonce (synchronous forced refresh, legacy callers) force is
         honored verbatim.
@@ -162,7 +173,7 @@ class QueryContextProcessor:
         """
         if not self._query_context.force:
             return False
-        nonce = self._query_context.force_nonce
+        nonce = self._force_nonce(query_obj)
         if not nonce or not cache_key:
             return True
         # Marker present => this forced refresh already computed and cached its
@@ -178,7 +189,9 @@ class QueryContextProcessor:
             return True
         return marker is None
 
-    def _mark_force_executed(self, cache_key: str | None, persisted: bool) -> None:
+    def _mark_force_executed(
+        self, query_obj: QueryObject, cache_key: str | None, persisted: bool
+    ) -> None:
         """Record that this ``force_nonce``'s recompute has been cached.
 
         No-op unless this is a nonce-bearing forced refresh whose fresh result was
@@ -190,7 +203,7 @@ class QueryContextProcessor:
         at worst one extra recompute. The marker shares the result's TTL, so the
         two expire together.
         """
-        nonce = self._query_context.force_nonce
+        nonce = self._force_nonce(query_obj)
         if not (persisted and self._query_context.force and nonce and cache_key):
             return
         try:
@@ -224,7 +237,8 @@ class QueryContextProcessor:
         cache_key = self.query_cache_key(query_obj)
         timeout = self.get_cache_timeout()
         force_query = (
-            self._resolve_forced_query(cache_key) or timeout == CACHE_DISABLED_TIMEOUT
+            self._resolve_forced_query(query_obj, cache_key)
+            or timeout == CACHE_DISABLED_TIMEOUT
         )
         query_planning_ns = max(0, time.perf_counter_ns() - query_planning_start_ns)
 
@@ -293,7 +307,7 @@ class QueryContextProcessor:
                 # Record — only if the fresh result was actually persisted — that
                 # this forced refresh ran, so a follow-up request carrying the same
                 # nonce reads the freshly-cached result instead of recomputing it.
-                self._mark_force_executed(cache_key, cache.result_persisted)
+                self._mark_force_executed(query_obj, cache_key, cache.result_persisted)
 
         payload_assembly_start_ns = time.perf_counter_ns()
         # the N-dimensional DataFrame has converted into flat DataFrame

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -167,6 +167,10 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         self.from_dttm = kwargs.get("from_dttm")
         self.to_dttm = kwargs.get("to_dttm")
         self.result_type = kwargs.get("result_type")
+        # Per-query forced-refresh idempotency nonce (the async task's UUID). Set
+        # on the async read-back so a re-issued force reads the warmed result the
+        # task cached instead of recomputing; see QueryContextProcessor.
+        self.force_nonce = kwargs.get("force_nonce")
         self.time_offsets = kwargs.get("time_offsets", [])
         self.time_compare_full_range = kwargs.get("time_compare_full_range", False)
         self.inner_from_dttm = kwargs.get("inner_from_dttm")

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -463,7 +463,7 @@ class CoordinationService:
         """
         try:
             return backend.stream_last_id(channel)
-        except RedisError:
+        except (RedisError, OSError):
             logger.debug(
                 "Baseline stream read on %s failed; starting from 0-0",
                 channel,

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -368,7 +368,7 @@ class CoordinationService:
         # Capture the stream position, then re-check: a signal that lands between the
         # fast-path check and now is caught here (peers write the authoritative state
         # before they notify); anything after is delivered by the blocking read.
-        last_id = backend.stream_last_id(channel)
+        last_id = cls._baseline_stream_id(backend, channel)
         if (result := check()) is not None:
             return result
         while True:
@@ -451,6 +451,26 @@ class CoordinationService:
                 last_id = new_id.decode() if isinstance(new_id, bytes) else new_id
         return last_id
 
+    @staticmethod
+    def _baseline_stream_id(backend: "CoordinationBackend", channel: str) -> str:
+        """Capture the stream position to start reading from.
+
+        Guarded like :meth:`_read_stream`: a transient backend error (connection
+        drop/failover) at the instant a waiter/listener starts must not escape and
+        kill the daemon thread or abort a lock acquisition — the DB predicate is the
+        source of truth, so we degrade to ``"0-0"`` (read from the stream start) and
+        let the blocking read recover.
+        """
+        try:
+            return backend.stream_last_id(channel)
+        except RedisError:
+            logger.debug(
+                "Baseline stream read on %s failed; starting from 0-0",
+                channel,
+                exc_info=True,
+            )
+            return "0-0"
+
     @classmethod
     def listen_for_signal(
         cls,
@@ -515,10 +535,13 @@ class CoordinationService:
         """Body of the background listener thread (see :meth:`listen_for_signal`)."""
         backend = cls.get_backend()
         # Baseline before the first check (see wait_for_signal), so a signal that
-        # lands between capturing it and the first check is not missed.
-        last_id = backend.stream_last_id(channel) if backend is not None else "0-0"
-        try:
-            while not stop_event.is_set():
+        # lands between capturing it and the first check is not missed. Guarded so a
+        # transient backend error at startup can't kill the thread before the loop.
+        last_id = (
+            cls._baseline_stream_id(backend, channel) if backend is not None else "0-0"
+        )
+        while not stop_event.is_set():
+            try:
                 if check():
                     on_signal()
                     return
@@ -528,6 +551,15 @@ class CoordinationService:
                     )
                 else:
                     stop_event.wait(timeout=poll_interval)
-        except Exception:  # pylint: disable=broad-except
-            if not stop_event.is_set():
-                logger.exception("Signal listener on %s crashed", channel)
+            except Exception:  # pylint: disable=broad-except
+                # A transient predicate/handler error (e.g. a metastore blip inside
+                # ``check``) must not permanently kill this one-shot listener — that
+                # would drop the awaited signal (cancel/abort) for the task's whole
+                # lifetime. Log and continue with a short backoff; termination is
+                # driven solely by ``stop_event``.
+                if stop_event.is_set():
+                    return
+                logger.exception(
+                    "Signal listener on %s errored; retrying after backoff", channel
+                )
+                stop_event.wait(timeout=_STREAM_ERROR_BACKOFF_SECONDS)

--- a/superset/daos/key_value.py
+++ b/superset/daos/key_value.py
@@ -42,9 +42,16 @@ class KeyValueDAO(BaseDAO[KeyValueEntry]):
     def get_entry(
         resource: KeyValueResource,
         key: Key,
+        for_update: bool = False,
     ) -> KeyValueEntry | None:
         filter_ = get_filter(resource, key)
-        return db.session.query(KeyValueEntry).filter_by(**filter_).first()
+        query = db.session.query(KeyValueEntry).filter_by(**filter_)
+        if for_update:
+            # Row-lock the entry for the rest of the transaction so an
+            # ownership-checked delete (see the distributed-lock release) can't race
+            # a concurrent expire+re-acquire between the read and the delete.
+            query = query.with_for_update()
+        return query.first()
 
     @classmethod
     def get_value(

--- a/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
+++ b/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
@@ -175,9 +175,7 @@ def downgrade():
     # rows first so restoring user_id NOT NULL does not fail on NULL user_id.
     op.execute(sa.text("DELETE FROM task_subscribers WHERE user_id IS NULL"))
     with op.batch_alter_table(TASK_SUBSCRIBERS_TABLE) as batch_op:
-        batch_op.drop_constraint(
-            "ck_task_subscribers_user_xor_guest", type_="check"
-        )
+        batch_op.drop_constraint("ck_task_subscribers_user_xor_guest", type_="check")
         batch_op.drop_constraint("uq_task_subscribers_task_guest", type_="unique")
         batch_op.drop_index("ix_task_subscribers_guest_key")
         batch_op.alter_column("user_id", existing_type=sa.Integer(), nullable=False)

--- a/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
+++ b/superset/migrations/versions/2026-08-21_12-00_7e2c9a4f1b83_create_task_dependencies_table.py
@@ -147,6 +147,13 @@ def upgrade():
         batch_op.create_unique_constraint(
             "uq_task_subscribers_task_guest", ["task_id", "guest_key"]
         )
+        # A subscription is identified by exactly one of user_id (authenticated) or
+        # guest_key (embedded guest); enforce that XOR at the DB so the principal
+        # model can't be violated by a stray write.
+        batch_op.create_check_constraint(
+            "ck_task_subscribers_user_xor_guest",
+            "(user_id IS NULL) <> (guest_key IS NULL)",
+        )
 
     # Liveness marker for orphan detection: the executing worker bumps
     # ``tasks.last_heartbeat`` on a background thread, and the reap_orphaned_tasks
@@ -168,6 +175,9 @@ def downgrade():
     # rows first so restoring user_id NOT NULL does not fail on NULL user_id.
     op.execute(sa.text("DELETE FROM task_subscribers WHERE user_id IS NULL"))
     with op.batch_alter_table(TASK_SUBSCRIBERS_TABLE) as batch_op:
+        batch_op.drop_constraint(
+            "ck_task_subscribers_user_xor_guest", type_="check"
+        )
         batch_op.drop_constraint("uq_task_subscribers_task_guest", type_="unique")
         batch_op.drop_index("ix_task_subscribers_guest_key")
         batch_op.alter_column("user_id", existing_type=sa.Integer(), nullable=False)

--- a/superset/models/task_subscribers.py
+++ b/superset/models/task_subscribers.py
@@ -18,6 +18,7 @@
 
 from flask_appbuilder import Model
 from sqlalchemy import (
+    CheckConstraint,
     Column,
     DateTime,
     ForeignKey,
@@ -75,6 +76,11 @@ class TaskSubscriber(CoreTaskSubscriber, AuditMixinNullable, Model):
     __table_args__ = (
         UniqueConstraint("task_id", "user_id", name="uq_task_subscribers_task_user"),
         UniqueConstraint("task_id", "guest_key", name="uq_task_subscribers_task_guest"),
+        # Exactly one of user_id / guest_key is set (see the field comment above).
+        CheckConstraint(
+            "(user_id IS NULL) <> (guest_key IS NULL)",
+            name="ck_task_subscribers_user_xor_guest",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -41,7 +41,7 @@ from superset.tasks.constants import TERMINAL_STATES
 from superset.tasks.utils import (
     error_update,
     get_finished_dedup_key,
-    merge_private_subtree,
+    merge_properties,
     naive_utcnow,
     parse_payload,
     parse_properties,
@@ -190,14 +190,8 @@ class Task(CoreTask, AuditMixinNullable, Model):
             task.update_properties({"is_abortable": True})
             task.update_properties(progress_update((50, 100)))
         """
-        current: dict[str, Any] = dict(self.properties_dict)
-        incoming: dict[str, Any] = dict(updates)
-        if "private" in incoming:
-            current["private"] = merge_private_subtree(
-                current.get("private"), incoming.pop("private")
-            )
-        current.update(incoming)  # shallow-merge the remaining top-level keys
-        self.properties = serialize_properties(cast(TaskProperties, current))
+        current = merge_properties(self.properties_dict, updates)
+        self.properties = serialize_properties(current)
 
     def update_framework_private(self, updates: dict[str, Any]) -> None:
         """Merge keys into ``private["framework"]`` (framework-owned internal state).

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -264,18 +264,26 @@ def execute_chart_query(
     DATA-cache entry. The query runs under ``_capture_query_cancellation`` so an
     abort/timeout can cancel it on engines that support query cancellation.
     """
-    from superset.charts.data.form_data import set_form_data
+    from superset.charts.data.form_data import set_query_context_form_data
 
     with override_user(_resolve_user(user_id, guest_token), force=False):
+        query_context = load_serialized_query(serialized_query)
         # Re-establish ``g.form_data`` from the serialized payload. There is no
         # request context in the worker, and Jinja helpers (``filter_values``,
         # ``url_param``, ``get_filters``) resolve form data from ``g`` via
-        # ``get_form_data()``. Without this, a templated dataset renders empty
-        # filter values — executing/caching the wrong SQL AND computing a
+        # ``get_form_data()``. That fallback reads query-level filters/columns/
+        # url_params from ``g.form_data["queries"][0]``, so ``g.form_data`` must be
+        # the full *body*-shaped dict, not just the top-level slice ``form_data``.
+        # ``set_query_context_form_data`` builds exactly that shape (datasource +
+        # per-query fields + form_data). Without it, a templated dataset renders
+        # empty filter values — executing/caching the wrong SQL AND computing a
         # ``query_cache_key`` that diverges from the submit-time ``task_key`` (so
         # the client's re-request never reads back the cache the task wrote).
-        set_form_data(serialized_query["form_data"] or {})
-        query_context = load_serialized_query(serialized_query)
+        set_query_context_form_data(
+            query_context,
+            int(query_context.datasource.id),
+            query_context.datasource.type,
+        )
         # Floor the result-cache TTL: async caches the result for a follow-up
         # request to read back (see get_cache_timeout).
         query_context.is_async_execution = True

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -288,6 +288,13 @@ def execute_chart_query(
         # request to read back (see get_cache_timeout).
         query_context.is_async_execution = True
         query_obj = query_context.queries[0]
+        # Stamp this query with the executing task's UUID as its forced-refresh
+        # nonce. A forced async refresh recomputes and records a marker keyed by
+        # (task_uuid, cache_key); the client's synchronous read-back carries the
+        # same task_id (from the 202) per query, so it reads the warmed result
+        # instead of recomputing — and a concurrent refresh joining this SHARED
+        # task reads back under the same id. Only consulted when force is true.
+        query_obj.force_nonce = str(get_context().task_uuid)
         if requires_totals:
             _inject_contribution_totals(query_obj, _get_dependency_cache_key())
         # Executes on cache miss and writes CacheRegion.DATA under query_cache_key.

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -390,7 +390,8 @@ class TaskContext(CoreTaskContext):
         exception: BaseException | None = None,
         error_message: str | None = None,
     ) -> TaskProperties:
-        """Build the full properties dict for a terminal FAILURE write.
+        """Build the full properties dict for a terminal FAILURE write, and keep
+        the cache authoritative.
 
         Merges the executor's authoritative in-memory property cache (runtime
         state, private handles written during execution) with error detail, so a
@@ -399,6 +400,12 @@ class TaskContext(CoreTaskContext):
         structured debug detail (class + traceback via ``error_update``);
         ``error_message`` sets a plain message when there is no exception (e.g. a
         self-fence or incomplete abort).
+
+        The merged result is written back to ``self._properties_cache`` so the cache
+        reflects what the caller commits to the DB (the DAO writes a *complete*
+        properties column and leaves merging to the caller's cache). Without this,
+        a later cleanup-failure write built from the cache would erase the error
+        detail recorded here.
         """
         if exception is not None:
             updates = error_update(exception)
@@ -406,7 +413,8 @@ class TaskContext(CoreTaskContext):
             updates = cast(TaskProperties, {"error_message": error_message})
         else:
             updates = cast(TaskProperties, {})
-        return merge_properties(self._properties_cache, updates)
+        self._properties_cache = merge_properties(self._properties_cache, updates)
+        return self._properties_cache
 
     def set_cancellation(self, database_id: int, cancel_query_id: str) -> None:
         """Record the engine cancel handle for the running warehouse query.
@@ -577,14 +585,17 @@ class TaskContext(CoreTaskContext):
         if self._app:
             ctx = self._app.app_context() if not has_app_context() else nullcontext()
             with ctx:
-                # Check if task already has an error (preserve original context).
-                # error_message is public (top-level); the exception class and
-                # traceback are internal debug detail under private["framework"].
-                task = self._task
-                private_fw = (task.properties_dict.get("private") or {}).get(
+                # Preserve any error already recorded for this task (e.g. a task-body
+                # exception written via ``error_properties`` before cleanup ran).
+                # Read it from the authoritative in-memory cache — NOT ``self._task``,
+                # which is a stale construction-time snapshot that never saw that
+                # out-of-band write. error_message is public (top-level); the
+                # exception class and traceback are debug detail under
+                # private["framework"].
+                private_fw = (self._properties_cache.get("private") or {}).get(
                     "framework"
                 ) or {}
-                original_error = task.properties_dict.get("error_message")
+                original_error = self._properties_cache.get("error_message")
                 original_type = private_fw.get("exception_type")
                 original_trace = private_fw.get("stack_trace")
 
@@ -642,13 +653,15 @@ class TaskContext(CoreTaskContext):
                 ).run()
                 if not transitioned:
                     # Task already reached a terminal state (e.g. SUCCESS committed
-                    # before cleanup ran). Preserve that status; record the handler
-                    # failure as debug-only detail so it isn't lost.
+                    # before cleanup ran, or a body FAILURE was already recorded).
+                    # Preserve that status and any existing error; record only the
+                    # handler failure as debug-only detail under distinct keys so it
+                    # isn't lost and doesn't clobber the original error.
                     logger.warning(
                         "Handler failure for task %s after it reached a terminal "
                         "state; recording detail without changing status: %s",
                         self._task_uuid,
-                        error_msg,
+                        handler_error_msg,
                     )
                     InternalUpdateTaskCommand(
                         task_uuid=self._task_uuid,
@@ -659,9 +672,11 @@ class TaskContext(CoreTaskContext):
                                 {
                                     "private": {
                                         "framework": {
-                                            "cleanup_error_message": error_msg,
-                                            "cleanup_exception_type": exception_type,
-                                            "cleanup_stack_trace": stack_trace,
+                                            "cleanup_error_message": handler_error_msg,
+                                            "cleanup_exception_type": (
+                                                handler_exception_type
+                                            ),
+                                            "cleanup_stack_trace": handler_stack_trace,
                                         }
                                     }
                                 },

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -32,7 +32,7 @@ from superset_core.tasks.types import (
 
 from superset.stats_logger import BaseStatsLogger
 from superset.tasks.constants import ABORT_STATES
-from superset.tasks.utils import progress_update
+from superset.tasks.utils import error_update, merge_properties, progress_update
 
 if TYPE_CHECKING:
     from superset.coordination.types import SignalListener
@@ -383,6 +383,29 @@ class TaskContext(CoreTaskContext):
             properties=self._properties_cache,
         ).run()
 
+    def error_properties(
+        self,
+        exception: BaseException | None = None,
+        error_message: str | None = None,
+    ) -> TaskProperties:
+        """Build the full properties dict for a terminal FAILURE write.
+
+        Merges the executor's authoritative in-memory property cache (runtime
+        state, private handles written during execution) with error detail, so a
+        zero-read FAILURE transition preserves existing fields instead of replacing
+        the properties column with only an error message. ``exception`` adds the
+        structured debug detail (class + traceback via ``error_update``);
+        ``error_message`` sets a plain message when there is no exception (e.g. a
+        self-fence or incomplete abort).
+        """
+        if exception is not None:
+            updates = error_update(exception)
+        elif error_message is not None:
+            updates = cast(TaskProperties, {"error_message": error_message})
+        else:
+            updates = cast(TaskProperties, {})
+        return merge_properties(self._properties_cache, updates)
+
     def set_cancellation(self, database_id: int, cancel_query_id: str) -> None:
         """Record the engine cancel handle for the running warehouse query.
 
@@ -515,7 +538,10 @@ class TaskContext(CoreTaskContext):
         If the task already has an error (e.g., task function threw exception),
         handler failures are APPENDED to preserve the original error context.
         """
-        from superset.commands.tasks.update import UpdateTaskCommand
+        from superset.commands.tasks.internal_update import (
+            InternalStatusTransitionCommand,
+            InternalUpdateTaskCommand,
+        )
 
         if not self._handler_failures:
             return
@@ -582,22 +608,64 @@ class TaskContext(CoreTaskContext):
                     stack_trace = handler_stack_trace
 
                 # Update task with combined error info. error_message is public;
-                # exception_type/stack_trace go under private["framework"] (merged
-                # recursively, so task/other framework handles are preserved).
-                UpdateTaskCommand(
-                    self._task_uuid,
-                    status=TaskStatus.FAILURE.value,
-                    properties={
-                        "error_message": error_msg,
-                        "private": {
-                            "framework": {
-                                "exception_type": exception_type,
-                                "stack_trace": stack_trace,
-                            }
+                # exception_type/stack_trace go under private["framework"]. Merge
+                # onto the executor's property cache so the write preserves runtime
+                # state instead of replacing the whole column.
+                failure_props = merge_properties(
+                    self._properties_cache,
+                    cast(
+                        TaskProperties,
+                        {
+                            "error_message": error_msg,
+                            "private": {
+                                "framework": {
+                                    "exception_type": exception_type,
+                                    "stack_trace": stack_trace,
+                                }
+                            },
                         },
-                    },
-                    skip_security_check=True,
+                    ),
+                )
+                # Conditional transition (like every other executor path): only
+                # flip to FAILURE from a non-terminal state. Cleanup runs in the
+                # executor's ``finally`` — *after* a SUCCESS commit — so an
+                # unconditional write here would rewrite a committed terminal
+                # result and make a waiter discard a valid, successful payload.
+                transitioned = InternalStatusTransitionCommand(
+                    task_uuid=self._task_uuid,
+                    new_status=TaskStatus.FAILURE,
+                    expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
+                    properties=failure_props,
+                    set_ended_at=True,
                 ).run()
+                if not transitioned:
+                    # Task already reached a terminal state (e.g. SUCCESS committed
+                    # before cleanup ran). Preserve that status; record the handler
+                    # failure as debug-only detail so it isn't lost.
+                    logger.warning(
+                        "Handler failure for task %s after it reached a terminal "
+                        "state; recording detail without changing status: %s",
+                        self._task_uuid,
+                        error_msg,
+                    )
+                    InternalUpdateTaskCommand(
+                        task_uuid=self._task_uuid,
+                        properties=merge_properties(
+                            self._properties_cache,
+                            cast(
+                                TaskProperties,
+                                {
+                                    "private": {
+                                        "framework": {
+                                            "cleanup_error_message": error_msg,
+                                            "cleanup_exception_type": exception_type,
+                                            "cleanup_stack_trace": stack_trace,
+                                        }
+                                    }
+                                },
+                            ),
+                        ),
+                    ).run()
 
         # Clear failures after writing
         self._handler_failures = []
@@ -720,7 +788,12 @@ class TaskContext(CoreTaskContext):
         with ctx:
             from superset.commands.tasks.update import UpdateTaskCommand
 
-            if not self._task.properties_dict.get("is_abortable", False):
+            # Gate on the authoritative in-execution flag (set by ``_set_abortable``
+            # when an abort handler registers), never the ``self._task`` ORM entity:
+            # this runs on a background timer/fence thread, where the entity is a
+            # stale construction-time snapshot (its targeted UPDATE never refreshes
+            # it) and touching it would risk a cross-thread session reload.
+            if not self._properties_cache.get("is_abortable", False):
                 logger.warning(
                     "Local abort requested for task %s but no abort handler is "
                     "registered. Task will continue running.",

--- a/superset/tasks/context.py
+++ b/superset/tasks/context.py
@@ -35,6 +35,8 @@ from superset.tasks.constants import ABORT_STATES
 from superset.tasks.utils import error_update, merge_properties, progress_update
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from superset.coordination.types import SignalListener
     from superset.models.tasks import Task
 
@@ -738,6 +740,11 @@ class TaskContext(CoreTaskContext):
         if self._timeout_timer is not None:
             self._timeout_timer.cancel()
             self._timeout_timer = None
+
+    @property
+    def task_uuid(self) -> "UUID":
+        """The executing task's UUID (its stable, server-assigned identity)."""
+        return self._task_uuid
 
     @property
     def timeout_triggered(self) -> bool:

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -464,6 +464,10 @@ class TaskWrapper(Generic[P]):
         while unmet is DAG_WAITING:
             for prerequisite in current.depends_on:
                 if prerequisite.status not in TERMINAL_STATES:
+                    # Unbounded wait by design: it mirrors the async path's
+                    # unbounded defer-retry (wait until the prerequisite is
+                    # terminal). Follow-up: bound it by TaskOptions.timeout for the
+                    # sync caller if a use case needs it.
                     TaskManager.wait_for_completion(
                         task_uuid=prerequisite.uuid, poll_interval=1.0, app=app
                     )

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -43,6 +43,8 @@ from superset.tasks.registry import TaskRegistry
 from superset.tasks.utils import generate_random_task_key
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from superset.models.tasks import Task
     from superset.tasks.subscription import TaskSubscriptionPolicy
 
@@ -427,6 +429,132 @@ class TaskWrapper(Generic[P]):
             refreshed = TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
             return refreshed if refreshed else task
 
+    def _gate_on_prerequisites(self, task: "Task") -> "Task | None":
+        """Block the inline caller until this task's prerequisites are terminal.
+
+        Same ``all_success`` DAG semantics as the async path (shared via
+        :mod:`superset.tasks.dependencies`): ready → returns ``None`` (proceed); a
+        prerequisite still running → block on the coordination completion signal
+        (the sync analogue of the async defer — the caller *is* the executor and
+        has no worker slot to free), then re-check; a prerequisite that ended
+        non-success → fail this dependent and return its terminal ``Task`` for the
+        caller to return.
+        """
+        from flask import current_app
+
+        from superset.daos.tasks import TaskDAO
+        from superset.tasks.dependencies import (
+            DAG_WAITING,
+            fail_dependent_on_unmet_prerequisite,
+            unmet_prerequisite,
+        )
+
+        try:
+            app = current_app._get_current_object()  # noqa: SLF001
+        except RuntimeError:
+            app = None
+
+        # Re-read fresh so ``depends_on`` reflects committed edges (the just-created
+        # task's selectin collection can be stale), matching the async path's fresh
+        # worker load.
+        current = (
+            TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True) or task
+        )
+        unmet = unmet_prerequisite(current)
+        while unmet is DAG_WAITING:
+            for prerequisite in current.depends_on:
+                if prerequisite.status not in TERMINAL_STATES:
+                    TaskManager.wait_for_completion(
+                        task_uuid=prerequisite.uuid, poll_interval=1.0, app=app
+                    )
+            current = (
+                TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
+                or current
+            )
+            unmet = unmet_prerequisite(current)
+        if unmet is not None:
+            fail_dependent_on_unmet_prerequisite(task.uuid, cast("Task", unmet))
+            return (
+                TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True) or task
+            )
+        return None
+
+    def _abort_if_preaborted(self, task: "Task") -> "Task | None":
+        """If the task was aborted before inline execution started, finalize it as
+        ABORTED and return the terminal task; otherwise return ``None`` to proceed.
+        Matches the async pre-execution check in ``scheduler.py``."""
+        from superset.commands.tasks.internal_update import (
+            InternalStatusTransitionCommand,
+        )
+        from superset.daos.tasks import TaskDAO
+        from superset.tasks.constants import ABORT_STATES
+
+        if task.status not in ABORT_STATES:
+            return None
+        logger.info(
+            "Task %s (uuid=%s) was aborted before execution started",
+            self.name,
+            task.uuid,
+        )
+        # Ensure status is ABORTED (not just ABORTING)
+        InternalStatusTransitionCommand(
+            task_uuid=task.uuid,
+            new_status=TaskStatus.ABORTED,
+            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
+            set_ended_at=True,
+        ).run()
+        refreshed = TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
+        return refreshed if refreshed else task
+
+    def _finalize_inline_terminal_status(
+        self, ctx: "TaskContext", task_uuid: "UUID"
+    ) -> None:
+        """After the inline body returned, write the terminal status via atomic
+        conditional transitions: TIMED_OUT / ABORTED when an abort was detected, or
+        IN_PROGRESS → SUCCESS on normal completion (a no-op if concurrently aborted).
+        """
+        from superset.commands.tasks.internal_update import (
+            InternalStatusTransitionCommand,
+        )
+
+        if ctx._abort_detected or ctx.timeout_triggered:  # noqa: SLF001
+            new_status = (
+                TaskStatus.TIMED_OUT if ctx.timeout_triggered else TaskStatus.ABORTED
+            )
+            InternalStatusTransitionCommand(
+                task_uuid=task_uuid,
+                new_status=new_status,
+                expected_status=TaskStatus.ABORTING,
+                set_ended_at=True,
+            ).run()
+            logger.info(
+                "Task %s (uuid=%s) finalized as %s",
+                self.name,
+                task_uuid,
+                new_status.value,
+            )
+            return
+        # Normal completion - atomic IN_PROGRESS → SUCCESS (a no-op if the task was
+        # concurrently aborted).
+        if InternalStatusTransitionCommand(
+            task_uuid=task_uuid,
+            new_status=TaskStatus.SUCCESS,
+            expected_status=TaskStatus.IN_PROGRESS,
+            set_ended_at=True,
+        ).run():
+            logger.debug(
+                "Synchronous execution of task %s (uuid=%s) completed successfully",
+                self.name,
+                task_uuid,
+            )
+        else:
+            logger.info(
+                "Task %s (uuid=%s) IN_PROGRESS → SUCCESS failed "
+                "(may have been aborted concurrently)",
+                self.name,
+                task_uuid,
+            )
+
     def _execute_inline(
         self,
         task: "Task",
@@ -450,26 +578,17 @@ class TaskWrapper(Generic[P]):
             InternalStatusTransitionCommand,
         )
         from superset.daos.tasks import TaskDAO
-        from superset.tasks.constants import ABORT_STATES
 
-        # PRE-EXECUTION CHECK: Don't execute if already aborted/aborting
-        # (Matches async flow in scheduler.py)
-        if task.status in ABORT_STATES:
-            logger.info(
-                "Task %s (uuid=%s) was aborted before execution started",
-                self.name,
-                task.uuid,
-            )
-            # Ensure status is ABORTED (not just ABORTING)
-            InternalStatusTransitionCommand(
-                task_uuid=task.uuid,
-                new_status=TaskStatus.ABORTED,
-                expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
-                set_ended_at=True,
-            ).run()
-            # Refresh to get updated task
-            refreshed = TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
-            return refreshed if refreshed else task
+        # PRE-EXECUTION CHECK: don't execute if already aborted/aborting.
+        if (preaborted := self._abort_if_preaborted(task)) is not None:
+            return preaborted
+
+        # DAG gate: block/fail on unmet prerequisites before claiming the task,
+        # mirroring the async path's all_success semantics (shared via
+        # superset.tasks.dependencies). Returns a terminal task if a prerequisite
+        # failed (fail-fast); otherwise proceeds once prerequisites succeed.
+        if (gated := self._gate_on_prerequisites(task)) is not None:
+            return gated
 
         # Atomic transition: PENDING → IN_PROGRESS (set started_at for duration
         # tracking)
@@ -517,57 +636,8 @@ class TaskWrapper(Generic[P]):
             # ABORTED if a cancel signal lands now (mirrors the async executor).
             ctx.mark_execution_completed()
 
-            # Determine terminal status based on abort detection
-            # Use atomic conditional updates to prevent overwriting concurrent abort
-            if ctx._abort_detected or ctx.timeout_triggered:
-                # Abort was detected - transition ABORTING → terminal
-                if ctx.timeout_triggered:
-                    InternalStatusTransitionCommand(
-                        task_uuid=task_uuid,
-                        new_status=TaskStatus.TIMED_OUT,
-                        expected_status=TaskStatus.ABORTING,
-                        set_ended_at=True,
-                    ).run()
-                    logger.info(
-                        "Task %s (uuid=%s) timed out and completed cleanup",
-                        self.name,
-                        task_uuid,
-                    )
-                else:
-                    InternalStatusTransitionCommand(
-                        task_uuid=task_uuid,
-                        new_status=TaskStatus.ABORTED,
-                        expected_status=TaskStatus.ABORTING,
-                        set_ended_at=True,
-                    ).run()
-                    logger.info(
-                        "Task %s (uuid=%s) was aborted by user",
-                        self.name,
-                        task_uuid,
-                    )
-            else:
-                # Normal completion - atomic IN_PROGRESS → SUCCESS
-                # This will fail (return False) if task was concurrently aborted
-                if InternalStatusTransitionCommand(
-                    task_uuid=task_uuid,
-                    new_status=TaskStatus.SUCCESS,
-                    expected_status=TaskStatus.IN_PROGRESS,
-                    set_ended_at=True,
-                ).run():
-                    logger.debug(
-                        "Synchronous execution of task %s (uuid=%s) "
-                        "completed successfully",
-                        self.name,
-                        task_uuid,
-                    )
-                else:
-                    # Transition failed - task was likely aborted concurrently
-                    logger.info(
-                        "Task %s (uuid=%s) IN_PROGRESS → SUCCESS failed "
-                        "(may have been aborted concurrently)",
-                        self.name,
-                        task_uuid,
-                    )
+            # Determine and write the terminal status (abort/timeout vs success).
+            self._finalize_inline_terminal_status(ctx, task_uuid)
 
             # Refresh once at end to return current state
             final_task = TaskDAO.find_one_or_none(uuid=task_uuid, skip_base_filter=True)

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -582,7 +582,7 @@ class TaskWrapper(Generic[P]):
                 task_uuid=task_uuid,
                 new_status=TaskStatus.FAILURE,
                 expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
-                properties={"error_message": str(ex)},
+                properties=ctx.error_properties(exception=ex),
                 set_ended_at=True,
             ).run()
 

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -468,9 +468,15 @@ class TaskWrapper(Generic[P]):
                     # unbounded defer-retry (wait until the prerequisite is
                     # terminal). Follow-up: bound it by TaskOptions.timeout for the
                     # sync caller if a use case needs it.
-                    TaskManager.wait_for_completion(
-                        task_uuid=prerequisite.uuid, poll_interval=1.0, app=app
-                    )
+                    try:
+                        TaskManager.wait_for_completion(
+                            task_uuid=prerequisite.uuid, poll_interval=1.0, app=app
+                        )
+                    except ValueError:
+                        # The prerequisite was pruned mid-wait (no row). Stop
+                        # waiting and let the re-check below treat it as failed,
+                        # matching the async path's missing-prerequisite handling.
+                        break
             current = (
                 TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
                 or current

--- a/superset/tasks/dependencies.py
+++ b/superset/tasks/dependencies.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared GTF task-dependency (DAG) gate.
+
+Both the async (Celery) and the sync (inline) execution paths gate a dependent on
+its prerequisites with identical ``all_success`` semantics. The *decision*
+(:func:`unmet_prerequisite`) and the *fail action*
+(:func:`fail_dependent_on_unmet_prerequisite`) are pure and shared here so there is
+a single source of truth; only the *wait* action differs between paths (the Celery
+path defers by re-enqueuing the message, the inline path blocks on the coordination
+signal), which is inherent to each path rather than duplicated gate logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from superset_core.tasks.types import TaskStatus
+
+from superset.daos.tasks import TaskDAO
+from superset.tasks.constants import TERMINAL_STATES
+
+if TYPE_CHECKING:
+    from superset.models.tasks import Task as TaskModel
+
+logger = logging.getLogger(__name__)
+
+# Sentinel: at least one prerequisite is not yet terminal (the caller waits/defers
+# and re-checks).
+DAG_WAITING = object()
+
+
+def unmet_prerequisite(task: "TaskModel") -> "TaskModel | object | None":
+    """Non-blocking ``all_success`` DAG gate for ``task``.
+
+    Returns ``None`` when the task has no prerequisites or all ended in
+    ``SUCCESS`` (ready to run); ``DAG_WAITING`` when at least one prerequisite is
+    not yet terminal (the caller waits/defers and re-checks); or the first
+    prerequisite that reached a terminal non-``SUCCESS`` state (the caller fails
+    the dependent, which cascades to its own dependents).
+
+    ``task.depends_on`` is ``selectin``-loaded with the task, so a prerequisite
+    already terminal in that snapshot is trusted with no extra read (a terminal
+    status never changes). A prerequisite that is *not* terminal in the snapshot
+    is re-read fresh, since the snapshot may lag its completion.
+
+    :param task: the dependent task about to run (with ``depends_on`` loaded)
+    :returns: ``None`` (ready), ``DAG_WAITING`` (wait), or a failed prerequisite
+    """
+    prerequisites = list(task.depends_on)
+    if not prerequisites:
+        return None
+
+    for prerequisite in prerequisites:
+        current = prerequisite
+        if current.status not in TERMINAL_STATES:
+            current = TaskDAO.find_one_or_none(
+                uuid=prerequisite.uuid, skip_base_filter=True
+            )
+            if current is None:
+                # Prerequisite no longer exists (e.g. pruned) — treat as failed.
+                return prerequisite
+        if current.status not in TERMINAL_STATES:
+            return DAG_WAITING
+        if current.status != TaskStatus.SUCCESS.value:
+            return current
+
+    return None
+
+
+def fail_dependent_on_unmet_prerequisite(native_uuid: UUID, unmet: "TaskModel") -> str:
+    """Fail a dependent whose prerequisite ended non-success; return committed status.
+
+    ``all_success`` semantics: a prerequisite that ended in a terminal non-success
+    state fails the dependent without running its body, which then cascades to the
+    dependent's own dependents. Publishes a completion for waiters when the FAILURE
+    transition wins; if the dependent moved to a terminal state concurrently (e.g.
+    aborted while waiting), the transition is a no-op and the committed status is
+    reported instead of publishing a contradictory FAILURE completion.
+
+    :param native_uuid: the dependent task's UUID
+    :param unmet: the prerequisite that ended in a terminal non-success state
+    :returns: the dependent's committed status string
+    """
+    from superset.commands.tasks.internal_update import InternalStatusTransitionCommand
+    from superset.tasks.manager import TaskManager
+
+    logger.info(
+        "Task %s failing: prerequisite %s did not succeed (status=%s)",
+        native_uuid,
+        unmet.uuid,
+        unmet.status,
+    )
+    failed_transition = InternalStatusTransitionCommand(
+        task_uuid=native_uuid,
+        new_status=TaskStatus.FAILURE,
+        expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
+        set_ended_at=True,
+        properties={
+            "error_message": (
+                f"Prerequisite task {unmet.uuid} did not "
+                f"succeed (status={unmet.status})"
+            )
+        },
+    ).run()
+    if failed_transition:
+        TaskManager.publish_completion(native_uuid, TaskStatus.FAILURE.value)
+        return TaskStatus.FAILURE.value
+    refreshed = TaskDAO.find_one_or_none(uuid=native_uuid, skip_base_filter=True)
+    return refreshed.status if refreshed else "unknown"

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -676,7 +676,7 @@ def _execute_task_body(  # noqa: C901
                 task_uuid=native_uuid,
                 new_status=TaskStatus.FAILURE,
                 expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
-                properties={"error_message": str(ex)},
+                properties=ctx.error_properties(exception=ex),
                 set_ended_at=True,
             ).run()
 
@@ -706,7 +706,7 @@ def _execute_task_body(  # noqa: C901
                 task_uuid=native_uuid,
                 new_status=TaskStatus.FAILURE,
                 expected_status=[TaskStatus.IN_PROGRESS, TaskStatus.ABORTING],
-                properties={"error_message": SELF_FENCE_ERROR_MESSAGE},
+                properties=ctx.error_properties(error_message=SELF_FENCE_ERROR_MESSAGE),
                 set_ended_at=True,
             ).run()
             logger.warning(
@@ -748,7 +748,9 @@ def _execute_task_body(  # noqa: C901
                     task_uuid=native_uuid,
                     new_status=TaskStatus.FAILURE,
                     expected_status=TaskStatus.ABORTING,
-                    properties={"error_message": "Abort handlers did not complete"},
+                    properties=ctx.error_properties(
+                        error_message="Abort handlers did not complete"
+                    ),
                     set_ended_at=True,
                 ).run()
                 logger.warning(

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -47,6 +47,11 @@ from superset.tasks.ambient_context import use_context
 from superset.tasks.constants import ABORT_STATES, TERMINAL_STATES
 from superset.tasks.context import TaskContext
 from superset.tasks.cron_util import cron_schedule_window
+from superset.tasks.dependencies import (
+    DAG_WAITING,
+    fail_dependent_on_unmet_prerequisite,
+    unmet_prerequisite,
+)
 from superset.tasks.heartbeat import (
     HeartbeatController,
     SELF_FENCE_ERROR_MESSAGE,
@@ -314,7 +319,9 @@ _DAG_DEFER_STEP_SECONDS = 2.0
 _DAG_DEFER_MAX_SECONDS = 30.0
 
 # Sentinel: at least one prerequisite is not yet terminal (defer and re-check).
-_DAG_WAITING = object()
+# The DAG decision and the fail action live in superset.tasks.dependencies so the
+# Celery and inline paths share one implementation; only the wait action (defer via
+# self.retry below vs. block on the coordination signal inline) is path-specific.
 
 
 def _dag_defer_countdown(retries: int) -> float:
@@ -331,46 +338,6 @@ def _dag_defer_countdown(retries: int) -> float:
     )
     # Jitter only spreads wake-ups; it is not security-sensitive.
     return base + random.uniform(0, min(base, 1.0))  # noqa: S311
-
-
-def _unmet_prerequisite(task: "TaskModel") -> "TaskModel | object | None":
-    """Non-blocking ``all_success`` DAG gate for ``task``.
-
-    Returns ``None`` when the task has no prerequisites or all ended in
-    ``SUCCESS`` (ready to run); ``_DAG_WAITING`` when at least one prerequisite is
-    not yet terminal (the caller defers and re-checks); or the first prerequisite
-    that reached a terminal non-``SUCCESS`` state (the caller fails the dependent,
-    which cascades to its own dependents).
-
-    ``task.depends_on`` is ``selectin``-loaded with the task, so a prerequisite
-    already terminal in that snapshot is trusted with no extra read (a terminal
-    status never changes). A prerequisite that is *not* terminal in the snapshot
-    is re-read fresh, since the snapshot may lag its completion. Unlike the old
-    block-and-wait resolver, this never parks the worker: waiting is expressed by
-    deferring the Celery message.
-
-    :param task: the dependent task about to run (with ``depends_on`` loaded)
-    :returns: ``None`` (ready), ``_DAG_WAITING`` (defer), or a failed prerequisite
-    """
-    prerequisites = list(task.depends_on)
-    if not prerequisites:
-        return None
-
-    for prerequisite in prerequisites:
-        current = prerequisite
-        if current.status not in TERMINAL_STATES:
-            current = TaskDAO.find_one_or_none(
-                uuid=prerequisite.uuid, skip_base_filter=True
-            )
-            if current is None:
-                # Prerequisite no longer exists (e.g. pruned) — treat as failed.
-                return prerequisite
-        if current.status not in TERMINAL_STATES:
-            return _DAG_WAITING
-        if current.status != TaskStatus.SUCCESS.value:
-            return current
-
-    return None
 
 
 def _persist_celery_task_id(task: "TaskModel", celery_task_id: str | None) -> None:
@@ -457,8 +424,8 @@ def execute_task(
     # carries no heartbeat and can't be mistaken for abandoned active work by the
     # reaper (which ignores null-heartbeat tasks). all_success semantics: if any
     # prerequisite ended non-success, fail without running (cascades to dependents).
-    unmet = _unmet_prerequisite(task)
-    if unmet is _DAG_WAITING:
+    unmet = unmet_prerequisite(task)
+    if unmet is DAG_WAITING:
         countdown = _dag_defer_countdown(self.request.retries)
         current_app.config["STATS_LOGGER"].incr("gtf.task.dag_deferred")
         logger.info(
@@ -497,39 +464,12 @@ def execute_task(
             return {"status": TaskStatus.FAILURE.value, "task_uuid": task_uuid}
     if unmet is not None:
         # A prerequisite ended non-success (unmet is that Task): fail without
-        # running the body. Its failure then cascades to this task's dependents.
-        # The _DAG_WAITING sentinel was handled above, so this is a Task.
-        unmet = cast("TaskModel", unmet)
-        logger.info(
-            "Task %s (uuid=%s) failing: prerequisite %s did not succeed (status=%s)",
-            task_type,
-            task_uuid,
-            unmet.uuid,
-            unmet.status,
+        # running the body. The DAG_WAITING sentinel was handled above, so this is
+        # a Task. Shared with the inline path via the dependencies helper.
+        status = fail_dependent_on_unmet_prerequisite(
+            native_uuid, cast("TaskModel", unmet)
         )
-        failed_transition = InternalStatusTransitionCommand(
-            task_uuid=native_uuid,
-            new_status=TaskStatus.FAILURE,
-            expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
-            set_ended_at=True,
-            properties={
-                "error_message": (
-                    f"Prerequisite task {unmet.uuid} did not "
-                    f"succeed (status={unmet.status})"
-                )
-            },
-        ).run()
-        if failed_transition:
-            TaskManager.publish_completion(native_uuid, TaskStatus.FAILURE.value)
-            return {"status": TaskStatus.FAILURE.value, "task_uuid": task_uuid}
-        # The dependent moved to a terminal state concurrently (e.g. aborted while
-        # deferred), so the FAILURE transition was a no-op — report the committed
-        # status instead of publishing a contradictory FAILURE completion.
-        refreshed = TaskDAO.find_one_or_none(uuid=native_uuid, skip_base_filter=True)
-        return {
-            "status": refreshed.status if refreshed else "unknown",
-            "task_uuid": task_uuid,
-        }
+        return {"status": status, "task_uuid": task_uuid}
 
     # Prerequisites satisfied → claim the task and run it under the heartbeat.
     _persist_celery_task_id(task, self.request.id)

--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -388,6 +388,28 @@ def merge_private_subtree(
     return merged
 
 
+def merge_properties(
+    current: TaskProperties | None, updates: TaskProperties
+) -> TaskProperties:
+    """Merge ``updates`` into ``current`` with task-properties semantics.
+
+    Top-level keys are shallow-merged; the ``private`` subtree merges recursively
+    (see :func:`merge_private_subtree`), so writing one namespace never clobbers the
+    other. This is the pure form of :meth:`superset.models.tasks.Task.update_properties`
+    — use it to build a complete properties dict for a zero-read write (e.g. a
+    terminal FAILURE that must preserve the executor's runtime state while adding
+    error detail) without loading the ORM entity.
+    """
+    merged: dict[str, Any] = dict(current or {})
+    incoming: dict[str, Any] = dict(updates)
+    if "private" in incoming:
+        merged["private"] = merge_private_subtree(
+            merged.get("private"), incoming.pop("private")
+        )
+    merged.update(incoming)
+    return cast(TaskProperties, merged)
+
+
 def parse_properties(json_str: str | None) -> TaskProperties:
     """
     Parse JSON string into TaskProperties dict.

--- a/superset/utils/feature_flag_manager.py
+++ b/superset/utils/feature_flag_manager.py
@@ -21,6 +21,15 @@ from flask import Flask
 
 logger = logging.getLogger(__name__)
 
+# Async chart data executes on the Global Task Framework, so enabling
+# GLOBAL_ASYNC_QUERIES implies GLOBAL_TASK_FRAMEWORK. This is enforced as a derived
+# rule at resolution time (see ``_apply_derived_flags``) so it holds even when a
+# dynamic callback (GET_FEATURE_FLAGS_FUNC/IS_FEATURE_ENABLED_FUNC) would otherwise
+# resolve GTF off — which would let async chart requests schedule work that
+# ``.schedule()`` then rejects with GlobalTaskFrameworkDisabledError.
+GLOBAL_ASYNC_QUERIES = "GLOBAL_ASYNC_QUERIES"
+GLOBAL_TASK_FRAMEWORK = "GLOBAL_TASK_FRAMEWORK"
+
 
 class FeatureFlagManager:
     def __init__(self) -> None:
@@ -36,12 +45,14 @@ class FeatureFlagManager:
         self._feature_flags.update(app.config["FEATURE_FLAGS"])
 
         # Async chart-data queries run on the Global Task Framework, so enabling
-        # GLOBAL_ASYNC_QUERIES force-enables GLOBAL_TASK_FRAMEWORK. (A deployment
-        # using IS_FEATURE_ENABLED_FUNC/GET_FEATURE_FLAGS_FUNC can still override
-        # the final decision there.)
+        # GLOBAL_ASYNC_QUERIES force-enables GLOBAL_TASK_FRAMEWORK. This static
+        # mutation is a convenience default; the authoritative enforcement is the
+        # derived rule applied at resolution time (see ``_apply_derived_flags``),
+        # which also covers deployments using IS_FEATURE_ENABLED_FUNC /
+        # GET_FEATURE_FLAGS_FUNC.
         if self._feature_flags.get(
-            "GLOBAL_ASYNC_QUERIES"
-        ) and not self._feature_flags.get("GLOBAL_TASK_FRAMEWORK"):
+            GLOBAL_ASYNC_QUERIES
+        ) and not self._feature_flags.get(GLOBAL_TASK_FRAMEWORK):
             logger.info(
                 "GLOBAL_ASYNC_QUERIES is enabled; force-enabling "
                 "GLOBAL_TASK_FRAMEWORK (async chart data runs on the Global Task "
@@ -49,20 +60,35 @@ class FeatureFlagManager:
             )
             self._feature_flags["GLOBAL_TASK_FRAMEWORK"] = True
 
+    @staticmethod
+    def _apply_derived_flags(flags: dict[str, bool]) -> dict[str, bool]:
+        """Apply cross-flag derived rules to a resolved flag map.
+
+        GAQ implies GTF (see the module note): if GLOBAL_ASYNC_QUERIES resolved on
+        but GLOBAL_TASK_FRAMEWORK resolved off, force GTF on. Returns a copy when a
+        rule fires so the source map is never mutated in place.
+        """
+        if flags.get(GLOBAL_ASYNC_QUERIES) and not flags.get(GLOBAL_TASK_FRAMEWORK):
+            return {**flags, GLOBAL_TASK_FRAMEWORK: True}
+        return flags
+
     def get_feature_flags(self) -> dict[str, bool]:
         if self._get_feature_flags_func:
-            return self._get_feature_flags_func(deepcopy(self._feature_flags))
-        if callable(self._is_feature_enabled_func):
-            return dict(  # noqa: C417
+            flags = self._get_feature_flags_func(deepcopy(self._feature_flags))
+        elif callable(self._is_feature_enabled_func):
+            flags = dict(  # noqa: C417
                 map(
                     lambda kv: (kv[0], self._is_feature_enabled_func(kv[0], kv[1])),
                     self._feature_flags.items(),
                 )
             )
-        return self._feature_flags
+        else:
+            flags = self._feature_flags
+        return self._apply_derived_flags(flags)
 
-    def is_feature_enabled(self, feature: str) -> bool:
-        """Utility function for checking whether a feature is turned on"""
+    def _resolve_flag(self, feature: str) -> bool:
+        """Resolve a single flag through the configured callback / static map,
+        WITHOUT applying derived rules (see :meth:`is_feature_enabled`)."""
         if self._is_feature_enabled_func:
             return (
                 self._is_feature_enabled_func(feature, self._feature_flags[feature])
@@ -73,3 +99,12 @@ class FeatureFlagManager:
         if feature_flags and feature in feature_flags:
             return feature_flags[feature]
         return False
+
+    def is_feature_enabled(self, feature: str) -> bool:
+        """Utility function for checking whether a feature is turned on"""
+        if feature == GLOBAL_TASK_FRAMEWORK:
+            # Derived rule: GAQ implies GTF, even under dynamic flag callbacks.
+            return self._resolve_flag(GLOBAL_TASK_FRAMEWORK) or self._resolve_flag(
+                GLOBAL_ASYNC_QUERIES
+            )
+        return self._resolve_flag(feature)

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -2456,9 +2456,14 @@ def test_get_native_annotation_data_requires_annotation_read_access():
 # =============================================================================
 
 
+# A query object with no per-query nonce: the force helpers then fall back to the
+# context-level nonce (the path these tests exercise).
+_QO_NO_NONCE = MagicMock(force_nonce=None)
+
+
 def test_resolve_forced_query_false_when_not_forced(processor, mock_query_context):
     mock_query_context.force = False
-    assert processor._resolve_forced_query("ck") is False
+    assert processor._resolve_forced_query(_QO_NO_NONCE, "ck") is False
 
 
 def test_resolve_forced_query_true_when_forced_without_nonce(
@@ -2467,7 +2472,7 @@ def test_resolve_forced_query_true_when_forced_without_nonce(
     """A forced refresh with no nonce (sync/legacy) forces verbatim."""
     mock_query_context.force = True
     mock_query_context.force_nonce = None
-    assert processor._resolve_forced_query("ck") is True
+    assert processor._resolve_forced_query(_QO_NO_NONCE, "ck") is True
 
 
 def test_resolve_forced_query_true_when_forced_without_cache_key(
@@ -2475,7 +2480,7 @@ def test_resolve_forced_query_true_when_forced_without_cache_key(
 ):
     mock_query_context.force = True
     mock_query_context.force_nonce = "nonce-1"
-    assert processor._resolve_forced_query(None) is True
+    assert processor._resolve_forced_query(_QO_NO_NONCE, None) is True
 
 
 def test_resolve_forced_query_reads_cache_when_marker_present(
@@ -2488,7 +2493,7 @@ def test_resolve_forced_query_reads_cache_when_marker_present(
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
         cache_manager.data_cache.get.return_value = 1  # marker exists
-        assert processor._resolve_forced_query("ck") is False
+        assert processor._resolve_forced_query(_QO_NO_NONCE, "ck") is False
     cache_manager.data_cache.get.assert_called_once_with("gtf-force-nonce:nonce-1:ck")
 
 
@@ -2502,7 +2507,7 @@ def test_resolve_forced_query_forces_when_marker_absent(processor, mock_query_co
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
         cache_manager.data_cache.get.return_value = None  # no marker
-        assert processor._resolve_forced_query("ck") is True
+        assert processor._resolve_forced_query(_QO_NO_NONCE, "ck") is True
 
 
 def test_mark_force_executed_sets_marker_for_nonce_refresh(
@@ -2514,7 +2519,7 @@ def test_mark_force_executed_sets_marker_for_nonce_refresh(
         patch("superset.common.query_context_processor.cache_manager") as cache_manager,
         patch.object(processor, "get_cache_timeout", return_value=123),
     ):
-        processor._mark_force_executed("ck", persisted=True)
+        processor._mark_force_executed(_QO_NO_NONCE, "ck", persisted=True)
     cache_manager.data_cache.set.assert_called_once_with(
         "gtf-force-nonce:nonce-1:ck", 1, timeout=123
     )
@@ -2531,7 +2536,7 @@ def test_mark_force_executed_noop_when_result_not_persisted(
     with patch(
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
-        processor._mark_force_executed("ck", persisted=False)
+        processor._mark_force_executed(_QO_NO_NONCE, "ck", persisted=False)
     cache_manager.data_cache.set.assert_not_called()
 
 
@@ -2541,7 +2546,7 @@ def test_mark_force_executed_noop_without_nonce(processor, mock_query_context):
     with patch(
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
-        processor._mark_force_executed("ck", persisted=True)
+        processor._mark_force_executed(_QO_NO_NONCE, "ck", persisted=True)
     cache_manager.data_cache.set.assert_not_called()
 
 
@@ -2554,7 +2559,9 @@ def test_mark_force_executed_swallows_marker_write_error(processor, mock_query_c
         patch.object(processor, "get_cache_timeout", return_value=123),
     ):
         cache_manager.data_cache.set.side_effect = RuntimeError("backend down")
-        processor._mark_force_executed("ck", persisted=True)  # must not raise
+        processor._mark_force_executed(
+            _QO_NO_NONCE, "ck", persisted=True
+        )  # must not raise
 
 
 def test_resolve_forced_query_forces_when_marker_read_errors(
@@ -2567,4 +2574,33 @@ def test_resolve_forced_query_forces_when_marker_read_errors(
         "superset.common.query_context_processor.cache_manager"
     ) as cache_manager:
         cache_manager.data_cache.get.side_effect = RuntimeError("backend down")
-        assert processor._resolve_forced_query("ck") is True
+        assert processor._resolve_forced_query(_QO_NO_NONCE, "ck") is True
+
+
+def test_resolve_forced_query_prefers_per_query_nonce(processor, mock_query_context):
+    """The per-query nonce (the async task's UUID, set on the read-back) takes
+    precedence over the context-level nonce and keys the marker lookup."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "ctx-nonce"
+    query_obj = MagicMock(force_nonce="task-uuid")
+    with patch(
+        "superset.common.query_context_processor.cache_manager"
+    ) as cache_manager:
+        cache_manager.data_cache.get.return_value = 1  # marker exists
+        assert processor._resolve_forced_query(query_obj, "ck") is False
+    cache_manager.data_cache.get.assert_called_once_with("gtf-force-nonce:task-uuid:ck")
+
+
+def test_mark_force_executed_uses_per_query_nonce(processor, mock_query_context):
+    """The marker is written under the per-query nonce when present."""
+    mock_query_context.force = True
+    mock_query_context.force_nonce = "ctx-nonce"
+    query_obj = MagicMock(force_nonce="task-uuid")
+    with (
+        patch("superset.common.query_context_processor.cache_manager") as cache_manager,
+        patch.object(processor, "get_cache_timeout", return_value=123),
+    ):
+        processor._mark_force_executed(query_obj, "ck", persisted=True)
+    cache_manager.data_cache.set.assert_called_once_with(
+        "gtf-force-nonce:task-uuid:ck", 1, timeout=123
+    )

--- a/tests/unit_tests/coordination/test_service.py
+++ b/tests/unit_tests/coordination/test_service.py
@@ -339,6 +339,40 @@ def test_listen_fires_via_stream(app_context: None, mocker: MockerFixture) -> No
     backend.xread.assert_called()
 
 
+def test_baseline_stream_id_degrades_on_backend_error(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    """A transient error capturing the baseline must not propagate (it would kill a
+    listener thread or abort a lock acquisition); it degrades to reading from 0-0."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    backend = mocker.MagicMock(name="backend")
+    backend.stream_last_id.side_effect = RedisConnectionError("down")
+    assert CoordinationService._baseline_stream_id(backend, "ch") == "0-0"
+
+
+def test_listen_survives_transient_check_error(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    """A transient predicate error must not permanently kill the one-shot listener
+    (that would drop the awaited cancel/abort signal); it retries and still fires."""
+    mocker.patch.object(CoordinationService, "get_backend", return_value=None)
+    # First check raises (metastore blip), then it recovers and reports satisfied.
+    calls = iter([RuntimeError("db blip")])
+
+    def check() -> bool:
+        for exc in calls:
+            raise exc
+        return True
+
+    fired = threading.Event()
+    listener = CoordinationService.listen_for_signal(
+        "ch", check=check, on_signal=fired.set, poll_interval=0.01, name="t"
+    )
+    assert fired.wait(timeout=2.0) is True
+    listener.stop()
+
+
 def test_signal_listener_stop_signals_and_joins(mocker: MockerFixture) -> None:
     thread = mocker.MagicMock(name="thread")
     thread.is_alive.side_effect = [True, False]

--- a/tests/unit_tests/distributed_lock/distributed_lock_tests.py
+++ b/tests/unit_tests/distributed_lock/distributed_lock_tests.py
@@ -18,7 +18,7 @@
 # pylint: disable=invalid-name
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
@@ -183,6 +183,33 @@ def test_distributed_lock_kv_release_only_deletes_own_lock() -> None:
 
         # B's lock survives.
         assert _get_lock(MAIN_KEY, session) == b_value
+
+
+def test_distributed_lock_kv_release_row_locks_the_entry() -> None:
+    """The KV release reads the entry with ``for_update=True`` so the ownership
+    check and the delete are atomic against a concurrent expire+re-acquire (the KV
+    equivalent of the Redis compare-and-delete). A token mismatch leaves it alone."""
+    from superset.commands.distributed_lock.release import ReleaseDistributedLock
+
+    cmd = ReleaseDistributedLock("ns", {"a": 1, "b": 2}, token="mine")  # noqa: S106
+    other_holder = MagicMock()
+    other_holder.is_expired.return_value = False
+    # A different acquisition now owns the row.
+    with (
+        patch(BACKEND_DEFINED, return_value=False),
+        patch(
+            "superset.commands.distributed_lock.release.KeyValueDAO.get_entry",
+            return_value=other_holder,
+        ) as get_entry,
+        patch.object(cmd.codec, "decode", return_value={"token": "theirs"}),
+        patch("superset.commands.distributed_lock.release.db") as db_mock,
+    ):
+        cmd._release_kv()
+
+    # The entry was row-locked for the ownership-checked delete...
+    assert get_entry.call_args.kwargs.get("for_update") is True
+    # ...and, since the token did not match, another holder's lock was NOT deleted.
+    db_mock.session.delete.assert_not_called()
 
 
 def test_distributed_lock_uses_redis_when_configured() -> None:

--- a/tests/unit_tests/feature_flag_test.py
+++ b/tests/unit_tests/feature_flag_test.py
@@ -65,13 +65,13 @@ def test_is_feature_enabled(mocker: MockerFixture) -> None:
     assert is_feature_enabled("Flag4") is True
 
 
-def _make_app(feature_flags: dict[str, bool]):
+def _make_app(feature_flags: dict[str, bool], get_func=None, is_func=None):
     """Minimal object exposing the config keys FeatureFlagManager.init_app reads."""
 
     class _App:
         config = {
-            "GET_FEATURE_FLAGS_FUNC": None,
-            "IS_FEATURE_ENABLED_FUNC": None,
+            "GET_FEATURE_FLAGS_FUNC": get_func,
+            "IS_FEATURE_ENABLED_FUNC": is_func,
             "DEFAULT_FEATURE_FLAGS": {},
             "FEATURE_FLAGS": feature_flags,
         }
@@ -93,4 +93,55 @@ def test_gtf_not_enabled_without_global_async_queries() -> None:
 
     manager = FeatureFlagManager()
     manager.init_app(_make_app({"GLOBAL_ASYNC_QUERIES": False}))
+    assert manager.is_feature_enabled("GLOBAL_TASK_FRAMEWORK") is False
+
+
+def test_gaq_implies_gtf_via_is_feature_enabled_func() -> None:
+    """The derived GAQ→GTF rule holds even when IS_FEATURE_ENABLED_FUNC resolves
+    GAQ on but GTF off — otherwise async chart requests would schedule work that
+    .schedule() rejects."""
+    from superset.utils.feature_flag_manager import FeatureFlagManager
+
+    def is_func(name: str, default: bool) -> bool:
+        return name == "GLOBAL_ASYNC_QUERIES"  # GAQ on, everything else (GTF) off
+
+    manager = FeatureFlagManager()
+    manager.init_app(
+        _make_app(
+            {"GLOBAL_ASYNC_QUERIES": False, "GLOBAL_TASK_FRAMEWORK": False},
+            is_func=is_func,
+        )
+    )
+    assert manager.is_feature_enabled("GLOBAL_ASYNC_QUERIES") is True
+    assert manager.is_feature_enabled("GLOBAL_TASK_FRAMEWORK") is True
+    assert manager.get_feature_flags()["GLOBAL_TASK_FRAMEWORK"] is True
+
+
+def test_gaq_implies_gtf_via_get_feature_flags_func() -> None:
+    """Same derived rule when GET_FEATURE_FLAGS_FUNC returns GAQ on / GTF off."""
+    from superset.utils.feature_flag_manager import FeatureFlagManager
+
+    def get_func(defaults: dict[str, bool]) -> dict[str, bool]:
+        return {"GLOBAL_ASYNC_QUERIES": True, "GLOBAL_TASK_FRAMEWORK": False}
+
+    manager = FeatureFlagManager()
+    manager.init_app(_make_app({}, get_func=get_func))
+    assert manager.get_feature_flags()["GLOBAL_TASK_FRAMEWORK"] is True
+    assert manager.is_feature_enabled("GLOBAL_TASK_FRAMEWORK") is True
+
+
+def test_callback_gtf_stays_off_when_gaq_off() -> None:
+    """The derived rule only fires when GAQ is on; it never turns GTF on otherwise."""
+    from superset.utils.feature_flag_manager import FeatureFlagManager
+
+    def is_func(name: str, default: bool) -> bool:
+        return False  # everything off
+
+    manager = FeatureFlagManager()
+    manager.init_app(
+        _make_app(
+            {"GLOBAL_ASYNC_QUERIES": False, "GLOBAL_TASK_FRAMEWORK": False},
+            is_func=is_func,
+        )
+    )
     assert manager.is_feature_enabled("GLOBAL_TASK_FRAMEWORK") is False

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -177,62 +177,85 @@ def test_execute_chart_query_reestablishes_form_data(
     mocker: MockerFixture,
 ) -> None:
     """The worker has no request context, so g.form_data must be re-established
-    from the serialized payload — otherwise templated datasets render empty filter
-    values and the cache key diverges from the submit-time task_key."""
+    from the serialized payload as a *body*-shaped dict (datasource + per-query
+    fields) — otherwise ``get_form_data()``'s fallback can't recover query-level
+    filters/url_params and templated datasets render empty, diverging the cache
+    key from the submit-time task_key."""
     from superset.tasks.async_queries import execute_chart_query
 
     query_context = mocker.MagicMock()
+    query_context.datasource.id = 5
+    query_context.datasource.type = "table"
     query_context.queries = [mocker.MagicMock()]
     query_context.get_df_payload_result.return_value.payload = {}
     mocker.patch(
         "superset.tasks.async_queries._resolve_user", return_value=mocker.MagicMock()
     )
     mocker.patch("superset.tasks.async_queries.override_user")
-    load = mocker.patch(
-        "superset.tasks.async_queries.load_serialized_query",
-        return_value=query_context,
+    manager = mocker.MagicMock()
+    manager.attach_mock(
+        mocker.patch(
+            "superset.tasks.async_queries.load_serialized_query",
+            return_value=query_context,
+        ),
+        "load",
+    )
+    manager.attach_mock(
+        mocker.patch("superset.charts.data.form_data.set_query_context_form_data"),
+        "set_fd",
     )
     mocker.patch(
         "superset.tasks.async_queries.get_context", return_value=mocker.MagicMock()
     )
-    set_form_data = mocker.patch("superset.charts.data.form_data.set_form_data")
 
-    form_data = {"queries": [{"url_params": {"region": "EMEA"}}]}
-    serialized = _serialized_query()
-    serialized["form_data"] = form_data
-    execute_chart_query.func(serialized, user_id=7)
-
-    # form data is re-established from the payload, before the context is rebuilt.
-    set_form_data.assert_called_once_with(form_data)
-    assert set_form_data.call_count == 1
-    load.assert_called_once()
-
-
-def test_execute_chart_query_form_data_defaults_to_empty(
-    mocker: MockerFixture,
-) -> None:
-    from superset.tasks.async_queries import execute_chart_query
-
-    query_context = mocker.MagicMock()
-    query_context.queries = [mocker.MagicMock()]
-    query_context.get_df_payload_result.return_value.payload = {}
-    mocker.patch(
-        "superset.tasks.async_queries._resolve_user", return_value=mocker.MagicMock()
-    )
-    mocker.patch("superset.tasks.async_queries.override_user")
-    mocker.patch(
-        "superset.tasks.async_queries.load_serialized_query",
-        return_value=query_context,
-    )
-    mocker.patch(
-        "superset.tasks.async_queries.get_context", return_value=mocker.MagicMock()
-    )
-    set_form_data = mocker.patch("superset.charts.data.form_data.set_form_data")
-
-    # _serialized_query() carries form_data=None → set to {} (never None).
     execute_chart_query.func(_serialized_query(), user_id=7)
 
-    set_form_data.assert_called_once_with({})
+    # The context is rebuilt first, then the body-shaped form data is set from it
+    # (using the canonical helper, not the flat top-level ``form_data``).
+    assert [call[0] for call in manager.mock_calls[:2]] == ["load", "set_fd"]
+    manager.set_fd.assert_called_once_with(query_context, 5, "table")
+
+
+def test_execute_chart_query_form_data_has_body_shape(
+    mocker: MockerFixture,
+) -> None:
+    """End-to-end of the worker's form-data reconstruction: the resulting
+    ``g.form_data`` is body-shaped and carries query-level fields (filters,
+    url_params) that the Jinja fallback reads from ``form_data['queries'][0]``."""
+    from flask import g
+
+    from superset.tasks.async_queries import execute_chart_query
+
+    query = mocker.MagicMock()
+    query.to_dict.return_value = {"metrics": ["count"], "columns": ["name"]}
+    query.filter = [{"col": "region", "op": "==", "val": "EMEA"}]
+    query.time_range = "No filter"
+
+    query_context = mocker.MagicMock()
+    query_context.datasource.id = 5
+    query_context.datasource.type = "table"
+    query_context.form_data = {"url_params": {"region": "EMEA"}, "slice_id": 9}
+    query_context.queries = [query]
+    query_context.get_df_payload_result.return_value.payload = {}
+    mocker.patch(
+        "superset.tasks.async_queries._resolve_user", return_value=mocker.MagicMock()
+    )
+    mocker.patch("superset.tasks.async_queries.override_user")
+    mocker.patch(
+        "superset.tasks.async_queries.load_serialized_query",
+        return_value=query_context,
+    )
+    mocker.patch(
+        "superset.tasks.async_queries.get_context", return_value=mocker.MagicMock()
+    )
+
+    # set_query_context_form_data is NOT mocked here — assert the real body shape.
+    execute_chart_query.func(_serialized_query(), user_id=7)
+
+    assert g.form_data["datasource"] == {"id": 5, "type": "table"}
+    assert len(g.form_data["queries"]) == 1
+    assert g.form_data["queries"][0]["url_params"] == {"region": "EMEA"}
+    assert g.form_data["queries"][0]["filters"] == query.filter
 
 
 def test_execute_chart_query_reads_totals_key_from_dependency_payload(

--- a/tests/unit_tests/tasks/test_dependencies.py
+++ b/tests/unit_tests/tasks/test_dependencies.py
@@ -38,14 +38,14 @@ class TestUnmetPrerequisite:
     """Tests for the scheduler's non-blocking ``all_success`` DAG gate."""
 
     def test_no_dependencies_returns_none(self):
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
-        assert _unmet_prerequisite(SimpleNamespace(depends_on=[])) is None
+        assert unmet_prerequisite(SimpleNamespace(depends_on=[])) is None
 
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_all_terminal_success_snapshot_needs_no_read(self, mock_find):
         """Prerequisites already SUCCESS in the loaded snapshot skip any DB read."""
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
         task = SimpleNamespace(
             depends_on=[
@@ -53,18 +53,18 @@ class TestUnmetPrerequisite:
                 _task(status=TaskStatus.SUCCESS.value),
             ]
         )
-        assert _unmet_prerequisite(task) is None
+        assert unmet_prerequisite(task) is None
         # A terminal status never changes, so no fresh read is issued.
         mock_find.assert_not_called()
 
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_failed_prerequisite_in_snapshot_is_returned(self, mock_find):
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
         succeeded = _task(status=TaskStatus.SUCCESS.value)
         failed = _task(status=TaskStatus.FAILURE.value)
         assert (
-            _unmet_prerequisite(SimpleNamespace(depends_on=[succeeded, failed]))
+            unmet_prerequisite(SimpleNamespace(depends_on=[succeeded, failed]))
             is failed
         )
         mock_find.assert_not_called()
@@ -72,45 +72,43 @@ class TestUnmetPrerequisite:
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_non_terminal_snapshot_reread_still_pending_defers(self, mock_find):
         """A prerequisite still non-terminal after a fresh read → defer signal."""
-        from superset.tasks.scheduler import _DAG_WAITING, _unmet_prerequisite
+        from superset.tasks.dependencies import DAG_WAITING, unmet_prerequisite
 
         pending = _task(status=TaskStatus.PENDING.value)
         mock_find.return_value = _task(status=TaskStatus.IN_PROGRESS.value)
 
-        assert (
-            _unmet_prerequisite(SimpleNamespace(depends_on=[pending])) is _DAG_WAITING
-        )
+        assert unmet_prerequisite(SimpleNamespace(depends_on=[pending])) is DAG_WAITING
         mock_find.assert_called_once()
 
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_non_terminal_snapshot_reread_succeeded_is_ready(self, mock_find):
         """A stale non-terminal snapshot that actually finished SUCCESS → ready."""
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
         stale = _task(status=TaskStatus.IN_PROGRESS.value)
         mock_find.return_value = _task(status=TaskStatus.SUCCESS.value)
 
-        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is None
+        assert unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is None
 
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_non_terminal_snapshot_reread_failed_is_returned(self, mock_find):
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
         stale = _task(status=TaskStatus.PENDING.value)
         failed = _task(status=TaskStatus.FAILURE.value)
         mock_find.return_value = failed
 
-        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is failed
+        assert unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is failed
 
     @patch("superset.tasks.scheduler.TaskDAO.find_one_or_none")
     def test_missing_prerequisite_treated_as_failed(self, mock_find):
-        from superset.tasks.scheduler import _unmet_prerequisite
+        from superset.tasks.dependencies import unmet_prerequisite
 
         stale = _task(status=TaskStatus.PENDING.value)
         mock_find.return_value = None  # prerequisite pruned/gone
 
         # The (stale) prerequisite is returned as failed rather than deferring.
-        assert _unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is stale
+        assert unmet_prerequisite(SimpleNamespace(depends_on=[stale])) is stale
 
 
 class TestDagDeferCountdown:
@@ -164,13 +162,20 @@ class TestExecuteTaskDagGate:
             if find_side_effect is not None
             else MagicMock(return_value=task)
         )
+        # The DAG-defer path publishes via scheduler's TaskManager; the failed-
+        # prerequisite path delegates to dependencies.fail_dependent_on_unmet_
+        # prerequisite, which imports TaskManager lazily from superset.tasks.manager.
+        # Patch both to the SAME mock so either path's publish_completion is captured.
+        task_manager = MagicMock()
         with (
             patch("superset.tasks.scheduler.TaskDAO.find_one_or_none", find),
+            patch("superset.tasks.dependencies.TaskDAO.find_one_or_none", find),
             patch(
-                "superset.tasks.scheduler._unmet_prerequisite",
+                "superset.tasks.scheduler.unmet_prerequisite",
                 return_value=unmet_return,
             ),
-            patch("superset.tasks.scheduler.TaskManager") as task_manager,
+            patch("superset.tasks.scheduler.TaskManager", task_manager),
+            patch("superset.tasks.manager.TaskManager", task_manager),
             patch("superset.tasks.scheduler.current_app", app),
             patch("superset.commands.tasks.internal_update.current_app", app),
         ):
@@ -180,7 +185,7 @@ class TestExecuteTaskDagGate:
     def test_waiting_defers_via_retry_and_emits_metric(self):
         from celery.exceptions import Retry
 
-        from superset.tasks.scheduler import _DAG_WAITING
+        from superset.tasks.dependencies import DAG_WAITING
 
         native = uuid4()
         task = SimpleNamespace(
@@ -195,7 +200,7 @@ class TestExecuteTaskDagGate:
 
         with pytest.raises(Retry):
             self._call(
-                fake_self, task, unmet_return=_DAG_WAITING, stats_logger=stats_logger
+                fake_self, task, unmet_return=DAG_WAITING, stats_logger=stats_logger
             )
 
         # A defer metric fired before the retry raised…
@@ -208,7 +213,7 @@ class TestExecuteTaskDagGate:
     def test_defer_publish_failure_fails_task(self):
         """If self.retry can't publish the replacement message (broker down), the
         task must be failed rather than left stranded PENDING with no heartbeat."""
-        from superset.tasks.scheduler import _DAG_WAITING
+        from superset.tasks.dependencies import DAG_WAITING
 
         native = uuid4()
         task = SimpleNamespace(
@@ -227,7 +232,7 @@ class TestExecuteTaskDagGate:
             transition,
         ):
             result, _, task_manager = self._call(
-                fake_self, task, unmet_return=_DAG_WAITING
+                fake_self, task, unmet_return=DAG_WAITING
             )
 
         assert result["status"] == TaskStatus.FAILURE.value
@@ -282,6 +287,76 @@ class TestExecuteTaskDagGate:
 
         assert result["status"] == TaskStatus.ABORTED.value
         task_manager.publish_completion.assert_not_called()
+
+
+class TestInlineDagGate:
+    """The sync/inline path enforces the same DAG gate as the async path."""
+
+    @staticmethod
+    def _wrapper():
+        from superset.tasks.decorators import task
+        from superset.tasks.registry import TaskRegistry
+
+        TaskRegistry._tasks.clear()
+
+        @task(name="inline_gate_probe")
+        def _fn() -> None:
+            pass
+
+        return _fn
+
+    def test_ready_returns_none(self):
+        wrapper = self._wrapper()
+        task = _task()
+        with (
+            patch("superset.daos.tasks.TaskDAO.find_one_or_none", return_value=task),
+            patch("superset.tasks.dependencies.unmet_prerequisite", return_value=None),
+        ):
+            assert wrapper._gate_on_prerequisites(task) is None
+
+    def test_failed_prerequisite_fails_and_returns_terminal(self):
+        wrapper = self._wrapper()
+        task = _task()
+        terminal = _task(status=TaskStatus.FAILURE.value)
+        failed_prereq = _task(status=TaskStatus.FAILURE.value)
+        with (
+            patch(
+                "superset.daos.tasks.TaskDAO.find_one_or_none",
+                side_effect=[task, terminal],
+            ),
+            patch(
+                "superset.tasks.dependencies.unmet_prerequisite",
+                return_value=failed_prereq,
+            ),
+            # fail_dependent_on_unmet_prerequisite is imported lazily inside the
+            # gate from superset.tasks.dependencies, so patch it there.
+            patch(
+                "superset.tasks.dependencies.fail_dependent_on_unmet_prerequisite"
+            ) as fail,
+        ):
+            result = wrapper._gate_on_prerequisites(task)
+
+        fail.assert_called_once()
+        assert result is terminal
+
+    def test_waits_on_pending_prerequisite_then_proceeds(self):
+        from superset.tasks.dependencies import DAG_WAITING
+
+        wrapper = self._wrapper()
+        pending = _task(status=TaskStatus.IN_PROGRESS.value)
+        current = SimpleNamespace(uuid=uuid4(), depends_on=[pending])
+        with (
+            patch("superset.daos.tasks.TaskDAO.find_one_or_none", return_value=current),
+            patch(
+                "superset.tasks.dependencies.unmet_prerequisite",
+                side_effect=[DAG_WAITING, None],
+            ),
+            # TaskManager is bound at decorators import time, so patch it there.
+            patch("superset.tasks.decorators.TaskManager") as task_manager,
+        ):
+            assert wrapper._gate_on_prerequisites(_task()) is None
+            # The inline wait action blocks on the coordination completion signal.
+            task_manager.wait_for_completion.assert_called_once()
 
 
 class TestPersistDependencies:

--- a/tests/unit_tests/tasks/test_handlers.py
+++ b/tests/unit_tests/tasks/test_handlers.py
@@ -693,3 +693,87 @@ class TestCleanupHandlers:
         task_context._run_cleanup()
 
         assert call_count == 1  # Still 1, not 2
+
+
+class TestHandlerFailureStatusWrite:
+    """The handler-failure writer must not rewrite a committed terminal status."""
+
+    def test_cleanup_failure_after_terminal_does_not_flip_status(self, task_context):
+        """Cleanup runs in the executor's finally — after a SUCCESS commit. A
+        raising cleanup handler must not flip the committed status: the write is a
+        conditional transition (no-op on a terminal task), and the failure detail
+        is instead recorded via a properties-only update."""
+        task_context._handler_failures = [("cleanup", RuntimeError("boom"), "trace")]
+        with (
+            patch(
+                "superset.commands.tasks.internal_update."
+                "InternalStatusTransitionCommand"
+            ) as transition,
+            patch(
+                "superset.commands.tasks.internal_update.InternalUpdateTaskCommand"
+            ) as update,
+        ):
+            # Simulate the task already being terminal (SUCCESS): the CAS no-ops.
+            transition.return_value.run.return_value = False
+            task_context._write_handler_failures_to_db()
+
+        # FAILURE was attempted only from non-terminal states...
+        assert transition.call_args.kwargs["new_status"] == TaskStatus.FAILURE
+        assert transition.call_args.kwargs["expected_status"] == [
+            TaskStatus.IN_PROGRESS,
+            TaskStatus.ABORTING,
+        ]
+        # ...and since it no-op'd, the detail was recorded without a status change.
+        update.assert_called_once()
+        assert "status" not in update.call_args.kwargs
+
+    def test_cleanup_failure_while_in_progress_marks_failure(self, task_context):
+        """When the task is still running, a handler failure does flip it to
+        FAILURE and does not need the properties-only fallback write."""
+        task_context._handler_failures = [("cleanup", RuntimeError("boom"), "trace")]
+        with (
+            patch(
+                "superset.commands.tasks.internal_update."
+                "InternalStatusTransitionCommand"
+            ) as transition,
+            patch(
+                "superset.commands.tasks.internal_update.InternalUpdateTaskCommand"
+            ) as update,
+        ):
+            transition.return_value.run.return_value = True  # transition succeeded
+            task_context._write_handler_failures_to_db()
+
+        transition.assert_called_once()
+        update.assert_not_called()
+
+
+class TestErrorProperties:
+    """error_properties merges the executor cache with error detail (no wipe)."""
+
+    def test_error_properties_preserves_cache_and_adds_detail(self, task_context):
+        task_context._properties_cache = {
+            "is_abortable": True,
+            "progress_percent": 0.5,
+            "private": {"task": {"cancel_query_id": "q1"}},
+        }
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as ex:
+            props = task_context.error_properties(exception=ex)
+
+        # Existing runtime fields and the private.task namespace are preserved...
+        assert props["is_abortable"] is True
+        assert props["progress_percent"] == 0.5
+        assert props["private"]["task"] == {"cancel_query_id": "q1"}
+        # ...and the structured error detail is added under the public message and
+        # the debug-only private.framework namespace.
+        assert props["error_message"] == "boom"
+        assert props["private"]["framework"]["exception_type"] == "RuntimeError"
+        assert "boom" in props["private"]["framework"]["stack_trace"]
+
+    def test_error_properties_plain_message_without_exception(self, task_context):
+        task_context._properties_cache = {"progress_percent": 0.5}
+        props = task_context.error_properties(error_message="fenced")
+        assert props["error_message"] == "fenced"
+        assert props["progress_percent"] == 0.5
+        assert "framework" not in props.get("private", {})

--- a/tests/unit_tests/tasks/test_handlers.py
+++ b/tests/unit_tests/tasks/test_handlers.py
@@ -746,6 +746,47 @@ class TestHandlerFailureStatusWrite:
         transition.assert_called_once()
         update.assert_not_called()
 
+    def test_cleanup_failure_after_body_failure_preserves_original_error(
+        self, task_context
+    ):
+        """Regression: a task-body exception writes the terminal error, then a
+        cleanup handler also fails. The properties-only fallback (task already
+        terminal) must PRESERVE the original body error — its message, exception
+        type, and stack trace — and add the cleanup detail alongside it, rather than
+        erasing it by writing a complete column built from a stale cache."""
+        # Body failed first: error_properties records the terminal error and keeps
+        # the cache authoritative.
+        try:
+            raise ValueError("body boom")
+        except ValueError as ex:
+            task_context.error_properties(exception=ex)
+
+        task_context._handler_failures = [
+            ("cleanup", RuntimeError("cleanup boom"), "cleanup-trace")
+        ]
+        with (
+            patch(
+                "superset.commands.tasks.internal_update."
+                "InternalStatusTransitionCommand"
+            ) as transition,
+            patch(
+                "superset.commands.tasks.internal_update.InternalUpdateTaskCommand"
+            ) as update,
+        ):
+            transition.return_value.run.return_value = False  # already terminal
+            task_context._write_handler_failures_to_db()
+
+        props = update.call_args.kwargs["properties"]
+        # The original body error survives...
+        assert props["error_message"] == "body boom"
+        assert props["private"]["framework"]["exception_type"] == "ValueError"
+        assert "body boom" in props["private"]["framework"]["stack_trace"]
+        # ...and the cleanup failure is recorded alongside it.
+        assert (
+            props["private"]["framework"]["cleanup_error_message"]
+            == "Cleanup handler failed: cleanup boom"
+        )
+
 
 class TestErrorProperties:
     """error_properties merges the executor cache with error detail (no wipe)."""

--- a/tests/unit_tests/tasks/test_scheduler_executor.py
+++ b/tests/unit_tests/tasks/test_scheduler_executor.py
@@ -56,6 +56,11 @@ def _run_body_with_raising_executor(
     ctx.timeout_triggered = timeout_triggered
     ctx.fence_triggered = fence_triggered
     ctx.abort_handlers_completed = True
+    # Echo the error detail back as a real dict (the real error_properties merges
+    # the executor cache with the error message / exception detail).
+    ctx.error_properties.side_effect = lambda exception=None, error_message=None: {
+        "error_message": error_message if error_message else str(exception)
+    }
 
     transition = MagicMock()
     transition.return_value.run.return_value = True  # PENDING->IN_PROGRESS succeeds

--- a/tests/unit_tests/tasks/test_timeout.py
+++ b/tests/unit_tests/tasks/test_timeout.py
@@ -314,6 +314,57 @@ class TestTimeoutTrigger:
             if ctx._abort_listener:
                 ctx.stop_abort_polling()
 
+    def test_timeout_triggers_abort_after_runtime_set_abortable(
+        self, mock_flask_app, mock_task_not_abortable
+    ):
+        """Regression: the task entity is NOT abortable at construction, but an
+        abort handler registered during execution flips the in-memory cache. The
+        timeout must gate on that authoritative cache, not the stale entity
+        snapshot — otherwise it would skip the abort and let the query run to
+        completion (and strand the task IN_PROGRESS)."""
+        abort_called = False
+
+        with (
+            patch("superset.tasks.context.current_app") as mock_current_app,
+            patch("superset.daos.tasks.TaskDAO") as mock_dao,
+            patch("superset.commands.tasks.internal_update.InternalUpdateTaskCommand"),
+            patch(
+                "superset.commands.tasks.update.UpdateTaskCommand"
+            ) as mock_update_cmd,
+            patch(
+                "superset.coordination.base.CoordinationService.get_backend",
+                return_value=None,
+            ),
+        ):
+            mock_current_app.config = mock_flask_app.config
+            mock_current_app._get_current_object.return_value = mock_flask_app
+            mock_dao.find_one_or_none.return_value = mock_task_not_abortable
+
+            ctx = TaskContext(mock_task_not_abortable)
+            ctx._app = mock_flask_app
+            # Entity reports not-abortable; the cache is empty at construction.
+            assert ctx._task.properties_dict.get("is_abortable") is None
+
+            @ctx.on_abort
+            def handle_abort():
+                nonlocal abort_called
+                abort_called = True
+
+            # on_abort → _set_abortable set the in-memory cache (not the entity).
+            assert ctx._properties_cache.get("is_abortable") is True
+
+            ctx.start_timeout_timer(1)
+            time.sleep(1.5)
+
+            assert abort_called
+            assert ctx._timeout_triggered
+            mock_update_cmd.assert_called()
+            assert mock_update_cmd.call_args[1].get("status") == "aborting"
+
+            ctx.stop_timeout_timer()
+            if ctx._abort_listener:
+                ctx.stop_abort_polling()
+
     def test_timeout_logs_warning_when_not_abortable(
         self, mock_flask_app, mock_task_not_abortable
     ):


### PR DESCRIPTION
### SUMMARY

Review-driven hardening of the GAQ→GTF epic, folded back onto `gaq-to-gtf`. This
branch implements fixes for **12 findings** surfaced by a fresh end-to-end review
(five parallel subsystem passes: coordination/locks, GTF task lifecycle, async
chart-data, realtime/websocket, frontend) plus an independent external review. Each
finding was verified against the code before fixing; every fix ships with tests.

Both reviews independently concluded there is **no in-scope security boundary
violation** (per `SECURITY.md`): the model remains "an authorized route creates a
task, the worker runs as the initiating principal, and task/list/result state is
fetched through protected APIs; websocket messages are nudges or targeted terminal
status, not authority."

#### Fixes (grouped by severity)

**HIGH**
- **Async worker rebuilt `g.form_data` with the wrong shape.** The worker set
  `g.form_data` to the top-level slice form-data (no `queries`), but
  `get_form_data()`'s no-request-context fallback and the Jinja macros
  (`filter_values`/`get_filters`/`url_param`) read query-level filters from
  `form_data["queries"][0]`. For a templated dataset this rendered empty filters in
  the worker, so it cached the wrong SQL under a `query_cache_key` that **diverged
  from the submit-time `task_key`** → a reschedule loop. Now the worker reconstructs
  a body-shaped `g.form_data` via the canonical
  `set_query_context_form_data(query_context, …)`. (Regressed the fix claimed in
  step #43701; the previous test masked it with a body-shaped dict `serialize_query`
  never emits — replaced with a real round-trip assertion.)
- **Concurrent forced refresh re-ran synchronously on a web worker.** The force
  idempotency marker was keyed by a **client-minted** random nonce, so a second
  concurrent forced refresh (new nonce) joined the shared task, then forced its own
  synchronous read-back and recomputed the query in-process. The nonce is now the
  **task's own UUID** — server-assigned, already returned in the 202 `task_ids`. The
  worker stamps each query with its task UUID and records the marker; the client
  threads each query's task id (index-aligned) as its per-query `force_nonce` on the
  synchronous read-back. Because the token is the task's identity, a concurrent
  refresh joining the same SHARED task reads back under the same id and does not
  re-execute. Drops client-side `nanoid` and the submit-path nonce threading.

**Important**
- **Cleanup-handler failure could flip a committed `SUCCESS` → `FAILURE`.** Cleanup
  runs in the executor's `finally`, *after* the `SUCCESS` commit; the write used
  `UpdateTaskCommand.set_status` with no compare-and-swap. It now routes through a
  conditional `InternalStatusTransitionCommand` (no-op on a terminal task) and, when
  the task already succeeded, records the cleanup-failure detail via a
  properties-only update — preserving `SUCCESS`.
- **Timeout/self-fence gated on a stale session-bound entity.** `_abort_locally`
  read `self._task.properties_dict` (a construction-time snapshot) from a background
  timer/fence thread; `is_abortable` is written to the in-memory `_properties_cache`
  during execution. It could skip the abort (stranding the task `IN_PROGRESS`) or
  trigger a cross-thread session reload. Now gates on `_properties_cache`.
- **Terminal `FAILURE` wiped the whole properties column.** `conditional_status_update`
  replaces the JSON column, and the failure callers passed only `{error_message}`,
  dropping runtime fields and the structured `error_update(ex)` debug detail
  (exception class + traceback). Failure writes now merge the executor's property
  cache with `error_update(ex)` via a new pure `merge_properties` helper (also used
  by `Task.update_properties`, DRY).
- **GAQ could be enabled without GTF via dynamic flag callbacks.** The "GAQ implies
  GTF" auto-enable only mutated the static flag map at `init_app`; an
  `IS_FEATURE_ENABLED_FUNC`/`GET_FEATURE_FLAGS_FUNC` could resolve GAQ=on/GTF=off, so
  `.schedule()` raised instead of degrading. The rule is now enforced at
  flag-resolution time, covering the callback paths.

**Medium**
- **DAG dependencies were ignored on the sync/inline path.** `_execute_inline` ran
  immediately regardless of `depends_on`; only the Celery path enforced the gate. The
  pure DAG *decision* (`unmet_prerequisite`) and *fail action* are extracted into a
  shared `superset/tasks/dependencies.py` that both paths call — fully DRY; only the
  *wait* action differs (async defers via `self.retry`; sync blocks on the existing
  `TaskManager.wait_for_completion`).
- **Websocket-enabled-but-unreachable hung charts for the full give-up window.** With
  `WEBSOCKET_ENABLE` on, the socket is the sole completion transport and a
  deployed-but-down server left charts spinning ~10 min. The socket is now
  self-healing and observable: exponential backoff + jitter with a cap (was a fixed
  5s loop), a reconnect-attempt counter, and a new connection-state signal
  (`connecting`/`open`/`reconnecting`/`unhealthy`). On each `reconnecting` transition
  the client runs the socket-independent `status_changes` catch-up (so a completion
  during an outage is still observed); on `unhealthy` it settles pending waiters with
  a prompt, bounded error. No interval poll is reintroduced. A synchronous
  `WebSocket` constructor failure now schedules a reconnect instead of dead-ending.
- **Coordination listener/waiter resilience + KV lock-release atomicity.** (a) The
  baseline `stream_last_id` capture is guarded so a transient backend error at
  startup degrades to reading from `0-0` instead of killing the daemon / aborting a
  lock acquisition. (b) A transient `check()`/`on_signal()` error inside the listen
  loop retries with backoff instead of permanently terminating the one-shot listener
  (which would drop the awaited cancel/abort signal). (c) The KV distributed-lock
  release row-locks the entry (`SELECT … FOR UPDATE`) so the ownership check and
  delete are atomic against a concurrent expire+re-acquire — the KV equivalent of the
  Redis compare-and-delete.

**Low (hygiene)**
- Typed the task payload / `TaskPayloadPopover` (`Record<string, unknown>`) and the
  `TaskList` subscriber predicate (`TaskSubscriber`) — removing the last `any`s in
  the touched task-UI files.
- Added a `CheckConstraint` enforcing the "exactly one of `user_id` / `guest_key`"
  invariant on `task_subscribers` (in the branch's own migration + the model
  `__table_args__`).

#### Deliberately deferred (both LOW; riskier/heavier than their value)
- Switching the `entity.changed` nudge id from the integer PK to the task UUID — it
  is cross-cutting to the entity-agnostic `useListViewResource` hook and the Task API
  row key, and the security review classed it a benign metadata side-channel, not an
  authorization bypass.
- Making `notify`'s `xadd`+`expire` atomic — requires extending the coordination
  backend abstraction (Lua/pipeline); the residual leak is a single MAXLEN-trimmed
  stream entry.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — backend correctness/resilience and typing changes, plus a websocket-client
robustness change with no visual surface (a genuinely-down socket now surfaces a
prompt chart error instead of a ~10-minute spinner).

### TESTING INSTRUCTIONS

Automated (all green except one pre-existing, unrelated failure — see below):

```bash
# Backend
pytest tests/unit_tests/tasks/ tests/unit_tests/coordination/ \
  tests/unit_tests/distributed_lock/ \
  tests/unit_tests/common/test_query_context_processor.py \
  tests/unit_tests/common/test_query_serialization.py \
  tests/unit_tests/charts/test_chart_data_api.py \
  tests/unit_tests/feature_flag_test.py tests/unit_tests/daos/test_tasks.py

# Frontend
npm run test -- src/middleware/realtime.test.ts \
  src/middleware/asyncEvent.test.ts src/components/Chart/chartActions.test.ts
```

Manual (end-to-end, with `GLOBAL_ASYNC_QUERIES` on and `DISTRIBUTED_COORDINATION_CONFIG` set):
1. Load a dashboard with a **Jinja-templated dataset** (`{{ filter_values(...) }}` /
   `{{ get_filters(...) }}`) under `async_mode`; confirm charts resolve with the
   correct filtered SQL and there is **no reschedule loop**.
2. **Double-force** a chart (two quick refreshes): confirm a single warehouse
   execution and both refreshes read back from cache.
3. With `WEBSOCKET_ENABLE` on, **stop the websocket server** while a chart is loading:
   confirm it surfaces a prompt error rather than a ~10-minute hang; restart the
   server and confirm reconnect + reconcile.
4. Cancel/timeout a running async chart on a cancellable engine (e.g. Postgres) and
   confirm the terminal task still carries the structured error detail.

> **Pre-existing failure (not from this branch):**
> `tests/unit_tests/tasks/test_deletion_retention.py::test_default_celery_config_registers_daily_purge`
> fails on this branch **with these changes stashed** — it depends on a local
> `superset_config.CeleryConfig` override, unrelated to this work.

> **CI note:** the frontend type-check may fail locally on a **stale, gitignored**
> `packages/superset-ui-core/lib/**/TableCollection/index.d.ts` (predates the branch's
> `TableCollection` prop additions — same class as the Butterfly `TS6305` errors). The
> source type-checks clean; a `npm run plugins:build` refreshes the artifact. oxlint /
> oxfmt / backend hooks pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (auto-enables `GLOBAL_TASK_FRAMEWORK`); optional `WEBSOCKET_ENABLE` for realtime transport
- [x] Changes UI (task payload/subscriber typing; websocket-client behavior — a down socket surfaces an error instead of spinning)
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [x] Migration is atomic, supports rollback & is backwards-compatible — adds a `CheckConstraint` to the branch's existing (unreleased) `task_subscribers` migration; downgrade drops it
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
