### PR TITLE
fix(gsheets): catch JSONDecodeError in validate_parameters for malformed service_account_info

### DIFF
--- a/superset/db_engine_specs/gsheets.py
+++ b/superset/db_engine_specs/gsheets.py
@@ -393,7 +393,22 @@ class GSheetsEngineSpec(ShillelaghEngineSpec):
         # On create the encrypted credentials are a string,
         # at all other times they are a dict
         if isinstance(encrypted_credentials, str):
-            encrypted_credentials = json.loads(encrypted_credentials)
+            try:
+                encrypted_credentials = json.loads(encrypted_credentials)
+            except json.JSONDecodeError:
+                errors.append(
+                    SupersetError(
+                        message=(
+                            "The service account credentials are not valid JSON. "
+                            "Please check that the field contains a valid service "
+                            "account key."
+                        ),
+                        error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
+                        level=ErrorLevel.ERROR,
+                        extra={"invalid": ["service_account_info"]},
+                    ),
+                )
+                return errors
 
         # We need a subject in case domain wide delegation is set, otherwise the
         # check will fail. This means that the admin will be able to add sheets

--- a/tests/unit_tests/db_engine_specs/test_gsheets.py
+++ b/tests/unit_tests/db_engine_specs/test_gsheets.py
@@ -110,6 +110,37 @@ def test_validate_parameters_no_catalog(mocker: MockerFixture) -> None:
     ]
 
 
+def test_validate_parameters_malformed_credentials(mocker: MockerFixture) -> None:
+    from superset.db_engine_specs.gsheets import (
+        GSheetsEngineSpec,
+        GSheetsPropertiesType,
+    )
+
+    g = mocker.patch("superset.db_engine_specs.gsheets.g")
+    g.user.email = "admin@example.org"
+
+    properties: GSheetsPropertiesType = {
+        "parameters": {
+            "service_account_info": "{not valid json",
+            "catalog": {},
+        },
+        "catalog": {},
+    }
+    errors = GSheetsEngineSpec.validate_parameters(properties)
+    assert errors == [
+        SupersetError(
+            message=(
+                "The service account credentials are not valid JSON. "
+                "Please check that the field contains a valid service "
+                "account key."
+            ),
+            error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
+            level=ErrorLevel.ERROR,
+            extra={"invalid": ["service_account_info"]},
+        ),
+    ]
+
+
 def test_validate_parameters_simple_with_in_root_catalog(mocker: MockerFixture) -> None:
     from superset.db_engine_specs.gsheets import (
         GSheetsEngineSpec,


### PR DESCRIPTION
### SUMMARY

When configuring a new Google Sheets connection, `GSheetsEngineSpec.validate_parameters` (`superset/db_engine_specs/gsheets.py`) called `json.loads` on the client-supplied `service_account_info` string **unguarded**:

```python
encrypted_credentials = parameters.get("service_account_info") or "{}"
if isinstance(encrypted_credentials, str):
    encrypted_credentials = json.loads(encrypted_credentials)  # <-- unguarded
```

That field arrives through `DatabaseValidateParametersSchema` as a free-form `fields.Raw` value with no marshmallow-level JSON validation (unlike `masked_encrypted_extra`, which is validated upstream via `encrypted_extra_validator`). So a user pasting malformed or truncated JSON into the "Service Account Credentials" field — a very plausible real-world typo — made `json.loads` raise a raw `json.JSONDecodeError`.

#### PROBLEM

The exception propagated unclassified through the whole validate flow: `POST /api/v1/database/validate_parameters/` → `DatabaseRestApi.validate_parameters` → `ValidateDatabaseParametersCommand.run()` → `engine_spec.validate_parameters()`. None of these layers wrap the call, so the raw `JSONDecodeError` reached Flask's global `@app.errorhandler(Exception)` catch-all in `superset/views/error_handling.py` and surfaced as an opaque **500** (`GENERIC_BACKEND_ERROR`) — instead of the **400** `InvalidParametersError` that this validate-parameters flow exists to return for user-fixable input.

#### FIX

Wrap the `json.loads` call in `try/except json.JSONDecodeError`. On failure, append a `SupersetError` with `error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR` and `level=ErrorLevel.ERROR` to the existing `errors` list and return early — mirroring the existing early-return-on-fatal-validation-error pattern already used in the same method (e.g. the "Sheet name is required" / "URL is required" checks). The message clearly states the credentials field is not valid JSON.

This is a **pure additive catch** — no existing behavior changes for valid input. The only behavioral change is intended: for malformed credentials the endpoint now returns a **400** with a clear, field-scoped error instead of a **500** opaque backend error. That is the fix, not a regression.

Same bug-class and pipeline as #42401 and #43725.

### TESTING INSTRUCTIONS

- New unit test `test_validate_parameters_malformed_credentials` in `tests/unit_tests/db_engine_specs/test_gsheets.py` passes `"service_account_info": "{not valid json"` and asserts `validate_parameters` returns an `errors` list containing the `INVALID_PAYLOAD_FORMAT_ERROR` `SupersetError` instead of raising.
- Verified empirically: on pre-fix code the same input raises `simplejson.errors.JSONDecodeError`; post-fix it returns the errors list cleanly.
- Full file: `pytest tests/unit_tests/db_engine_specs/test_gsheets.py` → 36 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
