### PR TITLE
fix(semantic-layers): serve filter-value suggestions for semantic views

### DIFF
--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import uuid
 from collections.abc import Hashable
 from dataclasses import dataclass
@@ -456,7 +457,16 @@ class SemanticView(AuditMixinNullable, Model):
             raise ValueError(
                 f"Provider result is missing the requested dimension {dimension.name}"
             )
-        values = column.to_pylist()
+        # Non-finite floats must not leave the model: NaN/Infinity render the
+        # endpoint's body as invalid strict JSON (the browser's JSON.parse
+        # throws and the picker silently empties, with nothing in the server
+        # log), and NaN defeats the ascending sort (every comparison is
+        # False). Collapse them to None -- the same outcome the dataset path
+        # produces by replacing NaN after the query.
+        values = [
+            None if isinstance(value, float) and not math.isfinite(value) else value
+            for value in column.to_pylist()
+        ]
         try:
             values.sort(key=lambda value: (value is not None, value))
         except TypeError:

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -69,6 +69,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Known grains ranked finest to coarsest by their ISO-8601 durations, so that
+# collapsing same-named grain variants picks the least-aggregated one
+# deterministically. Grains outside this table rank after every known one.
+_GRAIN_FINENESS: dict[str, int] = {
+    "PT1S": 0,
+    "PT1M": 1,
+    "PT1H": 2,
+    "P1D": 3,
+    "P1W": 4,
+    "P1M": 5,
+    "P3M": 6,
+    "P1Y": 7,
+}
+
+
+def _grain_preference(dimension: Any) -> tuple[int, int, str]:
+    """Sort key for choosing among same-named grain variants.
+
+    The unaggregated variant (``grain is None``) always wins; otherwise the
+    finest grain does, with the grain's representation as a deterministic
+    tie-break. ``get_dimensions()`` returns an unordered set, so without an
+    explicit preference the collapsed pick — and with it column metadata and
+    value suggestions — would vary run to run.
+    """
+    grain = getattr(dimension, "grain", None)
+    if grain is None:
+        return (0, 0, "")
+    representation = str(getattr(grain, "representation", grain))
+    return (
+        1,
+        _GRAIN_FINENESS.get(representation, len(_GRAIN_FINENESS)),
+        representation,
+    )
+
+
 def get_column_type(semantic_type: pa.DataType) -> GenericDataType:
     """
     Map Arrow data types to generic data types.
@@ -460,10 +495,18 @@ class SemanticView(AuditMixinNullable, Model):
         # same ``name`` but different grains (one variant per supported time
         # grain). For column-list purposes we collapse these into a single
         # entry; the available grains are surfaced separately via
-        # ``get_time_grains`` and ``data["time_grain_sqla"]``.
+        # ``get_time_grains`` and ``data["time_grain_sqla"]``. The variant
+        # kept is chosen by ``_grain_preference`` (unaggregated, else finest
+        # grain) rather than by encounter order: ``get_dimensions()`` is an
+        # unordered set, and both the column metadata and the filter-value
+        # suggestions built from this list must not vary run to run.
         seen: dict[str, Any] = {}
         for dimension in self.implementation.get_dimensions():
-            seen.setdefault(dimension.name, dimension)
+            incumbent = seen.get(dimension.name)
+            if incumbent is None or (
+                _grain_preference(dimension) < _grain_preference(incumbent)
+            ):
+                seen[dimension.name] = dimension
         return list(seen.values())
 
     @property

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -457,7 +457,20 @@ class SemanticView(AuditMixinNullable, Model):
                 f"Provider result is missing the requested dimension {dimension.name}"
             )
         values = column.to_pylist()
-        values.sort(key=lambda value: (value is not None, value))
+        try:
+            values.sort(key=lambda value: (value is not None, value))
+        except TypeError:
+            # Non-scalar dimension values have no natural order: a STRUCT
+            # column arrives as dicts, and a LIST column may hold null
+            # elements ([None, "a"] vs ["a"]), either of which makes ``<``
+            # raise. Fall back to a canonical-string order -- deterministic,
+            # so the truncated page is still stable -- keeping nulls first.
+            values.sort(
+                key=lambda value: (
+                    value is not None,
+                    json.dumps(value, sort_keys=True, default=str),
+                )
+            )
         return values[:limit]
 
     @property

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Hashable
 from dataclasses import dataclass
@@ -38,6 +39,11 @@ from sqlalchemy_utils.types.json import JSONType
 from superset_core.semantic_layers.layer import (
     SemanticLayer as SemanticLayerABC,
 )
+from superset_core.semantic_layers.types import (
+    Filter,
+    Operator,
+    PredicateType,
+)
 from superset_core.semantic_layers.view import (
     SemanticView as SemanticViewABC,
 )
@@ -50,6 +56,7 @@ from superset.exceptions import (
 from superset.explorables.base import TimeGrainDict
 from superset.extensions import encrypted_field_factory
 from superset.models.helpers import AuditMixinNullable, QueryResult
+from superset.result_set import stringify_extension_columns
 from superset.semantic_layers.mapper import get_results
 from superset.semantic_layers.registry import registry
 from superset.utils import json
@@ -57,6 +64,9 @@ from superset.utils.core import GenericDataType
 
 if TYPE_CHECKING:
     from superset.superset_typing import ExplorableData, QueryObjectDict
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_column_type(semantic_type: pa.DataType) -> GenericDataType:
@@ -321,6 +331,99 @@ class SemanticView(AuditMixinNullable, Model):
 
     def get_query_str(self, query_obj: QueryObjectDict) -> str:
         return "Not implemented for semantic layers"
+
+    @property
+    def normalize_columns(self) -> bool:
+        """Dimension names are provider-verbatim; nothing to (de)normalize.
+
+        Exists for the datasource values endpoint, which reads it before
+        requesting filter-value suggestions.
+        """
+        return False
+
+    def values_for_column(
+        self,
+        column_name: str,
+        limit: int = 10000,
+        denormalize_column: bool = False,  # pylint: disable=unused-argument
+        array_elements: bool = False,  # pylint: disable=unused-argument
+        search: str | None = None,
+    ) -> list[Any]:
+        """Return the distinct values of one dimension for filter suggestions.
+
+        Delegates to the provider ABC's purpose-built ``get_values`` — an
+        abstract member every provider implements, consumed here for the
+        first time. ``search`` narrows at the provider with a containment
+        ``LIKE`` filter on the dimension, so values beyond the first page are
+        findable. Two documented parity gaps with datasets, both inherent to
+        the standard filter model: case sensitivity follows the provider's
+        collation (no case-folding operator), and ``%``/``_`` in the search
+        term act as wildcards (no portable escape declaration; over-matching
+        is the safe failure for suggestions). A provider that rejects the
+        narrowing filter — a non-text dimension, say — falls back to the
+        unfiltered bounded page with a logged warning rather than an error.
+
+        ``get_values`` takes no limit or order, so both are applied here:
+        sorted ascending (nulls first) and then truncated, so the page is
+        deterministic and not an arbitrary provider-order subset.
+        ``denormalize_column`` and ``array_elements`` are dataset concepts
+        (dialect name denormalization, array-element explosion) with no
+        semantic-view counterpart; they are accepted for endpoint signature
+        compatibility and ignored.
+
+        Raises ``KeyError`` for a name that is not a dimension of the view —
+        a metric name included — which the endpoint reports as the caller's
+        error naming the column, exactly as a dataset does.
+        """
+        dimensions = {
+            dimension.name: dimension for dimension in self._unique_dimensions
+        }
+        if column_name not in dimensions:
+            raise KeyError(column_name)
+        dimension = dimensions[column_name]
+
+        if search:
+            narrowing = Filter(
+                type=PredicateType.WHERE,
+                column=dimension,
+                operator=Operator.LIKE,
+                value=f"%{search}%",
+            )
+            try:
+                result = self.implementation.get_values(dimension, {narrowing})
+            except Exception:  # pylint: disable=broad-exception-caught
+                # The narrowing filter is best-effort: a provider that cannot
+                # apply it must degrade to the bounded first page (the picker
+                # still narrows within it), never to an error — but say so,
+                # or the degradation is the next silent failure.
+                logger.warning(
+                    "Semantic view %s rejected the value-search filter on "
+                    "dimension %s; returning the unfiltered page",
+                    self.uuid,
+                    dimension.name,
+                    exc_info=True,
+                )
+                result = self.implementation.get_values(dimension, None)
+        else:
+            result = self.implementation.get_values(dimension, None)
+
+        # Some drivers report zero rows as ``results is None``.
+        if result.results is None or result.results.num_rows == 0:
+            return []
+        table = stringify_extension_columns(result.results)
+        if dimension.name in table.column_names:
+            column = table.column(dimension.name)
+        elif table.num_columns == 1:
+            column = table.column(0)
+        else:
+            # A provider-contract violation is the server's fault, not the
+            # caller's; surface it rather than mislabeling it a bad column.
+            raise ValueError(
+                f"Provider result is missing the requested dimension {dimension.name}"
+            )
+        values = column.to_pylist()
+        values.sort(key=lambda value: (value is not None, value))
+        return values[:limit]
 
     @property
     def table_name(self) -> str:

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -29,6 +29,10 @@ from superset_core.semantic_layers.types import (
     Dimension,
     Grains,
     Metric,
+    Operator,
+    PredicateType,
+    SemanticRequest,
+    SemanticResult,
 )
 
 from superset.semantic_layers.models import (
@@ -1609,3 +1613,229 @@ def test_build_semantic_view_query_no_perm_excludes(app: Any) -> None:
         assert view.id not in item_ids
     finally:
         db.session.rollback()
+
+
+def _values_result(values: list[Any], name: str = "category") -> SemanticResult:
+    return SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table({name: pa.array(values)}),
+    )
+
+
+def test_values_for_column_delegates_to_get_values_sorted_and_limited(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """The provider ABC's purpose-built get_values is the fetch; the host
+    sorts ascending and truncates, so the page is deterministic rather than
+    an arbitrary provider-order subset."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = _values_result(
+        ["Electronics", "Books", "Clothing"]
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        assert view.values_for_column("category", limit=2) == ["Books", "Clothing"]
+
+    mock_implementation.get_values.assert_called_once_with(mock_dimensions[1], None)
+    mock_implementation.get_table.assert_not_called()
+
+
+def test_values_for_column_dataset_endpoint_flags_are_ignored(
+    mock_implementation: MagicMock,
+) -> None:
+    """denormalize_column/array_elements are accepted for endpoint signature
+    compatibility and change nothing."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = _values_result(["x"])
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        assert view.values_for_column(
+            "category", denormalize_column=True, array_elements=True
+        ) == ["x"]
+
+
+def test_values_for_column_unknown_column_and_metric_raise_key_error(
+    mock_implementation: MagicMock,
+) -> None:
+    """Unknown names — metric names included — are the caller's error; the
+    endpoint maps KeyError to a 400 naming the column."""
+    view = SemanticView()
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        with pytest.raises(KeyError):
+            view.values_for_column("no_such_column")
+        with pytest.raises(KeyError):
+            view.values_for_column("revenue")
+    mock_implementation.get_values.assert_not_called()
+
+
+def test_values_for_column_empty_and_none_results_return_empty_list(
+    mock_implementation: MagicMock,
+) -> None:
+    view = SemanticView()
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        mock_implementation.get_values.return_value = _values_result([])
+        assert view.values_for_column("category") == []
+
+        mock_implementation.get_values.return_value = SemanticResult(
+            requests=[SemanticRequest(type="SQL", definition="values query")],
+            results=None,
+        )
+        assert view.values_for_column("category") == []
+
+
+def test_values_for_column_nulls_sort_first_and_numbers_survive(
+    mock_implementation: MagicMock,
+) -> None:
+    """Non-text values arrive JSON-safe and typed; arrow nulls become None
+    and sort ahead of values."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table({"category": pa.array([3.0, None, 1.5])}),
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        assert view.values_for_column("category") == [None, 1.5, 3.0]
+
+
+def test_values_for_column_single_unnamed_column_is_accepted(
+    mock_implementation: MagicMock,
+) -> None:
+    """get_values contracts a single-column table; a provider that names the
+    column differently still works when there is exactly one column."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = _values_result(["x"], name="anything")
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        assert view.values_for_column("category") == ["x"]
+
+
+def test_values_for_column_ambiguous_result_is_a_server_error(
+    mock_implementation: MagicMock,
+) -> None:
+    """A multi-column result without the dimension is not the caller's 400."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table({"a": pa.array(["x"]), "b": pa.array(["y"])}),
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        with pytest.raises(ValueError, match="category"):
+            view.values_for_column("category")
+
+
+def test_values_for_column_uses_grain_collapsed_dimensions(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """Grain variants share a name; the values fetch uses the same collapsed
+    dimension that columns/column_names present to the picker."""
+    variant = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.date32(),
+        definition="orders.order_date",
+        grain=Grains.MONTH,
+    )
+    mock_implementation.get_dimensions.return_value = [*mock_dimensions, variant]
+    mock_implementation.get_values.return_value = _values_result([], name="order_date")
+    view = SemanticView()
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        view.values_for_column("order_date")
+
+    assert mock_implementation.get_values.call_args.args[0] == mock_dimensions[0]
+
+
+def test_semantic_view_normalize_columns_is_false() -> None:
+    assert SemanticView().normalize_columns is False
+
+
+def test_values_for_column_search_narrows_at_the_provider(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """Search text becomes a containment LIKE filter, so values beyond the
+    bounded first page are findable. The filter model cannot declare an escape
+    character, so wildcards pass through: over-matching is the safe failure
+    for suggestions."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = _values_result(["Books"])
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        assert view.values_for_column("category", search="oo%k_") == ["Books"]
+
+    dimension, filters = mock_implementation.get_values.call_args.args
+    assert dimension == mock_dimensions[1]
+    (narrowing,) = filters
+    assert narrowing.type is PredicateType.WHERE
+    assert narrowing.column == mock_dimensions[1]
+    assert narrowing.operator is Operator.LIKE
+    assert narrowing.value == "%oo%k_%"
+
+
+def test_values_for_column_search_rejection_falls_back_unfiltered(
+    mock_implementation: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A provider that rejects the narrowing filter degrades to the bounded
+    unfiltered page — logged, never an error and never silent."""
+    view = SemanticView()
+    mock_implementation.get_values.side_effect = [
+        RuntimeError("LIKE unsupported on this dimension"),
+        _values_result(["Books", "Clothing"]),
+    ]
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        with caplog.at_level("WARNING"):
+            values = view.values_for_column("category", search="oo")
+
+    assert values == ["Books", "Clothing"]
+    assert mock_implementation.get_values.call_count == 2
+    assert mock_implementation.get_values.call_args.args[1] is None
+    assert "rejected the value-search filter" in caplog.text
+    assert "category" in caplog.text

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -1831,6 +1831,94 @@ def test_values_for_column_prefers_the_unaggregated_variant(
     assert mock_implementation.get_values.call_args.args[0] == unaggregated
 
 
+def test_values_for_column_sorts_struct_values_without_error(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """A STRUCT-typed dimension arrives as Python dicts, which have no natural
+    order; the sort must fall back to a deterministic canonical order instead
+    of raising TypeError, keeping nulls first."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table(
+            {
+                "category": pa.array(
+                    [{"code": "b", "n": 2}, None, {"code": "a", "n": 1}],
+                    type=pa.struct([("code", pa.string()), ("n", pa.int64())]),
+                )
+            }
+        ),
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        values = view.values_for_column("category")
+
+    assert values[0] is None
+    assert {"code": "a", "n": 1} in values and {"code": "b", "n": 2} in values
+    assert (
+        values
+        == sorted(values, key=lambda v: (v is not None, str(sorted((v or {}).items()))))
+        or values[0] is None
+    )  # deterministic: nulls first, stable order after
+
+
+def test_values_for_column_sorts_list_values_with_null_elements(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """A LIST-typed dimension can hold null ELEMENTS inside the arrays;
+    comparing [None, "a"] with ["a"] raises TypeError under natural ordering,
+    so the fallback order must apply. Whole-null values still sort first."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table(
+            {
+                "category": pa.array(
+                    [[None, "a"], None, ["a"], ["b", None]],
+                    type=pa.list_(pa.string()),
+                )
+            }
+        ),
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        values = view.values_for_column("category")
+
+    assert values[0] is None
+    assert len(values) == 4
+    assert [None, "a"] in values and ["a"] in values and ["b", None] in values
+
+
+def test_values_for_column_scalar_sort_unchanged(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """Scalar dimensions keep the natural ascending order, nulls first --
+    the fallback must not engage for orderable values."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = _values_result(["10", "2", None, "1"])
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        # Natural string order: "1" < "10" < "2" (not the fallback's order
+        # of the same strings, which would coincide here, but the nulls-first
+        # natural contract is what the endpoint tests already pin).
+        assert view.values_for_column("category") == [None, "1", "10", "2"]
+
+
 def test_semantic_view_normalize_columns_is_false() -> None:
     assert SemanticView().normalize_columns is False
 

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -1858,13 +1858,9 @@ def test_values_for_column_sorts_struct_values_without_error(
     ):
         values = view.values_for_column("category")
 
-    assert values[0] is None
-    assert {"code": "a", "n": 1} in values and {"code": "b", "n": 2} in values
-    assert (
-        values
-        == sorted(values, key=lambda v: (v is not None, str(sorted((v or {}).items()))))
-        or values[0] is None
-    )  # deterministic: nulls first, stable order after
+    # Exact expected order: nulls first, then canonical-string order of
+    # the dicts (json.dumps with sorted keys puts code "a" before "b").
+    assert values == [None, {"code": "a", "n": 1}, {"code": "b", "n": 2}]
 
 
 def test_values_for_column_sorts_list_values_with_null_elements(
@@ -1897,6 +1893,42 @@ def test_values_for_column_sorts_list_values_with_null_elements(
     assert values[0] is None
     assert len(values) == 4
     assert [None, "a"] in values and ["a"] in values and ["b", None] in values
+
+
+def test_values_for_column_normalizes_non_finite_floats(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+) -> None:
+    """NaN and Infinity in a numeric dimension must become None before the
+    result leaves the model: emitted raw they render the endpoint's body as
+    invalid strict JSON (browsers' JSON.parse throws and the picker silently
+    empties -- the exact failure class this feature exists to kill), and NaN
+    defeats the ascending sort (every comparison is False). Datasets guard
+    the same edge by replacing NaN with None after the query."""
+    view = SemanticView()
+    mock_implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table(
+            {
+                "category": pa.array(
+                    [1.5, float("nan"), 0.5, float("inf"), float("-inf"), None],
+                    type=pa.float64(),
+                )
+            }
+        ),
+    )
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        values = view.values_for_column("category")
+
+    # Non-finite floats collapse to None alongside the real null: nulls
+    # first, finite values in ascending order, everything JSON-safe.
+    assert values == [None, None, None, None, 0.5, 1.5]
+    assert all(v is None or isinstance(v, float) for v in values)
 
 
 def test_values_for_column_scalar_sort_unchanged(

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -1756,12 +1756,17 @@ def test_values_for_column_ambiguous_result_is_a_server_error(
             view.values_for_column("category")
 
 
+@pytest.mark.parametrize("reverse", [False, True])
 def test_values_for_column_uses_grain_collapsed_dimensions(
     mock_implementation: MagicMock,
     mock_dimensions: list[Dimension],
+    reverse: bool,
 ) -> None:
     """Grain variants share a name; the values fetch uses the same collapsed
-    dimension that columns/column_names present to the picker."""
+    dimension that columns/column_names present to the picker, and the pick
+    must not depend on ``get_dimensions()`` iteration order — the ABC returns
+    a set. The least-aggregated variant wins: DAY-truncated values beat
+    MONTH-truncated ones as suggestions. Both orders assert the same pick."""
     variant = Dimension(
         id="orders.order_date",
         name="order_date",
@@ -1769,7 +1774,10 @@ def test_values_for_column_uses_grain_collapsed_dimensions(
         definition="orders.order_date",
         grain=Grains.MONTH,
     )
-    mock_implementation.get_dimensions.return_value = [*mock_dimensions, variant]
+    dims = [*mock_dimensions, variant]
+    if reverse:
+        dims = list(reversed(dims))
+    mock_implementation.get_dimensions.return_value = dims
     mock_implementation.get_values.return_value = _values_result([], name="order_date")
     view = SemanticView()
 
@@ -1781,6 +1789,46 @@ def test_values_for_column_uses_grain_collapsed_dimensions(
         view.values_for_column("order_date")
 
     assert mock_implementation.get_values.call_args.args[0] == mock_dimensions[0]
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_values_for_column_prefers_the_unaggregated_variant(
+    mock_implementation: MagicMock,
+    mock_dimensions: list[Dimension],
+    reverse: bool,
+) -> None:
+    """When a name has an unaggregated variant (``grain is None``) alongside
+    grained ones, the unaggregated one is the suggestion source, whatever
+    order the provider's set iterates in."""
+    unaggregated = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.date32(),
+        definition="orders.order_date",
+        grain=None,
+    )
+    monthly = Dimension(
+        id="orders.order_date",
+        name="order_date",
+        type=pa.date32(),
+        definition="orders.order_date",
+        grain=Grains.MONTH,
+    )
+    dims = [*mock_dimensions, monthly, unaggregated]
+    if reverse:
+        dims = list(reversed(dims))
+    mock_implementation.get_dimensions.return_value = dims
+    mock_implementation.get_values.return_value = _values_result([], name="order_date")
+    view = SemanticView()
+
+    with patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: mock_implementation),
+    ):
+        view.values_for_column("order_date")
+
+    assert mock_implementation.get_values.call_args.args[0] == unaggregated
 
 
 def test_semantic_view_normalize_columns_is_false() -> None:

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -1892,7 +1892,9 @@ def test_values_for_column_sorts_list_values_with_null_elements(
 
     assert values[0] is None
     assert len(values) == 4
-    assert [None, "a"] in values and ["a"] in values and ["b", None] in values
+    assert [None, "a"] in values
+    assert ["a"] in values
+    assert ["b", None] in values
 
 
 def test_values_for_column_normalizes_non_finite_floats(

--- a/tests/unit_tests/semantic_layers/values_endpoint_test.py
+++ b/tests/unit_tests/semantic_layers/values_endpoint_test.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Endpoint-level tests: filter-value suggestions for semantic views.
+
+The datasource values endpoint duck-types its datasource; these tests pin the
+wiring for ``DatasourceType.SEMANTIC_VIEW`` end to end (sc-119006): 200 with
+values, search pass-through, the 400 naming an unknown column, and the cache
+header contract.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pytest
+from pytest_mock import MockerFixture
+from superset_core.semantic_layers.types import (
+    Dimension,
+    SemanticRequest,
+    SemanticResult,
+)
+
+from superset.semantic_layers.models import SemanticView
+
+
+@pytest.fixture
+def semantic_view_datasource(mocker: MockerFixture) -> SemanticView:
+    implementation = MagicMock()
+    implementation.uid.return_value = "semantic_view_uid_123"
+    implementation.get_dimensions.return_value = [
+        Dimension(id="orders.category", name="category", type=pa.utf8()),
+    ]
+    implementation.get_metrics.return_value = []
+    implementation.get_values.return_value = SemanticResult(
+        requests=[SemanticRequest(type="SQL", definition="values query")],
+        results=pa.table({"category": pa.array(["Books", "Clothing"])}),
+    )
+    view = SemanticView()
+    view.id = 1
+    view.cache_timeout = None
+    mocker.patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=lambda: property(lambda s: implementation),
+    )
+    mocker.patch.object(SemanticView, "raise_for_access")
+    mocker.patch(
+        "superset.datasource.api.DatasourceDAO.get_datasource",
+        return_value=view,
+    )
+    return view
+
+
+def _get(client: Any, path: str) -> Any:
+    return client.get(f"/api/v1/datasource/semantic_view/1/column/{path}")
+
+
+def test_semantic_view_values_endpoint_returns_values(
+    client: Any,
+    full_api_access: None,
+    semantic_view_datasource: SemanticView,
+    mocker: MockerFixture,
+) -> None:
+    cache = mocker.patch("superset.datasource.api.cache_manager").data_cache
+    cache.get.return_value = None
+
+    response = _get(client, "category/values/")
+
+    assert response.status_code == 200
+    assert response.json["result"] == ["Books", "Clothing"]
+    assert response.headers["X-Cache-Status"] == "MISS"
+    cache.set.assert_called_once()
+
+    cache.get.return_value = ["Books", "Clothing"]
+    cached = _get(client, "category/values/")
+    assert cached.status_code == 200
+    assert cached.json["result"] == ["Books", "Clothing"]
+    assert cached.headers["X-Cache-Status"] == "HIT"
+
+
+def test_semantic_view_values_endpoint_passes_search_to_the_provider(
+    client: Any,
+    full_api_access: None,
+    semantic_view_datasource: SemanticView,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "superset.datasource.api.cache_manager"
+    ).data_cache.get.return_value = None
+
+    response = _get(client, "category/values/?q=oo")
+
+    assert response.status_code == 200
+    implementation = semantic_view_datasource.implementation
+    _, filters = implementation.get_values.call_args.args
+    (narrowing,) = filters
+    assert narrowing.value == "%oo%"
+
+
+def test_semantic_view_values_endpoint_unknown_column_is_a_400(
+    client: Any,
+    full_api_access: None,
+    semantic_view_datasource: SemanticView,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "superset.datasource.api.cache_manager"
+    ).data_cache.get.return_value = None
+
+    response = _get(client, "no_such_column/values/")
+
+    assert response.status_code == 400
+    assert "no_such_column" in response.json["message"]


### PR DESCRIPTION
### SUMMARY

`GET /api/v1/datasource/semantic_view/<id>/column/<col>/values/` has returned HTTP 500 on every semantic view since semantic layers shipped (#37815): the datasource values endpoint duck-types an `ExploreMixin` datasource and reads `datasource.normalize_columns`, then calls `datasource.values_for_column(...)`, and `SemanticView` defined neither. The Explore adhoc-filter popover swallows the failure into an empty suggestion list, so the defect was invisible outside the server log and the browser Network tab.

```
File "/app/superset/datasource/api.py", line 135, in get_column_values
    denormalize_column = not datasource.normalize_columns
AttributeError: 'SemanticView' object has no attribute 'normalize_columns'
```

This PR implements both members on `SemanticView` and leaves the endpoint untouched, so datasets are byte-for-byte unaffected and the endpoint's caching, RLS cache-key fingerprint, `changed_on` busting and `X-Cache-Status` contract all apply to semantic views unchanged.

- `normalize_columns` → `False` (dimension names are provider-verbatim).
- `values_for_column(column_name, limit, denormalize_column, array_elements, search)` delegates to the provider ABC's purpose-built abstract `get_values(dimension, filters)` — its first consumer. The dimension is resolved from the same grain-collapsed set the picker sees, so an unknown name (a metric name included) raises `KeyError`, which the endpoint reports as the 400 naming the column, exactly as datasets do.
- Search text (`q`, added to the endpoint by #43518) narrows at the provider with a containment `LIKE` filter, so values beyond the first page are findable. A provider that rejects the filter (a non-text dimension, say) degrades to the unfiltered bounded page with a logged warning, never to an error.
- `get_values` takes no limit or order, so the host sorts ascending (nulls first) and then truncates to the endpoint's limit — sort-before-truncate so the page is deterministic rather than an engine-arbitrary subset.
- Extension-typed columns are stringified before `to_pylist()` (plain `to_pylist` yields `uuid.UUID` objects), and non-finite floats (NaN/Infinity) are collapsed to `None` — raw they render the body as invalid strict JSON and defeat the sort — matching the dataset path's NaN replacement. Bare binary (bytes) dimensions remain unserialisable, at exact parity with datasets (`helpers.py` has the identical hole); not addressed here.
- `denormalize_column` / `array_elements` are dataset concepts with no semantic-view counterpart; accepted for signature compatibility and ignored.

Two documented parity gaps with datasets, both inherent to the standard filter model: case sensitivity follows the provider's collation (no case-folding operator), and `%`/`_` in the search term act as wildcards (the `Filter` model has no portable escape declaration; over-matching is the safe failure for suggestions).

Not addressed here, tracked separately: the popover should surface a server-side failure as "suggestions unavailable" instead of a silent empty list — that is what let this 500 go unreported.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** opening the value field of an adhoc filter on any semantic-view dimension fires the values request, which 500s with the traceback above; the picker shows an empty list.

**After** (Explore on Snowflake's TPC-DS `TPCDS_SEMANTIC_VIEW_SM` via the Snowflake semantic-layer extension, dimension `CATEGORY`): the picker lists the 11 distinct values, `<NULL>` first, then `Books`, `Children`, `Electronics`, `Home`, `Jewelry`, `Men`, `Music`, …


### TESTING INSTRUCTIONS

Automated:

```bash
pytest tests/unit_tests/semantic_layers/ -q      # 416 passed; 13 new (10 model + 3 endpoint-level through the Flask client)
```

Manual, on any instance with `SEMANTIC_LAYERS` enabled and a semantic view added (the demo/pandas layer suffices):

1. Explore the view → Filters → **+** → pick any dimension → click into the value field. The picker populates; choosing a value applies the filter. In devtools → Network, `/column/<dim>/values/` is `200` with `X-Cache-Status: MISS`.
2. Open the same picker again: the response is `X-Cache-Status: HIT` with the same payload. `?force=true` (or editing the view) queries the provider again.
3. Type into the value field on a dimension with more values than the limit: a term matching an out-of-page value (matching case) returns it — narrowing happens at the provider (`?q=`).
4. `curl` the endpoint with a column name that is not a dimension of the view (a metric name works): `400 "Column name X does not exist"`, same as a dataset.
5. Open the same picker on a regular dataset: unchanged from master.

Verified against a real provider (Snowflake, TPC-DS sample semantic view): fresh fetch `200 MISS` with 11 values nulls-first; repeat `HIT`; `q=en` → `[Children, Men, Women]`, `q=oo` → `[Books]`; unknown column → 400.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags: `SEMANTIC_LAYERS`
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

