### PR TITLE
feat(build): use Webpack's native CSS handling

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -175,7 +175,6 @@
         "@emotion/babel-plugin": "^11.13.5",
         "@emotion/jest": "^11.14.2",
         "@formatjs/intl-durationformat": "^0.10.18",
-        "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@playwright/test": "^1.62.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.3",
         "@storybook/addon-docs": "10.5.10",
@@ -4850,22 +4849,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/nyc-config-typescript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
-      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "nyc": ">=15"
       }
     },
     "node_modules/@istanbuljs/schema": {

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -160,7 +160,6 @@
         "@babel/cli": "^7.29.7",
         "@babel/compat-data": "^7.28.4",
         "@babel/core": "^7.29.7",
-        "@babel/eslint-parser": "^7.29.7",
         "@babel/node": "^7.29.7",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-export-namespace-from": "^7.29.7",
@@ -222,7 +221,6 @@
         "concurrently": "^10.0.5",
         "copy-webpack-plugin": "^14.0.0",
         "cross-env": "^10.1.0",
-        "css-loader": "^7.1.4",
         "eslint": "^10.9.0",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^4.4.5",
@@ -250,7 +248,6 @@
         "jsdom": "^30.0.1",
         "lerna": "^10.0.1",
         "lightningcss": "^1.33.0",
-        "mini-css-extract-plugin": "^2.10.2",
         "minimizer-webpack-plugin": "^5.6.1",
         "open-cli": "^9.0.0",
         "oxfmt": "^0.65.0",
@@ -266,7 +263,6 @@
         "source-map-support": "^0.5.21",
         "speed-measure-webpack-plugin": "^1.6.0",
         "storybook": "10.5.10",
-        "style-loader": "^4.0.0",
         "stylelint": "^17.14.1",
         "swc-loader": "^0.2.7",
         "ts-jest": "^29.4.12",
@@ -601,35 +597,6 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
-      "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
@@ -6717,16 +6684,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -20245,40 +20202,6 @@
       "resolved": "eslint-rules/eslint-plugin-theme-colors",
       "link": true
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-scope/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -29660,27 +29583,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
-      "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "schema-utils": "^4.0.0",
-        "tapable": "^2.2.1"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
@@ -29704,16 +29606,16 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
+      "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
+        "schema-utils": "^4.3.3",
+        "terser": "^5.51.0"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -38732,14 +38634,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -40944,9 +40846,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.109.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
-      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+      "version": "5.110.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
+      "integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -40960,11 +40862,10 @@
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.24.4",
         "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
         "mime-db": "^1.54.0",
-        "minimizer-webpack-plugin": "^5.6.1",
+        "minimizer-webpack-plugin": "^5.7.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -252,7 +252,6 @@
     "@emotion/babel-plugin": "^11.13.5",
     "@emotion/jest": "^11.14.2",
     "@formatjs/intl-durationformat": "^0.10.18",
-    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@playwright/test": "^1.62.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.3",
     "@storybook/addon-docs": "10.5.10",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -237,7 +237,6 @@
     "@babel/cli": "^7.29.7",
     "@babel/compat-data": "^7.28.4",
     "@babel/core": "^7.29.7",
-    "@babel/eslint-parser": "^7.29.7",
     "@babel/node": "^7.29.7",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-export-namespace-from": "^7.29.7",
@@ -299,7 +298,6 @@
     "concurrently": "^10.0.5",
     "copy-webpack-plugin": "^14.0.0",
     "cross-env": "^10.1.0",
-    "css-loader": "^7.1.4",
     "eslint": "^10.9.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^4.4.5",
@@ -327,7 +325,6 @@
     "jsdom": "^30.0.1",
     "lerna": "^10.0.1",
     "lightningcss": "^1.33.0",
-    "mini-css-extract-plugin": "^2.10.2",
     "minimizer-webpack-plugin": "^5.6.1",
     "open-cli": "^9.0.0",
     "oxfmt": "^0.65.0",
@@ -343,7 +340,6 @@
     "source-map-support": "^0.5.21",
     "speed-measure-webpack-plugin": "^1.6.0",
     "storybook": "10.5.10",
-    "style-loader": "^4.0.0",
     "stylelint": "^17.14.1",
     "swc-loader": "^0.2.7",
     "ts-jest": "^29.4.12",
@@ -368,9 +364,6 @@
     "regenerator-runtime": "^0.14.1"
   },
   "overrides": {
-    "@babel/eslint-parser": {
-      "eslint": "$eslint"
-    },
     "@deck.gl/aggregation-layers": "~9.2.5",
     "@deck.gl/core": "~9.2.5",
     "@deck.gl/extensions": "~9.2.5",

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -25,7 +25,6 @@ const { ModuleFederationPlugin } = webpack.container;
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MinimizerPlugin = require('minimizer-webpack-plugin');
 const LightningCSS = require('lightningcss');
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
@@ -100,6 +99,10 @@ const output = {
 
 if (!isDevMode) {
   output.clean = true;
+  // CSS extraction for production builds
+  output.cssFilename = '[name].[chunkhash].entry.css';
+  output.cssChunkFilename = '[name].[chunkhash].chunk.css';
+  output.publicPath = MINI_CSS_EXTRACT_PUBLICPATH;
 }
 
 const plugins = [
@@ -217,13 +220,6 @@ if (isDevMode) {
 }
 
 if (!isDevMode) {
-  // CSS extraction for production builds
-  plugins.push(
-    new MiniCssExtractPlugin({
-      filename: '[name].[chunkhash].entry.css',
-      chunkFilename: '[name].[chunkhash].chunk.css',
-    }),
-  );
 }
 
 // TypeScript type checking and .d.ts generation
@@ -338,6 +334,9 @@ const config = {
     spa: addPreamble('src/views/index.tsx'),
     embedded: addPreamble('src/embedded/index.tsx'),
     'service-worker': path.join(APP_DIR, 'src/service-worker.ts'),
+  },
+  experiments: {
+    css: true,
   },
   cache: {
     type: 'filesystem',
@@ -530,22 +529,7 @@ const config = {
       {
         test: /\.css$/,
         include: [APP_DIR, /superset-ui.+\/src/],
-        use: [
-          isDevMode
-            ? 'style-loader'
-            : {
-                loader: MiniCssExtractPlugin.loader,
-                options: {
-                  publicPath: MINI_CSS_EXTRACT_PUBLICPATH,
-                },
-              },
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: !isDevMode,
-            },
-          },
-        ],
+        type: 'css/auto',
       },
       /* for css linking images (and viz plugin thumbnails) */
       {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->
feat(build): use Webpack's native CSS handling

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Webpack 5.110.0+ has introduced a built-in [CSS handling](https://webpack.js.org/blog/2026-08-29-webpack-5-110/#native-css-is-the-way-forward) to replace usage from external `mini-css-extract-plugin`, `style-loader` and `css-loader`.  This PR is to put that feature into usage.

Also there are removal of unused dev deps of `@istanbuljs/nyc-config-typescript` and `@babel/eslint-parser`.

Most pages are still good after rebuilding frontend both in DEV and PROD mode.

<img width="1511" height="773" alt="image" src="https://github.com/user-attachments/assets/79c22018-380a-4226-91ba-9773a560c2ab" />
<img width="1511" height="773" alt="image" src="https://github.com/user-attachments/assets/70840e40-e9d1-4dc2-9406-14332dc97fb9" />
<img width="1511" height="773" alt="image" src="https://github.com/user-attachments/assets/5005cf7a-ac7d-4869-8e16-09fb960ba7ca" />



### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
N/A

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Run `npm run dev-server`
2. Run `docker compose up superset` in another terminal
3. Go around different pages for sanity testing

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
