### PR TITLE
docs: point homepage Release Notes link to GitHub releases

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -58,7 +58,7 @@ A modern, enterprise-ready business intelligence web application.
 [**Why Superset?**](#why-superset) |
 [**Supported Databases**](#supported-databases) |
 [**Installation and Configuration**](#installation-and-configuration) |
-[**Release Notes**](https://github.com/apache/superset/blob/master/RELEASING/README.md#release-notes-for-recent-releases) |
+[**Release Notes**](https://github.com/apache/superset/releases) |
 [**Get Involved**](#get-involved) |
 [**Contributor Guide**](#contributor-guide) |
 [**Resources**](#resources) |


### PR DESCRIPTION
## Summary

The homepage nav row links **Release Notes** to `RELEASING/README.md#release-notes-for-recent-releases`, but that anchor doesn't exist on the page. `RELEASING/README.md` is the release-engineering how-to (headings are `Apache Releases`, `Release setup`, `Crafting a source release`, etc.), so the link lands on a dead fragment rather than any release notes.

This points it at the actual GitHub releases page — consistent with the `releases/latest` badge link already used higher up on the same page (line 30).

## Verification
- `docs/docs/index.mdx:61` is the only occurrence.
- Confirmed against current `master` (`e683aad`): no heading in `RELEASING/README.md` slugs to `release-notes-for-recent-releases`.

Docs-only, one line.