### PR TITLE
fix(gtf): async tab_id schema fix, stranded-PENDING hardening, and realtime transport reframing

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -84,9 +84,12 @@ completion transport for async chart-data — see the note on the interval poll)
 > When it is **enabled**, completion is delivered over the socket and the
 > recurring interval poll does not run; a one-shot `status_changes` catch-up on
 > waiter registration and on socket reconnect reconciles anything missed while
-> disconnected. Redis Pub/Sub is lossy, so a `task.status` lost while the socket
-> stays open is only recovered on the next reconnect/registration or, failing
-> that, a per-request give-up timeout (a page reload re-establishes state).
+> disconnected. The socket accelerates delivery over the authoritative
+> `status_changes` API rather than replacing it: Redis Pub/Sub is best-effort
+> (at-most-once, no replay), so a disconnect is reconciled by the catch-up on
+> reconnect/registration; in the rare case a `task.status` is missed while the
+> socket stays open, completion still resolves on the next reconnect/registration
+> or the per-request give-up (and a page reload re-establishes state).
 
 ```python
 WEBSOCKET_ENABLE = True

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -87,9 +87,11 @@ completion transport for async chart-data — see the note on the interval poll)
 > disconnected. The socket accelerates delivery over the authoritative
 > `status_changes` API rather than replacing it: Redis Pub/Sub is best-effort
 > (at-most-once, no replay), so a disconnect is reconciled by the catch-up on
-> reconnect/registration; in the rare case a `task.status` is missed while the
-> socket stays open, completion still resolves on the next reconnect/registration
-> or the per-request give-up (and a page reload re-establishes state).
+> reconnect/registration. In the rare case a `task.status` is missed while the
+> socket stays open, the request's give-up runs one final `status_changes` read
+> before timing out — so a chart whose query actually finished still resolves; only
+> if that read can't confirm completion does the request end in a bounded error (a
+> page reload re-establishes state).
 
 ```python
 WEBSOCKET_ENABLE = True

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -792,7 +792,7 @@ test('WS mode: an in-flight catch-up does not clobber a cursor rewound mid-fligh
 
 test('WS mode: a genuinely lost completion gives up after the timeout', async () => {
   jest.useFakeTimers();
-  queueStatuses(); // nothing ever reports success
+  queueStatuses(); // nothing ever reports success (neither catch-up finds it)
   asyncEvent.init({
     ...wsConfig,
     GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT: 1000,
@@ -805,7 +805,33 @@ test('WS mode: a genuinely lost completion gives up after the timeout', async ()
   // Attach the rejection handler before the give-up timer fires.
   const expectation = expect(promise).rejects.toThrow('Timed out');
 
-  await jest.advanceTimersByTimeAsync(1000);
+  // Past the jittered deadline (+ up to GIVE_UP_JITTER_MS) and the post-catch-up
+  // grace: the last-chance catch-up finds nothing, so the waiter is rejected.
+  await jest.advanceTimersByTimeAsync(1000 + 5000 + 3000 + 200);
   await expectation;
+  jest.useRealTimers();
+});
+
+test('WS mode: the last-chance catch-up before give-up recovers a missed completion', async () => {
+  jest.useFakeTimers();
+  // Registration catch-up consumes the empty baseline; by give-up time the task
+  // has completed, so the give-up's one-shot catch-up picks it up and the waiter
+  // resolves instead of rejecting (the "message missed but socket stayed open" case).
+  queueStatuses({ 'task-1': { status: 'success' } });
+  asyncEvent.init({
+    ...wsConfig,
+    GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT: 1000,
+  });
+
+  const refetch = jest.fn().mockResolvedValue([{ rows: 1 }]);
+  const promise = asyncEvent.waitForAsyncData(
+    { task_ids: ['task-1'] },
+    refetch,
+  );
+
+  // Reach the give-up deadline (+ jitter); its catch-up finds the completion.
+  await jest.advanceTimersByTimeAsync(1000 + 5000 + 200);
+  expect(await promise).toEqual([{ rows: 1 }]);
+  expect(refetch).toHaveBeenCalledTimes(1);
   jest.useRealTimers();
 });

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -805,9 +805,9 @@ test('WS mode: a genuinely lost completion gives up after the timeout', async ()
   // Attach the rejection handler before the give-up timer fires.
   const expectation = expect(promise).rejects.toThrow('Timed out');
 
-  // Past the jittered deadline (+ up to GIVE_UP_JITTER_MS) and the post-catch-up
-  // grace: the last-chance catch-up finds nothing, so the waiter is rejected.
-  await jest.advanceTimersByTimeAsync(1000 + 5000 + 3000 + 200);
+  // Past the jittered deadline (+ up to GIVE_UP_JITTER_MS); the awaited last-chance
+  // catch-up finds nothing, so the waiter is rejected.
+  await jest.advanceTimersByTimeAsync(1000 + 5000 + 200);
   await expectation;
   jest.useRealTimers();
 });

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -112,6 +112,16 @@ let wsEnabled = false;
 let catchUpScheduled = false;
 let catchUpInFlight = false;
 let catchUpQueued = false;
+// Resolvers awaiting the completion of a catch-up that observed their request (see
+// catchUpAndWait) — flushed when the coalesced run chain drains. Lets the WS
+// give-up await the last-chance reconciliation exactly, rather than racing a timer.
+let catchUpCompletionResolvers: (() => void)[] = [];
+
+const flushCatchUpResolvers = () => {
+  const resolvers = catchUpCompletionResolvers;
+  catchUpCompletionResolvers = [];
+  resolvers.forEach(resolve => resolve());
+};
 let pollingDelayMs: number;
 // Backoff state: the poll starts eager (`pollingDelayMs`), degrades — doubling up
 // to `pollBackoffMaxMs` — while awaited tasks are quiet, and snaps back to eager
@@ -125,11 +135,9 @@ let pollBackoffMaxMs: number;
 let pollStaleTimeoutMs: number;
 let lastProgressAt: number;
 // WS-mode give-up (see waitForAsyncData): spread the per-waiter deadline by up to
-// this jitter so many charts don't reach it at the same instant, and — after the
-// last-chance catch-up it triggers — wait this grace for that reconciliation to
-// settle the waiter before rejecting.
+// this jitter so many charts don't reach it at the same instant. After the
+// last-chance catch-up it triggers, the waiter is rejected only if still unresolved.
 const GIVE_UP_JITTER_MS = 5000;
-const GIVE_UP_CATCHUP_GRACE_MS = 3000;
 let pollingTimeoutId: number;
 // Whether the poll loop is running. It stops entirely when no waiters remain (no
 // idle heartbeat) and is restarted by ``ensurePolling`` when a waiter registers.
@@ -355,7 +363,10 @@ const ensurePolling = () => {
 // coalesced (see scheduleCatchUp) rather than each firing their own request.
 const runCatchUp = async () => {
   catchUpScheduled = false;
-  if (!wsEnabled || !waitersByTaskId.size) return;
+  if (!wsEnabled || !waitersByTaskId.size) {
+    flushCatchUpResolvers();
+    return;
+  }
   catchUpInFlight = true;
   try {
     // Capture the cursor this fetch starts from; a waiter registering mid-flight
@@ -385,6 +396,9 @@ const runCatchUp = async () => {
       catchUpQueued = false;
       catchUpScheduled = true;
       Promise.resolve().then(runCatchUp);
+    } else {
+      // Chain drained: wake anyone awaiting a catch-up that observed their request.
+      flushCatchUpResolvers();
     }
   }
 };
@@ -402,6 +416,20 @@ const scheduleCatchUp = () => {
   if (catchUpScheduled) return;
   catchUpScheduled = true;
   Promise.resolve().then(runCatchUp);
+};
+
+// Trigger a coalesced catch-up and resolve once a run that observed this call has
+// completed. Used by the WS give-up for an exact last-chance reconciliation (await
+// the actual reconciliation rather than racing a fixed grace timer). A no-op run
+// (WS off / no waiters) still resolves.
+const catchUpAndWait = (): Promise<void> => {
+  // scheduleCatchUp is a no-op when WS is off (it would never schedule a run, so
+  // no resolver would ever flush); resolve immediately in that case.
+  if (!wsEnabled) return Promise.resolve();
+  return new Promise<void>(resolve => {
+    catchUpCompletionResolvers.push(resolve);
+    scheduleCatchUp();
+  });
 };
 
 subscribeRealtimeOpen(scheduleCatchUp);
@@ -520,25 +548,25 @@ export const waitForAsyncData = async <T = unknown[]>(
       // dropped socket message with no reconnect) so a chart can't spin forever;
       // a reconnect catch-up normally settles it well before this fires. Before
       // rejecting, do ONE last-chance reconciliation (not a poll): the socket may
-      // have missed a `task.status` while staying open, so run the coalesced
-      // `status_changes` catch-up and reject only if still unresolved a short grace
-      // later (if the catch-up settles the waiter, `unregister` clears this timer).
-      // Jitter the deadline so many dashboard charts don't fire at the same instant.
-      const rejectIfStillPending = () => {
-        if (waiter.taskIds.some(id => waitersByTaskId.get(id)?.has(waiter))) {
-          settle(
-            waiter,
-            new Error('Timed out waiting for chart-data query results'),
-          );
-        }
-      };
+      // have missed a `task.status` while staying open. Await the coalesced
+      // `status_changes` catch-up (exact — no timer race even if the endpoint is
+      // slow), then reject only if still unresolved (if the catch-up settled the
+      // waiter, it's been unregistered and this is a no-op). Jitter the deadline so
+      // many dashboard charts don't fire at the same instant.
       waiter.giveUpId = window.setTimeout(
         () => {
-          scheduleCatchUp();
-          waiter.giveUpId = window.setTimeout(
-            rejectIfStillPending,
-            GIVE_UP_CATCHUP_GRACE_MS,
-          );
+          catchUpAndWait()
+            .then(() => {
+              if (
+                waiter.taskIds.some(id => waitersByTaskId.get(id)?.has(waiter))
+              ) {
+                settle(
+                  waiter,
+                  new Error('Timed out waiting for chart-data query results'),
+                );
+              }
+            })
+            .catch(() => {});
         },
         pollStaleTimeoutMs + Math.random() * GIVE_UP_JITTER_MS,
       );

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -124,6 +124,12 @@ let pollBackoffMaxMs: number;
 // progress (or waiter registration); it resets on any awaited-task change.
 let pollStaleTimeoutMs: number;
 let lastProgressAt: number;
+// WS-mode give-up (see waitForAsyncData): spread the per-waiter deadline by up to
+// this jitter so many charts don't reach it at the same instant, and — after the
+// last-chance catch-up it triggers — wait this grace for that reconciliation to
+// settle the waiter before rejecting.
+const GIVE_UP_JITTER_MS = 5000;
+const GIVE_UP_CATCHUP_GRACE_MS = 3000;
 let pollingTimeoutId: number;
 // Whether the poll loop is running. It stops entirely when no waiters remain (no
 // idle heartbeat) and is restarted by ``ensurePolling`` when a waiter registers.
@@ -512,13 +518,30 @@ export const waitForAsyncData = async <T = unknown[]>(
     if (wsEnabled) {
       // WS is the transport (no polling). Bound a genuinely-lost completion (a
       // dropped socket message with no reconnect) so a chart can't spin forever;
-      // a reconnect catch-up normally settles it well before this fires.
-      waiter.giveUpId = window.setTimeout(() => {
-        settle(
-          waiter,
-          new Error('Timed out waiting for chart-data query results'),
-        );
-      }, pollStaleTimeoutMs);
+      // a reconnect catch-up normally settles it well before this fires. Before
+      // rejecting, do ONE last-chance reconciliation (not a poll): the socket may
+      // have missed a `task.status` while staying open, so run the coalesced
+      // `status_changes` catch-up and reject only if still unresolved a short grace
+      // later (if the catch-up settles the waiter, `unregister` clears this timer).
+      // Jitter the deadline so many dashboard charts don't fire at the same instant.
+      const rejectIfStillPending = () => {
+        if (waiter.taskIds.some(id => waitersByTaskId.get(id)?.has(waiter))) {
+          settle(
+            waiter,
+            new Error('Timed out waiting for chart-data query results'),
+          );
+        }
+      };
+      waiter.giveUpId = window.setTimeout(
+        () => {
+          scheduleCatchUp();
+          waiter.giveUpId = window.setTimeout(
+            rejectIfStillPending,
+            GIVE_UP_CATCHUP_GRACE_MS,
+          );
+        },
+        pollStaleTimeoutMs + Math.random() * GIVE_UP_JITTER_MS,
+      );
     }
     // Wake the poll loop (poll mode only; a no-op under WS).
     ensurePolling();

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -74,7 +74,7 @@ is from **who** receives it:
 
 The two topics in use:
 
-1. **`entity.changed`** (`scope: authenticated_global`). A best-effort "an entity
+1. **`entity.changed`** (`scope: authenticated_global`). An "an entity
    changed" broadcast whose payload carries only opaque ids
    (`{entity_type, id}`) — no status or sensitive data — so a list view can learn
    that an entity of a type it renders changed and re-fetch just the affected rows
@@ -136,7 +136,7 @@ previous key configured on the websocket service until old cookies and open
 sockets have aged out, then remove it.
 
 The service is stateless apart from process-local live socket handles. Each
-replica subscribes to the same Redis Pub/Sub channel, receives the same best-effort
+replica subscribes to the same Redis Pub/Sub channel, receives the same
 events, and forwards only to matching sockets connected to that replica. Sticky
 sessions are not required; reconnecting to another replica reuses the JWT cookie
 and binds the socket to the same principal channel. Short websocket JWT

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -41,8 +41,10 @@ same browser-visible host.
 
 Realtime events are published to a single Redis **Pub/Sub** channel, `realtime`,
 by the Superset Flask app (`superset/tasks/manager.py`). Pub/Sub is intentionally
-lossy (fire-and-forget): a missed message must be reconciled by a frontend poll or
-REST refetch.
+best-effort (fire-and-forget, at-most-once — no replay): it accelerates each
+feature's authoritative REST/poll path rather than guaranteeing delivery, so a
+message missed during a disconnect is reconciled by a frontend catch-up / REST
+refetch.
 
 Each Redis message is a self-describing envelope that separates **what** a message
 is from **who** receives it:
@@ -72,7 +74,7 @@ is from **who** receives it:
 
 The two topics in use:
 
-1. **`entity.changed`** (`scope: authenticated_global`). A lossy "an entity
+1. **`entity.changed`** (`scope: authenticated_global`). A best-effort "an entity
    changed" broadcast whose payload carries only opaque ids
    (`{entity_type, id}`) — no status or sensitive data — so a list view can learn
    that an entity of a type it renders changed and re-fetch just the affected rows
@@ -134,7 +136,7 @@ previous key configured on the websocket service until old cookies and open
 sockets have aged out, then remove it.
 
 The service is stateless apart from process-local live socket handles. Each
-replica subscribes to the same Redis Pub/Sub channel, receives the same lossy
+replica subscribes to the same Redis Pub/Sub channel, receives the same best-effort
 events, and forwards only to matching sockets connected to that replica. Sticky
 sessions are not required; reconnecting to another replica reuses the JWT cookie
 and binds the socket to the same principal channel. Short websocket JWT

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -496,9 +496,10 @@ export const routeRedisMessage = (
  * every browser-bound message (broadcast and targeted, distinguished by each
  * envelope's scope).
  *
- * Pub/Sub is lossy and not replayable, so there is no server-side catch-up: a
- * message published while a socket was away is simply gone, and the browser's
- * interval poll is the correctness backstop.
+ * Pub/Sub is best-effort and not replayable, so there is no server-side catch-up:
+ * a message published while a socket was away is simply gone. The browser recovers
+ * by reconciling through the authorized REST API — a ``status_changes`` catch-up on
+ * (re)connect and a last-chance read before giving up — not an interval poll.
  *
  * Failure to subscribe at all is observable and self-healing rather than silent:
  * if the initial ``subscribe`` rejects (e.g. Redis unreachable at startup) it is

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1630,12 +1630,26 @@ class ChartDataQueryContextSchema(Schema):
         allow_none=True,
     )
 
+    tab_id = fields.String(
+        metadata={
+            "description": "Opaque per-browser-tab id (see the frontend `getTabId`). "
+            "On an async request it ref-counts this tab as a consumer of the shared "
+            "chart-data task so a cancel/navigate-away from one tab doesn't abort a "
+            "task another tab still awaits. Read by the API as a request-level "
+            "routing hint; not part of the query context."
+        },
+        required=False,
+        allow_none=True,
+    )
+
     # pylint: disable=unused-argument
     @post_load
     def make_query_context(self, data: dict[str, Any], **kwargs: Any) -> QueryContext:
-        # ``async_mode`` is a request-level flag (read by the API to decide sync vs
-        # async), not part of the QueryContext, so drop it before building one.
+        # ``async_mode`` and ``tab_id`` are request-level hints (read by the API to
+        # decide sync vs async and to route the per-tab subscription), not part of
+        # the QueryContext, so drop them before building one.
         data.pop("async_mode", None)
+        data.pop("tab_id", None)
         query_context = self.get_query_context_factory().create(**data)
         return query_context
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -2984,7 +2984,7 @@ GLOBAL_ASYNC_QUERIES_DEFAULT = True
 # Two delivery scopes, carried on one best-effort `realtime` pub/sub channel as a
 # self-describing `{topic, scope, routes, payload}` envelope:
 #   - `authenticated_global` — a broadcast nudge (e.g. topic `entity.changed`,
-#     opaque entity ids only) delivered to every authenticated socket for best-effort
+#     opaque entity ids only) delivered to every authenticated socket for
 #     list-view activity, and
 #   - `principal`/`tab` — targeted messages (e.g. topic `task.status` for the
 #     dashboard chart-data path), fanned out by the websocket server to the

--- a/superset/config.py
+++ b/superset/config.py
@@ -2981,10 +2981,10 @@ GLOBAL_ASYNC_QUERIES_DEFAULT = True
 # reconciles anything missed (the interval poll is used only when the websocket is
 # disabled). Requires the superset-websocket server, a Redis coordination
 # backend (DISTRIBUTED_COORDINATION_CONFIG), and `can_read` on `Realtime`.
-# Two delivery scopes, carried on one lossy `realtime` pub/sub channel as a
+# Two delivery scopes, carried on one best-effort `realtime` pub/sub channel as a
 # self-describing `{topic, scope, routes, payload}` envelope:
 #   - `authenticated_global` — a broadcast nudge (e.g. topic `entity.changed`,
-#     opaque entity ids only) delivered to every authenticated socket for lossy
+#     opaque entity ids only) delivered to every authenticated socket for best-effort
 #     list-view activity, and
 #   - `principal`/`tab` — targeted messages (e.g. topic `task.status` for the
 #     dashboard chart-data path), fanned out by the websocket server to the

--- a/superset/coordination/base.py
+++ b/superset/coordination/base.py
@@ -80,12 +80,14 @@ class CoordinationService:
       that connection instead of the shared coordinator.
     - **Await / notify** — ``notify`` (signal) plus ``wait_for_signal``
       (blocking) and ``listen_for_signal`` (background), combining a channel with a
-      caller-supplied predicate. Signals ride Redis Streams; because stream entries
-      are persisted, a waiter that reads slightly late, reconnects, or fails over
-      still receives them. With a backend the waiter blocks on the stream and wakes
-      when a signal lands (event-driven, no polling); without a backend it polls the
-      predicate. The predicate is the source of truth, so a duplicate or already-seen
-      signal is harmless.
+      caller-supplied predicate. Signals ride Redis Streams rather than pub/sub:
+      stream entries are persisted, so — unlike at-most-once pub/sub, which a waiter
+      that subscribed slightly late or reconnected would simply miss — a waiter that
+      reads slightly late, reconnects, or fails over still receives them. With a
+      backend the waiter blocks on the stream and wakes when a signal lands
+      (event-driven, no polling); without a backend it polls the predicate. The
+      predicate is the source of truth, so a duplicate or already-seen signal is
+      harmless.
 
     All methods are class-level: the service is app-global. Calls resolve the shared
     coordination backend from ``DISTRIBUTED_COORDINATION_CONFIG`` on each call, except

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -269,9 +269,9 @@ class TaskWrapper(Generic[P]):
                 depends_on=self.default_options.depends_on,
             )
 
-        # Merge: use override if provided, otherwise use default
-        # For timeout: if override_options.timeout is explicitly set (even to None),
-        # use it; otherwise fall back to decorator default
+        # Merge: use override if provided, otherwise use default.
+        # For timeout: use the override only when it is a concrete value; ``None``
+        # (the default) falls back to the decorator timeout — it does not disable it.
         return TaskOptions(
             task_key=override_options.task_key or self.default_options.task_key,
             task_name=override_options.task_name or self.default_options.task_name,

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -251,11 +251,9 @@ class TaskWrapper(Generic[P]):
         """
         Merge decorator defaults with call-time overrides.
 
-        Call-time options take precedence over decorator defaults. For ``timeout``,
-        ``None`` (the default) means "inherit the decorator's timeout"; a call-time
-        ``TaskOptions.timeout`` only overrides when it is a concrete value. There is
-        therefore no way to *disable* a decorator timeout for a single call — pass a
-        distinct value instead. (A sentinel could add that if a use case needs it.)
+        Call-time options take precedence over decorator defaults. A call-time
+        ``timeout`` overrides only when set to a concrete value; ``None`` inherits
+        the decorator's timeout.
 
         Args:
             override_options: Options provided at call time, or None

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -251,8 +251,11 @@ class TaskWrapper(Generic[P]):
         """
         Merge decorator defaults with call-time overrides.
 
-        Call-time options take precedence over decorator defaults.
-        For timeout, an explicit None in TaskOptions disables the decorator timeout.
+        Call-time options take precedence over decorator defaults. For ``timeout``,
+        ``None`` (the default) means "inherit the decorator's timeout"; a call-time
+        ``TaskOptions.timeout`` only overrides when it is a concrete value. There is
+        therefore no way to *disable* a decorator timeout for a single call — pass a
+        distinct value instead. (A sentinel could add that if a use case needs it.)
 
         Args:
             override_options: Options provided at call time, or None

--- a/superset/tasks/locks.py
+++ b/superset/tasks/locks.py
@@ -118,8 +118,20 @@ def task_lock(dedup_key: str) -> Iterator[None]:
         yield
     finally:
         # Release (delete) BEFORE notifying, so a woken waiter sees the freed lock.
-        # notify() needs a backend; without one, waiters are on the poll fallback.
-        ReleaseDistributedLock("gtf:task", params, token=acquire.token).run()
-        if CoordinationService.is_backend_defined():
-            CoordinationService.notify(release_channel)
-        logger.debug("Released task lock for key: %s", dedup_key)
+        # Best-effort: a release/notify failure must NOT propagate out of the lock.
+        # This teardown runs after the caller's create-or-join transaction has
+        # committed, so letting it escape would skip the caller's post-commit work
+        # (notably enqueuing the Celery job in submit_task), stranding a committed
+        # PENDING task the reaper won't reclaim. The lock's TTL reclaims the lock.
+        try:
+            ReleaseDistributedLock("gtf:task", params, token=acquire.token).run()
+            if CoordinationService.is_backend_defined():
+                CoordinationService.notify(release_channel)
+            logger.debug("Released task lock for key: %s", dedup_key)
+        except Exception:  # noqa: BLE001  pylint: disable=broad-except
+            logger.warning(
+                "Best-effort release/notify of task lock %s failed; the lock TTL "
+                "will reclaim it",
+                dedup_key,
+                exc_info=True,
+            )

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -96,7 +96,7 @@ class TaskManager:
 
         cls._initialized = True
 
-    # Single lossy Pub/Sub channel carrying every browser-bound realtime message
+    # Single best-effort Pub/Sub channel carrying every browser-bound realtime message
     # (superset-websocket subscribes to just this one). Each message is a
     # self-describing envelope ``{topic, scope, routes, payload}``:
     #   - ``topic``   - the semantic stream (``task.status``, ``entity.changed``,
@@ -112,7 +112,7 @@ class TaskManager:
     # This separates the semantic topic (what a message is) from the route (who
     # receives it): a new surface adds a topic without inventing channel names or
     # overloading payload shapes. The channel name and envelope shape are a
-    # wire-protocol contract with the Node server. Pub/Sub is lossy, so no message
+    # wire-protocol contract with the Node server. Pub/Sub is best-effort, so no message
     # here may carry a signal a receiver must not miss — each feature's authorized
     # REST poll/fetch is the correctness backstop.
     REALTIME_CHANNEL = "realtime"
@@ -177,7 +177,7 @@ class TaskManager:
 
     @classmethod
     def publish_entity_change(cls, task_uuid: UUID) -> bool:
-        """Publish a lossy, opaque "entity changed" nudge for realtime UIs.
+        """Publish a best-effort, opaque "entity changed" nudge for realtime UIs.
 
         Best-effort broadcast (may be dropped) carrying only ``{entity_type, id}``
         (the integer primary key, which a realtime list view matches and refetches

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -179,7 +179,7 @@ class TaskManager:
 
     @classmethod
     def publish_entity_change(cls, task_uuid: UUID) -> bool:
-        """Publish a best-effort, opaque "entity changed" nudge for realtime UIs.
+        """Publish an opaque "entity changed" nudge for realtime UIs.
 
         Best-effort broadcast (may be dropped) carrying only ``{entity_type, id}``
         (the integer primary key, which a realtime list view matches and refetches

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -112,9 +112,11 @@ class TaskManager:
     # This separates the semantic topic (what a message is) from the route (who
     # receives it): a new surface adds a topic without inventing channel names or
     # overloading payload shapes. The channel name and envelope shape are a
-    # wire-protocol contract with the Node server. Pub/Sub is best-effort, so no message
-    # here may carry a signal a receiver must not miss — each feature's authorized
-    # REST poll/fetch is the correctness backstop.
+    # wire-protocol contract with the Node server. Pub/Sub is best-effort, so no
+    # message here may carry a signal a receiver must not miss — each feature's
+    # authorized REST poll/fetch is the correctness backstop today. Moving a surface
+    # to websocket-only (retiring its poll) requires guaranteed, replayable delivery
+    # first (e.g. Redis Streams with a per-consumer cursor).
     REALTIME_CHANNEL = "realtime"
 
     # Envelope topics.

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -114,8 +114,8 @@ class TaskManager:
     # overloading payload shapes. The channel name and envelope shape are a
     # wire-protocol contract with the Node server. Pub/Sub is best-effort, so no
     # message here may carry a signal a receiver must not miss — each feature's
-    # authorized REST poll/fetch is the correctness backstop today. Moving a surface
-    # to websocket-only (retiring its poll) requires guaranteed, replayable delivery
+    # authorized REST poll/fetch is the correctness backstop. Moving a surface to
+    # websocket-only (retiring its poll) requires guaranteed, replayable delivery
     # first (e.g. Redis Streams with a per-consumer cursor).
     REALTIME_CHANNEL = "realtime"
 

--- a/superset/websocket/channel.py
+++ b/superset/websocket/channel.py
@@ -25,7 +25,7 @@ routing key.
 
 Targeted messages (``scope=principal``/``tab``) are delivered only to sockets
 bound to the intended routing key. Broadcast messages (``scope=authenticated_global``,
-e.g. the lossy ``entity.changed`` list-view nudge) go to all authenticated
+e.g. the best-effort ``entity.changed`` list-view nudge) go to all authenticated
 realtime sockets but carry only opaque entity nudges - see
 ``TaskManager.publish_entity_change``.
 """

--- a/superset/websocket/channel.py
+++ b/superset/websocket/channel.py
@@ -25,7 +25,7 @@ routing key.
 
 Targeted messages (``scope=principal``/``tab``) are delivered only to sockets
 bound to the intended routing key. Broadcast messages (``scope=authenticated_global``,
-e.g. the best-effort ``entity.changed`` list-view nudge) go to all authenticated
+e.g. the ``entity.changed`` list-view nudge) go to all authenticated
 realtime sockets but carry only opaque entity nudges - see
 ``TaskManager.publish_entity_change``.
 """

--- a/tests/unit_tests/charts/data/test_empty_query_context.py
+++ b/tests/unit_tests/charts/data/test_empty_query_context.py
@@ -27,6 +27,11 @@ def test_query_context_schema_accepts_empty_queries(app_context: Any) -> None:
     list and every layer is fetched client-side. The schema must accept
     that shape so the container chart can flow through /api/v1/chart/data,
     and the processor must return an empty result list for it.
+
+    Also exercises the request-level ``async_mode`` / ``tab_id`` hints the async
+    chart-data POST sends at the top level: the schema must accept and drop them
+    (``tab_id`` in particular is read by the API via ``get_request_tab_id``), not
+    reject ``tab_id`` as an unknown field — which would 400 every async request.
     """
     with patch(
         "superset.common.query_context_factory.DatasourceDAO.get_datasource",
@@ -38,6 +43,8 @@ def test_query_context_schema_accepts_empty_queries(app_context: Any) -> None:
                 "queries": [],
                 "result_format": "json",
                 "result_type": "full",
+                "async_mode": True,
+                "tab_id": "abc123",
             }
         )
     assert query_context.queries == []


### PR DESCRIPTION
### SUMMARY

Follow-ups after PR #43768 merged into `gaq-to-gtf`: a chart-data async regression fix, a stranded-PENDING hardening from a fresh review, and a documentation reframing of the realtime transport.

**Fixes**
- **Async chart-data 400 (`tab_id` unknown field).** The async chart-data POST sends a top-level `tab_id` (it ref-counts the browser tab as a consumer of the shared task; read by the API via `get_request_tab_id`). `ChartDataQueryContextSchema` neither declared nor excluded it, so marshmallow rejected **every** async request with `Request is incorrect: {'tab_id': ['Unknown field.']}`. `tab_id` is now declared and dropped in `make_query_context`, mirroring how `async_mode` is already handled (both are request-level hints, not query-context state). Pre-existing on `gaq-to-gtf`; surfaces whenever async chart data actually runs.
- **Stranded committed PENDING task (review finding).** `task_lock`'s teardown runs *after* the create-or-join transaction commits. On the no-Redis (KV) path a release failure raised and propagated out of the lock, skipping the caller's post-commit work — notably `execute_task.delay()` in `submit_task` — leaving a committed `PENDING` row with no heartbeat that the reaper won't reclaim. Release/notify is now **best-effort** (logged and swallowed); the lock's TTL reclaims the lock. (The broader crash-window between commit and enqueue remains the documented transactional-outbox follow-up.)

**Docs / framing**
- **Reframe the realtime transport as best-effort, not "lossy."** Redis Pub/Sub to a connected, healthy socket doesn't routinely drop messages; the realistic loss window is a *disconnect*, which the catch-up on reconnect/registration reconciles, over an authoritative `status_changes`/REST source. Reworded `UPDATING.md`, the websocket README, and the config/code comments accordingly so the wording stops reading as "drops messages routinely."
- **Point at the real trajectory.** The realtime-channel comment now states plainly that moving a surface to **websocket-only** (retiring its poll) requires guaranteed, replayable delivery first (e.g. Redis Streams with a per-consumer cursor) — best-effort Pub/Sub is only adequate while the REST poll remains the correctness backstop. (Analysis-only for now; see below.)
- **Minor:** correct the `_merge_options` `timeout` docstring — `None` inherits the decorator timeout (matching the implementation and its tests), it does not disable it.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/charts/data/test_empty_query_context.py \
  tests/unit_tests/tasks/test_timeout.py tests/unit_tests/tasks/test_decorators.py \
  tests/unit_tests/distributed_lock/
```

- The schema regression is covered by folding `async_mode`/`tab_id` into the existing `test_query_context_schema_accepts_empty_queries` (a body carrying both loads without a `ValidationError`).
- Manual: with `GLOBAL_ASYNC_QUERIES` on, open a dashboard and confirm charts no longer 400 with the `tab_id` error and resolve normally.

### ADDITIONAL INFORMATION

Roadmap note (analysis only, no code here): as more surfaces move to **websocket-exclusive** delivery and retire their polling fallback, best-effort Pub/Sub is no longer sufficient — those surfaces will need **guaranteed, replayable delivery** (Redis Streams with a per-consumer/replay cursor). The server↔server coordination layer already uses Streams; extending that to the browser transport is the enabling prerequisite for the ws-only direction and is called out in the code comment rather than built here.

Not included (deliberately): a hard fail-closed default for the websocket server's `ALLOWED_ORIGINS` — origin/network configuration is operator-owned per `SECURITY.md`, and the README already documents setting an allowlist; happy to add a startup warning if maintainers prefer.

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (the `tab_id` fix affects the async path); optional `WEBSOCKET_ENABLE`
- [ ] Changes UI
- [x] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351)) — no
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
