### PR TITLE
fix(themes): apply system default/dark theme changes live without a page refresh

### DIFF
--- a/superset-frontend/packages/superset-core/src/theme/types.ts
+++ b/superset-frontend/packages/superset-core/src/theme/types.ts
@@ -550,6 +550,12 @@ export interface ThemeContextType {
   canDetectOSPreference: () => boolean;
   createDashboardThemeProvider: (themeId: string) => Promise<Theme | null>;
   getAppliedThemeId: () => number | null;
+  /**
+   * Re-reads the persisted system default/dark themes from the server and
+   * re-applies them live, so changes made on the Themes admin page take effect
+   * without a full page reload.
+   */
+  refreshSystemThemes: () => Promise<void>;
 }
 
 /**

--- a/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
@@ -25,6 +25,7 @@ import {
 import fetchMock from 'fetch-mock';
 import * as hooks from 'src/views/CRUD/hooks';
 import { useThemeContext } from 'src/theme/ThemeProvider';
+import { setSystemDefaultTheme } from 'src/features/themes/api';
 import ThemesList from './index';
 
 // Mock the getBootstrapData function
@@ -63,6 +64,7 @@ jest.mock('src/views/CRUD/hooks', () => ({
 // Mock the useThemeContext hook
 const mockSetTemporaryTheme = jest.fn();
 const mockGetAppliedThemeId = jest.fn();
+const mockRefreshSystemThemes = jest.fn(() => Promise.resolve());
 jest.mock('src/theme/ThemeProvider', () => ({
   ...jest.requireActual('src/theme/ThemeProvider'),
   useThemeContext: jest.fn(),
@@ -149,6 +151,7 @@ beforeEach(() => {
     setTemporaryTheme: mockSetTemporaryTheme,
     hasDevOverride: jest.fn().mockReturnValue(false),
     getAppliedThemeId: mockGetAppliedThemeId,
+    refreshSystemThemes: mockRefreshSystemThemes,
   });
 
   fetchMock.clearHistory().removeRoutes();
@@ -562,6 +565,7 @@ test('component loads successfully with applied theme ID set', async () => {
     setTemporaryTheme: mockSetTemporaryTheme,
     hasDevOverride: jest.fn().mockReturnValue(true),
     getAppliedThemeId: mockGetAppliedThemeId,
+    refreshSystemThemes: mockRefreshSystemThemes,
   });
 
   render(
@@ -594,6 +598,7 @@ test('component loads successfully and preserves applied theme state', async () 
     setTemporaryTheme: mockSetTemporaryTheme,
     hasDevOverride: jest.fn().mockReturnValue(true),
     getAppliedThemeId: mockGetAppliedThemeId,
+    refreshSystemThemes: mockRefreshSystemThemes,
   });
 
   render(
@@ -615,4 +620,68 @@ test('component loads successfully and preserves applied theme state', async () 
 
   // Verify getAppliedThemeId is called during component mount
   expect(mockGetAppliedThemeId).toHaveBeenCalled();
+});
+
+test('setting a system default theme applies it live and refreshes the list', async () => {
+  // NOTE: the default export is withToasts(ThemesList), so react-redux connect
+  // overrides the addSuccessToast/addDangerToast props with its own dispatch-
+  // bound versions. Assert on the controllable mocks instead of the toast props.
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  const setDefaultButtons = await screen.findAllByTestId('set-default-action');
+  await userEvent.click(setDefaultButtons[0]);
+
+  const confirmButton = await screen.findByRole('button', { name: 'Confirm' });
+  await userEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(setSystemDefaultTheme as jest.Mock).toHaveBeenCalled();
+  });
+  // The live re-apply and the CRUD list refresh both run on success.
+  await waitFor(() => {
+    expect(mockRefreshSystemThemes).toHaveBeenCalled();
+  });
+  expect(mockRefreshData).toHaveBeenCalled();
+});
+
+test('a failed system default mutation skips the live refresh', async () => {
+  (setSystemDefaultTheme as jest.Mock).mockRejectedValueOnce(new Error('nope'));
+
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  const setDefaultButtons = await screen.findAllByTestId('set-default-action');
+  await userEvent.click(setDefaultButtons[0]);
+
+  const confirmButton = await screen.findByRole('button', { name: 'Confirm' });
+  await userEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(setSystemDefaultTheme as jest.Mock).toHaveBeenCalled();
+  });
+  // A failed mutation must not attempt the live re-apply.
+  expect(mockRefreshSystemThemes).not.toHaveBeenCalled();
 });

--- a/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
+++ b/superset-frontend/src/pages/ThemeList/ThemeList.test.tsx
@@ -55,6 +55,32 @@ jest.mock('src/features/themes/api', () => ({
   unsetSystemDarkTheme: jest.fn(() => Promise.resolve()),
 }));
 
+// Mock ThemeModal so we can trigger its save callback directly, without
+// rendering the full editor. onThemeAdd wiring is what we assert on.
+jest.mock('src/features/themes/ThemeModal', () => ({
+  __esModule: true,
+  default: ({
+    onThemeAdd,
+    show,
+  }: {
+    onThemeAdd: () => void;
+    show: boolean;
+  }) => {
+    const React = jest.requireActual('react');
+    return show
+      ? React.createElement(
+          'button',
+          {
+            type: 'button',
+            'data-test': 'mock-modal-save',
+            onClick: () => onThemeAdd(),
+          },
+          'save',
+        )
+      : null;
+  },
+}));
+
 // Mock the CRUD hooks
 jest.mock('src/views/CRUD/hooks', () => ({
   ...jest.requireActual('src/views/CRUD/hooks'),
@@ -684,4 +710,136 @@ test('a failed system default mutation skips the live refresh', async () => {
   });
   // A failed mutation must not attempt the live re-apply.
   expect(mockRefreshSystemThemes).not.toHaveBeenCalled();
+});
+
+test('editing the current system default theme re-applies it live on save', async () => {
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  // The first row (Light Theme) is the current system default.
+  const editButtons = await screen.findAllByTestId('edit-action');
+  await userEvent.click(editButtons[0]);
+
+  const save = await screen.findByTestId('mock-modal-save');
+  await userEvent.click(save);
+
+  await waitFor(() => {
+    expect(mockRefreshSystemThemes).toHaveBeenCalled();
+  });
+  expect(mockRefreshData).toHaveBeenCalled();
+});
+
+test('editing a non-system theme does not re-apply live on save', async () => {
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  // The third row (Custom Theme) is neither system default nor system dark.
+  const editButtons = await screen.findAllByTestId('edit-action');
+  await userEvent.click(editButtons[2]);
+
+  const save = await screen.findByTestId('mock-modal-save');
+  await userEvent.click(save);
+
+  await waitFor(() => {
+    expect(mockRefreshData).toHaveBeenCalled();
+  });
+  expect(mockRefreshSystemThemes).not.toHaveBeenCalled();
+});
+
+test('editing the current system dark theme re-applies it live on save', async () => {
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  // The second row (Dark Theme) is the current system dark theme.
+  const editButtons = await screen.findAllByTestId('edit-action');
+  await userEvent.click(editButtons[1]);
+
+  const save = await screen.findByTestId('mock-modal-save');
+  await userEvent.click(save);
+
+  await waitFor(() => {
+    expect(mockRefreshSystemThemes).toHaveBeenCalled();
+  });
+  expect(mockRefreshData).toHaveBeenCalled();
+});
+
+test('a slow live re-apply does not block the confirm modal, list refresh, or toast', async () => {
+  // Make the live re-apply hang to simulate a slow /system request.
+  let resolveRefresh: () => void = () => {};
+  mockRefreshSystemThemes.mockImplementationOnce(
+    () =>
+      new Promise<void>(resolve => {
+        resolveRefresh = resolve;
+      }),
+  );
+
+  render(
+    <ThemesList
+      user={mockUser}
+      addDangerToast={jest.fn()}
+      addSuccessToast={jest.fn()}
+    />,
+    {
+      useRedux: true,
+      useRouter: true,
+      useQueryParams: true,
+      useTheme: true,
+    },
+  );
+
+  const setDefaultButtons = await screen.findAllByTestId('set-default-action');
+  await userEvent.click(setDefaultButtons[0]);
+
+  const confirmButton = await screen.findByRole('button', { name: 'Confirm' });
+  await userEvent.click(confirmButton);
+
+  // The mutation ran and the list refreshed without waiting on the re-apply.
+  await waitFor(() => {
+    expect(setSystemDefaultTheme as jest.Mock).toHaveBeenCalled();
+  });
+  expect(mockRefreshData).toHaveBeenCalled();
+  expect(mockRefreshSystemThemes).toHaveBeenCalled();
+
+  // The confirm dialog closes even though the re-apply is still pending
+  // (it would stay open if the handler awaited refreshSystemThemes).
+  await waitFor(() => {
+    expect(
+      screen.queryByRole('button', { name: 'Confirm' }),
+    ).not.toBeInTheDocument();
+  });
+
+  resolveRefresh();
 });

--- a/superset-frontend/src/pages/ThemeList/index.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.tsx
@@ -698,7 +698,14 @@ function ThemesList({
       <ThemeModal
         addDangerToast={addDangerToast}
         theme={currentTheme}
-        onThemeAdd={() => refreshData()}
+        onThemeAdd={async () => {
+          // If the edited theme is the current system default/dark, re-apply it
+          // live so JSON edits take effect without a full page reload.
+          if (currentTheme?.is_system_default || currentTheme?.is_system_dark) {
+            await refreshSystemThemes();
+          }
+          refreshData();
+        }}
         onThemeApply={handleThemeModalApply}
         onHide={() => setThemeModalOpen(false)}
         show={themeModalOpen}

--- a/superset-frontend/src/pages/ThemeList/index.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.tsx
@@ -113,8 +113,12 @@ function ThemesList({
     refreshData,
     toggleBulkSelect,
   } = useListViewResource<ThemeObject>('theme', t('Themes'), addDangerToast);
-  const { setTemporaryTheme, hasDevOverride, getAppliedThemeId } =
-    useThemeContext();
+  const {
+    setTemporaryTheme,
+    hasDevOverride,
+    getAppliedThemeId,
+    refreshSystemThemes,
+  } = useThemeContext();
   const [themeModalOpen, setThemeModalOpen] = useState<boolean>(false);
   const [currentTheme, setCurrentTheme] = useState<ThemeObject | null>(null);
   const [preparingExport, setPreparingExport] = useState<boolean>(false);
@@ -294,6 +298,9 @@ function ThemesList({
         onConfirm: async () => {
           try {
             await setSystemDefaultTheme(theme.id!);
+            // Apply the new system theme live so it takes effect without a
+            // page reload. Non-throwing, so it never masks the success toast.
+            await refreshSystemThemes();
             refreshData();
             addSuccessToast(
               t('"%s" is now the system default theme', theme.theme_name),
@@ -306,7 +313,13 @@ function ThemesList({
         },
       });
     },
-    [showConfirm, refreshData, addSuccessToast, addDangerToast],
+    [
+      showConfirm,
+      refreshData,
+      refreshSystemThemes,
+      addSuccessToast,
+      addDangerToast,
+    ],
   );
 
   const handleSetSystemDark = useCallback(
@@ -333,6 +346,9 @@ function ThemesList({
         onConfirm: async () => {
           try {
             await setSystemDarkTheme(theme.id!);
+            // Apply the new system theme live so it takes effect without a
+            // page reload. Non-throwing, so it never masks the success toast.
+            await refreshSystemThemes();
             refreshData();
             addSuccessToast(
               t('"%s" is now the system dark theme', theme.theme_name),
@@ -345,7 +361,13 @@ function ThemesList({
         },
       });
     },
-    [showConfirm, refreshData, addSuccessToast, addDangerToast],
+    [
+      showConfirm,
+      refreshData,
+      refreshSystemThemes,
+      addSuccessToast,
+      addDangerToast,
+    ],
   );
 
   const handleUnsetSystemDefault = useCallback(() => {
@@ -357,6 +379,9 @@ function ThemesList({
       onConfirm: async () => {
         try {
           await unsetSystemDefaultTheme();
+          // Revert to the fallback theme live, without a page reload.
+          // Non-throwing, so it never masks the success toast.
+          await refreshSystemThemes();
           refreshData();
           addSuccessToast(t('System default theme removed'));
         } catch (err: any) {
@@ -366,7 +391,13 @@ function ThemesList({
         }
       },
     });
-  }, [showConfirm, refreshData, addSuccessToast, addDangerToast]);
+  }, [
+    showConfirm,
+    refreshData,
+    refreshSystemThemes,
+    addSuccessToast,
+    addDangerToast,
+  ]);
 
   const handleUnsetSystemDark = useCallback(() => {
     showConfirm({
@@ -377,6 +408,9 @@ function ThemesList({
       onConfirm: async () => {
         try {
           await unsetSystemDarkTheme();
+          // Revert to the fallback theme live, without a page reload.
+          // Non-throwing, so it never masks the success toast.
+          await refreshSystemThemes();
           refreshData();
           addSuccessToast(t('System dark theme removed'));
         } catch (err: any) {
@@ -386,7 +420,13 @@ function ThemesList({
         }
       },
     });
-  }, [showConfirm, refreshData, addSuccessToast, addDangerToast]);
+  }, [
+    showConfirm,
+    refreshData,
+    refreshSystemThemes,
+    addSuccessToast,
+    addDangerToast,
+  ]);
 
   const initialSort = [{ id: 'theme_name', desc: true }];
   const columns = useMemo(

--- a/superset-frontend/src/pages/ThemeList/index.tsx
+++ b/superset-frontend/src/pages/ThemeList/index.tsx
@@ -298,13 +298,14 @@ function ThemesList({
         onConfirm: async () => {
           try {
             await setSystemDefaultTheme(theme.id!);
-            // Apply the new system theme live so it takes effect without a
-            // page reload. Non-throwing, so it never masks the success toast.
-            await refreshSystemThemes();
             refreshData();
             addSuccessToast(
               t('"%s" is now the system default theme', theme.theme_name),
             );
+            // Re-apply the new system theme live in the background. Not awaited
+            // (and non-throwing) so a slow /system request never blocks the
+            // confirm modal from closing, the list refresh, or the toast.
+            refreshSystemThemes();
           } catch (err: any) {
             addDangerToast(
               t('Failed to set system default theme: %s', err.message),
@@ -346,13 +347,14 @@ function ThemesList({
         onConfirm: async () => {
           try {
             await setSystemDarkTheme(theme.id!);
-            // Apply the new system theme live so it takes effect without a
-            // page reload. Non-throwing, so it never masks the success toast.
-            await refreshSystemThemes();
             refreshData();
             addSuccessToast(
               t('"%s" is now the system dark theme', theme.theme_name),
             );
+            // Re-apply the new system theme live in the background. Not awaited
+            // (and non-throwing) so a slow /system request never blocks the
+            // confirm modal from closing, the list refresh, or the toast.
+            refreshSystemThemes();
           } catch (err: any) {
             addDangerToast(
               t('Failed to set system dark theme: %s', err.message),
@@ -379,11 +381,12 @@ function ThemesList({
       onConfirm: async () => {
         try {
           await unsetSystemDefaultTheme();
-          // Revert to the fallback theme live, without a page reload.
-          // Non-throwing, so it never masks the success toast.
-          await refreshSystemThemes();
           refreshData();
           addSuccessToast(t('System default theme removed'));
+          // Revert to the fallback theme live in the background. Not awaited
+          // (and non-throwing) so a slow /system request never blocks the
+          // confirm modal from closing, the list refresh, or the toast.
+          refreshSystemThemes();
         } catch (err: any) {
           addDangerToast(
             t('Failed to remove system default theme: %s', err.message),
@@ -408,11 +411,12 @@ function ThemesList({
       onConfirm: async () => {
         try {
           await unsetSystemDarkTheme();
-          // Revert to the fallback theme live, without a page reload.
-          // Non-throwing, so it never masks the success toast.
-          await refreshSystemThemes();
           refreshData();
           addSuccessToast(t('System dark theme removed'));
+          // Revert to the fallback theme live in the background. Not awaited
+          // (and non-throwing) so a slow /system request never blocks the
+          // confirm modal from closing, the list refresh, or the toast.
+          refreshSystemThemes();
         } catch (err: any) {
           addDangerToast(
             t('Failed to remove system dark theme: %s', err.message),
@@ -699,12 +703,14 @@ function ThemesList({
         addDangerToast={addDangerToast}
         theme={currentTheme}
         onThemeAdd={async () => {
+          // Refresh the list row first so it is decoupled from the live
+          // re-apply below (a slow /system request must not block it).
+          refreshData();
           // If the edited theme is the current system default/dark, re-apply it
           // live so JSON edits take effect without a full page reload.
           if (currentTheme?.is_system_default || currentTheme?.is_system_dark) {
             await refreshSystemThemes();
           }
-          refreshData();
         }}
         onThemeApply={handleThemeModalApply}
         onHide={() => setThemeModalOpen(false)}

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -116,6 +116,9 @@ export class ThemeController {
 
   private initialMode: ThemeMode | undefined;
 
+  // Monotonic counter used to drop out-of-order refreshSystemThemes responses.
+  private refreshSeq = 0;
+
   constructor({
     storage = new LocalStorageAdapter(),
     modeStorageKey = STORAGE_KEYS.THEME_MODE,
@@ -576,15 +579,31 @@ export class ThemeController {
    * without a full page reload. The endpoint returns the same resolved theme
    * slice used to bootstrap the page, so the live result matches a reload.
    *
+   * Skips entirely when an explicit theme-config override is active (e.g. from
+   * the Embedded SDK), so it can never clobber an externally-provided theme.
+   *
    * Non-throwing: the server mutation has already succeeded by the time this
-   * runs, so a failed refresh must not surface a failure to the caller; it logs
-   * and leaves the current theme untouched (a later reload still corrects it).
+   * runs, so a failed refresh must not surface a failure to the caller. A
+   * failed fetch or parse logs and leaves the current theme unchanged; if a
+   * fetched slice is valid-shaped but throws while applying, updateTheme's own
+   * recovery path handles the fallback.
    */
   public async refreshSystemThemes(): Promise<void> {
+    // An explicit theme-config override takes precedence over system themes.
+    if (this.themeConfigOverride) return;
+
+    // Only the most recent refresh may apply its slice, so two rapid mutations
+    // cannot let an out-of-order (stale) response win.
+    const seq = this.refreshSeq + 1;
+    this.refreshSeq = seq;
+
     try {
       const response = await SupersetClient.get({
         endpoint: '/api/v1/theme/system',
       });
+      // A newer refresh started while this request was in flight; drop this one.
+      if (seq !== this.refreshSeq) return;
+
       const themeConfig = response.json?.result as
         | BootstrapThemeDataConfig
         | undefined;

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -82,13 +82,18 @@ export class ThemeController {
 
   private darkTheme: AnyThemeConfig | null;
 
+  // The built-in/config fallback default theme captured at construction. Used
+  // when no system default theme is set, so a live refresh reproduces the
+  // constructor's default-theme fallback without a page reload.
+  private builtInDefaultTheme: AnyThemeConfig | null;
+
   private systemMode: ThemeMode.DARK | ThemeMode.DEFAULT;
 
   private currentMode: ThemeMode;
 
   private onChangeCallbacks: Set<(theme: Theme) => void> = new Set();
 
-  private mediaQuery: MediaQueryList;
+  private mediaQuery: MediaQueryList | undefined;
 
   private crudThemeId: string | null = null;
 
@@ -133,9 +138,14 @@ export class ThemeController {
       bootstrapDefaultMode,
     }: BootstrapThemeData = this.loadBootstrapData();
 
+    // Capture the built-in/config fallback default theme so a live refresh can
+    // reproduce this same fallback (see refreshSystemThemes).
+    this.builtInDefaultTheme = defaultTheme;
+
     // Set themes from bootstrap data
     // These will be the THEME_DEFAULT and THEME_DARK from config
-    this.defaultTheme = bootstrapDefaultTheme || defaultTheme || null;
+    this.defaultTheme =
+      bootstrapDefaultTheme || this.builtInDefaultTheme || null;
     this.darkTheme = bootstrapDarkTheme;
     this.bootstrapDefaultMode = bootstrapDefaultMode;
 
@@ -561,6 +571,54 @@ export class ThemeController {
   }
 
   /**
+   * Re-reads the persisted system default/dark themes from the server and
+   * re-applies them live, so changes made on the Themes admin page take effect
+   * without a full page reload. The endpoint returns the same resolved theme
+   * slice used to bootstrap the page, so the live result matches a reload.
+   *
+   * Non-throwing: the server mutation has already succeeded by the time this
+   * runs, so a failed refresh must not surface a failure to the caller; it logs
+   * and leaves the current theme untouched (a later reload still corrects it).
+   */
+  public async refreshSystemThemes(): Promise<void> {
+    try {
+      const response = await SupersetClient.get({
+        endpoint: '/api/v1/theme/system',
+      });
+      const themeConfig = response.json?.result as
+        | BootstrapThemeDataConfig
+        | undefined;
+      if (!themeConfig) return;
+
+      const {
+        bootstrapDefaultTheme,
+        bootstrapDarkTheme,
+        bootstrapDefaultMode,
+      } = this.parseThemeConfig(themeConfig);
+
+      // Reproduce the constructor's slot assignments so live == reload.
+      this.defaultTheme =
+        bootstrapDefaultTheme || this.builtInDefaultTheme || null;
+      this.darkTheme = bootstrapDarkTheme;
+      this.bootstrapDefaultMode = bootstrapDefaultMode;
+
+      // Dark-theme availability may have changed (set or unset); re-sync the
+      // prefers-color-scheme listener so SYSTEM-mode OS switching stays correct.
+      this.reconcileMediaQueryListener();
+
+      // Recompute the mode exactly as the constructor would on a reload.
+      this.currentMode = this.determineInitialMode();
+
+      // No-arg updateTheme re-resolves via getThemeForMode(currentMode) and
+      // notifies subscribers, repainting the app without a reload. It honors an
+      // active devThemeOverride and never sets themeConfigOverride.
+      await this.updateTheme();
+    } catch (error) {
+      console.warn('Failed to refresh system themes:', error);
+    }
+  }
+
+  /**
    * Handles system theme changes with error recovery.
    */
   private handleSystemThemeChange = (): void => {
@@ -685,6 +743,23 @@ export class ThemeController {
   }
 
   /**
+   * Re-syncs the prefers-color-scheme listener with the current dark-theme
+   * availability. Idempotent: always removes any existing listener before
+   * conditionally re-adding one, so repeated refreshes never double-register.
+   */
+  private reconcileMediaQueryListener(): void {
+    if (this.mediaQuery) {
+      this.mediaQuery.removeEventListener(
+        'change',
+        this.handleSystemThemeChange,
+      );
+      this.mediaQuery = undefined;
+    }
+    if (this.shouldInitializeMediaQueryListener())
+      this.initializeMediaQueryListener();
+  }
+
+  /**
    * Loads and validates bootstrap theme data.
    */
   private loadBootstrapData(): BootstrapThemeData {
@@ -692,6 +767,17 @@ export class ThemeController {
       common: { theme = {} as BootstrapThemeDataConfig },
     } = getBootstrapData();
 
+    return this.parseThemeConfig(theme);
+  }
+
+  /**
+   * Parses and validates a resolved theme config slice (the shape shared by the
+   * page bootstrap and the /api/v1/theme/system endpoint) into the controller's
+   * internal theme representation.
+   */
+  private parseThemeConfig(
+    theme: BootstrapThemeDataConfig,
+  ): BootstrapThemeData {
     const { default: defaultTheme, dark: darkTheme, defaultMode } = theme;
 
     const hasValidDefault: boolean = this.isNonEmptyObject(defaultTheme);

--- a/superset-frontend/src/theme/ThemeController.ts
+++ b/superset-frontend/src/theme/ThemeController.ts
@@ -116,8 +116,12 @@ export class ThemeController {
 
   private initialMode: ThemeMode | undefined;
 
-  // Monotonic counter used to drop out-of-order refreshSystemThemes responses.
+  // Assigns a monotonically increasing id to each refreshSystemThemes call, and
+  // tracks the highest id that has actually applied a slice, so out-of-order or
+  // superseded /system responses can be dropped ("newest applied wins").
   private refreshSeq = 0;
+
+  private appliedRefreshSeq = 0;
 
   constructor({
     storage = new LocalStorageAdapter(),
@@ -579,8 +583,9 @@ export class ThemeController {
    * without a full page reload. The endpoint returns the same resolved theme
    * slice used to bootstrap the page, so the live result matches a reload.
    *
-   * Skips entirely when an explicit theme-config override is active (e.g. from
-   * the Embedded SDK), so it can never clobber an externally-provided theme.
+   * Bails before applying whenever an explicit theme-config override is active
+   * (e.g. from the Embedded SDK) — checked both at entry and again after the
+   * fetch resolves — so it does not overwrite an externally-provided theme.
    *
    * Non-throwing: the server mutation has already succeeded by the time this
    * runs, so a failed refresh must not surface a failure to the caller. A
@@ -592,22 +597,29 @@ export class ThemeController {
     // An explicit theme-config override takes precedence over system themes.
     if (this.themeConfigOverride) return;
 
-    // Only the most recent refresh may apply its slice, so two rapid mutations
-    // cannot let an out-of-order (stale) response win.
-    const seq = this.refreshSeq + 1;
-    this.refreshSeq = seq;
+    // Assign this refresh a monotonically increasing id so out-of-order
+    // responses can be resolved by "newest successfully-applied wins".
+    this.refreshSeq += 1;
+    const seq = this.refreshSeq;
 
     try {
       const response = await SupersetClient.get({
         endpoint: '/api/v1/theme/system',
       });
-      // A newer refresh started while this request was in flight; drop this one.
-      if (seq !== this.refreshSeq) return;
+      // Drop this response if a newer refresh has already applied a slice (so a
+      // slow older request can't clobber it, and a newer request that fails to
+      // fetch can't discard this valid one), or if an embedded theme-config
+      // override took over while this request was in flight.
+      if (seq <= this.appliedRefreshSeq || this.themeConfigOverride) return;
 
       const themeConfig = response.json?.result as
         | BootstrapThemeDataConfig
         | undefined;
       if (!themeConfig) return;
+
+      // This response wins; record it before mutating so an older in-flight
+      // response can't overwrite it.
+      this.appliedRefreshSeq = seq;
 
       const {
         bootstrapDefaultTheme,

--- a/superset-frontend/src/theme/ThemeProvider.tsx
+++ b/superset-frontend/src/theme/ThemeProvider.tsx
@@ -137,6 +137,11 @@ export function SupersetThemeProvider({
     [themeController],
   );
 
+  const refreshSystemThemes = useCallback(
+    () => themeController.refreshSystemThemes(),
+    [themeController],
+  );
+
   const contextValue = useMemo(
     () => ({
       theme: currentTheme,
@@ -154,6 +159,7 @@ export function SupersetThemeProvider({
       canDetectOSPreference,
       createDashboardThemeProvider,
       getAppliedThemeId,
+      refreshSystemThemes,
     }),
     [
       currentTheme,
@@ -171,6 +177,7 @@ export function SupersetThemeProvider({
       canDetectOSPreference,
       createDashboardThemeProvider,
       getAppliedThemeId,
+      refreshSystemThemes,
     ],
   );
 

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -2385,3 +2385,79 @@ test('refreshSystemThemes is a no-op when the server returns no result', async (
 
   getSpy.mockRestore();
 });
+
+test('refreshSystemThemes is skipped when an embedded theme-config override is active', async () => {
+  const controller = createController();
+  controller.setThemeConfig({
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  });
+  expect(controller.hasThemeConfigOverride()).toBe(true);
+
+  mockSetConfig.mockClear();
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: { result: { default: DEFAULT_THEME, dark: DARK_THEME } },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  // An SDK-provided theme must not be clobbered: no fetch, no re-apply.
+  expect(getSpy).not.toHaveBeenCalled();
+  expect(mockSetConfig).not.toHaveBeenCalled();
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes ignores a stale out-of-order response', async () => {
+  const controller = createController();
+  mockSetConfig.mockClear();
+
+  const NEW_DEFAULT: AnyThemeConfig = {
+    token: { colorBgBase: '#new111', colorPrimary: '#111' },
+  };
+  const STALE_DEFAULT: AnyThemeConfig = {
+    token: { colorBgBase: '#old999', colorPrimary: '#999' },
+  };
+
+  let resolveStale: (value: unknown) => void = () => {};
+  const stalePending = new Promise(resolve => {
+    resolveStale = resolve;
+  });
+
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    // The first (older) request stays pending until we resolve it last.
+    .mockImplementationOnce(() => stalePending as any)
+    // The second (newer) request resolves immediately and should win.
+    .mockResolvedValueOnce({
+      json: {
+        result: {
+          default: NEW_DEFAULT,
+          dark: DARK_THEME,
+          defaultMode: 'default',
+        },
+      },
+    } as any);
+
+  const older = controller.refreshSystemThemes(); // seq 1, pending
+  const newer = controller.refreshSystemThemes(); // seq 2, applies NEW_DEFAULT
+  await newer;
+
+  // Deliver the stale response last; it must be dropped, not applied.
+  resolveStale({
+    json: {
+      result: {
+        default: STALE_DEFAULT,
+        dark: DARK_THEME,
+        defaultMode: 'default',
+      },
+    },
+  });
+  await older;
+
+  const lastConfig =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastConfig.token.colorBgBase).toBe('#new111');
+
+  getSpy.mockRestore();
+});

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -2461,3 +2461,84 @@ test('refreshSystemThemes ignores a stale out-of-order response', async () => {
 
   getSpy.mockRestore();
 });
+
+test('refreshSystemThemes applies a valid earlier response when a newer refresh fails', async () => {
+  const controller = createController();
+  mockSetConfig.mockClear();
+
+  const EARLIER_DEFAULT: AnyThemeConfig = {
+    token: { colorBgBase: '#aaa111', colorPrimary: '#a1' },
+  };
+
+  let resolveEarlier: (value: unknown) => void = () => {};
+  const earlierPending = new Promise(resolve => {
+    resolveEarlier = resolve;
+  });
+
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    // Earlier request (seq 1) stays pending.
+    .mockImplementationOnce(() => earlierPending as any)
+    // Newer request (seq 2) fails outright.
+    .mockRejectedValueOnce(new Error('newer refresh failed'));
+
+  const earlier = controller.refreshSystemThemes(); // seq 1, pending
+  const newer = controller.refreshSystemThemes(); // seq 2, rejects, applies nothing
+  await newer;
+
+  // The earlier request now resolves with a valid slice. Because the newer one
+  // never applied, the earlier (still-valid) response must not be discarded.
+  resolveEarlier({
+    json: {
+      result: {
+        default: EARLIER_DEFAULT,
+        dark: DARK_THEME,
+        defaultMode: 'default',
+      },
+    },
+  });
+  await earlier;
+
+  const lastConfig =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastConfig.token.colorBgBase).toBe('#aaa111');
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes does not clobber an override applied while its fetch was in flight', async () => {
+  const controller = createController();
+
+  let resolveGet: (value: unknown) => void = () => {};
+  const pending = new Promise(resolve => {
+    resolveGet = resolve;
+  });
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockImplementationOnce(() => pending as any);
+
+  // Override is inactive at entry, so the refresh proceeds and awaits the GET.
+  const refresh = controller.refreshSystemThemes();
+
+  // An embedded theme-config override is applied while the request is in flight.
+  controller.setThemeConfig({
+    theme_default: DEFAULT_THEME,
+    theme_dark: DARK_THEME,
+  });
+  expect(controller.hasThemeConfigOverride()).toBe(true);
+  mockSetConfig.mockClear();
+
+  // The in-flight refresh resolves; the post-await guard must drop it so the
+  // SDK-provided theme is preserved.
+  resolveGet({
+    json: {
+      result: { default: { token: { colorBgBase: '#stale' } }, dark: {} },
+    },
+  });
+  await refresh;
+
+  expect(mockSetConfig).not.toHaveBeenCalled();
+  expect(controller.hasThemeConfigOverride()).toBe(true);
+
+  getSpy.mockRestore();
+});

--- a/superset-frontend/src/theme/tests/ThemeController.test.ts
+++ b/superset-frontend/src/theme/tests/ThemeController.test.ts
@@ -100,6 +100,7 @@ const createMockBootstrapData = (
 const mockThemeObject = {
   setConfig: mockSetConfig,
   theme: DEFAULT_THEME,
+  toSerializedConfig: jest.fn(() => DEFAULT_THEME),
 } as unknown as Theme;
 
 // Helper to create a fresh ThemeController with common setup
@@ -2209,4 +2210,178 @@ test('bootstrapDefaultMode: explicit initialMode takes precedence over bootstrap
   );
   const controller = createController({ initialMode: ThemeMode.DEFAULT });
   expect(controller.getCurrentMode()).toBe(ThemeMode.DEFAULT);
+});
+
+// refreshSystemThemes tests
+test('refreshSystemThemes applies a new system default live and notifies subscribers', async () => {
+  const callback = jest.fn();
+  const controller = createController({ onChange: callback });
+  callback.mockClear();
+  mockSetConfig.mockClear();
+
+  const NEW_DEFAULT: AnyThemeConfig = {
+    token: { colorBgBase: '#abcdef', colorPrimary: '#123456' },
+  };
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: {
+        default: NEW_DEFAULT,
+        dark: DARK_THEME,
+        defaultMode: 'default',
+      },
+    },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  expect(getSpy).toHaveBeenCalledWith({ endpoint: '/api/v1/theme/system' });
+  // A subscriber fired, proving the app re-rendered without a reload.
+  expect(callback).toHaveBeenCalled();
+  // The refresh must not trip the embedded-SDK precedence flag.
+  expect(controller.hasThemeConfigOverride()).toBe(false);
+  const lastConfig =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastConfig.token.colorBgBase).toBe('#abcdef');
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes preserves an active dev theme override', async () => {
+  const controller = createController();
+  controller.setTemporaryTheme({ token: { colorPrimary: '#dev' } }, 42);
+  expect(controller.hasDevOverride()).toBe(true);
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: {
+        default: DEFAULT_THEME,
+        dark: DARK_THEME,
+        defaultMode: 'default',
+      },
+    },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  expect(controller.hasDevOverride()).toBe(true);
+  expect(controller.hasThemeConfigOverride()).toBe(false);
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes removes the OS listener when dark is unset and does not double-register', async () => {
+  const mockMediaQuery = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQuery);
+
+  // Dark present at construction → listener registered once.
+  const controller = createController();
+  expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: { default: DEFAULT_THEME, dark: {}, defaultMode: 'default' },
+    },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  expect(controller.canDetectOSPreference()).toBe(false);
+  expect(controller.canSetMode()).toBe(false);
+  expect(mockMediaQuery.removeEventListener).toHaveBeenCalledTimes(1);
+
+  // A second refresh with dark still unset must not re-register the listener.
+  await controller.refreshSystemThemes();
+  expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes registers the OS listener once when dark is set for the first time', async () => {
+  mockGetBootstrapData.mockReturnValue(
+    createMockBootstrapData({ default: DEFAULT_THEME, dark: {} }),
+  );
+  const mockMediaQuery = {
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  };
+  mockMatchMedia.mockReturnValue(mockMediaQuery);
+
+  // No dark at construction → no listener registered.
+  const controller = createController();
+  expect(mockMediaQuery.addEventListener).not.toHaveBeenCalled();
+  expect(controller.canDetectOSPreference()).toBe(false);
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: {
+      result: {
+        default: DEFAULT_THEME,
+        dark: DARK_THEME,
+        defaultMode: 'system',
+      },
+    },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  expect(controller.canDetectOSPreference()).toBe(true);
+  expect(mockMediaQuery.addEventListener).toHaveBeenCalledTimes(1);
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes falls back to the built-in default when the server default is empty', async () => {
+  const BUILT_IN: AnyThemeConfig = {
+    token: { colorBgBase: '#builtin', colorPrimary: '#000fff' },
+  };
+  const controller = createController({ defaultTheme: BUILT_IN });
+  mockSetConfig.mockClear();
+
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: { result: { default: {}, dark: DARK_THEME, defaultMode: 'default' } },
+  } as any);
+
+  await controller.refreshSystemThemes();
+
+  const lastConfig =
+    mockSetConfig.mock.calls[mockSetConfig.mock.calls.length - 1][0];
+  expect(lastConfig.token.colorBgBase).toBe('#builtin');
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes does not throw and leaves the theme unchanged when the request fails', async () => {
+  const controller = createController();
+  mockSetConfig.mockClear();
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockRejectedValue(new Error('boom'));
+
+  await expect(controller.refreshSystemThemes()).resolves.toBeUndefined();
+
+  expect(mockSetConfig).not.toHaveBeenCalled();
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'Failed to refresh system themes:',
+    expect.any(Error),
+  );
+
+  getSpy.mockRestore();
+});
+
+test('refreshSystemThemes is a no-op when the server returns no result', async () => {
+  const controller = createController();
+  mockSetConfig.mockClear();
+  const getSpy = jest
+    .spyOn(SupersetClient, 'get')
+    .mockResolvedValue({ json: {} } as any);
+
+  await controller.refreshSystemThemes();
+
+  expect(mockSetConfig).not.toHaveBeenCalled();
+
+  getSpy.mockRestore();
 });

--- a/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
+++ b/superset-frontend/src/theme/tests/ThemeProvider.test.tsx
@@ -92,6 +92,7 @@ describe('SupersetThemeProvider', () => {
       canDetectOSPreference: jest.fn().mockReturnValue(true),
       createDashboardThemeProvider: jest.fn(),
       getAppliedThemeId: jest.fn().mockReturnValue(null),
+      refreshSystemThemes: jest.fn().mockResolvedValue(undefined),
       destroy: jest.fn(),
     } as unknown as jest.Mocked<ThemeController>;
 
@@ -131,6 +132,20 @@ describe('SupersetThemeProvider', () => {
       expect(mockThemeController.getCurrentMode).toHaveBeenCalled();
       expect(result.current.theme).toBe(mockTheme);
       expect(result.current.themeMode).toBe(ThemeMode.DEFAULT);
+    });
+
+    test('exposes refreshSystemThemes and delegates to the controller', async () => {
+      const wrapper = createWrapper(mockThemeController);
+
+      const { result } = renderHook((): ThemeContextType => useThemeContext(), {
+        wrapper,
+      });
+
+      await act(async () => {
+        await result.current.refreshSystemThemes();
+      });
+
+      expect(mockThemeController.refreshSystemThemes).toHaveBeenCalledTimes(1);
     });
 
     test('should register onChange listener on mount', () => {

--- a/superset/themes/api.py
+++ b/superset/themes/api.py
@@ -79,6 +79,7 @@ class ThemeRestApi(BaseSupersetModelRestApi):
         "set_system_dark",
         "unset_system_default",
         "unset_system_dark",
+        "system",
     }
     class_permission_name = "Theme"
     method_permission_name = {
@@ -87,6 +88,7 @@ class ThemeRestApi(BaseSupersetModelRestApi):
         "set_system_dark": "write",
         "unset_system_default": "write",
         "unset_system_dark": "write",
+        "system": "read",
     }
 
     resource_name = "theme"
@@ -790,3 +792,52 @@ class ThemeRestApi(BaseSupersetModelRestApi):
             return self.response(200, result="success")
         except Exception as ex:
             return self.response_422(message=str(ex))
+
+    @expose("/system", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.system",
+        log_to_statsd=False,
+    )
+    def system(self) -> Response:
+        """Return the resolved system theme slice used to bootstrap the page.
+        ---
+        get:
+          summary: Get the resolved system default and dark themes
+          description: >-
+            Returns the same processed theme payload embedded in the page
+            bootstrap: the resolved system default and dark themes, the default
+            mode, and the UI theme administration flag. The client uses this to
+            apply system theme changes live without a full page reload, keeping
+            the result identical to what a reload would render.
+          responses:
+            200:
+              description: Resolved system theme slice
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+                        properties:
+                          default:
+                            type: object
+                          dark:
+                            type: object
+                          defaultMode:
+                            type: string
+                          enableUiThemeAdministration:
+                            type: boolean
+            401:
+              $ref: '#/components/responses/401'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        # Local import to avoid a circular import between superset.views.base
+        # and this module (mirrors the security_manager import pattern above).
+        from superset.views.base import get_theme_bootstrap_data
+
+        return self.response(200, result=get_theme_bootstrap_data()["theme"])

--- a/superset/themes/api.py
+++ b/superset/themes/api.py
@@ -833,6 +833,8 @@ class ThemeRestApi(BaseSupersetModelRestApi):
                             type: boolean
             401:
               $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
             500:
               $ref: '#/components/responses/500'
         """

--- a/tests/integration_tests/themes/test_theme_api_permissions.py
+++ b/tests/integration_tests/themes/test_theme_api_permissions.py
@@ -331,3 +331,11 @@ class TestThemeAPIPermissions(SupersetTestCase):
         assert after["enableUiThemeAdministration"] is True
         assert isinstance(after["default"], dict)
         assert after["default"]  # non-empty: the DB theme is now resolved
+
+    def test_anonymous_cannot_get_system_theme_slice(self):
+        """An unauthenticated request to /system is rejected with 401."""
+        self.logout()
+
+        response = self.client.get("/api/v1/theme/system")
+
+        assert response.status_code == 401

--- a/tests/integration_tests/themes/test_theme_api_permissions.py
+++ b/tests/integration_tests/themes/test_theme_api_permissions.py
@@ -284,3 +284,50 @@ class TestThemeAPIPermissions(SupersetTestCase):
 
         # Note: Gamma users' ability to create/update/delete themes
         # depends on the specific permissions configuration
+
+    def test_admin_can_get_system_theme_slice(self):
+        """Admin can read the resolved system theme slice used for bootstrap."""
+        self.login(ADMIN_USERNAME)
+
+        response = self.client.get("/api/v1/theme/system")
+
+        assert response.status_code == 200
+        result = response.get_json()["result"]
+        # Mirrors the page bootstrap theme payload shape.
+        assert "default" in result
+        assert "dark" in result
+        assert "defaultMode" in result
+        assert "enableUiThemeAdministration" in result
+
+    def test_gamma_can_get_system_theme_slice(self):
+        """Reading the system theme slice requires only theme read access, so a
+        Gamma user (read-only) can fetch it, mirroring the list/show endpoints.
+        The slice is already sent to every user in the page bootstrap, so this
+        exposes nothing new."""
+        self.login(GAMMA_USERNAME)
+
+        response = self.client.get("/api/v1/theme/system")
+
+        assert response.status_code == 200
+
+    @with_config({"ENABLE_UI_THEME_ADMINISTRATION": True})
+    def test_system_theme_slice_reflects_a_freshly_set_default(self):
+        """A subsequent /system read reflects a newly set system default,
+        proving it reads current DB state rather than a cached payload."""
+        self.login(ADMIN_USERNAME)
+
+        # The enabled administration flag is surfaced in the slice.
+        before = self.client.get("/api/v1/theme/system").get_json()["result"]
+        assert before["enableUiThemeAdministration"] is True
+
+        # Persist a DB-backed system default theme.
+        set_response = self.client.put(
+            f"/api/v1/theme/{self.regular_theme.id}/set_system_default"
+        )
+        assert set_response.status_code == 200
+
+        # The subsequent read resolves the newly persisted theme.
+        after = self.client.get("/api/v1/theme/system").get_json()["result"]
+        assert after["enableUiThemeAdministration"] is True
+        assert isinstance(after["default"], dict)
+        assert after["default"]  # non-empty: the DB theme is now resolved


### PR DESCRIPTION
### SUMMARY

Setting a new **system default** or **system dark** theme from the Themes admin page did not take effect until a full browser refresh — a regression from the previous behavior where it applied immediately.

**Root cause:** the four save/unset handlers in `ThemeList` only called `refreshData()` (which re-fetches the CRUD list rows) and never updated the live `ThemeController`. The controller reads its `defaultTheme`/`darkTheme` once at construction from `getBootstrapData()`, which memoizes the server-rendered bootstrap JSON in a module-level variable that is never invalidated for the SPA session. So the app kept rendering the constructor-time theme until a reload rebuilt it.

**Fix:**
- New `GET /api/v1/theme/system` endpoint on `ThemeRestApi` returning the resolved system theme slice — the *same* processed payload used to bootstrap the page (the config-file merge and slot-algorithm coercion happen server-side, so a live apply matches a reload by construction). Gated on `can_read`; the slice is already sent to every user in the page bootstrap, so it exposes nothing new.
- New non-throwing `ThemeController.refreshSystemThemes()` that re-reads that endpoint, reassigns the theme slots exactly as the constructor does, re-syncs the `prefers-color-scheme` listener (so first-time-dark / unset-dark transitions keep OS auto-switching correct), recomputes the mode, and re-applies the theme live through the existing `updateTheme()` path — preserving any active dev theme override and never setting the embedded-SDK override flag.
- Exposed it on the theme context; the four set/unset handlers now `await refreshSystemThemes()` after a successful mutation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_Before:_ changing the system default/dark theme required a manual page refresh to take effect.

_After:_ the new theme applies immediately, no refresh needed.

### TESTING INSTRUCTIONS

Manual:
1. Enable `ENABLE_UI_THEME_ADMINISTRATION` and log in as an admin.
2. Go to **Settings → Themes**.
3. Pick a theme and choose **Set as system default** (or **system dark**) and confirm.
4. The theme applies immediately — no page refresh. Repeat for **unset**; the app reverts live to the config-file fallback.

Automated:
- Frontend: `superset-frontend/src/theme/tests/ThemeController.test.ts`, `ThemeProvider.test.tsx`, and `src/pages/ThemeList/ThemeList.test.tsx` cover live apply, dev-override preservation, media-query listener reconciliation, unset fallback, and the handler wiring.
- Backend: `tests/integration_tests/themes/test_theme_api_permissions.py` covers admin/gamma read access to `/theme/system` and that a freshly set default is reflected on a subsequent read.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags: `ENABLE_UI_THEME_ADMINISTRATION` (needed to reach the affected admin UI)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
