### PR TITLE
chore: fix typos in comments and docstrings

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -94,7 +94,7 @@ EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True
 
-# This config is used to enable/disable the folowing security menu items:
+# This config is used to enable/disable the following security menu items:
 # List Users, List Roles, List Groups
 SUPERSET_SECURITY_VIEW_MENU = True
 
@@ -2703,7 +2703,7 @@ DATABASE_OAUTH2_CLIENTS: dict[str, dict[str, Any]] = {
     # },
 }
 
-# OAuth2 state is encoded in a JWT using the alogorithm below.
+# OAuth2 state is encoded in a JWT using the algorithm below.
 DATABASE_OAUTH2_JWT_ALGORITHM = "HS256"
 
 # By default the redirect URI points to /api/v1/database/oauth2/ and doesn't have to be

--- a/superset/databases/filters.py
+++ b/superset/databases/filters.py
@@ -45,7 +45,7 @@ class DatabaseFilter(BaseFilter):  # pylint: disable=too-few-public-methods
         """
         Dynamic Filters need to be applied to the Query before we filter
         databases with anything else. This way you can show/hide databases using
-        Feature Flags for example in conjuction with the regular role filtering.
+        Feature Flags for example in conjunction with the regular role filtering.
         If not, if an user has access to all Databases it would skip this dynamic
         filtering.
         """

--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -1586,7 +1586,7 @@ class QualifiedTableSchema(Schema):
     """
     Schema for a qualified table reference.
 
-    Catalog and schema can be ommited, to fallback to default values. Table name must be
+    Catalog and schema can be omitted, to fallback to default values. Table name must be
     present.
     """
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1715,7 +1715,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         response["id"] = table.id
         response[API_RESULT_RES_KEY] = show_model_schema.dump(table, many=False)
 
-        # remove folders from resposne if `DATASET_FOLDERS` is disabled, so that it's
+        # remove folders from response if `DATASET_FOLDERS` is disabled, so that it's
         # possible to inspect if the feature is supported or not
         if (
             not is_feature_enabled("DATASET_FOLDERS")

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -1038,7 +1038,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             if engine.dialect.identifier_preparer._double_percents:  # noqa
                 sql = sql.replace("%%", "%")
 
-        # for nwo we only optimize queries on virtual datasources, since the only
+        # for now we only optimize queries on virtual datasources, since the only
         # optimization available is predicate pushdown
         if is_feature_enabled("OPTIMIZE_SQL") and is_virtual:
             script = SQLScript(sql, self.db_engine_spec.engine).optimize()

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -726,7 +726,7 @@ def cancel_query(query: Query) -> bool:
     """
     Cancel a running query.
 
-    Note some engines implicitly handle the cancelation of a query and thus no explicit
+    Note some engines implicitly handle the cancellation of a query and thus no explicit
     action is required.
 
     :param query: Query to cancel

--- a/superset/utils/oauth2.py
+++ b/superset/utils/oauth2.py
@@ -102,7 +102,7 @@ def get_oauth2_access_token(
     return a fresh token and store it in the database for further requests. The function
     has a retry decorator, in case a dashboard with multiple charts triggers
     simultaneous requests for refreshing a stale token; in that case only the first
-    process to acquire the lock will perform the refresh, and othe process should find a
+    process to acquire the lock will perform the refresh, and other processes should find
     a valid token when they retry.
     """  # noqa: E501
     # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
### SUMMARY

Fixes eight spelling mistakes in Python comments and docstrings found with `codespell` (`folowing`, `alogorithm`, `cancelation`, `conjuction`, `ommited`, `resposne`, `othe`, `nwo`). While fixing `othe` in `superset/utils/oauth2.py` I also removed a duplicated `a` that ran across the line break in the same sentence.

No identifiers, behaviour, or user-facing strings changed. Deliberately left alone: `unparseable` (an accepted variant, used consistently across the codebase), `selectin` (a SQLAlchemy loading strategy), `astroid` (a real library), `fave` (Superset's own term), and typos inside historical `migrations/versions/` files.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — comments only.

### TESTING INSTRUCTIONS

None required; no code paths changed. All touched files still parse.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API