### PR TITLE
chore(api): regenerate the OpenAPI spec

### DIFF
--- a/docs/developer_docs_versioned_docs/version-6.1.0/api.mdx
+++ b/docs/developer_docs_versioned_docs/version-6.1.0/api.mdx
@@ -49,10 +49,10 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                               | Description                     |
 | ------ | ---------------------------------------------------------------------- | ------------------------------- |
-| `GET`  | [Get the CSRF token](/developer-docs/api/get-the-csrf-token)           | `/api/v1/security/csrf_token/`  |
-| `POST` | [Get a guest token](/developer-docs/api/get-a-guest-token)             | `/api/v1/security/guest_token/` |
-| `POST` | [Create security login](/developer-docs/api/create-security-login)     | `/api/v1/security/login`        |
-| `POST` | [Create security refresh](/developer-docs/api/create-security-refresh) | `/api/v1/security/refresh`      |
+| `GET`  | [Get the CSRF token](/developer-docs/6.1.0/api/get-the-csrf-token)           | `/api/v1/security/csrf_token/`  |
+| `POST` | [Get a guest token](/developer-docs/6.1.0/api/get-a-guest-token)             | `/api/v1/security/guest_token/` |
+| `POST` | [Create security login](/developer-docs/6.1.0/api/create-security-login)     | `/api/v1/security/login`        |
+| `POST` | [Create security refresh](/developer-docs/6.1.0/api/create-security-refresh) | `/api/v1/security/refresh`      |
 
 ---
 
@@ -65,34 +65,34 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                               | Description                                          |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `DELETE` | [Bulk delete dashboards](/developer-docs/api/bulk-delete-dashboards)                                                                                                   | `/api/v1/dashboard/`                                 |
-| `GET`    | [Get a list of dashboards](/developer-docs/api/get-a-list-of-dashboards)                                                                                               | `/api/v1/dashboard/`                                 |
-| `POST`   | [Create a new dashboard](/developer-docs/api/create-a-new-dashboard)                                                                                                   | `/api/v1/dashboard/`                                 |
-| `GET`    | [Get metadata information about this API resource (dashboard--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-dashboard-info)              | `/api/v1/dashboard/_info`                            |
-| `GET`    | [Get a dashboard detail information](/developer-docs/api/get-a-dashboard-detail-information)                                                                           | `/api/v1/dashboard/{id_or_slug}`                     |
-| `GET`    | [Get a dashboard's chart definitions.](/developer-docs/api/get-a-dashboards-chart-definitions)                                                                         | `/api/v1/dashboard/{id_or_slug}/charts`              |
-| `POST`   | [Create a copy of an existing dashboard](/developer-docs/api/create-a-copy-of-an-existing-dashboard)                                                                   | `/api/v1/dashboard/{id_or_slug}/copy/`               |
-| `GET`    | [Get dashboard's datasets](/developer-docs/api/get-dashboards-datasets)                                                                                                | `/api/v1/dashboard/{id_or_slug}/datasets`            |
-| `DELETE` | [Delete a dashboard's embedded configuration](/developer-docs/api/delete-a-dashboards-embedded-configuration)                                                          | `/api/v1/dashboard/{id_or_slug}/embedded`            |
-| `GET`    | [Get the dashboard's embedded configuration](/developer-docs/api/get-the-dashboards-embedded-configuration)                                                            | `/api/v1/dashboard/{id_or_slug}/embedded`            |
-| `POST`   | [Set a dashboard's embedded configuration](/developer-docs/api/set-a-dashboards-embedded-configuration)                                                                | `/api/v1/dashboard/{id_or_slug}/embedded`            |
-| `PUT`    | [Update dashboard by id_or_slug embedded](/developer-docs/api/update-dashboard-by-id-or-slug-embedded)                                                                 | `/api/v1/dashboard/{id_or_slug}/embedded`            |
-| `GET`    | [Get dashboard's tabs](/developer-docs/api/get-dashboards-tabs)                                                                                                        | `/api/v1/dashboard/{id_or_slug}/tabs`                |
-| `DELETE` | [Delete a dashboard](/developer-docs/api/delete-a-dashboard)                                                                                                           | `/api/v1/dashboard/{pk}`                             |
-| `PUT`    | [Update a dashboard](/developer-docs/api/update-a-dashboard)                                                                                                           | `/api/v1/dashboard/{pk}`                             |
-| `POST`   | [Compute and cache a screenshot (dashboard-pk-cache-dashboard-screenshot)](/developer-docs/api/compute-and-cache-a-screenshot-dashboard-pk-cache-dashboard-screenshot) | `/api/v1/dashboard/{pk}/cache_dashboard_screenshot/` |
-| `PUT`    | [Update chart customizations configuration for a dashboard.](/developer-docs/api/update-chart-customizations-configuration-for-a-dashboard)                            | `/api/v1/dashboard/{pk}/chart_customizations`        |
-| `PUT`    | [Update colors configuration for a dashboard.](/developer-docs/api/update-colors-configuration-for-a-dashboard)                                                        | `/api/v1/dashboard/{pk}/colors`                      |
-| `GET`    | [Export dashboard as example bundle](/developer-docs/api/export-dashboard-as-example-bundle)                                                                           | `/api/v1/dashboard/{pk}/export_as_example/`          |
-| `DELETE` | [Remove the dashboard from the user favorite list](/developer-docs/api/remove-the-dashboard-from-the-user-favorite-list)                                               | `/api/v1/dashboard/{pk}/favorites/`                  |
-| `POST`   | [Mark the dashboard as favorite for the current user](/developer-docs/api/mark-the-dashboard-as-favorite-for-the-current-user)                                         | `/api/v1/dashboard/{pk}/favorites/`                  |
-| `PUT`    | [Update native filters configuration for a dashboard.](/developer-docs/api/update-native-filters-configuration-for-a-dashboard)                                        | `/api/v1/dashboard/{pk}/filters`                     |
-| `GET`    | [Get a computed screenshot from cache (dashboard-pk-screenshot-digest)](/developer-docs/api/get-a-computed-screenshot-from-cache-dashboard-pk-screenshot-digest)       | `/api/v1/dashboard/{pk}/screenshot/{digest}/`        |
-| `GET`    | [Get dashboard's thumbnail](/developer-docs/api/get-dashboards-thumbnail)                                                                                              | `/api/v1/dashboard/{pk}/thumbnail/{digest}/`         |
-| `GET`    | [Download multiple dashboards as YAML files](/developer-docs/api/download-multiple-dashboards-as-yaml-files)                                                           | `/api/v1/dashboard/export/`                          |
-| `GET`    | [Check favorited dashboards for current user](/developer-docs/api/check-favorited-dashboards-for-current-user)                                                         | `/api/v1/dashboard/favorite_status/`                 |
-| `POST`   | [Import dashboard(s) with associated charts/datasets/databases](/developer-docs/api/import-dashboard-s-with-associated-charts-datasets-databases)                      | `/api/v1/dashboard/import/`                          |
-| `GET`    | [Get related fields data (dashboard-related-column-name)](/developer-docs/api/get-related-fields-data-dashboard-related-column-name)                                   | `/api/v1/dashboard/related/{column_name}`            |
+| `DELETE` | [Bulk delete dashboards](/developer-docs/6.1.0/api/bulk-delete-dashboards)                                                                                                   | `/api/v1/dashboard/`                                 |
+| `GET`    | [Get a list of dashboards](/developer-docs/6.1.0/api/get-a-list-of-dashboards)                                                                                               | `/api/v1/dashboard/`                                 |
+| `POST`   | [Create a new dashboard](/developer-docs/6.1.0/api/create-a-new-dashboard)                                                                                                   | `/api/v1/dashboard/`                                 |
+| `GET`    | [Get metadata information about this API resource (dashboard--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-dashboard-info)              | `/api/v1/dashboard/_info`                            |
+| `GET`    | [Get a dashboard detail information](/developer-docs/6.1.0/api/get-a-dashboard-detail-information)                                                                           | `/api/v1/dashboard/{id_or_slug}`                     |
+| `GET`    | [Get a dashboard's chart definitions.](/developer-docs/6.1.0/api/get-a-dashboards-chart-definitions)                                                                         | `/api/v1/dashboard/{id_or_slug}/charts`              |
+| `POST`   | [Create a copy of an existing dashboard](/developer-docs/6.1.0/api/create-a-copy-of-an-existing-dashboard)                                                                   | `/api/v1/dashboard/{id_or_slug}/copy/`               |
+| `GET`    | [Get dashboard's datasets](/developer-docs/6.1.0/api/get-dashboards-datasets)                                                                                                | `/api/v1/dashboard/{id_or_slug}/datasets`            |
+| `DELETE` | [Delete a dashboard's embedded configuration](/developer-docs/6.1.0/api/delete-a-dashboards-embedded-configuration)                                                          | `/api/v1/dashboard/{id_or_slug}/embedded`            |
+| `GET`    | [Get the dashboard's embedded configuration](/developer-docs/6.1.0/api/get-the-dashboards-embedded-configuration)                                                            | `/api/v1/dashboard/{id_or_slug}/embedded`            |
+| `POST`   | [Set a dashboard's embedded configuration](/developer-docs/6.1.0/api/set-a-dashboards-embedded-configuration)                                                                | `/api/v1/dashboard/{id_or_slug}/embedded`            |
+| `PUT`    | [Update dashboard by id_or_slug embedded](/developer-docs/6.1.0/api/update-dashboard-by-id-or-slug-embedded)                                                                 | `/api/v1/dashboard/{id_or_slug}/embedded`            |
+| `GET`    | [Get dashboard's tabs](/developer-docs/6.1.0/api/get-dashboards-tabs)                                                                                                        | `/api/v1/dashboard/{id_or_slug}/tabs`                |
+| `DELETE` | [Delete a dashboard](/developer-docs/6.1.0/api/delete-a-dashboard)                                                                                                           | `/api/v1/dashboard/{pk}`                             |
+| `PUT`    | [Update a dashboard](/developer-docs/6.1.0/api/update-a-dashboard)                                                                                                           | `/api/v1/dashboard/{pk}`                             |
+| `POST`   | [Compute and cache a screenshot (dashboard-pk-cache-dashboard-screenshot)](/developer-docs/6.1.0/api/compute-and-cache-a-screenshot-dashboard-pk-cache-dashboard-screenshot) | `/api/v1/dashboard/{pk}/cache_dashboard_screenshot/` |
+| `PUT`    | [Update chart customizations configuration for a dashboard.](/developer-docs/6.1.0/api/update-chart-customizations-configuration-for-a-dashboard)                            | `/api/v1/dashboard/{pk}/chart_customizations`        |
+| `PUT`    | [Update colors configuration for a dashboard.](/developer-docs/6.1.0/api/update-colors-configuration-for-a-dashboard)                                                        | `/api/v1/dashboard/{pk}/colors`                      |
+| `GET`    | [Export dashboard as example bundle](/developer-docs/6.1.0/api/export-dashboard-as-example-bundle)                                                                           | `/api/v1/dashboard/{pk}/export_as_example/`          |
+| `DELETE` | [Remove the dashboard from the user favorite list](/developer-docs/6.1.0/api/remove-the-dashboard-from-the-user-favorite-list)                                               | `/api/v1/dashboard/{pk}/favorites/`                  |
+| `POST`   | [Mark the dashboard as favorite for the current user](/developer-docs/6.1.0/api/mark-the-dashboard-as-favorite-for-the-current-user)                                         | `/api/v1/dashboard/{pk}/favorites/`                  |
+| `PUT`    | [Update native filters configuration for a dashboard.](/developer-docs/6.1.0/api/update-native-filters-configuration-for-a-dashboard)                                        | `/api/v1/dashboard/{pk}/filters`                     |
+| `GET`    | [Get a computed screenshot from cache (dashboard-pk-screenshot-digest)](/developer-docs/6.1.0/api/get-a-computed-screenshot-from-cache-dashboard-pk-screenshot-digest)       | `/api/v1/dashboard/{pk}/screenshot/{digest}/`        |
+| `GET`    | [Get dashboard's thumbnail](/developer-docs/6.1.0/api/get-dashboards-thumbnail)                                                                                              | `/api/v1/dashboard/{pk}/thumbnail/{digest}/`         |
+| `GET`    | [Download multiple dashboards as YAML files](/developer-docs/6.1.0/api/download-multiple-dashboards-as-yaml-files)                                                           | `/api/v1/dashboard/export/`                          |
+| `GET`    | [Check favorited dashboards for current user](/developer-docs/6.1.0/api/check-favorited-dashboards-for-current-user)                                                         | `/api/v1/dashboard/favorite_status/`                 |
+| `POST`   | [Import dashboard(s) with associated charts/datasets/databases](/developer-docs/6.1.0/api/import-dashboard-s-with-associated-charts-datasets-databases)                      | `/api/v1/dashboard/import/`                          |
+| `GET`    | [Get related fields data (dashboard-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-dashboard-related-column-name)                                   | `/api/v1/dashboard/related/{column_name}`            |
 
 </details>
 
@@ -101,26 +101,26 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                             | Description                               |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `DELETE` | [Bulk delete charts](/developer-docs/api/bulk-delete-charts)                                                                                                         | `/api/v1/chart/`                          |
-| `GET`    | [Get a list of charts](/developer-docs/api/get-a-list-of-charts)                                                                                                     | `/api/v1/chart/`                          |
-| `POST`   | [Create a new chart](/developer-docs/api/create-a-new-chart)                                                                                                         | `/api/v1/chart/`                          |
-| `GET`    | [Get metadata information about this API resource (chart--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-chart-info)                    | `/api/v1/chart/_info`                     |
-| `GET`    | [Get a chart detail information](/developer-docs/api/get-a-chart-detail-information)                                                                                 | `/api/v1/chart/{id_or_uuid}`              |
-| `DELETE` | [Delete a chart](/developer-docs/api/delete-a-chart)                                                                                                                 | `/api/v1/chart/{pk}`                      |
-| `PUT`    | [Update a chart](/developer-docs/api/update-a-chart)                                                                                                                 | `/api/v1/chart/{pk}`                      |
-| `GET`    | [Compute and cache a screenshot (chart-pk-cache-screenshot)](/developer-docs/api/compute-and-cache-a-screenshot-chart-pk-cache-screenshot)                           | `/api/v1/chart/{pk}/cache_screenshot/`    |
-| `GET`    | [Return payload data response for a chart](/developer-docs/api/return-payload-data-response-for-a-chart)                                                             | `/api/v1/chart/{pk}/data/`                |
-| `DELETE` | [Remove the chart from the user favorite list](/developer-docs/api/remove-the-chart-from-the-user-favorite-list)                                                     | `/api/v1/chart/{pk}/favorites/`           |
-| `POST`   | [Mark the chart as favorite for the current user](/developer-docs/api/mark-the-chart-as-favorite-for-the-current-user)                                               | `/api/v1/chart/{pk}/favorites/`           |
-| `GET`    | [Get a computed screenshot from cache (chart-pk-screenshot-digest)](/developer-docs/api/get-a-computed-screenshot-from-cache-chart-pk-screenshot-digest)             | `/api/v1/chart/{pk}/screenshot/{digest}/` |
-| `GET`    | [Get chart thumbnail](/developer-docs/api/get-chart-thumbnail)                                                                                                       | `/api/v1/chart/{pk}/thumbnail/{digest}/`  |
-| `POST`   | [Return payload data response for the given query (chart-data)](/developer-docs/api/return-payload-data-response-for-the-given-query-chart-data)                     | `/api/v1/chart/data`                      |
-| `GET`    | [Return payload data response for the given query (chart-data-cache-key)](/developer-docs/api/return-payload-data-response-for-the-given-query-chart-data-cache-key) | `/api/v1/chart/data/{cache_key}`          |
-| `GET`    | [Download multiple charts as YAML files](/developer-docs/api/download-multiple-charts-as-yaml-files)                                                                 | `/api/v1/chart/export/`                   |
-| `GET`    | [Check favorited charts for current user](/developer-docs/api/check-favorited-charts-for-current-user)                                                               | `/api/v1/chart/favorite_status/`          |
-| `POST`   | [Import chart(s) with associated datasets and databases](/developer-docs/api/import-chart-s-with-associated-datasets-and-databases)                                  | `/api/v1/chart/import/`                   |
-| `GET`    | [Get related fields data (chart-related-column-name)](/developer-docs/api/get-related-fields-data-chart-related-column-name)                                         | `/api/v1/chart/related/{column_name}`     |
-| `PUT`    | [Warm up the cache for the chart](/developer-docs/api/warm-up-the-cache-for-the-chart)                                                                               | `/api/v1/chart/warm_up_cache`             |
+| `DELETE` | [Bulk delete charts](/developer-docs/6.1.0/api/bulk-delete-charts)                                                                                                         | `/api/v1/chart/`                          |
+| `GET`    | [Get a list of charts](/developer-docs/6.1.0/api/get-a-list-of-charts)                                                                                                     | `/api/v1/chart/`                          |
+| `POST`   | [Create a new chart](/developer-docs/6.1.0/api/create-a-new-chart)                                                                                                         | `/api/v1/chart/`                          |
+| `GET`    | [Get metadata information about this API resource (chart--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-chart-info)                    | `/api/v1/chart/_info`                     |
+| `GET`    | [Get a chart detail information](/developer-docs/6.1.0/api/get-a-chart-detail-information)                                                                                 | `/api/v1/chart/{id_or_uuid}`              |
+| `DELETE` | [Delete a chart](/developer-docs/6.1.0/api/delete-a-chart)                                                                                                                 | `/api/v1/chart/{pk}`                      |
+| `PUT`    | [Update a chart](/developer-docs/6.1.0/api/update-a-chart)                                                                                                                 | `/api/v1/chart/{pk}`                      |
+| `GET`    | [Compute and cache a screenshot (chart-pk-cache-screenshot)](/developer-docs/6.1.0/api/compute-and-cache-a-screenshot-chart-pk-cache-screenshot)                           | `/api/v1/chart/{pk}/cache_screenshot/`    |
+| `GET`    | [Return payload data response for a chart](/developer-docs/6.1.0/api/return-payload-data-response-for-a-chart)                                                             | `/api/v1/chart/{pk}/data/`                |
+| `DELETE` | [Remove the chart from the user favorite list](/developer-docs/6.1.0/api/remove-the-chart-from-the-user-favorite-list)                                                     | `/api/v1/chart/{pk}/favorites/`           |
+| `POST`   | [Mark the chart as favorite for the current user](/developer-docs/6.1.0/api/mark-the-chart-as-favorite-for-the-current-user)                                               | `/api/v1/chart/{pk}/favorites/`           |
+| `GET`    | [Get a computed screenshot from cache (chart-pk-screenshot-digest)](/developer-docs/6.1.0/api/get-a-computed-screenshot-from-cache-chart-pk-screenshot-digest)             | `/api/v1/chart/{pk}/screenshot/{digest}/` |
+| `GET`    | [Get chart thumbnail](/developer-docs/6.1.0/api/get-chart-thumbnail)                                                                                                       | `/api/v1/chart/{pk}/thumbnail/{digest}/`  |
+| `POST`   | [Return payload data response for the given query (chart-data)](/developer-docs/6.1.0/api/return-payload-data-response-for-the-given-query-chart-data)                     | `/api/v1/chart/data`                      |
+| `GET`    | [Return payload data response for the given query (chart-data-cache-key)](/developer-docs/6.1.0/api/return-payload-data-response-for-the-given-query-chart-data-cache-key) | `/api/v1/chart/data/{cache_key}`          |
+| `GET`    | [Download multiple charts as YAML files](/developer-docs/6.1.0/api/download-multiple-charts-as-yaml-files)                                                                 | `/api/v1/chart/export/`                   |
+| `GET`    | [Check favorited charts for current user](/developer-docs/6.1.0/api/check-favorited-charts-for-current-user)                                                               | `/api/v1/chart/favorite_status/`          |
+| `POST`   | [Import chart(s) with associated datasets and databases](/developer-docs/6.1.0/api/import-chart-s-with-associated-datasets-and-databases)                                  | `/api/v1/chart/import/`                   |
+| `GET`    | [Get related fields data (chart-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-chart-related-column-name)                                         | `/api/v1/chart/related/{column_name}`     |
+| `PUT`    | [Warm up the cache for the chart](/developer-docs/6.1.0/api/warm-up-the-cache-for-the-chart)                                                                               | `/api/v1/chart/warm_up_cache`             |
 
 </details>
 
@@ -129,25 +129,25 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                   | Description                                    |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `DELETE` | [Bulk delete datasets](/developer-docs/api/bulk-delete-datasets)                                                                                           | `/api/v1/dataset/`                             |
-| `GET`    | [Get a list of datasets](/developer-docs/api/get-a-list-of-datasets)                                                                                       | `/api/v1/dataset/`                             |
-| `POST`   | [Create a new dataset](/developer-docs/api/create-a-new-dataset)                                                                                           | `/api/v1/dataset/`                             |
-| `GET`    | [Get metadata information about this API resource (dataset--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-dataset-info)      | `/api/v1/dataset/_info`                        |
-| `GET`    | [Get a dataset](/developer-docs/api/get-a-dataset)                                                                                                         | `/api/v1/dataset/{id_or_uuid}`                 |
-| `GET`    | [Get charts and dashboards count associated to a dataset](/developer-docs/api/get-charts-and-dashboards-count-associated-to-a-dataset)                     | `/api/v1/dataset/{id_or_uuid}/related_objects` |
-| `DELETE` | [Delete a dataset](/developer-docs/api/delete-a-dataset)                                                                                                   | `/api/v1/dataset/{pk}`                         |
-| `PUT`    | [Update a dataset](/developer-docs/api/update-a-dataset)                                                                                                   | `/api/v1/dataset/{pk}`                         |
-| `DELETE` | [Delete a dataset column](/developer-docs/api/delete-a-dataset-column)                                                                                     | `/api/v1/dataset/{pk}/column/{column_id}`      |
-| `GET`    | [Get dataset drill info](/developer-docs/api/get-dataset-drill-info)                                                                                       | `/api/v1/dataset/{pk}/drill_info/`             |
-| `DELETE` | [Delete a dataset metric](/developer-docs/api/delete-a-dataset-metric)                                                                                     | `/api/v1/dataset/{pk}/metric/{metric_id}`      |
-| `PUT`    | [Refresh and update columns of a dataset](/developer-docs/api/refresh-and-update-columns-of-a-dataset)                                                     | `/api/v1/dataset/{pk}/refresh`                 |
-| `GET`    | [Get distinct values from field data (dataset-distinct-column-name)](/developer-docs/api/get-distinct-values-from-field-data-dataset-distinct-column-name) | `/api/v1/dataset/distinct/{column_name}`       |
-| `POST`   | [Duplicate a dataset](/developer-docs/api/duplicate-a-dataset)                                                                                             | `/api/v1/dataset/duplicate`                    |
-| `GET`    | [Download multiple datasets as YAML files](/developer-docs/api/download-multiple-datasets-as-yaml-files)                                                   | `/api/v1/dataset/export/`                      |
-| `POST`   | [Retrieve a table by name, or create it if it does not exist](/developer-docs/api/retrieve-a-table-by-name-or-create-it-if-it-does-not-exist)              | `/api/v1/dataset/get_or_create/`               |
-| `POST`   | [Import dataset(s) with associated databases](/developer-docs/api/import-dataset-s-with-associated-databases)                                              | `/api/v1/dataset/import/`                      |
-| `GET`    | [Get related fields data (dataset-related-column-name)](/developer-docs/api/get-related-fields-data-dataset-related-column-name)                           | `/api/v1/dataset/related/{column_name}`        |
-| `PUT`    | [Warm up the cache for each chart powered by the given table](/developer-docs/api/warm-up-the-cache-for-each-chart-powered-by-the-given-table)             | `/api/v1/dataset/warm_up_cache`                |
+| `DELETE` | [Bulk delete datasets](/developer-docs/6.1.0/api/bulk-delete-datasets)                                                                                           | `/api/v1/dataset/`                             |
+| `GET`    | [Get a list of datasets](/developer-docs/6.1.0/api/get-a-list-of-datasets)                                                                                       | `/api/v1/dataset/`                             |
+| `POST`   | [Create a new dataset](/developer-docs/6.1.0/api/create-a-new-dataset)                                                                                           | `/api/v1/dataset/`                             |
+| `GET`    | [Get metadata information about this API resource (dataset--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-dataset-info)      | `/api/v1/dataset/_info`                        |
+| `GET`    | [Get a dataset](/developer-docs/6.1.0/api/get-a-dataset)                                                                                                         | `/api/v1/dataset/{id_or_uuid}`                 |
+| `GET`    | [Get charts and dashboards count associated to a dataset](/developer-docs/6.1.0/api/get-charts-and-dashboards-count-associated-to-a-dataset)                     | `/api/v1/dataset/{id_or_uuid}/related_objects` |
+| `DELETE` | [Delete a dataset](/developer-docs/6.1.0/api/delete-a-dataset)                                                                                                   | `/api/v1/dataset/{pk}`                         |
+| `PUT`    | [Update a dataset](/developer-docs/6.1.0/api/update-a-dataset)                                                                                                   | `/api/v1/dataset/{pk}`                         |
+| `DELETE` | [Delete a dataset column](/developer-docs/6.1.0/api/delete-a-dataset-column)                                                                                     | `/api/v1/dataset/{pk}/column/{column_id}`      |
+| `GET`    | [Get dataset drill info](/developer-docs/6.1.0/api/get-dataset-drill-info)                                                                                       | `/api/v1/dataset/{pk}/drill_info/`             |
+| `DELETE` | [Delete a dataset metric](/developer-docs/6.1.0/api/delete-a-dataset-metric)                                                                                     | `/api/v1/dataset/{pk}/metric/{metric_id}`      |
+| `PUT`    | [Refresh and update columns of a dataset](/developer-docs/6.1.0/api/refresh-and-update-columns-of-a-dataset)                                                     | `/api/v1/dataset/{pk}/refresh`                 |
+| `GET`    | [Get distinct values from field data (dataset-distinct-column-name)](/developer-docs/6.1.0/api/get-distinct-values-from-field-data-dataset-distinct-column-name) | `/api/v1/dataset/distinct/{column_name}`       |
+| `POST`   | [Duplicate a dataset](/developer-docs/6.1.0/api/duplicate-a-dataset)                                                                                             | `/api/v1/dataset/duplicate`                    |
+| `GET`    | [Download multiple datasets as YAML files](/developer-docs/6.1.0/api/download-multiple-datasets-as-yaml-files)                                                   | `/api/v1/dataset/export/`                      |
+| `POST`   | [Retrieve a table by name, or create it if it does not exist](/developer-docs/6.1.0/api/retrieve-a-table-by-name-or-create-it-if-it-does-not-exist)              | `/api/v1/dataset/get_or_create/`               |
+| `POST`   | [Import dataset(s) with associated databases](/developer-docs/6.1.0/api/import-dataset-s-with-associated-databases)                                              | `/api/v1/dataset/import/`                      |
+| `GET`    | [Get related fields data (dataset-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-dataset-related-column-name)                           | `/api/v1/dataset/related/{column_name}`        |
+| `PUT`    | [Warm up the cache for each chart powered by the given table](/developer-docs/6.1.0/api/warm-up-the-cache-for-each-chart-powered-by-the-given-table)             | `/api/v1/dataset/warm_up_cache`                |
 
 </details>
 
@@ -156,36 +156,36 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                                                     | Description                                                     |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `GET`    | [Get a list of databases](/developer-docs/api/get-a-list-of-databases)                                                                                                                       | `/api/v1/database/`                                             |
-| `POST`   | [Create a new database](/developer-docs/api/create-a-new-database)                                                                                                                           | `/api/v1/database/`                                             |
-| `GET`    | [Get metadata information about this API resource (database--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-database-info)                                      | `/api/v1/database/_info`                                        |
-| `DELETE` | [Delete a database](/developer-docs/api/delete-a-database)                                                                                                                                   | `/api/v1/database/{pk}`                                         |
-| `GET`    | [Get a database](/developer-docs/api/get-a-database)                                                                                                                                         | `/api/v1/database/{pk}`                                         |
-| `PUT`    | [Change a database](/developer-docs/api/change-a-database)                                                                                                                                   | `/api/v1/database/{pk}`                                         |
-| `GET`    | [Get all catalogs from a database](/developer-docs/api/get-all-catalogs-from-a-database)                                                                                                     | `/api/v1/database/{pk}/catalogs/`                               |
-| `GET`    | [Get a database connection info](/developer-docs/api/get-a-database-connection-info)                                                                                                         | `/api/v1/database/{pk}/connection`                              |
-| `GET`    | [Get function names supported by a database](/developer-docs/api/get-function-names-supported-by-a-database)                                                                                 | `/api/v1/database/{pk}/function_names/`                         |
-| `GET`    | [Get charts and dashboards count associated to a database](/developer-docs/api/get-charts-and-dashboards-count-associated-to-a-database)                                                     | `/api/v1/database/{pk}/related_objects/`                        |
-| `GET`    | [The list of the database schemas where to upload information](/developer-docs/api/the-list-of-the-database-schemas-where-to-upload-information)                                             | `/api/v1/database/{pk}/schemas_access_for_file_upload/`         |
-| `GET`    | [Get all schemas from a database](/developer-docs/api/get-all-schemas-from-a-database)                                                                                                       | `/api/v1/database/{pk}/schemas/`                                |
-| `GET`    | [Get database select star for table (database-pk-select-star-table-name)](/developer-docs/api/get-database-select-star-for-table-database-pk-select-star-table-name)                         | `/api/v1/database/{pk}/select_star/{table_name}/`               |
-| `GET`    | [Get database select star for table (database-pk-select-star-table-name-schema-name)](/developer-docs/api/get-database-select-star-for-table-database-pk-select-star-table-name-schema-name) | `/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/` |
-| `POST`   | [Re-sync all permissions for a database connection](/developer-docs/api/re-sync-all-permissions-for-a-database-connection)                                                                   | `/api/v1/database/{pk}/sync_permissions/`                       |
-| `GET`    | [Get table extra metadata (database-pk-table-extra-table-name-schema-name)](/developer-docs/api/get-table-extra-metadata-database-pk-table-extra-table-name-schema-name)                     | `/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/` |
-| `GET`    | [Get table metadata](/developer-docs/api/get-table-metadata)                                                                                                                                 | `/api/v1/database/{pk}/table_metadata/`                         |
-| `GET`    | [Get table extra metadata (database-pk-table-metadata-extra)](/developer-docs/api/get-table-extra-metadata-database-pk-table-metadata-extra)                                                 | `/api/v1/database/{pk}/table_metadata/extra/`                   |
-| `GET`    | [Get database table metadata](/developer-docs/api/get-database-table-metadata)                                                                                                               | `/api/v1/database/{pk}/table/{table_name}/{schema_name}/`       |
-| `GET`    | [Get a list of tables for given database](/developer-docs/api/get-a-list-of-tables-for-given-database)                                                                                       | `/api/v1/database/{pk}/tables/`                                 |
-| `POST`   | [Upload a file to a database table](/developer-docs/api/upload-a-file-to-a-database-table)                                                                                                   | `/api/v1/database/{pk}/upload/`                                 |
-| `POST`   | [Validate arbitrary SQL](/developer-docs/api/validate-arbitrary-sql)                                                                                                                         | `/api/v1/database/{pk}/validate_sql/`                           |
-| `GET`    | [Get names of databases currently available](/developer-docs/api/get-names-of-databases-currently-available)                                                                                 | `/api/v1/database/available/`                                   |
-| `GET`    | [Download database(s) and associated dataset(s) as a zip file](/developer-docs/api/download-database-s-and-associated-dataset-s-as-a-zip-file)                                               | `/api/v1/database/export/`                                      |
-| `POST`   | [Import database(s) with associated datasets](/developer-docs/api/import-database-s-with-associated-datasets)                                                                                | `/api/v1/database/import/`                                      |
-| `GET`    | [Receive personal access tokens from OAuth2](/developer-docs/api/receive-personal-access-tokens-from-o-auth-2)                                                                               | `/api/v1/database/oauth2/`                                      |
-| `GET`    | [Get related fields data (database-related-column-name)](/developer-docs/api/get-related-fields-data-database-related-column-name)                                                           | `/api/v1/database/related/{column_name}`                        |
-| `POST`   | [Test a database connection](/developer-docs/api/test-a-database-connection)                                                                                                                 | `/api/v1/database/test_connection/`                             |
-| `POST`   | [Upload a file and returns file metadata](/developer-docs/api/upload-a-file-and-returns-file-metadata)                                                                                       | `/api/v1/database/upload_metadata/`                             |
-| `POST`   | [Validate database connection parameters](/developer-docs/api/validate-database-connection-parameters)                                                                                       | `/api/v1/database/validate_parameters/`                         |
+| `GET`    | [Get a list of databases](/developer-docs/6.1.0/api/get-a-list-of-databases)                                                                                                                       | `/api/v1/database/`                                             |
+| `POST`   | [Create a new database](/developer-docs/6.1.0/api/create-a-new-database)                                                                                                                           | `/api/v1/database/`                                             |
+| `GET`    | [Get metadata information about this API resource (database--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-database-info)                                      | `/api/v1/database/_info`                                        |
+| `DELETE` | [Delete a database](/developer-docs/6.1.0/api/delete-a-database)                                                                                                                                   | `/api/v1/database/{pk}`                                         |
+| `GET`    | [Get a database](/developer-docs/6.1.0/api/get-a-database)                                                                                                                                         | `/api/v1/database/{pk}`                                         |
+| `PUT`    | [Change a database](/developer-docs/6.1.0/api/change-a-database)                                                                                                                                   | `/api/v1/database/{pk}`                                         |
+| `GET`    | [Get all catalogs from a database](/developer-docs/6.1.0/api/get-all-catalogs-from-a-database)                                                                                                     | `/api/v1/database/{pk}/catalogs/`                               |
+| `GET`    | [Get a database connection info](/developer-docs/6.1.0/api/get-a-database-connection-info)                                                                                                         | `/api/v1/database/{pk}/connection`                              |
+| `GET`    | [Get function names supported by a database](/developer-docs/6.1.0/api/get-function-names-supported-by-a-database)                                                                                 | `/api/v1/database/{pk}/function_names/`                         |
+| `GET`    | [Get charts and dashboards count associated to a database](/developer-docs/6.1.0/api/get-charts-and-dashboards-count-associated-to-a-database)                                                     | `/api/v1/database/{pk}/related_objects/`                        |
+| `GET`    | [The list of the database schemas where to upload information](/developer-docs/6.1.0/api/the-list-of-the-database-schemas-where-to-upload-information)                                             | `/api/v1/database/{pk}/schemas_access_for_file_upload/`         |
+| `GET`    | [Get all schemas from a database](/developer-docs/6.1.0/api/get-all-schemas-from-a-database)                                                                                                       | `/api/v1/database/{pk}/schemas/`                                |
+| `GET`    | [Get database select star for table (database-pk-select-star-table-name)](/developer-docs/6.1.0/api/get-database-select-star-for-table-database-pk-select-star-table-name)                         | `/api/v1/database/{pk}/select_star/{table_name}/`               |
+| `GET`    | [Get database select star for table (database-pk-select-star-table-name-schema-name)](/developer-docs/6.1.0/api/get-database-select-star-for-table-database-pk-select-star-table-name-schema-name) | `/api/v1/database/{pk}/select_star/{table_name}/{schema_name}/` |
+| `POST`   | [Re-sync all permissions for a database connection](/developer-docs/6.1.0/api/re-sync-all-permissions-for-a-database-connection)                                                                   | `/api/v1/database/{pk}/sync_permissions/`                       |
+| `GET`    | [Get table extra metadata (database-pk-table-extra-table-name-schema-name)](/developer-docs/6.1.0/api/get-table-extra-metadata-database-pk-table-extra-table-name-schema-name)                     | `/api/v1/database/{pk}/table_extra/{table_name}/{schema_name}/` |
+| `GET`    | [Get table metadata](/developer-docs/6.1.0/api/get-table-metadata)                                                                                                                                 | `/api/v1/database/{pk}/table_metadata/`                         |
+| `GET`    | [Get table extra metadata (database-pk-table-metadata-extra)](/developer-docs/6.1.0/api/get-table-extra-metadata-database-pk-table-metadata-extra)                                                 | `/api/v1/database/{pk}/table_metadata/extra/`                   |
+| `GET`    | [Get database table metadata](/developer-docs/6.1.0/api/get-database-table-metadata)                                                                                                               | `/api/v1/database/{pk}/table/{table_name}/{schema_name}/`       |
+| `GET`    | [Get a list of tables for given database](/developer-docs/6.1.0/api/get-a-list-of-tables-for-given-database)                                                                                       | `/api/v1/database/{pk}/tables/`                                 |
+| `POST`   | [Upload a file to a database table](/developer-docs/6.1.0/api/upload-a-file-to-a-database-table)                                                                                                   | `/api/v1/database/{pk}/upload/`                                 |
+| `POST`   | [Validate arbitrary SQL](/developer-docs/6.1.0/api/validate-arbitrary-sql)                                                                                                                         | `/api/v1/database/{pk}/validate_sql/`                           |
+| `GET`    | [Get names of databases currently available](/developer-docs/6.1.0/api/get-names-of-databases-currently-available)                                                                                 | `/api/v1/database/available/`                                   |
+| `GET`    | [Download database(s) and associated dataset(s) as a zip file](/developer-docs/6.1.0/api/download-database-s-and-associated-dataset-s-as-a-zip-file)                                               | `/api/v1/database/export/`                                      |
+| `POST`   | [Import database(s) with associated datasets](/developer-docs/6.1.0/api/import-database-s-with-associated-datasets)                                                                                | `/api/v1/database/import/`                                      |
+| `GET`    | [Receive personal access tokens from OAuth2](/developer-docs/6.1.0/api/receive-personal-access-tokens-from-o-auth-2)                                                                               | `/api/v1/database/oauth2/`                                      |
+| `GET`    | [Get related fields data (database-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-database-related-column-name)                                                           | `/api/v1/database/related/{column_name}`                        |
+| `POST`   | [Test a database connection](/developer-docs/6.1.0/api/test-a-database-connection)                                                                                                                 | `/api/v1/database/test_connection/`                             |
+| `POST`   | [Upload a file and returns file metadata](/developer-docs/6.1.0/api/upload-a-file-and-returns-file-metadata)                                                                                       | `/api/v1/database/upload_metadata/`                             |
+| `POST`   | [Validate database connection parameters](/developer-docs/6.1.0/api/validate-database-connection-parameters)                                                                                       | `/api/v1/database/validate_parameters/`                         |
 
 </details>
 
@@ -196,7 +196,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                                                   | Description        |
 | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `GET`  | [Assemble Explore related information in a single endpoint](/developer-docs/api/assemble-explore-related-information-in-a-single-endpoint) | `/api/v1/explore/` |
+| `GET`  | [Assemble Explore related information in a single endpoint](/developer-docs/6.1.0/api/assemble-explore-related-information-in-a-single-endpoint) | `/api/v1/explore/` |
 
 </details>
 
@@ -205,13 +205,13 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                             | Description                          |
 | ------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `GET`  | [Get the bootstrap data for SqlLab page](/developer-docs/api/get-the-bootstrap-data-for-sql-lab-page)                | `/api/v1/sqllab/`                    |
-| `POST` | [Estimate the SQL query execution cost](/developer-docs/api/estimate-the-sql-query-execution-cost)                   | `/api/v1/sqllab/estimate/`           |
-| `POST` | [Execute a SQL query](/developer-docs/api/execute-a-sql-query)                                                       | `/api/v1/sqllab/execute/`            |
-| `POST` | [Export SQL query results to CSV with streaming](/developer-docs/api/export-sql-query-results-to-csv-with-streaming) | `/api/v1/sqllab/export_streaming/`   |
-| `GET`  | [Export the SQL query results to a CSV](/developer-docs/api/export-the-sql-query-results-to-a-csv)                   | `/api/v1/sqllab/export/{client_id}/` |
-| `POST` | [Format SQL code](/developer-docs/api/format-sql-code)                                                               | `/api/v1/sqllab/format_sql/`         |
-| `GET`  | [Get the result of a SQL query execution](/developer-docs/api/get-the-result-of-a-sql-query-execution)               | `/api/v1/sqllab/results/`            |
+| `GET`  | [Get the bootstrap data for SqlLab page](/developer-docs/6.1.0/api/get-the-bootstrap-data-for-sql-lab-page)                | `/api/v1/sqllab/`                    |
+| `POST` | [Estimate the SQL query execution cost](/developer-docs/6.1.0/api/estimate-the-sql-query-execution-cost)                   | `/api/v1/sqllab/estimate/`           |
+| `POST` | [Execute a SQL query](/developer-docs/6.1.0/api/execute-a-sql-query)                                                       | `/api/v1/sqllab/execute/`            |
+| `POST` | [Export SQL query results to CSV with streaming](/developer-docs/6.1.0/api/export-sql-query-results-to-csv-with-streaming) | `/api/v1/sqllab/export_streaming/`   |
+| `GET`  | [Export the SQL query results to a CSV](/developer-docs/6.1.0/api/export-the-sql-query-results-to-a-csv)                   | `/api/v1/sqllab/export/{client_id}/` |
+| `POST` | [Format SQL code](/developer-docs/6.1.0/api/format-sql-code)                                                               | `/api/v1/sqllab/format_sql/`         |
+| `GET`  | [Get the result of a SQL query execution](/developer-docs/6.1.0/api/get-the-result-of-a-sql-query-execution)               | `/api/v1/sqllab/results/`            |
 
 </details>
 
@@ -220,23 +220,23 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                           | Description                                  |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| `GET`    | [Get a list of queries](/developer-docs/api/get-a-list-of-queries)                                                                                                 | `/api/v1/query/`                             |
-| `GET`    | [Get query detail information](/developer-docs/api/get-query-detail-information)                                                                                   | `/api/v1/query/{pk}`                         |
-| `GET`    | [Get distinct values from field data (query-distinct-column-name)](/developer-docs/api/get-distinct-values-from-field-data-query-distinct-column-name)             | `/api/v1/query/distinct/{column_name}`       |
-| `GET`    | [Get related fields data (query-related-column-name)](/developer-docs/api/get-related-fields-data-query-related-column-name)                                       | `/api/v1/query/related/{column_name}`        |
-| `POST`   | [Manually stop a query with client_id](/developer-docs/api/manually-stop-a-query-with-client-id)                                                                   | `/api/v1/query/stop`                         |
-| `GET`    | [Get a list of queries that changed after last_updated_ms](/developer-docs/api/get-a-list-of-queries-that-changed-after-last-updated-ms)                           | `/api/v1/query/updated_since`                |
-| `DELETE` | [Bulk delete saved queries](/developer-docs/api/bulk-delete-saved-queries)                                                                                         | `/api/v1/saved_query/`                       |
-| `GET`    | [Get a list of saved queries](/developer-docs/api/get-a-list-of-saved-queries)                                                                                     | `/api/v1/saved_query/`                       |
-| `POST`   | [Create a saved query](/developer-docs/api/create-a-saved-query)                                                                                                   | `/api/v1/saved_query/`                       |
-| `GET`    | [Get metadata information about this API resource (saved-query--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-saved-query-info)      | `/api/v1/saved_query/_info`                  |
-| `DELETE` | [Delete a saved query](/developer-docs/api/delete-a-saved-query)                                                                                                   | `/api/v1/saved_query/{pk}`                   |
-| `GET`    | [Get a saved query](/developer-docs/api/get-a-saved-query)                                                                                                         | `/api/v1/saved_query/{pk}`                   |
-| `PUT`    | [Update a saved query](/developer-docs/api/update-a-saved-query)                                                                                                   | `/api/v1/saved_query/{pk}`                   |
-| `GET`    | [Get distinct values from field data (saved-query-distinct-column-name)](/developer-docs/api/get-distinct-values-from-field-data-saved-query-distinct-column-name) | `/api/v1/saved_query/distinct/{column_name}` |
-| `GET`    | [Download multiple saved queries as YAML files](/developer-docs/api/download-multiple-saved-queries-as-yaml-files)                                                 | `/api/v1/saved_query/export/`                |
-| `POST`   | [Import saved queries with associated databases](/developer-docs/api/import-saved-queries-with-associated-databases)                                               | `/api/v1/saved_query/import/`                |
-| `GET`    | [Get related fields data (saved-query-related-column-name)](/developer-docs/api/get-related-fields-data-saved-query-related-column-name)                           | `/api/v1/saved_query/related/{column_name}`  |
+| `GET`    | [Get a list of queries](/developer-docs/6.1.0/api/get-a-list-of-queries)                                                                                                 | `/api/v1/query/`                             |
+| `GET`    | [Get query detail information](/developer-docs/6.1.0/api/get-query-detail-information)                                                                                   | `/api/v1/query/{pk}`                         |
+| `GET`    | [Get distinct values from field data (query-distinct-column-name)](/developer-docs/6.1.0/api/get-distinct-values-from-field-data-query-distinct-column-name)             | `/api/v1/query/distinct/{column_name}`       |
+| `GET`    | [Get related fields data (query-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-query-related-column-name)                                       | `/api/v1/query/related/{column_name}`        |
+| `POST`   | [Manually stop a query with client_id](/developer-docs/6.1.0/api/manually-stop-a-query-with-client-id)                                                                   | `/api/v1/query/stop`                         |
+| `GET`    | [Get a list of queries that changed after last_updated_ms](/developer-docs/6.1.0/api/get-a-list-of-queries-that-changed-after-last-updated-ms)                           | `/api/v1/query/updated_since`                |
+| `DELETE` | [Bulk delete saved queries](/developer-docs/6.1.0/api/bulk-delete-saved-queries)                                                                                         | `/api/v1/saved_query/`                       |
+| `GET`    | [Get a list of saved queries](/developer-docs/6.1.0/api/get-a-list-of-saved-queries)                                                                                     | `/api/v1/saved_query/`                       |
+| `POST`   | [Create a saved query](/developer-docs/6.1.0/api/create-a-saved-query)                                                                                                   | `/api/v1/saved_query/`                       |
+| `GET`    | [Get metadata information about this API resource (saved-query--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-saved-query-info)      | `/api/v1/saved_query/_info`                  |
+| `DELETE` | [Delete a saved query](/developer-docs/6.1.0/api/delete-a-saved-query)                                                                                                   | `/api/v1/saved_query/{pk}`                   |
+| `GET`    | [Get a saved query](/developer-docs/6.1.0/api/get-a-saved-query)                                                                                                         | `/api/v1/saved_query/{pk}`                   |
+| `PUT`    | [Update a saved query](/developer-docs/6.1.0/api/update-a-saved-query)                                                                                                   | `/api/v1/saved_query/{pk}`                   |
+| `GET`    | [Get distinct values from field data (saved-query-distinct-column-name)](/developer-docs/6.1.0/api/get-distinct-values-from-field-data-saved-query-distinct-column-name) | `/api/v1/saved_query/distinct/{column_name}` |
+| `GET`    | [Download multiple saved queries as YAML files](/developer-docs/6.1.0/api/download-multiple-saved-queries-as-yaml-files)                                                 | `/api/v1/saved_query/export/`                |
+| `POST`   | [Import saved queries with associated databases](/developer-docs/6.1.0/api/import-saved-queries-with-associated-databases)                                               | `/api/v1/saved_query/import/`                |
+| `GET`    | [Get related fields data (saved-query-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-saved-query-related-column-name)                           | `/api/v1/saved_query/related/{column_name}`  |
 
 </details>
 
@@ -245,8 +245,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                             | Description                                                                         |
 | ------ | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `GET`  | [Get possible values for a datasource column](/developer-docs/api/get-possible-values-for-a-datasource-column)       | `/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/` |
-| `POST` | [Validate a SQL expression against a datasource](/developer-docs/api/validate-a-sql-expression-against-a-datasource) | `/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/`         |
+| `GET`  | [Get possible values for a datasource column](/developer-docs/6.1.0/api/get-possible-values-for-a-datasource-column)       | `/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/` |
+| `POST` | [Validate a SQL expression against a datasource](/developer-docs/6.1.0/api/validate-a-sql-expression-against-a-datasource) | `/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/`         |
 
 </details>
 
@@ -255,8 +255,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                             | Description                          |
 | ------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `GET`  | [Return an AdvancedDataTypeResponse](/developer-docs/api/return-an-advanced-data-type-response)                      | `/api/v1/advanced_data_type/convert` |
-| `GET`  | [Return a list of available advanced data types](/developer-docs/api/return-a-list-of-available-advanced-data-types) | `/api/v1/advanced_data_type/types`   |
+| `GET`  | [Return an AdvancedDataTypeResponse](/developer-docs/6.1.0/api/return-an-advanced-data-type-response)                      | `/api/v1/advanced_data_type/convert` |
+| `GET`  | [Return a list of available advanced data types](/developer-docs/6.1.0/api/return-a-list-of-available-advanced-data-types) | `/api/v1/advanced_data_type/types`   |
 
 </details>
 
@@ -267,21 +267,21 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                 | Description                                    |
 | -------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| `DELETE` | [Bulk delete tags](/developer-docs/api/bulk-delete-tags)                                                                 | `/api/v1/tag/`                                 |
-| `GET`    | [Get a list of tags](/developer-docs/api/get-a-list-of-tags)                                                             | `/api/v1/tag/`                                 |
-| `POST`   | [Create a tag](/developer-docs/api/create-a-tag)                                                                         | `/api/v1/tag/`                                 |
-| `GET`    | [Get metadata information about tag API endpoints](/developer-docs/api/get-metadata-information-about-tag-api-endpoints) | `/api/v1/tag/_info`                            |
-| `POST`   | [Add tags to an object](/developer-docs/api/add-tags-to-an-object)                                                       | `/api/v1/tag/{object_type}/{object_id}/`       |
-| `DELETE` | [Delete a tagged object](/developer-docs/api/delete-a-tagged-object)                                                     | `/api/v1/tag/{object_type}/{object_id}/{tag}/` |
-| `DELETE` | [Delete a tag](/developer-docs/api/delete-a-tag)                                                                         | `/api/v1/tag/{pk}`                             |
-| `GET`    | [Get a tag detail information](/developer-docs/api/get-a-tag-detail-information)                                         | `/api/v1/tag/{pk}`                             |
-| `PUT`    | [Update a tag](/developer-docs/api/update-a-tag)                                                                         | `/api/v1/tag/{pk}`                             |
-| `DELETE` | [Delete tag by pk favorites](/developer-docs/api/delete-tag-by-pk-favorites)                                             | `/api/v1/tag/{pk}/favorites/`                  |
-| `POST`   | [Create tag by pk favorites](/developer-docs/api/create-tag-by-pk-favorites)                                             | `/api/v1/tag/{pk}/favorites/`                  |
-| `POST`   | [Bulk create tags and tagged objects](/developer-docs/api/bulk-create-tags-and-tagged-objects)                           | `/api/v1/tag/bulk_create`                      |
-| `GET`    | [Get tag favorite status](/developer-docs/api/get-tag-favorite-status)                                                   | `/api/v1/tag/favorite_status/`                 |
-| `GET`    | [Get all objects associated with a tag](/developer-docs/api/get-all-objects-associated-with-a-tag)                       | `/api/v1/tag/get_objects/`                     |
-| `GET`    | [Get related fields data (tag-related-column-name)](/developer-docs/api/get-related-fields-data-tag-related-column-name) | `/api/v1/tag/related/{column_name}`            |
+| `DELETE` | [Bulk delete tags](/developer-docs/6.1.0/api/bulk-delete-tags)                                                                 | `/api/v1/tag/`                                 |
+| `GET`    | [Get a list of tags](/developer-docs/6.1.0/api/get-a-list-of-tags)                                                             | `/api/v1/tag/`                                 |
+| `POST`   | [Create a tag](/developer-docs/6.1.0/api/create-a-tag)                                                                         | `/api/v1/tag/`                                 |
+| `GET`    | [Get metadata information about tag API endpoints](/developer-docs/6.1.0/api/get-metadata-information-about-tag-api-endpoints) | `/api/v1/tag/_info`                            |
+| `POST`   | [Add tags to an object](/developer-docs/6.1.0/api/add-tags-to-an-object)                                                       | `/api/v1/tag/{object_type}/{object_id}/`       |
+| `DELETE` | [Delete a tagged object](/developer-docs/6.1.0/api/delete-a-tagged-object)                                                     | `/api/v1/tag/{object_type}/{object_id}/{tag}/` |
+| `DELETE` | [Delete a tag](/developer-docs/6.1.0/api/delete-a-tag)                                                                         | `/api/v1/tag/{pk}`                             |
+| `GET`    | [Get a tag detail information](/developer-docs/6.1.0/api/get-a-tag-detail-information)                                         | `/api/v1/tag/{pk}`                             |
+| `PUT`    | [Update a tag](/developer-docs/6.1.0/api/update-a-tag)                                                                         | `/api/v1/tag/{pk}`                             |
+| `DELETE` | [Delete tag by pk favorites](/developer-docs/6.1.0/api/delete-tag-by-pk-favorites)                                             | `/api/v1/tag/{pk}/favorites/`                  |
+| `POST`   | [Create tag by pk favorites](/developer-docs/6.1.0/api/create-tag-by-pk-favorites)                                             | `/api/v1/tag/{pk}/favorites/`                  |
+| `POST`   | [Bulk create tags and tagged objects](/developer-docs/6.1.0/api/bulk-create-tags-and-tagged-objects)                           | `/api/v1/tag/bulk_create`                      |
+| `GET`    | [Get tag favorite status](/developer-docs/6.1.0/api/get-tag-favorite-status)                                                   | `/api/v1/tag/favorite_status/`                 |
+| `GET`    | [Get all objects associated with a tag](/developer-docs/6.1.0/api/get-all-objects-associated-with-a-tag)                       | `/api/v1/tag/get_objects/`                     |
+| `GET`    | [Get related fields data (tag-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-tag-related-column-name) | `/api/v1/tag/related/{column_name}`            |
 
 </details>
 
@@ -290,20 +290,20 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                                 | Description                                                |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| `DELETE` | [Delete multiple annotation layers in a bulk operation](/developer-docs/api/delete-multiple-annotation-layers-in-a-bulk-operation)                                       | `/api/v1/annotation_layer/`                                |
-| `GET`    | [Get a list of annotation layers (annotation-layer)](/developer-docs/api/get-a-list-of-annotation-layers-annotation-layer)                                               | `/api/v1/annotation_layer/`                                |
-| `POST`   | [Create an annotation layer (annotation-layer)](/developer-docs/api/create-an-annotation-layer-annotation-layer)                                                         | `/api/v1/annotation_layer/`                                |
-| `GET`    | [Get metadata information about this API resource (annotation-layer--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-annotation-layer-info)  | `/api/v1/annotation_layer/_info`                           |
-| `DELETE` | [Delete annotation layer (annotation-layer-pk)](/developer-docs/api/delete-annotation-layer-annotation-layer-pk)                                                         | `/api/v1/annotation_layer/{pk}`                            |
-| `GET`    | [Get an annotation layer (annotation-layer-pk)](/developer-docs/api/get-an-annotation-layer-annotation-layer-pk)                                                         | `/api/v1/annotation_layer/{pk}`                            |
-| `PUT`    | [Update an annotation layer (annotation-layer-pk)](/developer-docs/api/update-an-annotation-layer-annotation-layer-pk)                                                   | `/api/v1/annotation_layer/{pk}`                            |
-| `DELETE` | [Bulk delete annotation layers](/developer-docs/api/bulk-delete-annotation-layers)                                                                                       | `/api/v1/annotation_layer/{pk}/annotation/`                |
-| `GET`    | [Get a list of annotation layers (annotation-layer-pk-annotation)](/developer-docs/api/get-a-list-of-annotation-layers-annotation-layer-pk-annotation)                   | `/api/v1/annotation_layer/{pk}/annotation/`                |
-| `POST`   | [Create an annotation layer (annotation-layer-pk-annotation)](/developer-docs/api/create-an-annotation-layer-annotation-layer-pk-annotation)                             | `/api/v1/annotation_layer/{pk}/annotation/`                |
-| `DELETE` | [Delete annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/api/delete-annotation-layer-annotation-layer-pk-annotation-annotation-id)       | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
-| `GET`    | [Get an annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/api/get-an-annotation-layer-annotation-layer-pk-annotation-annotation-id)       | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
-| `PUT`    | [Update an annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/api/update-an-annotation-layer-annotation-layer-pk-annotation-annotation-id) | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
-| `GET`    | [Get related fields data (annotation-layer-related-column-name)](/developer-docs/api/get-related-fields-data-annotation-layer-related-column-name)                       | `/api/v1/annotation_layer/related/{column_name}`           |
+| `DELETE` | [Delete multiple annotation layers in a bulk operation](/developer-docs/6.1.0/api/delete-multiple-annotation-layers-in-a-bulk-operation)                                       | `/api/v1/annotation_layer/`                                |
+| `GET`    | [Get a list of annotation layers (annotation-layer)](/developer-docs/6.1.0/api/get-a-list-of-annotation-layers-annotation-layer)                                               | `/api/v1/annotation_layer/`                                |
+| `POST`   | [Create an annotation layer (annotation-layer)](/developer-docs/6.1.0/api/create-an-annotation-layer-annotation-layer)                                                         | `/api/v1/annotation_layer/`                                |
+| `GET`    | [Get metadata information about this API resource (annotation-layer--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-annotation-layer-info)  | `/api/v1/annotation_layer/_info`                           |
+| `DELETE` | [Delete annotation layer (annotation-layer-pk)](/developer-docs/6.1.0/api/delete-annotation-layer-annotation-layer-pk)                                                         | `/api/v1/annotation_layer/{pk}`                            |
+| `GET`    | [Get an annotation layer (annotation-layer-pk)](/developer-docs/6.1.0/api/get-an-annotation-layer-annotation-layer-pk)                                                         | `/api/v1/annotation_layer/{pk}`                            |
+| `PUT`    | [Update an annotation layer (annotation-layer-pk)](/developer-docs/6.1.0/api/update-an-annotation-layer-annotation-layer-pk)                                                   | `/api/v1/annotation_layer/{pk}`                            |
+| `DELETE` | [Bulk delete annotation layers](/developer-docs/6.1.0/api/bulk-delete-annotation-layers)                                                                                       | `/api/v1/annotation_layer/{pk}/annotation/`                |
+| `GET`    | [Get a list of annotation layers (annotation-layer-pk-annotation)](/developer-docs/6.1.0/api/get-a-list-of-annotation-layers-annotation-layer-pk-annotation)                   | `/api/v1/annotation_layer/{pk}/annotation/`                |
+| `POST`   | [Create an annotation layer (annotation-layer-pk-annotation)](/developer-docs/6.1.0/api/create-an-annotation-layer-annotation-layer-pk-annotation)                             | `/api/v1/annotation_layer/{pk}/annotation/`                |
+| `DELETE` | [Delete annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/6.1.0/api/delete-annotation-layer-annotation-layer-pk-annotation-annotation-id)       | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
+| `GET`    | [Get an annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/6.1.0/api/get-an-annotation-layer-annotation-layer-pk-annotation-annotation-id)       | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
+| `PUT`    | [Update an annotation layer (annotation-layer-pk-annotation-annotation-id)](/developer-docs/6.1.0/api/update-an-annotation-layer-annotation-layer-pk-annotation-annotation-id) | `/api/v1/annotation_layer/{pk}/annotation/{annotation_id}` |
+| `GET`    | [Get related fields data (annotation-layer-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-annotation-layer-related-column-name)                       | `/api/v1/annotation_layer/related/{column_name}`           |
 
 </details>
 
@@ -312,14 +312,14 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                        | Description                                  |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `DELETE` | [Bulk delete CSS templates](/developer-docs/api/bulk-delete-css-templates)                                                                                      | `/api/v1/css_template/`                      |
-| `GET`    | [Get a list of CSS templates](/developer-docs/api/get-a-list-of-css-templates)                                                                                  | `/api/v1/css_template/`                      |
-| `POST`   | [Create a CSS template](/developer-docs/api/create-a-css-template)                                                                                              | `/api/v1/css_template/`                      |
-| `GET`    | [Get metadata information about this API resource (css-template--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-css-template-info) | `/api/v1/css_template/_info`                 |
-| `DELETE` | [Delete a CSS template](/developer-docs/api/delete-a-css-template)                                                                                              | `/api/v1/css_template/{pk}`                  |
-| `GET`    | [Get a CSS template](/developer-docs/api/get-a-css-template)                                                                                                    | `/api/v1/css_template/{pk}`                  |
-| `PUT`    | [Update a CSS template](/developer-docs/api/update-a-css-template)                                                                                              | `/api/v1/css_template/{pk}`                  |
-| `GET`    | [Get related fields data (css-template-related-column-name)](/developer-docs/api/get-related-fields-data-css-template-related-column-name)                      | `/api/v1/css_template/related/{column_name}` |
+| `DELETE` | [Bulk delete CSS templates](/developer-docs/6.1.0/api/bulk-delete-css-templates)                                                                                      | `/api/v1/css_template/`                      |
+| `GET`    | [Get a list of CSS templates](/developer-docs/6.1.0/api/get-a-list-of-css-templates)                                                                                  | `/api/v1/css_template/`                      |
+| `POST`   | [Create a CSS template](/developer-docs/6.1.0/api/create-a-css-template)                                                                                              | `/api/v1/css_template/`                      |
+| `GET`    | [Get metadata information about this API resource (css-template--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-css-template-info) | `/api/v1/css_template/_info`                 |
+| `DELETE` | [Delete a CSS template](/developer-docs/6.1.0/api/delete-a-css-template)                                                                                              | `/api/v1/css_template/{pk}`                  |
+| `GET`    | [Get a CSS template](/developer-docs/6.1.0/api/get-a-css-template)                                                                                                    | `/api/v1/css_template/{pk}`                  |
+| `PUT`    | [Update a CSS template](/developer-docs/6.1.0/api/update-a-css-template)                                                                                              | `/api/v1/css_template/{pk}`                  |
+| `GET`    | [Get related fields data (css-template-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-css-template-related-column-name)                      | `/api/v1/css_template/related/{column_name}` |
 
 </details>
 
@@ -330,8 +330,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                              | Description                         |
 | ------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `POST` | [Create a new dashboard's permanent link](/developer-docs/api/create-a-new-dashboards-permanent-link) | `/api/v1/dashboard/{pk}/permalink`  |
-| `GET`  | [Get dashboard's permanent link state](/developer-docs/api/get-dashboards-permanent-link-state)       | `/api/v1/dashboard/permalink/{key}` |
+| `POST` | [Create a new dashboard's permanent link](/developer-docs/6.1.0/api/create-a-new-dashboards-permanent-link) | `/api/v1/dashboard/{pk}/permalink`  |
+| `GET`  | [Get dashboard's permanent link state](/developer-docs/6.1.0/api/get-dashboards-permanent-link-state)       | `/api/v1/dashboard/permalink/{key}` |
 
 </details>
 
@@ -340,8 +340,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                             | Description                       |
 | ------ | -------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `POST` | [Create a new permanent link (explore-permalink)](/developer-docs/api/create-a-new-permanent-link-explore-permalink) | `/api/v1/explore/permalink`       |
-| `GET`  | [Get chart's permanent link state](/developer-docs/api/get-charts-permanent-link-state)                              | `/api/v1/explore/permalink/{key}` |
+| `POST` | [Create a new permanent link (explore-permalink)](/developer-docs/6.1.0/api/create-a-new-permanent-link-explore-permalink) | `/api/v1/explore/permalink`       |
+| `GET`  | [Get chart's permanent link state](/developer-docs/6.1.0/api/get-charts-permanent-link-state)                              | `/api/v1/explore/permalink/{key}` |
 
 </details>
 
@@ -350,8 +350,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                           | Description                      |
 | ------ | ------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| `POST` | [Create a new permanent link (sqllab-permalink)](/developer-docs/api/create-a-new-permanent-link-sqllab-permalink) | `/api/v1/sqllab/permalink`       |
-| `GET`  | [Get permanent link state for SQLLab editor.](/developer-docs/api/get-permanent-link-state-for-sql-lab-editor)     | `/api/v1/sqllab/permalink/{key}` |
+| `POST` | [Create a new permanent link (sqllab-permalink)](/developer-docs/6.1.0/api/create-a-new-permanent-link-sqllab-permalink) | `/api/v1/sqllab/permalink`       |
+| `GET`  | [Get permanent link state for SQLLab editor.](/developer-docs/6.1.0/api/get-permanent-link-state-for-sql-lab-editor)     | `/api/v1/sqllab/permalink/{key}` |
 
 </details>
 
@@ -360,7 +360,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                                     | Description                         |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `GET`  | [Get a report schedule log (embedded-dashboard-uuid)](/developer-docs/api/get-a-report-schedule-log-embedded-dashboard-uuid) | `/api/v1/embedded_dashboard/{uuid}` |
+| `GET`  | [Get a report schedule log (embedded-dashboard-uuid)](/developer-docs/6.1.0/api/get-a-report-schedule-log-embedded-dashboard-uuid) | `/api/v1/embedded_dashboard/{uuid}` |
 
 </details>
 
@@ -369,10 +369,10 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                              | Description                                 |
 | -------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `POST`   | [Create a dashboard's filter state](/developer-docs/api/create-a-dashboards-filter-state)             | `/api/v1/dashboard/{pk}/filter_state`       |
-| `DELETE` | [Delete a dashboard's filter state value](/developer-docs/api/delete-a-dashboards-filter-state-value) | `/api/v1/dashboard/{pk}/filter_state/{key}` |
-| `GET`    | [Get a dashboard's filter state value](/developer-docs/api/get-a-dashboards-filter-state-value)       | `/api/v1/dashboard/{pk}/filter_state/{key}` |
-| `PUT`    | [Update a dashboard's filter state value](/developer-docs/api/update-a-dashboards-filter-state-value) | `/api/v1/dashboard/{pk}/filter_state/{key}` |
+| `POST`   | [Create a dashboard's filter state](/developer-docs/6.1.0/api/create-a-dashboards-filter-state)             | `/api/v1/dashboard/{pk}/filter_state`       |
+| `DELETE` | [Delete a dashboard's filter state value](/developer-docs/6.1.0/api/delete-a-dashboards-filter-state-value) | `/api/v1/dashboard/{pk}/filter_state/{key}` |
+| `GET`    | [Get a dashboard's filter state value](/developer-docs/6.1.0/api/get-a-dashboards-filter-state-value)       | `/api/v1/dashboard/{pk}/filter_state/{key}` |
+| `PUT`    | [Update a dashboard's filter state value](/developer-docs/6.1.0/api/update-a-dashboards-filter-state-value) | `/api/v1/dashboard/{pk}/filter_state/{key}` |
 
 </details>
 
@@ -381,10 +381,10 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                         | Description                       |
 | -------- | -------------------------------------------------------------------------------- | --------------------------------- |
-| `POST`   | [Create a new form_data](/developer-docs/api/create-a-new-form-data)             | `/api/v1/explore/form_data`       |
-| `DELETE` | [Delete a form_data](/developer-docs/api/delete-a-form-data)                     | `/api/v1/explore/form_data/{key}` |
-| `GET`    | [Get a form_data](/developer-docs/api/get-a-form-data)                           | `/api/v1/explore/form_data/{key}` |
-| `PUT`    | [Update an existing form_data](/developer-docs/api/update-an-existing-form-data) | `/api/v1/explore/form_data/{key}` |
+| `POST`   | [Create a new form_data](/developer-docs/6.1.0/api/create-a-new-form-data)             | `/api/v1/explore/form_data`       |
+| `DELETE` | [Delete a form_data](/developer-docs/6.1.0/api/delete-a-form-data)                     | `/api/v1/explore/form_data/{key}` |
+| `GET`    | [Get a form_data](/developer-docs/6.1.0/api/get-a-form-data)                           | `/api/v1/explore/form_data/{key}` |
+| `PUT`    | [Update an existing form_data](/developer-docs/6.1.0/api/update-an-existing-form-data) | `/api/v1/explore/form_data/{key}` |
 
 </details>
 
@@ -395,17 +395,17 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                            | Description                            |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `DELETE` | [Bulk delete report schedules](/developer-docs/api/bulk-delete-report-schedules)                                                                    | `/api/v1/report/`                      |
-| `GET`    | [Get a list of report schedules](/developer-docs/api/get-a-list-of-report-schedules)                                                                | `/api/v1/report/`                      |
-| `POST`   | [Create a report schedule](/developer-docs/api/create-a-report-schedule)                                                                            | `/api/v1/report/`                      |
-| `GET`    | [Get metadata information about this API resource (report--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-report-info) | `/api/v1/report/_info`                 |
-| `DELETE` | [Delete a report schedule](/developer-docs/api/delete-a-report-schedule)                                                                            | `/api/v1/report/{pk}`                  |
-| `GET`    | [Get a report schedule](/developer-docs/api/get-a-report-schedule)                                                                                  | `/api/v1/report/{pk}`                  |
-| `PUT`    | [Update a report schedule](/developer-docs/api/update-a-report-schedule)                                                                            | `/api/v1/report/{pk}`                  |
-| `GET`    | [Get a list of report schedule logs](/developer-docs/api/get-a-list-of-report-schedule-logs)                                                        | `/api/v1/report/{pk}/log/`             |
-| `GET`    | [Get a report schedule log (report-pk-log-log-id)](/developer-docs/api/get-a-report-schedule-log-report-pk-log-log-id)                              | `/api/v1/report/{pk}/log/{log_id}`     |
-| `GET`    | [Get related fields data (report-related-column-name)](/developer-docs/api/get-related-fields-data-report-related-column-name)                      | `/api/v1/report/related/{column_name}` |
-| `GET`    | [Get slack channels](/developer-docs/api/get-slack-channels)                                                                                        | `/api/v1/report/slack_channels/`       |
+| `DELETE` | [Bulk delete report schedules](/developer-docs/6.1.0/api/bulk-delete-report-schedules)                                                                    | `/api/v1/report/`                      |
+| `GET`    | [Get a list of report schedules](/developer-docs/6.1.0/api/get-a-list-of-report-schedules)                                                                | `/api/v1/report/`                      |
+| `POST`   | [Create a report schedule](/developer-docs/6.1.0/api/create-a-report-schedule)                                                                            | `/api/v1/report/`                      |
+| `GET`    | [Get metadata information about this API resource (report--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-report-info) | `/api/v1/report/_info`                 |
+| `DELETE` | [Delete a report schedule](/developer-docs/6.1.0/api/delete-a-report-schedule)                                                                            | `/api/v1/report/{pk}`                  |
+| `GET`    | [Get a report schedule](/developer-docs/6.1.0/api/get-a-report-schedule)                                                                                  | `/api/v1/report/{pk}`                  |
+| `PUT`    | [Update a report schedule](/developer-docs/6.1.0/api/update-a-report-schedule)                                                                            | `/api/v1/report/{pk}`                  |
+| `GET`    | [Get a list of report schedule logs](/developer-docs/6.1.0/api/get-a-list-of-report-schedule-logs)                                                        | `/api/v1/report/{pk}/log/`             |
+| `GET`    | [Get a report schedule log (report-pk-log-log-id)](/developer-docs/6.1.0/api/get-a-report-schedule-log-report-pk-log-log-id)                              | `/api/v1/report/{pk}/log/{log_id}`     |
+| `GET`    | [Get related fields data (report-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-report-related-column-name)                      | `/api/v1/report/related/{column_name}` |
+| `GET`    | [Get slack channels](/developer-docs/6.1.0/api/get-slack-channels)                                                                                        | `/api/v1/report/slack_channels/`       |
 
 </details>
 
@@ -416,17 +416,17 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                         | Description                                     |
 | -------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `GET`    | [Get security roles](/developer-docs/api/get-security-roles)                                                     | `/api/v1/security/roles/`                       |
-| `POST`   | [Create security roles](/developer-docs/api/create-security-roles)                                               | `/api/v1/security/roles/`                       |
-| `GET`    | [Get security roles info](/developer-docs/api/get-security-roles-info)                                           | `/api/v1/security/roles/_info`                  |
-| `DELETE` | [Delete security roles by pk](/developer-docs/api/delete-security-roles-by-pk)                                   | `/api/v1/security/roles/{pk}`                   |
-| `GET`    | [Get security roles by pk](/developer-docs/api/get-security-roles-by-pk)                                         | `/api/v1/security/roles/{pk}`                   |
-| `PUT`    | [Update security roles by pk](/developer-docs/api/update-security-roles-by-pk)                                   | `/api/v1/security/roles/{pk}`                   |
-| `PUT`    | [Update security roles by role_id groups](/developer-docs/api/update-security-roles-by-role-id-groups)           | `/api/v1/security/roles/{role_id}/groups`       |
-| `POST`   | [Create security roles by role_id permissions](/developer-docs/api/create-security-roles-by-role-id-permissions) | `/api/v1/security/roles/{role_id}/permissions`  |
-| `GET`    | [Get security roles by role_id permissions](/developer-docs/api/get-security-roles-by-role-id-permissions)       | `/api/v1/security/roles/{role_id}/permissions/` |
-| `PUT`    | [Update security roles by role_id users](/developer-docs/api/update-security-roles-by-role-id-users)             | `/api/v1/security/roles/{role_id}/users`        |
-| `GET`    | [List roles](/developer-docs/api/list-roles)                                                                     | `/api/v1/security/roles/search/`                |
+| `GET`    | [Get security roles](/developer-docs/6.1.0/api/get-security-roles)                                                     | `/api/v1/security/roles/`                       |
+| `POST`   | [Create security roles](/developer-docs/6.1.0/api/create-security-roles)                                               | `/api/v1/security/roles/`                       |
+| `GET`    | [Get security roles info](/developer-docs/6.1.0/api/get-security-roles-info)                                           | `/api/v1/security/roles/_info`                  |
+| `DELETE` | [Delete security roles by pk](/developer-docs/6.1.0/api/delete-security-roles-by-pk)                                   | `/api/v1/security/roles/{pk}`                   |
+| `GET`    | [Get security roles by pk](/developer-docs/6.1.0/api/get-security-roles-by-pk)                                         | `/api/v1/security/roles/{pk}`                   |
+| `PUT`    | [Update security roles by pk](/developer-docs/6.1.0/api/update-security-roles-by-pk)                                   | `/api/v1/security/roles/{pk}`                   |
+| `PUT`    | [Update security roles by role_id groups](/developer-docs/6.1.0/api/update-security-roles-by-role-id-groups)           | `/api/v1/security/roles/{role_id}/groups`       |
+| `POST`   | [Create security roles by role_id permissions](/developer-docs/6.1.0/api/create-security-roles-by-role-id-permissions) | `/api/v1/security/roles/{role_id}/permissions`  |
+| `GET`    | [Get security roles by role_id permissions](/developer-docs/6.1.0/api/get-security-roles-by-role-id-permissions)       | `/api/v1/security/roles/{role_id}/permissions/` |
+| `PUT`    | [Update security roles by role_id users](/developer-docs/6.1.0/api/update-security-roles-by-role-id-users)             | `/api/v1/security/roles/{role_id}/users`        |
+| `GET`    | [List roles](/developer-docs/6.1.0/api/list-roles)                                                                     | `/api/v1/security/roles/search/`                |
 
 </details>
 
@@ -435,12 +435,12 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                       | Description                    |
 | -------- | ------------------------------------------------------------------------------ | ------------------------------ |
-| `GET`    | [Get security users](/developer-docs/api/get-security-users)                   | `/api/v1/security/users/`      |
-| `POST`   | [Create security users](/developer-docs/api/create-security-users)             | `/api/v1/security/users/`      |
-| `GET`    | [Get security users info](/developer-docs/api/get-security-users-info)         | `/api/v1/security/users/_info` |
-| `DELETE` | [Delete security users by pk](/developer-docs/api/delete-security-users-by-pk) | `/api/v1/security/users/{pk}`  |
-| `GET`    | [Get security users by pk](/developer-docs/api/get-security-users-by-pk)       | `/api/v1/security/users/{pk}`  |
-| `PUT`    | [Update security users by pk](/developer-docs/api/update-security-users-by-pk) | `/api/v1/security/users/{pk}`  |
+| `GET`    | [Get security users](/developer-docs/6.1.0/api/get-security-users)                   | `/api/v1/security/users/`      |
+| `POST`   | [Create security users](/developer-docs/6.1.0/api/create-security-users)             | `/api/v1/security/users/`      |
+| `GET`    | [Get security users info](/developer-docs/6.1.0/api/get-security-users-info)         | `/api/v1/security/users/_info` |
+| `DELETE` | [Delete security users by pk](/developer-docs/6.1.0/api/delete-security-users-by-pk) | `/api/v1/security/users/{pk}`  |
+| `GET`    | [Get security users by pk](/developer-docs/6.1.0/api/get-security-users-by-pk)       | `/api/v1/security/users/{pk}`  |
+| `PUT`    | [Update security users by pk](/developer-docs/6.1.0/api/update-security-users-by-pk) | `/api/v1/security/users/{pk}`  |
 
 </details>
 
@@ -449,9 +449,9 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                             | Description                          |
 | ------ | ------------------------------------------------------------------------------------ | ------------------------------------ |
-| `GET`  | [Get security permissions](/developer-docs/api/get-security-permissions)             | `/api/v1/security/permissions/`      |
-| `GET`  | [Get security permissions info](/developer-docs/api/get-security-permissions-info)   | `/api/v1/security/permissions/_info` |
-| `GET`  | [Get security permissions by pk](/developer-docs/api/get-security-permissions-by-pk) | `/api/v1/security/permissions/{pk}`  |
+| `GET`  | [Get security permissions](/developer-docs/6.1.0/api/get-security-permissions)             | `/api/v1/security/permissions/`      |
+| `GET`  | [Get security permissions info](/developer-docs/6.1.0/api/get-security-permissions-info)   | `/api/v1/security/permissions/_info` |
+| `GET`  | [Get security permissions by pk](/developer-docs/6.1.0/api/get-security-permissions-by-pk) | `/api/v1/security/permissions/{pk}`  |
 
 </details>
 
@@ -460,12 +460,12 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                               | Description                        |
 | -------- | -------------------------------------------------------------------------------------- | ---------------------------------- |
-| `GET`    | [Get security resources](/developer-docs/api/get-security-resources)                   | `/api/v1/security/resources/`      |
-| `POST`   | [Create security resources](/developer-docs/api/create-security-resources)             | `/api/v1/security/resources/`      |
-| `GET`    | [Get security resources info](/developer-docs/api/get-security-resources-info)         | `/api/v1/security/resources/_info` |
-| `DELETE` | [Delete security resources by pk](/developer-docs/api/delete-security-resources-by-pk) | `/api/v1/security/resources/{pk}`  |
-| `GET`    | [Get security resources by pk](/developer-docs/api/get-security-resources-by-pk)       | `/api/v1/security/resources/{pk}`  |
-| `PUT`    | [Update security resources by pk](/developer-docs/api/update-security-resources-by-pk) | `/api/v1/security/resources/{pk}`  |
+| `GET`    | [Get security resources](/developer-docs/6.1.0/api/get-security-resources)                   | `/api/v1/security/resources/`      |
+| `POST`   | [Create security resources](/developer-docs/6.1.0/api/create-security-resources)             | `/api/v1/security/resources/`      |
+| `GET`    | [Get security resources info](/developer-docs/6.1.0/api/get-security-resources-info)         | `/api/v1/security/resources/_info` |
+| `DELETE` | [Delete security resources by pk](/developer-docs/6.1.0/api/delete-security-resources-by-pk) | `/api/v1/security/resources/{pk}`  |
+| `GET`    | [Get security resources by pk](/developer-docs/6.1.0/api/get-security-resources-by-pk)       | `/api/v1/security/resources/{pk}`  |
+| `PUT`    | [Update security resources by pk](/developer-docs/6.1.0/api/update-security-resources-by-pk) | `/api/v1/security/resources/{pk}`  |
 
 </details>
 
@@ -474,12 +474,12 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                       | Description                                    |
 | -------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `GET`    | [Get security permissions resources](/developer-docs/api/get-security-permissions-resources)                   | `/api/v1/security/permissions-resources/`      |
-| `POST`   | [Create security permissions resources](/developer-docs/api/create-security-permissions-resources)             | `/api/v1/security/permissions-resources/`      |
-| `GET`    | [Get security permissions resources info](/developer-docs/api/get-security-permissions-resources-info)         | `/api/v1/security/permissions-resources/_info` |
-| `DELETE` | [Delete security permissions resources by pk](/developer-docs/api/delete-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}`  |
-| `GET`    | [Get security permissions resources by pk](/developer-docs/api/get-security-permissions-resources-by-pk)       | `/api/v1/security/permissions-resources/{pk}`  |
-| `PUT`    | [Update security permissions resources by pk](/developer-docs/api/update-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}`  |
+| `GET`    | [Get security permissions resources](/developer-docs/6.1.0/api/get-security-permissions-resources)                   | `/api/v1/security/permissions-resources/`      |
+| `POST`   | [Create security permissions resources](/developer-docs/6.1.0/api/create-security-permissions-resources)             | `/api/v1/security/permissions-resources/`      |
+| `GET`    | [Get security permissions resources info](/developer-docs/6.1.0/api/get-security-permissions-resources-info)         | `/api/v1/security/permissions-resources/_info` |
+| `DELETE` | [Delete security permissions resources by pk](/developer-docs/6.1.0/api/delete-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}`  |
+| `GET`    | [Get security permissions resources by pk](/developer-docs/6.1.0/api/get-security-permissions-resources-by-pk)       | `/api/v1/security/permissions-resources/{pk}`  |
+| `PUT`    | [Update security permissions resources by pk](/developer-docs/6.1.0/api/update-security-permissions-resources-by-pk) | `/api/v1/security/permissions-resources/{pk}`  |
 
 </details>
 
@@ -488,14 +488,14 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                                | Description                                      |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `DELETE` | [Bulk delete RLS rules](/developer-docs/api/bulk-delete-rls-rules)                                                                                                      | `/api/v1/rowlevelsecurity/`                      |
-| `GET`    | [Get a list of RLS](/developer-docs/api/get-a-list-of-rls)                                                                                                              | `/api/v1/rowlevelsecurity/`                      |
-| `POST`   | [Create a new RLS rule](/developer-docs/api/create-a-new-rls-rule)                                                                                                      | `/api/v1/rowlevelsecurity/`                      |
-| `GET`    | [Get metadata information about this API resource (rowlevelsecurity--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-rowlevelsecurity-info) | `/api/v1/rowlevelsecurity/_info`                 |
-| `DELETE` | [Delete an RLS](/developer-docs/api/delete-an-rls)                                                                                                                      | `/api/v1/rowlevelsecurity/{pk}`                  |
-| `GET`    | [Get an RLS](/developer-docs/api/get-an-rls)                                                                                                                            | `/api/v1/rowlevelsecurity/{pk}`                  |
-| `PUT`    | [Update an RLS rule](/developer-docs/api/update-an-rls-rule)                                                                                                            | `/api/v1/rowlevelsecurity/{pk}`                  |
-| `GET`    | [Get related fields data (rowlevelsecurity-related-column-name)](/developer-docs/api/get-related-fields-data-rowlevelsecurity-related-column-name)                      | `/api/v1/rowlevelsecurity/related/{column_name}` |
+| `DELETE` | [Bulk delete RLS rules](/developer-docs/6.1.0/api/bulk-delete-rls-rules)                                                                                                      | `/api/v1/rowlevelsecurity/`                      |
+| `GET`    | [Get a list of RLS](/developer-docs/6.1.0/api/get-a-list-of-rls)                                                                                                              | `/api/v1/rowlevelsecurity/`                      |
+| `POST`   | [Create a new RLS rule](/developer-docs/6.1.0/api/create-a-new-rls-rule)                                                                                                      | `/api/v1/rowlevelsecurity/`                      |
+| `GET`    | [Get metadata information about this API resource (rowlevelsecurity--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-rowlevelsecurity-info) | `/api/v1/rowlevelsecurity/_info`                 |
+| `DELETE` | [Delete an RLS](/developer-docs/6.1.0/api/delete-an-rls)                                                                                                                      | `/api/v1/rowlevelsecurity/{pk}`                  |
+| `GET`    | [Get an RLS](/developer-docs/6.1.0/api/get-an-rls)                                                                                                                            | `/api/v1/rowlevelsecurity/{pk}`                  |
+| `PUT`    | [Update an RLS rule](/developer-docs/6.1.0/api/update-an-rls-rule)                                                                                                            | `/api/v1/rowlevelsecurity/{pk}`                  |
+| `GET`    | [Get related fields data (rowlevelsecurity-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-rowlevelsecurity-related-column-name)                      | `/api/v1/rowlevelsecurity/related/{column_name}` |
 
 </details>
 
@@ -506,8 +506,8 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                             | Description              |
 | ------ | -------------------------------------------------------------------- | ------------------------ |
-| `GET`  | [Export all assets](/developer-docs/api/export-all-assets)           | `/api/v1/assets/export/` |
-| `POST` | [Import multiple assets](/developer-docs/api/import-multiple-assets) | `/api/v1/assets/import/` |
+| `GET`  | [Export all assets](/developer-docs/6.1.0/api/export-all-assets)           | `/api/v1/assets/export/` |
+| `POST` | [Import multiple assets](/developer-docs/6.1.0/api/import-multiple-assets) | `/api/v1/assets/import/` |
 
 </details>
 
@@ -516,7 +516,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                                                                 | Description                   |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `POST` | [Invalidate cache records and remove the database records](/developer-docs/api/invalidate-cache-records-and-remove-the-database-records) | `/api/v1/cachekey/invalidate` |
+| `POST` | [Invalidate cache records and remove the database records](/developer-docs/6.1.0/api/invalidate-cache-records-and-remove-the-database-records) | `/api/v1/cachekey/invalidate` |
 
 </details>
 
@@ -525,10 +525,10 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                       | Description                    |
 | ------ | ---------------------------------------------------------------------------------------------- | ------------------------------ |
-| `GET`  | [Get a list of logs](/developer-docs/api/get-a-list-of-logs)                                   | `/api/v1/log/`                 |
-| `POST` | [Create log](/developer-docs/api/create-log)                                                   | `/api/v1/log/`                 |
-| `GET`  | [Get a log detail information](/developer-docs/api/get-a-log-detail-information)               | `/api/v1/log/{pk}`             |
-| `GET`  | [Get recent activity data for a user](/developer-docs/api/get-recent-activity-data-for-a-user) | `/api/v1/log/recent_activity/` |
+| `GET`  | [Get a list of logs](/developer-docs/6.1.0/api/get-a-list-of-logs)                                   | `/api/v1/log/`                 |
+| `POST` | [Create log](/developer-docs/6.1.0/api/create-log)                                                   | `/api/v1/log/`                 |
+| `GET`  | [Get a log detail information](/developer-docs/6.1.0/api/get-a-log-detail-information)               | `/api/v1/log/{pk}`             |
+| `GET`  | [Get recent activity data for a user](/developer-docs/6.1.0/api/get-recent-activity-data-for-a-user) | `/api/v1/log/recent_activity/` |
 
 </details>
 
@@ -539,9 +539,9 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                               | Description         |
 | ------ | ---------------------------------------------------------------------- | ------------------- |
-| `GET`  | [Get the user object](/developer-docs/api/get-the-user-object)         | `/api/v1/me/`       |
-| `PUT`  | [Update the current user](/developer-docs/api/update-the-current-user) | `/api/v1/me/`       |
-| `GET`  | [Get the user roles](/developer-docs/api/get-the-user-roles)           | `/api/v1/me/roles/` |
+| `GET`  | [Get the user object](/developer-docs/6.1.0/api/get-the-user-object)         | `/api/v1/me/`       |
+| `PUT`  | [Update the current user](/developer-docs/6.1.0/api/update-the-current-user) | `/api/v1/me/`       |
+| `GET`  | [Get the user roles](/developer-docs/6.1.0/api/get-the-user-roles)           | `/api/v1/me/roles/` |
 
 </details>
 
@@ -550,7 +550,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                       | Description                         |
 | ------ | -------------------------------------------------------------- | ----------------------------------- |
-| `GET`  | [Get the user avatar](/developer-docs/api/get-the-user-avatar) | `/api/v1/user/{user_id}/avatar.png` |
+| `GET`  | [Get the user avatar](/developer-docs/6.1.0/api/get-the-user-avatar) | `/api/v1/user/{user_id}/avatar.png` |
 
 </details>
 
@@ -559,7 +559,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                 | Description     |
 | ------ | ---------------------------------------- | --------------- |
-| `GET`  | [Get menu](/developer-docs/api/get-menu) | `/api/v1/menu/` |
+| `GET`  | [Get menu](/developer-docs/6.1.0/api/get-menu) | `/api/v1/menu/` |
 
 </details>
 
@@ -568,7 +568,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                   | Description                  |
 | ------ | -------------------------------------------------------------------------- | ---------------------------- |
-| `GET`  | [Get all available domains](/developer-docs/api/get-all-available-domains) | `/api/v1/available_domains/` |
+| `GET`  | [Get all available domains](/developer-docs/6.1.0/api/get-all-available-domains) | `/api/v1/available_domains/` |
 
 </details>
 
@@ -577,7 +577,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                                       | Description            |
 | ------ | ---------------------------------------------------------------------------------------------- | ---------------------- |
-| `GET`  | [Read off of the Redis events stream](/developer-docs/api/read-off-of-the-redis-events-stream) | `/api/v1/async_event/` |
+| `GET`  | [Read off of the Redis events stream](/developer-docs/6.1.0/api/read-off-of-the-redis-events-stream) | `/api/v1/async_event/` |
 
 </details>
 
@@ -586,7 +586,7 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method | Endpoint                                                                     | Description               |
 | ------ | ---------------------------------------------------------------------------- | ------------------------- |
-| `GET`  | [Get api by version openapi](/developer-docs/api/get-api-by-version-openapi) | `/api/{version}/_openapi` |
+| `GET`  | [Get api by version openapi](/developer-docs/6.1.0/api/get-api-by-version-openapi) | `/api/{version}/_openapi` |
 
 </details>
 
@@ -597,12 +597,12 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                         | Description                     |
 | -------- | -------------------------------------------------------------------------------- | ------------------------------- |
-| `GET`    | [Get security groups](/developer-docs/api/get-security-groups)                   | `/api/v1/security/groups/`      |
-| `POST`   | [Create security groups](/developer-docs/api/create-security-groups)             | `/api/v1/security/groups/`      |
-| `GET`    | [Get security groups info](/developer-docs/api/get-security-groups-info)         | `/api/v1/security/groups/_info` |
-| `DELETE` | [Delete security groups by pk](/developer-docs/api/delete-security-groups-by-pk) | `/api/v1/security/groups/{pk}`  |
-| `GET`    | [Get security groups by pk](/developer-docs/api/get-security-groups-by-pk)       | `/api/v1/security/groups/{pk}`  |
-| `PUT`    | [Update security groups by pk](/developer-docs/api/update-security-groups-by-pk) | `/api/v1/security/groups/{pk}`  |
+| `GET`    | [Get security groups](/developer-docs/6.1.0/api/get-security-groups)                   | `/api/v1/security/groups/`      |
+| `POST`   | [Create security groups](/developer-docs/6.1.0/api/create-security-groups)             | `/api/v1/security/groups/`      |
+| `GET`    | [Get security groups info](/developer-docs/6.1.0/api/get-security-groups-info)         | `/api/v1/security/groups/_info` |
+| `DELETE` | [Delete security groups by pk](/developer-docs/6.1.0/api/delete-security-groups-by-pk) | `/api/v1/security/groups/{pk}`  |
+| `GET`    | [Get security groups by pk](/developer-docs/6.1.0/api/get-security-groups-by-pk)       | `/api/v1/security/groups/{pk}`  |
+| `PUT`    | [Update security groups by pk](/developer-docs/6.1.0/api/update-security-groups-by-pk) | `/api/v1/security/groups/{pk}`  |
 
 </details>
 
@@ -611,20 +611,20 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                          | Description                             |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `DELETE` | [Bulk delete themes](/developer-docs/api/bulk-delete-themes)                                                                                      | `/api/v1/theme/`                        |
-| `GET`    | [Get a list of themes](/developer-docs/api/get-a-list-of-themes)                                                                                  | `/api/v1/theme/`                        |
-| `POST`   | [Create a theme](/developer-docs/api/create-a-theme)                                                                                              | `/api/v1/theme/`                        |
-| `GET`    | [Get metadata information about this API resource (theme--info)](/developer-docs/api/get-metadata-information-about-this-api-resource-theme-info) | `/api/v1/theme/_info`                   |
-| `DELETE` | [Delete a theme](/developer-docs/api/delete-a-theme)                                                                                              | `/api/v1/theme/{pk}`                    |
-| `GET`    | [Get a theme](/developer-docs/api/get-a-theme)                                                                                                    | `/api/v1/theme/{pk}`                    |
-| `PUT`    | [Update a theme](/developer-docs/api/update-a-theme)                                                                                              | `/api/v1/theme/{pk}`                    |
-| `PUT`    | [Set a theme as the system dark theme](/developer-docs/api/set-a-theme-as-the-system-dark-theme)                                                  | `/api/v1/theme/{pk}/set_system_dark`    |
-| `PUT`    | [Set a theme as the system default theme](/developer-docs/api/set-a-theme-as-the-system-default-theme)                                            | `/api/v1/theme/{pk}/set_system_default` |
-| `GET`    | [Download multiple themes as YAML files](/developer-docs/api/download-multiple-themes-as-yaml-files)                                              | `/api/v1/theme/export/`                 |
-| `POST`   | [Import themes from a ZIP file](/developer-docs/api/import-themes-from-a-zip-file)                                                                | `/api/v1/theme/import/`                 |
-| `GET`    | [Get related fields data (theme-related-column-name)](/developer-docs/api/get-related-fields-data-theme-related-column-name)                      | `/api/v1/theme/related/{column_name}`   |
-| `DELETE` | [Clear the system dark theme](/developer-docs/api/clear-the-system-dark-theme)                                                                    | `/api/v1/theme/unset_system_dark`       |
-| `DELETE` | [Clear the system default theme](/developer-docs/api/clear-the-system-default-theme)                                                              | `/api/v1/theme/unset_system_default`    |
+| `DELETE` | [Bulk delete themes](/developer-docs/6.1.0/api/bulk-delete-themes)                                                                                      | `/api/v1/theme/`                        |
+| `GET`    | [Get a list of themes](/developer-docs/6.1.0/api/get-a-list-of-themes)                                                                                  | `/api/v1/theme/`                        |
+| `POST`   | [Create a theme](/developer-docs/6.1.0/api/create-a-theme)                                                                                              | `/api/v1/theme/`                        |
+| `GET`    | [Get metadata information about this API resource (theme--info)](/developer-docs/6.1.0/api/get-metadata-information-about-this-api-resource-theme-info) | `/api/v1/theme/_info`                   |
+| `DELETE` | [Delete a theme](/developer-docs/6.1.0/api/delete-a-theme)                                                                                              | `/api/v1/theme/{pk}`                    |
+| `GET`    | [Get a theme](/developer-docs/6.1.0/api/get-a-theme)                                                                                                    | `/api/v1/theme/{pk}`                    |
+| `PUT`    | [Update a theme](/developer-docs/6.1.0/api/update-a-theme)                                                                                              | `/api/v1/theme/{pk}`                    |
+| `PUT`    | [Set a theme as the system dark theme](/developer-docs/6.1.0/api/set-a-theme-as-the-system-dark-theme)                                                  | `/api/v1/theme/{pk}/set_system_dark`    |
+| `PUT`    | [Set a theme as the system default theme](/developer-docs/6.1.0/api/set-a-theme-as-the-system-default-theme)                                            | `/api/v1/theme/{pk}/set_system_default` |
+| `GET`    | [Download multiple themes as YAML files](/developer-docs/6.1.0/api/download-multiple-themes-as-yaml-files)                                              | `/api/v1/theme/export/`                 |
+| `POST`   | [Import themes from a ZIP file](/developer-docs/6.1.0/api/import-themes-from-a-zip-file)                                                                | `/api/v1/theme/import/`                 |
+| `GET`    | [Get related fields data (theme-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-theme-related-column-name)                      | `/api/v1/theme/related/{column_name}`   |
+| `DELETE` | [Clear the system dark theme](/developer-docs/6.1.0/api/clear-the-system-dark-theme)                                                                    | `/api/v1/theme/unset_system_dark`       |
+| `DELETE` | [Clear the system default theme](/developer-docs/6.1.0/api/clear-the-system-default-theme)                                                              | `/api/v1/theme/unset_system_default`    |
 
 </details>
 
@@ -633,14 +633,14 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 | Method   | Endpoint                                                                                                                                                                                           | Description                                                  |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `GET`    | [Get security user registrations](/developer-docs/api/get-security-user-registrations)                                                                                                             | `/api/v1/security/user_registrations/`                       |
-| `POST`   | [Create security user registrations](/developer-docs/api/create-security-user-registrations)                                                                                                       | `/api/v1/security/user_registrations/`                       |
-| `GET`    | [Get security user registrations info](/developer-docs/api/get-security-user-registrations-info)                                                                                                   | `/api/v1/security/user_registrations/_info`                  |
-| `DELETE` | [Delete security user registrations by pk](/developer-docs/api/delete-security-user-registrations-by-pk)                                                                                           | `/api/v1/security/user_registrations/{pk}`                   |
-| `GET`    | [Get security user registrations by pk](/developer-docs/api/get-security-user-registrations-by-pk)                                                                                                 | `/api/v1/security/user_registrations/{pk}`                   |
-| `PUT`    | [Update security user registrations by pk](/developer-docs/api/update-security-user-registrations-by-pk)                                                                                           | `/api/v1/security/user_registrations/{pk}`                   |
-| `GET`    | [Get distinct values from field data (security-user-registrations-distinct-column-name)](/developer-docs/api/get-distinct-values-from-field-data-security-user-registrations-distinct-column-name) | `/api/v1/security/user_registrations/distinct/{column_name}` |
-| `GET`    | [Get related fields data (security-user-registrations-related-column-name)](/developer-docs/api/get-related-fields-data-security-user-registrations-related-column-name)                           | `/api/v1/security/user_registrations/related/{column_name}`  |
+| `GET`    | [Get security user registrations](/developer-docs/6.1.0/api/get-security-user-registrations)                                                                                                             | `/api/v1/security/user_registrations/`                       |
+| `POST`   | [Create security user registrations](/developer-docs/6.1.0/api/create-security-user-registrations)                                                                                                       | `/api/v1/security/user_registrations/`                       |
+| `GET`    | [Get security user registrations info](/developer-docs/6.1.0/api/get-security-user-registrations-info)                                                                                                   | `/api/v1/security/user_registrations/_info`                  |
+| `DELETE` | [Delete security user registrations by pk](/developer-docs/6.1.0/api/delete-security-user-registrations-by-pk)                                                                                           | `/api/v1/security/user_registrations/{pk}`                   |
+| `GET`    | [Get security user registrations by pk](/developer-docs/6.1.0/api/get-security-user-registrations-by-pk)                                                                                                 | `/api/v1/security/user_registrations/{pk}`                   |
+| `PUT`    | [Update security user registrations by pk](/developer-docs/6.1.0/api/update-security-user-registrations-by-pk)                                                                                           | `/api/v1/security/user_registrations/{pk}`                   |
+| `GET`    | [Get distinct values from field data (security-user-registrations-distinct-column-name)](/developer-docs/6.1.0/api/get-distinct-values-from-field-data-security-user-registrations-distinct-column-name) | `/api/v1/security/user_registrations/distinct/{column_name}` |
+| `GET`    | [Get related fields data (security-user-registrations-related-column-name)](/developer-docs/6.1.0/api/get-related-fields-data-security-user-registrations-related-column-name)                           | `/api/v1/security/user_registrations/related/{column_name}`  |
 
 </details>
 

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -3863,7 +3863,12 @@
             "additionalProperties": {},
             "type": "object"
           },
-          "shared_label_colors": {}
+          "shared_label_colors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
         },
         "type": "object"
       },

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -1604,7 +1604,8 @@
             "enum": [
               "csv",
               "json",
-              "xlsx"
+              "xlsx",
+              "arrow"
             ]
           },
           "result_type": {
@@ -7050,6 +7051,111 @@
         "required": [
           "datasource_type"
         ],
+        "type": "object"
+      },
+      "DatasourceQueryOrder": {
+        "additionalProperties": false,
+        "properties": {
+          "column": {
+            "description": "Metric or dimension name to sort by.",
+            "type": "string"
+          },
+          "descending": {
+            "default": true,
+            "description": "Sort this column descending.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "column"
+        ],
+        "type": "object"
+      },
+      "DatasourceQuerySchema": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_timeout": {
+            "default": null,
+            "description": "Seconds to cache for; -1 disables caching.",
+            "minimum": -1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "dimensions": {
+            "description": "Dimension/column names to group by.",
+            "items": {},
+            "type": "array"
+          },
+          "filters": {
+            "description": "Filters to apply, AND-ed together.",
+            "items": {
+              "$ref": "#/components/schemas/ChartDataFilter"
+            },
+            "type": "array"
+          },
+          "force": {
+            "default": false,
+            "type": "boolean"
+          },
+          "limit": {
+            "default": null,
+            "description": "Rows to return. Also clamped server-side by ROW_LIMIT.",
+            "maximum": 50000,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "metrics": {
+            "description": "Saved metric names, or ad-hoc metric objects (datasets only). See ChartDataAdhocMetricSchema.",
+            "items": {},
+            "type": "array"
+          },
+          "offset": {
+            "default": 0,
+            "description": "Rows to skip, for pagination.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "order": {
+            "description": "Ordering terms, applied in sequence. Each carries its own direction.",
+            "items": {
+              "$ref": "#/components/schemas/DatasourceQueryOrder"
+            },
+            "type": "array"
+          },
+          "result_format": {
+            "default": "json",
+            "description": "'json' (default) or 'arrow' for an Arrow IPC stream.",
+            "enum": [
+              "csv",
+              "json",
+              "xlsx",
+              "arrow"
+            ]
+          },
+          "time_column": {
+            "default": null,
+            "description": "Temporal column the time range applies to. Inferred from the datasource when omitted.",
+            "nullable": true,
+            "type": "string"
+          },
+          "time_grain": {
+            "default": null,
+            "description": "ISO 8601 duration, e.g. 'P1D' or 'PT1H'.",
+            "nullable": true,
+            "type": "string"
+          },
+          "time_range": {
+            "default": null,
+            "description": "e.g. 'Last 30 days' or '2024-01-01 : 2024-12-31'.",
+            "nullable": true,
+            "type": "string"
+          },
+          "use_cache": {
+            "default": true,
+            "type": "boolean"
+          }
+        },
         "type": "object"
       },
       "DistincResponseSchema": {
@@ -25181,6 +25287,69 @@
         ]
       }
     },
+    "/api/v1/datasource/{datasource_type}/{datasource_id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "datasource_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "datasource_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Datasource metadata plus a capabilities block"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get datasource metadata and capabilities",
+        "tags": [
+          "Datasources"
+        ]
+      }
+    },
     "/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/": {
       "get": {
         "parameters": [
@@ -25381,6 +25550,88 @@
           }
         ],
         "summary": "Get compatible metrics and dimensions",
+        "tags": [
+          "Datasources"
+        ]
+      }
+    },
+    "/api/v1/datasource/{datasource_type}/{datasource_id}/query": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "datasource_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "datasource_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasourceQuerySchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "items": {
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "application/vnd.apache.arrow.stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Query result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Query a datasource by its semantic definitions",
         "tags": [
           "Datasources"
         ]
@@ -36107,6 +36358,63 @@
           }
         ],
         "summary": "Get related fields data",
+        "tags": [
+          "Themes"
+        ]
+      }
+    },
+    "/api/v1/theme/system": {
+      "get": {
+        "description": "Returns the same processed theme payload embedded in the page bootstrap: the resolved system default and dark themes, the default mode, and the UI theme administration flag. The client uses this to apply system theme changes live without a full page reload, keeping the result identical to what a reload would render.",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "properties": {
+                        "dark": {
+                          "type": "object"
+                        },
+                        "default": {
+                          "type": "object"
+                        },
+                        "defaultMode": {
+                          "type": "string"
+                        },
+                        "enableUiThemeAdministration": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resolved system theme slice"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get the resolved system default and dark themes",
         "tags": [
           "Themes"
         ]

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -190,7 +190,6 @@
     },
     "schemas": {
       "ActivityChangedBy": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -205,7 +204,6 @@
         "type": "object"
       },
       "ActivityImpact": {
-        "additionalProperties": false,
         "properties": {
           "charts": {
             "description": "Number of sibling charts on the path entity affected by the same related-record change at this transaction.",
@@ -215,7 +213,6 @@
         "type": "object"
       },
       "ActivityRecord": {
-        "additionalProperties": false,
         "properties": {
           "action_kind": {
             "description": "Transaction-level avenue that produced this record's batch: ``restore`` / ``import`` / ``clone``. ``null`` for ordinary saves. All records sharing a ``transaction_id`` share the same action_kind. The schema's third ``*_kind`` column (entity_kind / kind / action_kind), at transaction scope.",
@@ -229,16 +226,13 @@
             "type": "string"
           },
           "changed_by": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/ActivityChangedBy"
-              },
-              {
-                "nullable": true,
-                "type": "object"
               }
             ],
-            "description": "User who produced the change, or ``null`` when the saving user no longer exists in ``ab_user``."
+            "description": "User who produced the change, or ``null`` when the saving user no longer exists in ``ab_user``.",
+            "nullable": true
           },
           "entity_deleted": {
             "description": "True iff the source entity is hard-deleted (no live row by ``entity_id``). False for live and soft-deleted entities.",
@@ -280,16 +274,13 @@
             "nullable": true
           },
           "impact": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/ActivityImpact"
-              },
-              {
-                "nullable": true,
-                "type": "object"
               }
             ],
-            "description": "Optional dependent-count for ``source: \"related\"`` records \u2014 e.g., ``{\"charts\": 4}`` for a dataset edit that affected 4 charts on the path dashboard at the change's transaction. Absent for ``source: \"self\"`` records and for related records without dependents."
+            "description": "Optional dependent-count for ``source: \"related\"`` records \u2014 e.g., ``{\"charts\": 4}`` for a dataset edit that affected 4 charts on the path dashboard at the change's transaction. Absent for ``source: \"self\"`` records and for related records without dependents.",
+            "nullable": true
           },
           "issued_at": {
             "description": "UTC timestamp; primary ordering key (DESC).",
@@ -365,7 +356,6 @@
         "type": "object"
       },
       "ActivityResponse": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Total record count across all pages (the filtered + denormalized stream), not just the current page. When ``truncated`` is true this is a floor (the count within the fetched window), not the absolute total.",
@@ -385,7 +375,6 @@
         "type": "object"
       },
       "AdvancedDataTypeSchema": {
-        "additionalProperties": false,
         "properties": {
           "display_value": {
             "description": "The string representation of the parsed values",
@@ -411,7 +400,6 @@
         "type": "object"
       },
       "AnnotationLayer": {
-        "additionalProperties": false,
         "properties": {
           "annotationType": {
             "description": "Type of annotation layer",
@@ -530,7 +518,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "descr": {
             "nullable": true,
@@ -548,7 +535,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
@@ -585,7 +571,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -603,7 +588,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -621,7 +605,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "descr": {
             "description": "Give a description for this annotation layer",
@@ -641,7 +624,6 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "descr": {
             "description": "Give a description for this annotation layer",
@@ -657,7 +639,6 @@
         "type": "object"
       },
       "AnnotationRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -695,7 +676,6 @@
         "type": "object"
       },
       "AnnotationRestApi.get.AnnotationLayer": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -709,7 +689,6 @@
         "type": "object"
       },
       "AnnotationRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
@@ -746,7 +725,6 @@
         "type": "object"
       },
       "AnnotationRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -762,7 +740,6 @@
         "type": "object"
       },
       "AnnotationRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -778,7 +755,6 @@
         "type": "object"
       },
       "AnnotationRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "description": "The annotation end date time",
@@ -815,7 +791,6 @@
         "type": "object"
       },
       "AnnotationRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "description": "The annotation end date time",
@@ -847,7 +822,6 @@
         "type": "object"
       },
       "AvailableDomainsSchema": {
-        "additionalProperties": false,
         "properties": {
           "domains": {
             "items": {
@@ -859,7 +833,6 @@
         "type": "object"
       },
       "CacheInvalidationRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "datasource_uids": {
             "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasource_uid` ",
@@ -879,7 +852,6 @@
         "type": "object"
       },
       "CacheRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -888,7 +860,6 @@
         "type": "object"
       },
       "CacheRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -897,7 +868,6 @@
         "type": "object"
       },
       "CacheRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -906,7 +876,6 @@
         "type": "object"
       },
       "CacheRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -915,7 +884,6 @@
         "type": "object"
       },
       "CatalogsResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "items": {
@@ -928,7 +896,6 @@
         "type": "object"
       },
       "ChartCacheScreenshotResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "cache_key": {
             "description": "The cache key",
@@ -954,7 +921,6 @@
         "type": "object"
       },
       "ChartCacheWarmUpRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart to warm up cache for",
@@ -975,7 +941,6 @@
         "type": "object"
       },
       "ChartCacheWarmUpResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of each chart's warmup status and errors if any",
@@ -988,7 +953,6 @@
         "type": "object"
       },
       "ChartCacheWarmUpResponseSingle": {
-        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart the status belongs to",
@@ -1006,7 +970,6 @@
         "type": "object"
       },
       "ChartDataAdhocMetricSchema": {
-        "additionalProperties": false,
         "properties": {
           "aggregate": {
             "description": "Aggregation operator.Only required for simple expression types.",
@@ -1071,10 +1034,8 @@
         "type": "object"
       },
       "ChartDataAggregateOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "aggregates": {
-            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -1091,7 +1052,6 @@
         "type": "object"
       },
       "ChartDataAsyncResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "channel_id": {
             "description": "Unique session async channel ID",
@@ -1118,7 +1078,6 @@
         "type": "object"
       },
       "ChartDataBoxplotOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "groupby": {
             "items": {
@@ -1158,7 +1117,6 @@
         "type": "object"
       },
       "ChartDataColumn": {
-        "additionalProperties": false,
         "properties": {
           "column_name": {
             "description": "The name of the target column",
@@ -1174,7 +1132,6 @@
         "type": "object"
       },
       "ChartDataContributionOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "orientation": {
             "description": "Should cell values be calculated across the row or column.",
@@ -1192,7 +1149,6 @@
         "type": "object"
       },
       "ChartDataDatasource": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "Datasource id or uuid"
@@ -1216,7 +1172,6 @@
         "type": "object"
       },
       "ChartDataExtras": {
-        "additionalProperties": false,
         "properties": {
           "column_order": {
             "description": "Ordered list of column names for result ordering. Used to preserve user's column reordering (including mixed dimension columns and metrics)",
@@ -1292,7 +1247,6 @@
         "type": "object"
       },
       "ChartDataFilter": {
-        "additionalProperties": false,
         "properties": {
           "col": {
             "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)",
@@ -1357,7 +1311,6 @@
         "type": "object"
       },
       "ChartDataGeodeticParseOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "altitude": {
             "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.",
@@ -1384,7 +1337,6 @@
         "type": "object"
       },
       "ChartDataGeohashDecodeOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "geohash": {
             "description": "Name of source column containing geohash string",
@@ -1407,7 +1359,6 @@
         "type": "object"
       },
       "ChartDataGeohashEncodeOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "geohash": {
             "description": "Name of target column for encoded geohash string",
@@ -1430,10 +1381,8 @@
         "type": "object"
       },
       "ChartDataPivotOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "aggregates": {
-            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -1477,7 +1426,6 @@
         "type": "object"
       },
       "ChartDataPostProcessingOperation": {
-        "additionalProperties": false,
         "properties": {
           "operation": {
             "description": "Post processing operation type",
@@ -1485,7 +1433,6 @@
             "type": "string"
           },
           "options": {
-            "additionalProperties": {},
             "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
             "example": {
               "aggregates": {
@@ -1515,7 +1462,6 @@
         "type": "object"
       },
       "ChartDataProphetOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "confidence_interval": {
             "description": "Width of predicted confidence interval",
@@ -1576,7 +1522,6 @@
         "type": "object"
       },
       "ChartDataQueryContextSchema": {
-        "additionalProperties": false,
         "properties": {
           "custom_cache_timeout": {
             "description": "Override the default cache timeout",
@@ -1634,7 +1579,6 @@
             "type": "array"
           },
           "applied_time_extras": {
-            "additionalProperties": {},
             "description": "A mapping of temporal extras that have been applied to the query",
             "example": {
               "__time_range": "1 year ago : now"
@@ -1654,27 +1598,21 @@
             "type": "array"
           },
           "datasource": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataDatasource"
               }
-            ]
+            ],
+            "nullable": true
           },
           "extras": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/ChartDataExtras"
-              },
-              {
-                "nullable": true,
-                "type": "object"
               }
             ],
-            "description": "Extra parameters to add to the query."
+            "description": "Extra parameters to add to the query.",
+            "nullable": true
           },
           "filters": {
             "items": {
@@ -1764,15 +1702,12 @@
           "post_processing": {
             "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.",
             "items": {
-              "anyOf": [
-                {
-                  "nullable": true,
-                  "type": "object"
-                },
+              "allOf": [
                 {
                   "$ref": "#/components/schemas/ChartDataPostProcessingOperation"
                 }
-              ]
+              ],
+              "nullable": true
             },
             "nullable": true,
             "type": "array"
@@ -1869,7 +1804,6 @@
         "type": "object"
       },
       "ChartDataQueryTiming": {
-        "additionalProperties": false,
         "properties": {
           "cache_resolution_ms": {
             "nullable": true,
@@ -1901,7 +1835,6 @@
         "type": "object"
       },
       "ChartDataResponseResult": {
-        "additionalProperties": false,
         "properties": {
           "annotation_data": {
             "description": "All requested annotation data",
@@ -1917,7 +1850,6 @@
           "applied_filters": {
             "description": "A list with applied filters",
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -1954,7 +1886,6 @@
           "data": {
             "description": "A list with results",
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -1992,7 +1923,6 @@
           "rejected_filters": {
             "description": "A list with rejected filters",
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -2048,7 +1978,6 @@
         "type": "object"
       },
       "ChartDataResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_filters": {
             "allOf": [
@@ -2069,7 +1998,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2078,7 +2006,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "nullable": true,
@@ -2217,7 +2144,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.Dashboard": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -2231,7 +2157,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.SqlaTable": {
-        "additionalProperties": false,
         "properties": {
           "default_endpoint": {
             "nullable": true,
@@ -2248,7 +2173,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2268,7 +2192,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.Subject1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2288,7 +2211,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.Tag": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2310,7 +2232,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2331,7 +2252,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2352,7 +2272,6 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.User2": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2373,7 +2292,6 @@
         "type": "object"
       },
       "ChartDataRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2491,7 +2409,6 @@
         "type": "object"
       },
       "ChartDataRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2640,7 +2557,6 @@
         "type": "object"
       },
       "ChartDataRollingOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "center": {
             "description": "Should the label be at the center of the window.Default: `false`",
@@ -2681,7 +2597,6 @@
             "type": "string"
           },
           "rolling_type_options": {
-            "additionalProperties": {},
             "description": "Optional options to pass to rolling method. Needed for e.g. quantile operation.",
             "example": {},
             "type": "object"
@@ -2722,7 +2637,6 @@
         "type": "object"
       },
       "ChartDataSelectOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "columns": {
             "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
@@ -2754,7 +2668,6 @@
               }
             ],
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -2763,10 +2676,8 @@
         "type": "object"
       },
       "ChartDataSortOptionsSchema": {
-        "additionalProperties": false,
         "properties": {
           "aggregates": {
-            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -2780,7 +2691,6 @@
             "type": "object"
           },
           "columns": {
-            "additionalProperties": {},
             "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.",
             "example": {
               "country": true,
@@ -2795,7 +2705,6 @@
         "type": "object"
       },
       "ChartDataTiming": {
-        "additionalProperties": false,
         "properties": {
           "query": {
             "$ref": "#/components/schemas/ChartDataQueryTiming"
@@ -2814,7 +2723,6 @@
         "type": "object"
       },
       "ChartEntityResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2842,7 +2750,6 @@
             "type": "string"
           },
           "form_data": {
-            "additionalProperties": {},
             "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
           },
@@ -2862,7 +2769,6 @@
         "type": "object"
       },
       "ChartFavStarResponseResult": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "The Chart id",
@@ -2876,7 +2782,6 @@
         "type": "object"
       },
       "ChartGetDatasourceObjectDataResponse": {
-        "additionalProperties": false,
         "properties": {
           "datasource_id": {
             "description": "The datasource identifier",
@@ -2890,7 +2795,6 @@
         "type": "object"
       },
       "ChartGetDatasourceObjectResponse": {
-        "additionalProperties": false,
         "properties": {
           "label": {
             "description": "The name of the datasource",
@@ -2903,7 +2807,6 @@
         "type": "object"
       },
       "ChartGetDatasourceResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of datasources",
@@ -2916,7 +2819,6 @@
         "type": "object"
       },
       "ChartGetResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "type": "string"
@@ -3006,7 +2908,6 @@
         "type": "object"
       },
       "ChartRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3015,7 +2916,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "nullable": true,
@@ -3154,7 +3054,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.Dashboard": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -3168,7 +3067,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.SqlaTable": {
-        "additionalProperties": false,
         "properties": {
           "default_endpoint": {
             "nullable": true,
@@ -3185,7 +3083,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3205,7 +3102,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.Subject1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3225,7 +3121,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.Tag": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3247,7 +3142,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3268,7 +3162,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3289,7 +3182,6 @@
         "type": "object"
       },
       "ChartRestApi.get_list.User2": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3310,7 +3202,6 @@
         "type": "object"
       },
       "ChartRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -3428,7 +3319,6 @@
         "type": "object"
       },
       "ChartRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -3577,7 +3467,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get.User"
@@ -3604,7 +3493,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3625,7 +3513,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3646,7 +3533,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
@@ -3678,7 +3564,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3699,7 +3584,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3720,7 +3604,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "css": {
             "nullable": true,
@@ -3735,7 +3618,6 @@
         "type": "object"
       },
       "CssTemplateRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "css": {
             "nullable": true,
@@ -3750,7 +3632,6 @@
         "type": "object"
       },
       "CurrentUserPutSchema": {
-        "additionalProperties": false,
         "properties": {
           "current_password": {
             "description": "The current user's existing password",
@@ -3777,7 +3658,6 @@
         "type": "object"
       },
       "Dashboard": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "type": "string"
@@ -3792,7 +3672,6 @@
         "type": "object"
       },
       "DashboardCacheScreenshotResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "cache_key": {
             "description": "The cache key",
@@ -3818,7 +3697,6 @@
         "type": "object"
       },
       "DashboardChartCustomizationsConfigUpdateSchema": {
-        "additionalProperties": false,
         "properties": {
           "deleted": {
             "items": {
@@ -3840,7 +3718,6 @@
         "type": "object"
       },
       "DashboardColorsConfigUpdateSchema": {
-        "additionalProperties": false,
         "properties": {
           "color_namespace": {
             "nullable": true,
@@ -3857,11 +3734,9 @@
             "type": "array"
           },
           "label_colors": {
-            "additionalProperties": {},
             "type": "object"
           },
           "map_label_colors": {
-            "additionalProperties": {},
             "type": "object"
           },
           "shared_label_colors": {
@@ -3874,7 +3749,6 @@
         "type": "object"
       },
       "DashboardCopySchema": {
-        "additionalProperties": false,
         "properties": {
           "css": {
             "description": "Override CSS for the dashboard.",
@@ -3902,7 +3776,6 @@
         "type": "object"
       },
       "DashboardDatasetSchema": {
-        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "type": "boolean"
@@ -3911,7 +3784,6 @@
             "type": "integer"
           },
           "column_formats": {
-            "additionalProperties": {},
             "type": "object"
           },
           "column_names": {
@@ -3928,7 +3800,6 @@
           },
           "columns": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -3986,7 +3857,6 @@
           },
           "metrics": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -4055,11 +3925,9 @@
         "type": "object"
       },
       "DashboardExportXlsxPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "active_data_mask": {
             "additionalProperties": {
-              "additionalProperties": {},
               "type": "object"
             },
             "description": "Live dashboard filter state keyed by native filter id, each carrying an extraFormData object.",
@@ -4078,7 +3946,6 @@
         "type": "object"
       },
       "DashboardExportXlsxResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "job_id": {
             "description": "Correlation id for the async export task",
@@ -4088,7 +3955,6 @@
         "type": "object"
       },
       "DashboardFilterInfo": {
-        "additionalProperties": false,
         "properties": {
           "column": {
             "description": "Target column name for the filter",
@@ -4116,7 +3982,6 @@
         "type": "object"
       },
       "DashboardFiltersResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "filters": {
             "description": "Metadata about each in-scope dashboard native filter and whether its default value was applied to the query",
@@ -4129,7 +3994,6 @@
         "type": "object"
       },
       "DashboardGetResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -4217,15 +4081,12 @@
             "type": "array"
           },
           "theme": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/Theme"
               }
-            ]
+            ],
+            "nullable": true
           },
           "thumbnail_url": {
             "nullable": true,
@@ -4249,7 +4110,6 @@
         "type": "object"
       },
       "DashboardNativeFiltersConfigUpdateSchema": {
-        "additionalProperties": false,
         "properties": {
           "deleted": {
             "items": {
@@ -4271,7 +4131,6 @@
         "type": "object"
       },
       "DashboardPermalinkStateSchema": {
-        "additionalProperties": false,
         "properties": {
           "activeTabs": {
             "description": "Current active dashboard tabs",
@@ -4288,13 +4147,11 @@
             "type": "string"
           },
           "chartStates": {
-            "additionalProperties": {},
             "description": "Chart-level state for stateful tables (column order, sorting, filtering)",
             "nullable": true,
             "type": "object"
           },
           "dataMask": {
-            "additionalProperties": {},
             "description": "Data mask used for native filter state",
             "nullable": true,
             "type": "object"
@@ -4312,7 +4169,6 @@
         "type": "object"
       },
       "DashboardRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4321,7 +4177,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "nullable": true,
@@ -4406,7 +4261,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4426,7 +4280,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.Subject1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4446,7 +4299,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.Tag": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4468,7 +4320,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -4489,7 +4340,6 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -4510,7 +4360,6 @@
         "type": "object"
       },
       "DashboardRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -4593,7 +4442,6 @@
         "type": "object"
       },
       "DashboardRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -4690,7 +4538,6 @@
         "type": "object"
       },
       "DashboardScreenshotPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "activeTabs": {
             "description": "A list representing active tabs.",
@@ -4717,7 +4564,6 @@
         "type": "object"
       },
       "Database": {
-        "additionalProperties": false,
         "properties": {
           "allow_multi_catalog": {
             "type": "boolean"
@@ -4753,7 +4599,6 @@
         "type": "object"
       },
       "Database1": {
-        "additionalProperties": false,
         "properties": {
           "database_name": {
             "type": "string"
@@ -4762,7 +4607,6 @@
         "type": "object"
       },
       "DatabaseConnectionSchema": {
-        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "description": "Allow CREATE TABLE AS option in SQL Lab",
@@ -4868,15 +4712,12 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ]
+            ],
+            "nullable": true
           },
           "uuid": {
             "type": "string"
@@ -4885,7 +4726,6 @@
         "type": "object"
       },
       "DatabaseFunctionNamesResponse": {
-        "additionalProperties": false,
         "properties": {
           "function_names": {
             "items": {
@@ -4897,7 +4737,6 @@
         "type": "object"
       },
       "DatabaseRelatedChart": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4912,7 +4751,6 @@
         "type": "object"
       },
       "DatabaseRelatedCharts": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Chart count",
@@ -4929,13 +4767,11 @@
         "type": "object"
       },
       "DatabaseRelatedDashboard": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
           },
           "json_metadata": {
-            "additionalProperties": {},
             "type": "object"
           },
           "slug": {
@@ -4948,7 +4784,6 @@
         "type": "object"
       },
       "DatabaseRelatedDashboards": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Dashboard count",
@@ -4965,7 +4800,6 @@
         "type": "object"
       },
       "DatabaseRelatedObjectsResponse": {
-        "additionalProperties": false,
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatabaseRelatedCharts"
@@ -4977,7 +4811,6 @@
         "type": "object"
       },
       "DatabaseRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "nullable": true,
@@ -5052,7 +4885,6 @@
         "type": "object"
       },
       "DatabaseRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "nullable": true,
@@ -5152,7 +4984,6 @@
         "type": "object"
       },
       "DatabaseRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -5170,7 +5001,6 @@
         "type": "object"
       },
       "DatabaseRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -5288,15 +5118,12 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ]
+            ],
+            "nullable": true
           },
           "uuid": {
             "type": "string"
@@ -5409,15 +5236,12 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ]
+            ],
+            "nullable": true
           },
           "uuid": {
             "type": "string"
@@ -5426,7 +5250,6 @@
         "type": "object"
       },
       "DatabaseSSHTunnel": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "SSH Tunnel ID (for updates)",
@@ -5466,7 +5289,6 @@
         "type": "object"
       },
       "DatabaseSSHTunnelValidation": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "SSH Tunnel ID (for updates)",
@@ -5505,7 +5327,6 @@
         "type": "object"
       },
       "DatabaseSchemaAccessForFileUploadResponse": {
-        "additionalProperties": false,
         "properties": {
           "schemas": {
             "description": "The list of schemas allowed for the database to upload information",
@@ -5518,10 +5339,8 @@
         "type": "object"
       },
       "DatabaseTablesResponse": {
-        "additionalProperties": false,
         "properties": {
           "extra": {
-            "additionalProperties": {},
             "description": "Extra data used to specify column metadata",
             "type": "object"
           },
@@ -5537,7 +5356,6 @@
         "type": "object"
       },
       "DatabaseTestConnectionSchema": {
-        "additionalProperties": false,
         "properties": {
           "configuration_method": {
             "default": "sqlalchemy_form",
@@ -5594,15 +5412,12 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "type": "object"
@@ -5670,15 +5485,12 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnelValidation"
               }
-            ]
+            ],
+            "nullable": true
           }
         },
         "required": [
@@ -5688,27 +5500,23 @@
         "type": "object"
       },
       "Dataset": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this dataset.",
             "type": "integer"
           },
           "column_formats": {
-            "additionalProperties": {},
             "description": "Column formats.",
             "type": "object"
           },
           "columns": {
             "description": "Columns metadata.",
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "database": {
-            "additionalProperties": {},
             "description": "Database associated with the dataset.",
             "type": "object"
           },
@@ -5736,7 +5544,6 @@
             "type": "array"
           },
           "extra": {
-            "additionalProperties": {},
             "description": "JSON string containing extra configuration elements.",
             "type": "object"
           },
@@ -5756,7 +5563,6 @@
             "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
             "items": {
               "items": {
-                "additionalProperties": {},
                 "type": "object"
               },
               "type": "array"
@@ -5782,7 +5588,6 @@
           "metrics": {
             "description": "Dataset metrics.",
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -5806,7 +5611,6 @@
             "type": "array"
           },
           "params": {
-            "additionalProperties": {},
             "description": "Extra params for the dataset.",
             "type": "object"
           },
@@ -5839,7 +5643,6 @@
             "type": "string"
           },
           "template_params": {
-            "additionalProperties": {},
             "description": "Table template params.",
             "type": "object"
           },
@@ -5862,7 +5665,6 @@
             "type": "string"
           },
           "verbose_map": {
-            "additionalProperties": {},
             "description": "Mapping from raw name to verbose name.",
             "type": "object"
           }
@@ -5870,7 +5672,6 @@
         "type": "object"
       },
       "DatasetCacheWarmUpRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_id": {
             "description": "The ID of the dashboard to get filters for when warming cache",
@@ -5896,7 +5697,6 @@
         "type": "object"
       },
       "DatasetCacheWarmUpResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of each chart's warmup status and errors if any",
@@ -5909,7 +5709,6 @@
         "type": "object"
       },
       "DatasetCacheWarmUpResponseSingle": {
-        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart the status belongs to",
@@ -5927,7 +5726,6 @@
         "type": "object"
       },
       "DatasetColumnsPut": {
-        "additionalProperties": false,
         "properties": {
           "advanced_data_type": {
             "maxLength": 255,
@@ -6001,7 +5799,6 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6010,7 +5807,6 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6019,7 +5815,6 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6028,7 +5823,6 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6037,7 +5831,6 @@
         "type": "object"
       },
       "DatasetDuplicateSchema": {
-        "additionalProperties": false,
         "properties": {
           "base_model_id": {
             "type": "integer"
@@ -6055,7 +5848,6 @@
         "type": "object"
       },
       "DatasetMetricCurrencyPut": {
-        "additionalProperties": false,
         "properties": {
           "symbol": {
             "maxLength": 128,
@@ -6071,7 +5863,6 @@
         "type": "object"
       },
       "DatasetMetricRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6080,7 +5871,6 @@
         "type": "object"
       },
       "DatasetMetricRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6089,7 +5879,6 @@
         "type": "object"
       },
       "DatasetMetricRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6098,7 +5887,6 @@
         "type": "object"
       },
       "DatasetMetricRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6107,18 +5895,14 @@
         "type": "object"
       },
       "DatasetMetricsPut": {
-        "additionalProperties": false,
         "properties": {
           "currency": {
-            "anyOf": [
-              {
-                "nullable": true,
-                "type": "object"
-              },
+            "allOf": [
               {
                 "$ref": "#/components/schemas/DatasetMetricCurrencyPut"
               }
-            ]
+            ],
+            "nullable": true
           },
           "d3format": {
             "maxLength": 128,
@@ -6172,7 +5956,6 @@
         "type": "object"
       },
       "DatasetPurgeImpactCollection": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "minimum": 0,
@@ -6197,7 +5980,6 @@
         "type": "object"
       },
       "DatasetPurgeImpactObject": {
-        "additionalProperties": false,
         "properties": {
           "archived": {
             "type": "boolean"
@@ -6223,7 +6005,6 @@
         "type": "object"
       },
       "DatasetPurgeImpactSchema": {
-        "additionalProperties": false,
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatasetPurgeImpactCollection"
@@ -6243,7 +6024,6 @@
         "type": "object"
       },
       "DatasetPurgeRequestSchema": {
-        "additionalProperties": false,
         "properties": {
           "confirmed_impact_token": {
             "minLength": 1,
@@ -6256,7 +6036,6 @@
         "type": "object"
       },
       "DatasetRelatedChart": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6271,7 +6050,6 @@
         "type": "object"
       },
       "DatasetRelatedCharts": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Chart count",
@@ -6288,13 +6066,11 @@
         "type": "object"
       },
       "DatasetRelatedDashboard": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
           },
           "json_metadata": {
-            "additionalProperties": {},
             "type": "object"
           },
           "slug": {
@@ -6307,7 +6083,6 @@
         "type": "object"
       },
       "DatasetRelatedDashboards": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Dashboard count",
@@ -6324,7 +6099,6 @@
         "type": "object"
       },
       "DatasetRelatedObjectsResponse": {
-        "additionalProperties": false,
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatasetRelatedCharts"
@@ -6336,7 +6110,6 @@
         "type": "object"
       },
       "DatasetRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "nullable": true,
@@ -6512,7 +6285,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.Database": {
-        "additionalProperties": false,
         "properties": {
           "allow_multi_catalog": {
             "readOnly": true
@@ -6539,7 +6311,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.SqlMetric": {
-        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "readOnly": true
@@ -6616,7 +6387,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6636,7 +6406,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.TableColumn": {
-        "additionalProperties": false,
         "properties": {
           "advanced_data_type": {
             "maxLength": 255,
@@ -6729,7 +6498,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -6747,7 +6515,6 @@
         "type": "object"
       },
       "DatasetRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -6765,7 +6532,6 @@
         "type": "object"
       },
       "DatasetRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -6843,7 +6609,6 @@
         "type": "object"
       },
       "DatasetRestApi.get_list.Database": {
-        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -6864,7 +6629,6 @@
         "type": "object"
       },
       "DatasetRestApi.get_list.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6884,7 +6648,6 @@
         "type": "object"
       },
       "DatasetRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -6905,7 +6668,6 @@
         "type": "object"
       },
       "DatasetRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -6976,7 +6738,6 @@
         "type": "object"
       },
       "DatasetRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -7100,7 +6861,6 @@
         "type": "object"
       },
       "Datasource": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "description": "Datasource catalog",
@@ -7138,7 +6898,6 @@
         "type": "object"
       },
       "DatasourceQueryOrder": {
-        "additionalProperties": false,
         "properties": {
           "column": {
             "description": "Metric or dimension name to sort by.",
@@ -7156,7 +6915,6 @@
         "type": "object"
       },
       "DatasourceQuerySchema": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "default": null,
@@ -7243,7 +7001,6 @@
         "type": "object"
       },
       "DistincResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of distinct values",
@@ -7259,7 +7016,6 @@
         "type": "object"
       },
       "DistinctResultResponse": {
-        "additionalProperties": false,
         "properties": {
           "text": {
             "description": "The distinct item",
@@ -7269,7 +7025,6 @@
         "type": "object"
       },
       "EmbeddedDashboardConfig": {
-        "additionalProperties": false,
         "properties": {
           "allowed_domains": {
             "items": {
@@ -7284,7 +7039,6 @@
         "type": "object"
       },
       "EmbeddedDashboardResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "allowed_domains": {
             "items": {
@@ -7309,7 +7063,6 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -7319,7 +7072,6 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -7329,7 +7081,6 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -7339,7 +7090,6 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -7349,7 +7099,6 @@
         "type": "object"
       },
       "EngineInformation": {
-        "additionalProperties": false,
         "properties": {
           "disable_ssh_tunneling": {
             "description": "SSH tunnel is not available to the database",
@@ -7387,7 +7136,6 @@
         "type": "object"
       },
       "EstimateQueryCostSchema": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "description": "The database catalog",
@@ -7408,7 +7156,6 @@
             "type": "string"
           },
           "template_params": {
-            "additionalProperties": {},
             "description": "The SQL query template params",
             "type": "object"
           }
@@ -7420,7 +7167,6 @@
         "type": "object"
       },
       "ExecutePayloadSchema": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "nullable": true,
@@ -7485,13 +7231,11 @@
         "type": "object"
       },
       "ExploreContextSchema": {
-        "additionalProperties": false,
         "properties": {
           "dataset": {
             "$ref": "#/components/schemas/Dataset"
           },
           "form_data": {
-            "additionalProperties": {},
             "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
           },
@@ -7506,16 +7250,13 @@
         "type": "object"
       },
       "ExplorePermalinkStateSchema": {
-        "additionalProperties": false,
         "properties": {
           "chartState": {
-            "additionalProperties": {},
             "description": "Chart-level state for stateful tables (column filters, sorting, column order)",
             "nullable": true,
             "type": "object"
           },
           "formData": {
-            "additionalProperties": {},
             "description": "Chart form data",
             "type": "object"
           },
@@ -7535,7 +7276,6 @@
         "type": "object"
       },
       "Folder": {
-        "additionalProperties": false,
         "properties": {
           "children": {
             "items": {
@@ -7574,7 +7314,6 @@
         "type": "object"
       },
       "FormDataPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The chart ID",
@@ -7609,7 +7348,6 @@
         "type": "object"
       },
       "FormDataPutSchema": {
-        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The chart ID",
@@ -7644,7 +7382,6 @@
         "type": "object"
       },
       "FormatQueryPayloadSchema": {
-        "additionalProperties": false,
         "properties": {
           "database_id": {
             "description": "The database id",
@@ -7670,7 +7407,6 @@
         "type": "object"
       },
       "GetFavStarIdsSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of results for each corresponding chart in the request",
@@ -7683,7 +7419,6 @@
         "type": "object"
       },
       "GetOrCreateDatasetSchema": {
-        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -7727,7 +7462,6 @@
         "type": "object"
       },
       "GroupPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -7770,7 +7504,6 @@
         "type": "object"
       },
       "GroupPutSchema": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -7843,7 +7576,6 @@
         "type": "object"
       },
       "IdentifierQuote": {
-        "additionalProperties": false,
         "properties": {
           "end": {
             "description": "Character that closes a quoted identifier",
@@ -7861,7 +7593,6 @@
         "type": "object"
       },
       "LogRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -7905,7 +7636,6 @@
         "type": "object"
       },
       "LogRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -7928,7 +7658,6 @@
         "type": "object"
       },
       "LogRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -7972,7 +7701,6 @@
         "type": "object"
       },
       "LogRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -7995,7 +7723,6 @@
         "type": "object"
       },
       "LogRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8004,7 +7731,6 @@
         "type": "object"
       },
       "LogRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -8027,7 +7753,6 @@
         "type": "object"
       },
       "PermissionApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8043,7 +7768,6 @@
         "type": "object"
       },
       "PermissionApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8059,7 +7783,6 @@
         "type": "object"
       },
       "PermissionApi.post": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
@@ -8072,7 +7795,6 @@
         "type": "object"
       },
       "PermissionApi.put": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
@@ -8085,25 +7807,21 @@
         "type": "object"
       },
       "QueryExecutionResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "columns": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "data": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "expanded_columns": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -8116,7 +7834,6 @@
           },
           "selected_columns": {
             "items": {
-              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -8128,7 +7845,6 @@
         "type": "object"
       },
       "QueryRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -8243,7 +7959,6 @@
         "type": "object"
       },
       "QueryRestApi.get.Database": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8252,7 +7967,6 @@
         "type": "object"
       },
       "QueryRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -8307,7 +8021,6 @@
         "type": "object"
       },
       "QueryRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8316,7 +8029,6 @@
         "type": "object"
       },
       "QueryRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8325,7 +8037,6 @@
         "type": "object"
       },
       "QueryResult": {
-        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -8351,7 +8062,6 @@
             "type": "string"
           },
           "extra": {
-            "additionalProperties": {},
             "type": "object"
           },
           "id": {
@@ -8418,7 +8128,6 @@
         "type": "object"
       },
       "RLSRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -8464,7 +8173,6 @@
         "type": "object"
       },
       "RLSRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/User"
@@ -8516,7 +8224,6 @@
         "type": "object"
       },
       "RLSRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -8571,7 +8278,6 @@
         "type": "object"
       },
       "RLSRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -8620,7 +8326,6 @@
         "type": "object"
       },
       "RecentActivity": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "description": "Action taken describing type of activity",
@@ -8650,7 +8355,6 @@
         "type": "object"
       },
       "RecentActivityResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of recent activity objects",
@@ -8663,7 +8367,6 @@
         "type": "object"
       },
       "RecentActivitySchema": {
-        "additionalProperties": false,
         "properties": {
           "action": {
             "description": "Action taken describing type of activity",
@@ -8693,7 +8396,6 @@
         "type": "object"
       },
       "RelatedResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of related values",
@@ -8709,10 +8411,8 @@
         "type": "object"
       },
       "RelatedResultResponse": {
-        "additionalProperties": false,
         "properties": {
           "extra": {
-            "additionalProperties": {},
             "description": "The extra metadata for related item",
             "type": "object"
           },
@@ -8728,7 +8428,6 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -8776,7 +8475,6 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -8824,7 +8522,6 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8833,7 +8530,6 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -8842,7 +8538,6 @@
         "type": "object"
       },
       "ReportRecipient": {
-        "additionalProperties": false,
         "properties": {
           "recipient_config_json": {
             "$ref": "#/components/schemas/ReportRecipientConfigJSON"
@@ -8864,7 +8559,6 @@
         "type": "object"
       },
       "ReportRecipientConfigJSON": {
-        "additionalProperties": false,
         "properties": {
           "bccTarget": {
             "type": "string"
@@ -8879,7 +8573,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -9031,7 +8724,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.Dashboard": {
-        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -9045,7 +8737,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.Database": {
-        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -9061,7 +8752,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.ReportRecipients": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9081,7 +8771,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.Slice": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9100,7 +8789,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9120,7 +8808,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -9234,7 +8921,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.ReportRecipients": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9250,7 +8936,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.Subject": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9270,7 +8955,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9288,7 +8972,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9306,7 +8989,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -9368,7 +9050,6 @@
             "type": "string"
           },
           "extra": {
-            "additionalProperties": {},
             "type": "object"
           },
           "force_screenshot": {
@@ -10084,7 +9765,6 @@
         "type": "object"
       },
       "ReportScheduleRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -10148,7 +9828,6 @@
             "type": "string"
           },
           "extra": {
-            "additionalProperties": {},
             "type": "object"
           },
           "force_screenshot": {
@@ -10874,7 +10553,6 @@
         "type": "object"
       },
       "RlsFilter": {
-        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "RLS filter clause.",
@@ -10916,7 +10594,6 @@
         "type": "object"
       },
       "RlsRole": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "Role ID.",
@@ -10946,7 +10623,6 @@
         "type": "object"
       },
       "RoleGroupPutSchema": {
-        "additionalProperties": false,
         "properties": {
           "group_ids": {
             "description": "List of group ids",
@@ -10962,7 +10638,6 @@
         "type": "object"
       },
       "RolePermissionListSchema": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10977,7 +10652,6 @@
         "type": "object"
       },
       "RolePermissionPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "permission_view_menu_ids": {
             "description": "List of permission view menu id",
@@ -11016,7 +10690,6 @@
         "type": "object"
       },
       "RoleUserPutSchema": {
-        "additionalProperties": false,
         "properties": {
           "user_ids": {
             "description": "List of user ids",
@@ -11052,7 +10725,6 @@
         "type": "object"
       },
       "SQLLabBootstrapDatabase": {
-        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "type": "boolean"
@@ -11119,7 +10791,6 @@
         "type": "object"
       },
       "SQLLabBootstrapSchema": {
-        "additionalProperties": false,
         "properties": {
           "active_tab": {
             "$ref": "#/components/schemas/TabState"
@@ -11146,7 +10817,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -11202,7 +10872,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get.Database": {
-        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -11218,7 +10887,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11239,7 +10907,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11260,7 +10927,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -11337,7 +11003,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get_list.Database": {
-        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -11353,7 +11018,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get_list.Tag": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11375,7 +11039,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11396,7 +11059,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11417,7 +11079,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -11458,7 +11119,6 @@
         "type": "object"
       },
       "SavedQueryRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -11499,7 +11159,6 @@
         "type": "object"
       },
       "SchemasResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "items": {
@@ -11512,7 +11171,6 @@
         "type": "object"
       },
       "SelectStarResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "SQL select star",
@@ -11521,49 +11179,7 @@
         },
         "type": "object"
       },
-      "SemanticViewRestApi.get": {
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "SemanticViewRestApi.get_list": {
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "SemanticViewRestApi.post": {
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "SemanticViewRestApi.put": {
-        "additionalProperties": false,
-        "properties": {
-          "cache_timeout": {
-            "nullable": true,
-            "type": "integer"
-          },
-          "description": {
-            "nullable": true,
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "Slice": {
-        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart.",
@@ -11610,7 +11226,6 @@
             "type": "array"
           },
           "form_data": {
-            "additionalProperties": {},
             "description": "Form data associated with the slice.",
             "type": "object"
           },
@@ -11623,7 +11238,6 @@
             "type": "string"
           },
           "query_context": {
-            "additionalProperties": {},
             "description": "The context associated with the query.",
             "type": "object"
           },
@@ -11643,7 +11257,6 @@
         "type": "object"
       },
       "SqlLabPermalinkSchema": {
-        "additionalProperties": false,
         "properties": {
           "autorun": {
             "type": "boolean"
@@ -11684,7 +11297,6 @@
         "type": "object"
       },
       "StopQuerySchema": {
-        "additionalProperties": false,
         "properties": {
           "client_id": {
             "type": "string"
@@ -11693,7 +11305,6 @@
         "type": "object"
       },
       "SubjectResponse": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11714,7 +11325,6 @@
         "type": "object"
       },
       "SubjectRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -11790,7 +11400,6 @@
         "type": "object"
       },
       "SubjectRestApi.get.Group": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -11816,7 +11425,6 @@
         "type": "object"
       },
       "SubjectRestApi.get.Role": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11832,7 +11440,6 @@
         "type": "object"
       },
       "SubjectRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -11867,7 +11474,6 @@
         "type": "object"
       },
       "SubjectRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11885,7 +11491,6 @@
         "type": "object"
       },
       "SubjectRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -11952,7 +11557,6 @@
         "type": "object"
       },
       "SubjectRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11970,7 +11574,6 @@
         "type": "object"
       },
       "SubjectRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11979,7 +11582,6 @@
         "type": "object"
       },
       "SubjectRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11988,7 +11590,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -12026,7 +11627,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get.Role": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12042,7 +11642,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12058,7 +11657,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -12096,7 +11694,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get_list.Role": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12112,7 +11709,6 @@
         "type": "object"
       },
       "SupersetGroupApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12128,7 +11724,6 @@
         "type": "object"
       },
       "SupersetGroupApi.post": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -12171,7 +11766,6 @@
         "type": "object"
       },
       "SupersetGroupApi.put": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -12211,7 +11805,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12230,7 +11823,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get.Permission": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
@@ -12243,7 +11835,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get.ViewMenu": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
@@ -12256,7 +11847,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12275,7 +11865,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get_list.Permission": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
@@ -12288,7 +11877,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.get_list.ViewMenu": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
@@ -12301,7 +11889,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.post": {
-        "additionalProperties": false,
         "properties": {
           "permission_id": {
             "default": null,
@@ -12315,7 +11902,6 @@
         "type": "object"
       },
       "SupersetPermissionViewMenuApi.put": {
-        "additionalProperties": false,
         "properties": {
           "permission_id": {
             "default": null,
@@ -12329,7 +11915,6 @@
         "type": "object"
       },
       "SupersetRoleApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12345,7 +11930,6 @@
         "type": "object"
       },
       "SupersetRoleApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12361,7 +11945,6 @@
         "type": "object"
       },
       "SupersetRoleApi.post": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 64,
@@ -12374,7 +11957,6 @@
         "type": "object"
       },
       "SupersetRoleApi.put": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 64,
@@ -12387,7 +11969,6 @@
         "type": "object"
       },
       "SupersetUserApi.get": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -12463,7 +12044,6 @@
         "type": "object"
       },
       "SupersetUserApi.get.Group": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -12489,7 +12069,6 @@
         "type": "object"
       },
       "SupersetUserApi.get.Role": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12505,7 +12084,6 @@
         "type": "object"
       },
       "SupersetUserApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12514,7 +12092,6 @@
         "type": "object"
       },
       "SupersetUserApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12523,7 +12100,6 @@
         "type": "object"
       },
       "SupersetUserApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -12599,7 +12175,6 @@
         "type": "object"
       },
       "SupersetUserApi.get_list.Group": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -12625,7 +12200,6 @@
         "type": "object"
       },
       "SupersetUserApi.get_list.Role": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12641,7 +12215,6 @@
         "type": "object"
       },
       "SupersetUserApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12650,7 +12223,6 @@
         "type": "object"
       },
       "SupersetUserApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -12659,7 +12231,6 @@
         "type": "object"
       },
       "SupersetUserApi.post": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "description": "Is user active?It's not a good policy to remove a user, just make it inactive",
@@ -12712,7 +12283,6 @@
         "type": "object"
       },
       "SupersetUserApi.put": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "description": "Is user active?It's not a good policy to remove a user, just make it inactive",
@@ -12758,7 +12328,6 @@
         "type": "object"
       },
       "Tab": {
-        "additionalProperties": false,
         "properties": {
           "children": {
             "items": {
@@ -12782,7 +12351,6 @@
         "type": "object"
       },
       "TabState": {
-        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -12794,7 +12362,6 @@
             "type": "integer"
           },
           "extra_json": {
-            "additionalProperties": {},
             "type": "object"
           },
           "hide_left_bar": {
@@ -12813,7 +12380,6 @@
             "type": "integer"
           },
           "saved_query": {
-            "additionalProperties": {},
             "nullable": true,
             "type": "object"
           },
@@ -12836,7 +12402,6 @@
         "type": "object"
       },
       "Table": {
-        "additionalProperties": false,
         "properties": {
           "database_id": {
             "type": "integer"
@@ -12863,25 +12428,20 @@
         "type": "object"
       },
       "TableExtraMetadataResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "clustering": {
-            "additionalProperties": {},
             "type": "object"
           },
           "metadata": {
-            "additionalProperties": {},
             "type": "object"
           },
           "partitions": {
-            "additionalProperties": {},
             "type": "object"
           }
         },
         "type": "object"
       },
       "TableMetadataColumnsResponse": {
-        "additionalProperties": false,
         "properties": {
           "duplicates_constraint": {
             "type": "string"
@@ -12909,7 +12469,6 @@
         "type": "object"
       },
       "TableMetadataForeignKeysIndexesResponse": {
-        "additionalProperties": false,
         "properties": {
           "column_names": {
             "items": {
@@ -12944,7 +12503,6 @@
         "type": "object"
       },
       "TableMetadataOptionsResponse": {
-        "additionalProperties": false,
         "properties": {
           "deferrable": {
             "type": "boolean"
@@ -12965,7 +12523,6 @@
         "type": "object"
       },
       "TableMetadataPrimaryKeyResponse": {
-        "additionalProperties": false,
         "properties": {
           "column_names": {
             "items": {
@@ -12985,7 +12542,6 @@
         "type": "object"
       },
       "TableMetadataResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "columns": {
             "description": "A list of columns and their metadata",
@@ -13028,7 +12584,6 @@
         "type": "object"
       },
       "Tables": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13043,7 +12598,6 @@
         "type": "object"
       },
       "TabsPayloadSchema": {
-        "additionalProperties": false,
         "properties": {
           "all_tabs": {
             "additionalProperties": {
@@ -13061,7 +12615,6 @@
         "type": "object"
       },
       "Tag": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13081,7 +12634,6 @@
         "type": "object"
       },
       "Tag1": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13101,7 +12653,6 @@
         "type": "object"
       },
       "TagGetResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13116,7 +12667,6 @@
         "type": "object"
       },
       "TagObject": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -13135,7 +12685,6 @@
         "type": "object"
       },
       "TagPostBulkResponseObject": {
-        "additionalProperties": false,
         "properties": {
           "objects_skipped": {
             "description": "Objects to tag",
@@ -13151,7 +12700,6 @@
         "type": "object"
       },
       "TagPostBulkResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "result": {
             "$ref": "#/components/schemas/TagPostBulkResponseObject"
@@ -13160,7 +12708,6 @@
         "type": "object"
       },
       "TagPostBulkSchema": {
-        "additionalProperties": false,
         "properties": {
           "tags": {
             "items": {
@@ -13172,7 +12719,6 @@
         "type": "object"
       },
       "TagRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/TagRestApi.get.User"
@@ -13210,7 +12756,6 @@
         "type": "object"
       },
       "TagRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13228,7 +12773,6 @@
         "type": "object"
       },
       "TagRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13246,7 +12790,6 @@
         "type": "object"
       },
       "TagRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/TagRestApi.get_list.User"
@@ -13284,7 +12827,6 @@
         "type": "object"
       },
       "TagRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13302,7 +12844,6 @@
         "type": "object"
       },
       "TagRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13320,7 +12861,6 @@
         "type": "object"
       },
       "TagRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -13339,7 +12879,6 @@
         "type": "object"
       },
       "TagRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -13358,7 +12897,6 @@
         "type": "object"
       },
       "TaggedObjectEntityResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -13398,7 +12936,6 @@
         "type": "object"
       },
       "TemporaryCachePostSchema": {
-        "additionalProperties": false,
         "properties": {
           "value": {
             "description": "Any type of JSON supported text.",
@@ -13411,7 +12948,6 @@
         "type": "object"
       },
       "TemporaryCachePutSchema": {
-        "additionalProperties": false,
         "properties": {
           "value": {
             "description": "Any type of JSON supported text.",
@@ -13424,7 +12960,6 @@
         "type": "object"
       },
       "Theme": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13439,7 +12974,6 @@
         "type": "object"
       },
       "ThemeRestApi.get": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/ThemeRestApi.get.User"
@@ -13480,7 +13014,6 @@
         "type": "object"
       },
       "ThemeRestApi.get.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13501,7 +13034,6 @@
         "type": "object"
       },
       "ThemeRestApi.get.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13522,7 +13054,6 @@
         "type": "object"
       },
       "ThemeRestApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/ThemeRestApi.get_list.User"
@@ -13571,7 +13102,6 @@
         "type": "object"
       },
       "ThemeRestApi.get_list.User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13592,7 +13122,6 @@
         "type": "object"
       },
       "ThemeRestApi.get_list.User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -13613,7 +13142,6 @@
         "type": "object"
       },
       "ThemeRestApi.post": {
-        "additionalProperties": false,
         "properties": {
           "json_data": {
             "type": "string"
@@ -13629,7 +13157,6 @@
         "type": "object"
       },
       "ThemeRestApi.put": {
-        "additionalProperties": false,
         "properties": {
           "json_data": {
             "type": "string"
@@ -13645,7 +13172,6 @@
         "type": "object"
       },
       "UploadFileMetadata": {
-        "additionalProperties": false,
         "properties": {
           "items": {
             "items": {
@@ -13657,7 +13183,6 @@
         "type": "object"
       },
       "UploadFileMetadataItem": {
-        "additionalProperties": false,
         "properties": {
           "column_names": {
             "description": "A list of columns names in the sheet",
@@ -13674,7 +13199,6 @@
         "type": "object"
       },
       "UploadFileMetadataPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "delimiter": {
             "description": "The character used to separate values in the CSV file (e.g., a comma, semicolon, or tab).",
@@ -13705,7 +13229,6 @@
         "type": "object"
       },
       "UploadPostSchema": {
-        "additionalProperties": false,
         "properties": {
           "already_exists": {
             "default": "fail",
@@ -13824,7 +13347,6 @@
         "type": "object"
       },
       "User": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -13839,7 +13361,6 @@
         "type": "object"
       },
       "User1": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -13878,7 +13399,6 @@
         "type": "object"
       },
       "UserGroup": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13890,7 +13410,6 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13899,7 +13418,6 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.get_list": {
-        "additionalProperties": false,
         "properties": {
           "email": {
             "maxLength": 320,
@@ -13935,7 +13453,6 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.post": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13944,7 +13461,6 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.put": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -13953,7 +13469,6 @@
         "type": "object"
       },
       "UserResponseSchema": {
-        "additionalProperties": false,
         "properties": {
           "email": {
             "type": "string"
@@ -13989,7 +13504,6 @@
         "type": "object"
       },
       "ValidateSQLRequest": {
-        "additionalProperties": false,
         "properties": {
           "catalog": {
             "nullable": true,
@@ -14004,7 +13518,6 @@
             "type": "string"
           },
           "template_params": {
-            "additionalProperties": {},
             "nullable": true,
             "type": "object"
           }
@@ -14015,7 +13528,6 @@
         "type": "object"
       },
       "ValidateSQLResponse": {
-        "additionalProperties": false,
         "properties": {
           "end_column": {
             "type": "integer"
@@ -14033,7 +13545,6 @@
         "type": "object"
       },
       "ValidatorConfigJSON": {
-        "additionalProperties": false,
         "properties": {
           "op": {
             "description": "The operation to compare with a threshold to apply to the SQL output\n",
@@ -14054,7 +13565,6 @@
         "type": "object"
       },
       "VersionChangeRecord": {
-        "additionalProperties": false,
         "properties": {
           "from_value": {
             "description": "Value at path before the save; null when the field did not exist.",
@@ -14079,7 +13589,6 @@
         "type": "object"
       },
       "VersionChangedBy": {
-        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -14094,19 +13603,15 @@
         "type": "object"
       },
       "VersionListItemSchema": {
-        "additionalProperties": false,
         "properties": {
           "changed_by": {
-            "anyOf": [
+            "allOf": [
               {
                 "$ref": "#/components/schemas/VersionChangedBy"
-              },
-              {
-                "nullable": true,
-                "type": "object"
               }
             ],
-            "description": "User who produced the version, or null when the commit had no authenticated Flask user (CLI, Celery, import)."
+            "description": "User who produced the version, or null when the commit had no authenticated Flask user (CLI, Celery, import).",
+            "nullable": true
           },
           "changes": {
             "description": "Structured diff records describing the atomic field-level changes at this version, ordered by emission sequence. Empty for baseline (op=0) transactions per spec M4.",
@@ -14141,7 +13646,6 @@
         "type": "object"
       },
       "ViewMenuApi.get": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -14157,7 +13661,6 @@
         "type": "object"
       },
       "ViewMenuApi.get_list": {
-        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -14173,7 +13676,6 @@
         "type": "object"
       },
       "ViewMenuApi.post": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
@@ -14186,7 +13688,6 @@
         "type": "object"
       },
       "ViewMenuApi.put": {
-        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
@@ -33727,731 +33228,6 @@
         ],
         "tags": [
           "Security Users"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "A list of semantic layers"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "List all semantic layers",
-        "tags": [
-          "Semantic Layers"
-        ]
-      },
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "cache_timeout": {
-                    "type": "integer"
-                  },
-                  "configuration": {
-                    "type": "object"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Semantic layer created"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Create a semantic layer",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/connections/": {
-      "get": {
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_list_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Combined list of databases and semantic layers"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "List databases and semantic layers combined",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/schema/configuration": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "configuration": {
-                    "type": "object"
-                  },
-                  "type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Configuration JSON Schema"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Get configuration schema for a semantic layer type",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/types": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "A list of semantic layer types"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "List available semantic layer types",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/{uuid}": {
-      "delete": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "uuid",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Semantic layer deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Delete a semantic layer",
-        "tags": [
-          "Semantic Layers"
-        ]
-      },
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "uuid",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A semantic layer"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Get a semantic layer by UUID",
-        "tags": [
-          "Semantic Layers"
-        ]
-      },
-      "put": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "uuid",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "cache_timeout": {
-                    "type": "integer"
-                  },
-                  "configuration": {
-                    "type": "object"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Semantic layer updated"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Update a semantic layer",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/{uuid}/schema/runtime": {
-      "post": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "uuid",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "runtime_data": {
-                    "type": "object"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Runtime JSON Schema"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Get runtime schema for a semantic layer",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_layer/{uuid}/views": {
-      "post": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "uuid",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "runtime_data": {
-                    "type": "object"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Available views"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "List available views from a semantic layer",
-        "tags": [
-          "Semantic Layers"
-        ]
-      }
-    },
-    "/api/v1/semantic_view/": {
-      "delete": {
-        "parameters": [
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_delete_ids_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Semantic views deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Bulk delete semantic views",
-        "tags": [
-          "SemanticViewRestApi"
-        ]
-      },
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "views": {
-                    "items": {
-                      "properties": {
-                        "cache_timeout": {
-                          "type": "integer"
-                        },
-                        "configuration": {
-                          "type": "object"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "semantic_layer_uuid": {
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "type": "array"
-                  }
-                },
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Semantic views created"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Create semantic views",
-        "tags": [
-          "SemanticViewRestApi"
-        ]
-      }
-    },
-    "/api/v1/semantic_view/{pk}": {
-      "delete": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Semantic view deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Delete a semantic view",
-        "tags": [
-          "SemanticViewRestApi"
-        ]
-      },
-      "put": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SemanticViewRestApi.put"
-              }
-            }
-          },
-          "description": "Semantic view schema",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "id": {
-                      "type": "number"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/SemanticViewRestApi.put"
-                    }
-                  },
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Semantic view changed"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Update a semantic view",
-        "tags": [
-          "SemanticViewRestApi"
-        ]
-      }
-    },
-    "/api/v1/semantic_view/{pk}/structure": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Semantic view structure"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "403": {
-            "$ref": "#/components/responses/403"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Get semantic view structure",
-        "tags": [
-          "SemanticViewRestApi"
         ]
       }
     },

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -24896,6 +24896,7 @@
     },
     "/api/v1/dataset/{uuid_str}/activity/": {
       "get": {
+        "description": "A dataset's own edits only. Datasets have no transitive layer in V2 \u2014 chart and dashboard edits that touch this dataset do NOT appear here. ``?include=self`` and ``?include=all`` return the dataset's own edits; ``?include=related`` returns an empty stream (a dataset has no related entities to fan out to).",
         "parameters": [
           {
             "description": "Dataset UUID",
@@ -24996,7 +24997,7 @@
             "api_key": []
           }
         ],
-        "summary": "Activity stream \u2014 dataset's own edits only. Datasets have no transitive layer in V2 \u2014 chart and dashboard edits that touch this dataset do NOT appear here. ``?include=self`` and ``?include=all`` return the dataset's own edits; ``?include=related`` returns an empty stream (a dataset has no related entities to fan out to).",
+        "summary": "Get a dataset's activity stream",
         "tags": [
           "Datasets"
         ]

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -11,9 +11,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Bad request: Invalid parameters provided"
             }
           }
         },
@@ -29,9 +26,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Unauthorized: Authentication required"
             }
           }
         },
@@ -47,9 +41,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Forbidden: You don't have permission to access this resource"
             }
           }
         },
@@ -65,9 +56,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Not found: The requested resource does not exist"
             }
           }
         },
@@ -144,7 +132,11 @@
                         "type": "object"
                       },
                       "level": {
-                        "enum": ["info", "warning", "error"],
+                        "enum": [
+                          "info",
+                          "warning",
+                          "error"
+                        ],
                         "type": "string"
                       },
                       "message": {
@@ -175,9 +167,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Unprocessable entity: Validation error"
             }
           }
         },
@@ -193,9 +182,6 @@
                 }
               },
               "type": "object"
-            },
-            "example": {
-              "message": "Internal server error: An unexpected error occurred"
             }
           }
         },
@@ -203,7 +189,203 @@
       }
     },
     "schemas": {
+      "ActivityChangedBy": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityImpact": {
+        "additionalProperties": false,
+        "properties": {
+          "charts": {
+            "description": "Number of sibling charts on the path entity affected by the same related-record change at this transaction.",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityRecord": {
+        "additionalProperties": false,
+        "properties": {
+          "action_kind": {
+            "description": "Transaction-level avenue that produced this record's batch: ``restore`` / ``import`` / ``clone``. ``null`` for ordinary saves. All records sharing a ``transaction_id`` share the same action_kind. The schema's third ``*_kind`` column (entity_kind / kind / action_kind), at transaction scope.",
+            "enum": [
+              "clone",
+              "import",
+              "restore",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "changed_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ActivityChangedBy"
+              },
+              {
+                "nullable": true,
+                "type": "object"
+              }
+            ],
+            "description": "User who produced the change, or ``null`` when the saving user no longer exists in ``ab_user``."
+          },
+          "entity_deleted": {
+            "description": "True iff the source entity is hard-deleted (no live row by ``entity_id``). False for live and soft-deleted entities.",
+            "type": "boolean"
+          },
+          "entity_deletion_state": {
+            "description": "Present when the source entity has non-null ``deleted_at`` Absent or ``null`` otherwise.",
+            "enum": [
+              "soft_deleted",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "entity_kind": {
+            "description": "User-facing kind of the source entity: one of ``\"dashboard\"`` / ``\"chart\"`` / ``\"dataset\"``.",
+            "enum": [
+              "dashboard",
+              "chart",
+              "dataset"
+            ],
+            "type": "string"
+          },
+          "entity_name": {
+            "description": "Name of the source entity *at the time of the change* \u2014 denormalized from the validity-strategy shadow row. Survives entity rename / delete.",
+            "type": "string"
+          },
+          "entity_uuid": {
+            "description": "UUID of the source entity; ``null`` only when ``entity_deleted: true`` (the entity has been hard-deleted since the change was recorded).",
+            "nullable": true,
+            "type": "string"
+          },
+          "first_tracked_save": {
+            "description": "True when this record's transaction is the entity's FIRST tracked save (first UPDATE after the retroactive baseline). Such transactions can carry dozens of params-normalization records for entities that predate versioning; clients use the marker to collapse them rather than render each delta as a user edit. Matched against the LIVE row's (id, uuid), so it is always false for hard-deleted entities (no live row) and for shadow rows predating the entity's current uuid.",
+            "type": "boolean"
+          },
+          "from_value": {
+            "description": "Prior value; ``null`` = didn't exist.",
+            "nullable": true
+          },
+          "impact": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ActivityImpact"
+              },
+              {
+                "nullable": true,
+                "type": "object"
+              }
+            ],
+            "description": "Optional dependent-count for ``source: \"related\"`` records \u2014 e.g., ``{\"charts\": 4}`` for a dataset edit that affected 4 charts on the path dashboard at the change's transaction. Absent for ``source: \"self\"`` records and for related records without dependents."
+          },
+          "issued_at": {
+            "description": "UTC timestamp; primary ordering key (DESC).",
+            "format": "date-time",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Content category \u2014 what kind of thing changed. ``field`` is the fallback for scalar changes without a more specific category. Per-record.",
+            "enum": [
+              "filter",
+              "metric",
+              "dimension",
+              "column",
+              "chart",
+              "row",
+              "tab",
+              "tabs",
+              "header",
+              "markdown",
+              "divider",
+              "time_range",
+              "color_palette",
+              "field",
+              "__meta__"
+            ],
+            "type": "string"
+          },
+          "operation": {
+            "description": "Per-record verb: ``add`` / ``remove`` / ``move`` / ``edit``. Explicit instead of inferred from ``from_value`` / ``to_value`` null-tests. ``move`` only fires for layout records.",
+            "enum": [
+              "add",
+              "remove",
+              "move",
+              "edit",
+              "update",
+              "announce"
+            ],
+            "type": "string"
+          },
+          "path": {
+            "description": "Pure navigation address \u2014 no verb or kind embedded. Examples: ``['slice_name']``, ``['params', 'adhoc_filters', 'country']``, ``['CHART-x']`` for a layout add/remove/move, ``['HEADER-y', 'text']`` for a layout edit leaf. The verb lives in ``operation``, the element type in ``kind``.",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "source": {
+            "description": "``\"self\"`` if ``(entity_kind, entity_id)`` matches the path entity; else ``\"related\"``. Drives the frontend's no-group-under-save rendering rule.",
+            "enum": [
+              "self",
+              "related"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "description": "Synthesized headline for ``source: \"related\"`` records \u2014 e.g., ``\"Dataset updated: Sales Transactions\"``. Empty string for ``source: \"self\"`` records, except ``__meta__`` self records (e.g. restore announcements), which carry their own headline.",
+            "type": "string"
+          },
+          "to_value": {
+            "description": "New value; ``null`` = removed.",
+            "nullable": true
+          },
+          "transaction_id": {
+            "description": "Stable secondary ordering key; never reused.",
+            "type": "integer"
+          },
+          "version_uuid": {
+            "description": "Stable UUIDv5 identifier for the source version (``derive_version_uuid(entity_uuid, transaction_id)``). Identical to what ``/versions/<version_uuid>/`` would return for the same change.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "description": "Total record count across all pages (the filtered + denormalized stream), not just the current page. When ``truncated`` is true this is a floor (the count within the fetched window), not the absolute total.",
+            "type": "integer"
+          },
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/ActivityRecord"
+            },
+            "type": "array"
+          },
+          "truncated": {
+            "description": "True when the request hit the per-request fetch ceiling and older records exist beyond the returned window. Narrow the time range (``since``/``until``) to see them.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "AdvancedDataTypeSchema": {
+        "additionalProperties": false,
         "properties": {
           "display_value": {
             "description": "The string representation of the parsed values",
@@ -229,10 +411,16 @@
         "type": "object"
       },
       "AnnotationLayer": {
+        "additionalProperties": false,
         "properties": {
           "annotationType": {
             "description": "Type of annotation layer",
-            "enum": ["FORMULA", "INTERVAL", "EVENT", "TIME_SERIES"],
+            "enum": [
+              "FORMULA",
+              "INTERVAL",
+              "EVENT",
+              "TIME_SERIES"
+            ],
             "type": "string"
           },
           "color": {
@@ -263,7 +451,13 @@
           },
           "opacity": {
             "description": "Opacity of layer",
-            "enum": ["", "opacityLow", "opacityMedium", "opacityHigh", null],
+            "enum": [
+              "",
+              "opacityLow",
+              "opacityMedium",
+              "opacityHigh",
+              null
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -290,12 +484,22 @@
           },
           "sourceType": {
             "description": "Type of source for annotation data",
-            "enum": ["", "line", "NATIVE", "table"],
+            "enum": [
+              "",
+              "line",
+              "NATIVE",
+              "table"
+            ],
             "type": "string"
           },
           "style": {
             "description": "Line style. Only applies to time-series annotations",
-            "enum": ["dashed", "dotted", "solid", "longDashed"],
+            "enum": [
+              "dashed",
+              "dotted",
+              "solid",
+              "longDashed"
+            ],
             "type": "string"
           },
           "timeColumn": {
@@ -317,10 +521,16 @@
             "type": "number"
           }
         },
-        "required": ["name", "show", "showMarkers", "value"],
+        "required": [
+          "name",
+          "show",
+          "showMarkers",
+          "value"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "descr": {
             "nullable": true,
@@ -338,6 +548,7 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationLayerRestApi.get_list.User1"
@@ -374,6 +585,7 @@
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -384,10 +596,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -398,10 +614,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "descr": {
             "description": "Give a description for this annotation layer",
@@ -415,10 +635,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "AnnotationLayerRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "descr": {
             "description": "Give a description for this annotation layer",
@@ -434,6 +657,7 @@
         "type": "object"
       },
       "AnnotationRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -465,10 +689,13 @@
             "type": "string"
           }
         },
-        "required": ["layer"],
+        "required": [
+          "layer"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get.AnnotationLayer": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -482,6 +709,7 @@
         "type": "object"
       },
       "AnnotationRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/AnnotationRestApi.get_list.User"
@@ -518,6 +746,7 @@
         "type": "object"
       },
       "AnnotationRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -527,10 +756,13 @@
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -540,10 +772,13 @@
             "type": "integer"
           }
         },
-        "required": ["first_name"],
+        "required": [
+          "first_name"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "description": "The annotation end date time",
@@ -572,10 +807,15 @@
             "type": "string"
           }
         },
-        "required": ["end_dttm", "short_descr", "start_dttm"],
+        "required": [
+          "end_dttm",
+          "short_descr",
+          "start_dttm"
+        ],
         "type": "object"
       },
       "AnnotationRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "description": "The annotation end date time",
@@ -607,6 +847,7 @@
         "type": "object"
       },
       "AvailableDomainsSchema": {
+        "additionalProperties": false,
         "properties": {
           "domains": {
             "items": {
@@ -618,6 +859,7 @@
         "type": "object"
       },
       "CacheInvalidationRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "datasource_uids": {
             "description": "The uid of the dataset/datasource this new chart will use. A complete datasource identification needs `datasource_uid` ",
@@ -637,6 +879,7 @@
         "type": "object"
       },
       "CacheRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -645,6 +888,7 @@
         "type": "object"
       },
       "CacheRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -653,6 +897,7 @@
         "type": "object"
       },
       "CacheRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -661,6 +906,7 @@
         "type": "object"
       },
       "CacheRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -669,6 +915,7 @@
         "type": "object"
       },
       "CatalogsResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "items": {
@@ -681,6 +928,7 @@
         "type": "object"
       },
       "ChartCacheScreenshotResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "cache_key": {
             "description": "The cache key",
@@ -706,6 +954,7 @@
         "type": "object"
       },
       "ChartCacheWarmUpRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart to warm up cache for",
@@ -720,10 +969,13 @@
             "type": "string"
           }
         },
-        "required": ["chart_id"],
+        "required": [
+          "chart_id"
+        ],
         "type": "object"
       },
       "ChartCacheWarmUpResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of each chart's warmup status and errors if any",
@@ -736,6 +988,7 @@
         "type": "object"
       },
       "ChartCacheWarmUpResponseSingle": {
+        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart the status belongs to",
@@ -753,10 +1006,21 @@
         "type": "object"
       },
       "ChartDataAdhocMetricSchema": {
+        "additionalProperties": false,
         "properties": {
           "aggregate": {
             "description": "Aggregation operator.Only required for simple expression types.",
-            "enum": ["AVG", "COUNT", "COUNT_DISTINCT", "MAX", "MIN", "SUM"],
+            "enum": [
+              "AVG",
+              "COUNT",
+              "COUNT_DISTINCT",
+              "MAX",
+              "MIN",
+              "SUM",
+              "MEDIAN",
+              "STDDEV_SAMP",
+              "VAR_SAMP"
+            ],
             "type": "string"
           },
           "column": {
@@ -764,7 +1028,10 @@
           },
           "expressionType": {
             "description": "Simple or SQL metric",
-            "enum": ["SIMPLE", "SQL"],
+            "enum": [
+              "SIMPLE",
+              "SQL"
+            ],
             "example": "SQL",
             "type": "string"
           },
@@ -798,12 +1065,16 @@
             "type": "string"
           }
         },
-        "required": ["expressionType"],
+        "required": [
+          "expressionType"
+        ],
         "type": "object"
       },
       "ChartDataAggregateOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "aggregates": {
+            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -820,6 +1091,7 @@
         "type": "object"
       },
       "ChartDataAsyncResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "channel_id": {
             "description": "Unique session async channel ID",
@@ -846,6 +1118,7 @@
         "type": "object"
       },
       "ChartDataBoxplotOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "groupby": {
             "items": {
@@ -863,19 +1136,29 @@
           },
           "percentiles": {
             "description": "Upper and lower percentiles for percentile whisker type.",
-            "example": [1, 99]
+            "example": [
+              1,
+              99
+            ]
           },
           "whisker_type": {
             "description": "Whisker type. Any numpy function will work.",
-            "enum": ["tukey", "min/max", "percentile"],
+            "enum": [
+              "tukey",
+              "min/max",
+              "percentile"
+            ],
             "example": "tukey",
             "type": "string"
           }
         },
-        "required": ["whisker_type"],
+        "required": [
+          "whisker_type"
+        ],
         "type": "object"
       },
       "ChartDataColumn": {
+        "additionalProperties": false,
         "properties": {
           "column_name": {
             "description": "The name of the target column",
@@ -891,32 +1174,49 @@
         "type": "object"
       },
       "ChartDataContributionOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "orientation": {
             "description": "Should cell values be calculated across the row or column.",
-            "enum": ["row", "column"],
+            "enum": [
+              "row",
+              "column"
+            ],
             "example": "row",
             "type": "string"
           }
         },
-        "required": ["orientation"],
+        "required": [
+          "orientation"
+        ],
         "type": "object"
       },
       "ChartDataDatasource": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "Datasource id or uuid"
           },
           "type": {
             "description": "Datasource type",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           }
         },
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "type": "object"
       },
       "ChartDataExtras": {
+        "additionalProperties": false,
         "properties": {
           "column_order": {
             "description": "Ordered list of column names for result ordering. Used to preserve user's column reordering (including mixed dimension columns and metrics)",
@@ -937,12 +1237,18 @@
           },
           "relative_end": {
             "description": "End time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "relative_start": {
             "description": "Start time for relative time deltas. Default: `config[\"DEFAULT_RELATIVE_START_TIME\"]`",
-            "enum": ["today", "now"],
+            "enum": [
+              "today",
+              "now"
+            ],
             "type": "string"
           },
           "time_grain_sqla": {
@@ -986,6 +1292,7 @@
         "type": "object"
       },
       "ChartDataFilter": {
+        "additionalProperties": false,
         "properties": {
           "col": {
             "description": "The column to filter by. Can be either a string (physical or saved expression) or an object (adhoc column)",
@@ -1019,21 +1326,38 @@
               "NOT IN",
               "IS TRUE",
               "IS FALSE",
-              "TEMPORAL_RANGE"
+              "TEMPORAL_RANGE",
+              "CONTAINS_ANY",
+              "CONTAINS_ALL",
+              "IS_EMPTY",
+              "IS_NOT_EMPTY",
+              "LENGTH_EQUALS",
+              "LENGTH_GREATER_THAN",
+              "LENGTH_LESS_THAN",
+              "LENGTH_GREATER_THAN_OR_EQUALS",
+              "LENGTH_LESS_THAN_OR_EQUALS"
             ],
             "example": "IN",
             "type": "string"
           },
           "val": {
             "description": "The value or values to compare against. Can be a string, integer, decimal, None or list, depending on the operator.",
-            "example": ["China", "France", "Japan"],
+            "example": [
+              "China",
+              "France",
+              "Japan"
+            ],
             "nullable": true
           }
         },
-        "required": ["col", "op"],
+        "required": [
+          "col",
+          "op"
+        ],
         "type": "object"
       },
       "ChartDataGeodeticParseOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "altitude": {
             "description": "Name of target column for decoded altitude. If omitted, altitude information in geodetic string is ignored.",
@@ -1052,10 +1376,15 @@
             "type": "string"
           }
         },
-        "required": ["geodetic", "latitude", "longitude"],
+        "required": [
+          "geodetic",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashDecodeOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "geohash": {
             "description": "Name of source column containing geohash string",
@@ -1070,10 +1399,15 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataGeohashEncodeOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "geohash": {
             "description": "Name of target column for encoded geohash string",
@@ -1088,12 +1422,18 @@
             "type": "string"
           }
         },
-        "required": ["geohash", "latitude", "longitude"],
+        "required": [
+          "geohash",
+          "latitude",
+          "longitude"
+        ],
         "type": "object"
       },
       "ChartDataPivotOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "aggregates": {
+            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -1137,36 +1477,15 @@
         "type": "object"
       },
       "ChartDataPostProcessingOperation": {
+        "additionalProperties": false,
         "properties": {
           "operation": {
             "description": "Post processing operation type",
-            "enum": [
-              "aggregate",
-              "boxplot",
-              "compare",
-              "contribution",
-              "cum",
-              "diff",
-              "escape_separator",
-              "flatten",
-              "geodetic_parse",
-              "geohash_decode",
-              "geohash_encode",
-              "histogram",
-              "pivot",
-              "prophet",
-              "rank",
-              "rename",
-              "resample",
-              "rolling",
-              "select",
-              "sort",
-              "unescape_separator"
-            ],
             "example": "aggregate",
             "type": "string"
           },
           "options": {
+            "additionalProperties": {},
             "description": "Options specifying how to perform the operation. Please refer to the respective post processing operation option schemas. For example, `ChartDataPostProcessingOperationOptions` specifies the required options for the pivot operation.",
             "example": {
               "aggregates": {
@@ -1182,15 +1501,21 @@
                   }
                 }
               },
-              "groupby": ["country", "gender"]
+              "groupby": [
+                "country",
+                "gender"
+              ]
             },
             "type": "object"
           }
         },
-        "required": ["operation"],
+        "required": [
+          "operation"
+        ],
         "type": "object"
       },
       "ChartDataProphetOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "confidence_interval": {
             "description": "Width of predicted confidence interval",
@@ -1243,10 +1568,15 @@
             "example": false
           }
         },
-        "required": ["confidence_interval", "periods", "time_grain"],
+        "required": [
+          "confidence_interval",
+          "periods",
+          "time_grain"
+        ],
         "type": "object"
       },
       "ChartDataQueryContextSchema": {
+        "additionalProperties": false,
         "properties": {
           "custom_cache_timeout": {
             "description": "Override the default cache timeout",
@@ -1271,7 +1601,11 @@
             "type": "array"
           },
           "result_format": {
-            "enum": ["csv", "json", "xlsx"]
+            "enum": [
+              "csv",
+              "json",
+              "xlsx"
+            ]
           },
           "result_type": {
             "enum": [
@@ -1299,6 +1633,7 @@
             "type": "array"
           },
           "applied_time_extras": {
+            "additionalProperties": {},
             "description": "A mapping of temporal extras that have been applied to the query",
             "example": {
               "__time_range": "1 year ago : now"
@@ -1318,21 +1653,27 @@
             "type": "array"
           },
           "datasource": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/ChartDataDatasource"
               }
-            ],
-            "nullable": true
+            ]
           },
           "extras": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/ChartDataExtras"
+              },
+              {
+                "nullable": true,
+                "type": "object"
               }
             ],
-            "description": "Extra parameters to add to the query.",
-            "nullable": true
+            "description": "Extra parameters to add to the query."
           },
           "filters": {
             "items": {
@@ -1361,6 +1702,18 @@
           "groupby": {
             "description": "Columns by which to group the query. This field is deprecated, use `columns` instead.",
             "items": {},
+            "nullable": true,
+            "type": "array"
+          },
+          "grouping_sets": {
+            "default": null,
+            "description": "Rollup levels for non-additive totals: each entry is the list of groupby columns to group at that level (e.g. the empty list is the grand total). When set and the engine supports it, the levels are computed in a single GROUPING SETS query.",
+            "items": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "nullable": true,
             "type": "array"
           },
@@ -1394,8 +1747,14 @@
           "orderby": {
             "description": "Expects a list of lists where the first element is the column name which to sort by, and the second element is a boolean.",
             "example": [
-              ["my_col_1", false],
-              ["my_col_2", true]
+              [
+                "my_col_1",
+                false
+              ],
+              [
+                "my_col_2",
+                true
+              ]
             ],
             "items": {},
             "nullable": true,
@@ -1404,12 +1763,15 @@
           "post_processing": {
             "description": "Post processing operations to be applied to the result set. Operations are applied to the result set in sequential order.",
             "items": {
-              "allOf": [
+              "anyOf": [
+                {
+                  "nullable": true,
+                  "type": "object"
+                },
                 {
                   "$ref": "#/components/schemas/ChartDataPostProcessingOperation"
                 }
-              ],
-              "nullable": true
+              ]
             },
             "nullable": true,
             "type": "array"
@@ -1454,6 +1816,11 @@
           "series_limit_metric": {
             "description": "Metric used to limit timeseries queries by. Requires `series` and `series_limit` to be set.",
             "nullable": true
+          },
+          "time_compare_full_range": {
+            "description": "When using a time comparison (time_offsets), plot each shifted series across its full time range instead of truncating it to the main series' range. Useful for comparing a partial current period against complete prior periods.",
+            "nullable": true,
+            "type": "boolean"
           },
           "time_offsets": {
             "items": {
@@ -1500,7 +1867,40 @@
         },
         "type": "object"
       },
+      "ChartDataQueryTiming": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_resolution_ms": {
+            "nullable": true,
+            "type": "number"
+          },
+          "data_acquisition_ms": {
+            "nullable": true,
+            "type": "number"
+          },
+          "payload_assembly_ms": {
+            "nullable": true,
+            "type": "number"
+          },
+          "query_planning_ms": {
+            "nullable": true,
+            "type": "number"
+          },
+          "total_ms": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "cache_resolution_ms",
+          "data_acquisition_ms",
+          "payload_assembly_ms",
+          "query_planning_ms",
+          "total_ms"
+        ],
+        "type": "object"
+      },
       "ChartDataResponseResult": {
+        "additionalProperties": false,
         "properties": {
           "annotation_data": {
             "description": "All requested annotation data",
@@ -1516,6 +1916,7 @@
           "applied_filters": {
             "description": "A list with applied filters",
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -1552,6 +1953,7 @@
           "data": {
             "description": "A list with results",
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -1589,6 +1991,7 @@
           "rejected_filters": {
             "description": "A list with rejected filters",
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -1615,10 +2018,23 @@
             ],
             "type": "string"
           },
+          "timing": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChartDataTiming"
+              }
+            ],
+            "description": "Optional versioned query lifecycle timing breakdown in milliseconds. Present only when CHART_DATA_INCLUDE_TIMING is enabled; disabled by default."
+          },
           "to_dttm": {
             "description": "End timestamp of time range",
             "nullable": true,
             "type": "integer"
+          },
+          "warning": {
+            "description": "Warning message when results were truncated",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -1631,7 +2047,16 @@
         "type": "object"
       },
       "ChartDataResponseSchema": {
+        "additionalProperties": false,
         "properties": {
+          "dashboard_filters": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DashboardFiltersResponseSchema"
+              }
+            ],
+            "description": "Metadata about dashboard native filters applied to the query. Only present when filters_dashboard_id is provided."
+          },
           "result": {
             "description": "A list of results for each corresponding query in the request.",
             "items": {
@@ -1643,6 +2068,7 @@
         "type": "object"
       },
       "ChartDataRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -1651,6 +2077,7 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "nullable": true,
@@ -1689,7 +2116,10 @@
             "readOnly": true
           },
           "dashboards": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
+            "items": {
+              "$ref": "#/components/schemas/ChartDataRestApi.get_list.Dashboard"
+            },
+            "type": "array"
           },
           "datasource_id": {
             "nullable": true,
@@ -1716,6 +2146,12 @@
           "edit_url": {
             "readOnly": true
           },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/ChartDataRestApi.get_list.Subject"
+            },
+            "type": "array"
+          },
           "form_data": {
             "readOnly": true
           },
@@ -1733,9 +2169,6 @@
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.User2"
           },
-          "owners": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.User3"
-          },
           "params": {
             "nullable": true,
             "type": "string"
@@ -1752,7 +2185,10 @@
             "$ref": "#/components/schemas/ChartDataRestApi.get_list.SqlaTable"
           },
           "tags": {
-            "$ref": "#/components/schemas/ChartDataRestApi.get_list.Tag"
+            "items": {
+              "$ref": "#/components/schemas/ChartDataRestApi.get_list.Tag"
+            },
+            "type": "array"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -1765,6 +2201,12 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "$ref": "#/components/schemas/ChartDataRestApi.get_list.Subject1"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "maxLength": 250,
             "nullable": true,
@@ -1774,6 +2216,7 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.Dashboard": {
+        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -1787,6 +2230,7 @@
         "type": "object"
       },
       "ChartDataRestApi.get_list.SqlaTable": {
+        "additionalProperties": false,
         "properties": {
           "default_endpoint": {
             "nullable": true,
@@ -1797,10 +2241,53 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "ChartDataRestApi.get_list.Subject": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChartDataRestApi.get_list.Subject1": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.Tag": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -1811,12 +2298,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "ChartDataRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -1830,10 +2323,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -1847,10 +2344,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.get_list.User2": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -1864,27 +2365,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartDataRestApi.get_list.User3": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -1919,13 +2407,27 @@
           },
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           },
           "description": {
             "description": "A description of the chart propose.",
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the chart.",
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -1934,13 +2436,6 @@
           "is_managed_externally": {
             "nullable": true,
             "type": "boolean"
-          },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "type": "integer"
-            },
-            "type": "array"
           },
           "params": {
             "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
@@ -1968,18 +2463,34 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the chart.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartDataRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2010,7 +2521,15 @@
           },
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
-            "enum": ["table", "dataset", "query", "saved_query", "view", null],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view",
+              null
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -2018,6 +2537,13 @@
             "description": "A description of the chart propose.",
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the chart.",
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -2027,12 +2553,34 @@
             "nullable": true,
             "type": "boolean"
           },
-          "owners": {
+          "normalization_changes": {
+            "description": "Optional advisory Explore hydration transitions used only to remove exact automatic normalization changes from human-readable version history. Invalid metadata is ignored.",
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "type": "integer"
+              "properties": {
+                "control": {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                "from_present": {
+                  "type": "boolean"
+                },
+                "from_value": {},
+                "to_present": {
+                  "type": "boolean"
+                },
+                "to_value": {}
+              },
+              "required": [
+                "control",
+                "from_present",
+                "to_present"
+              ],
+              "type": "object"
             },
-            "type": "array"
+            "maxItems": 256,
+            "nullable": true,
+            "type": "array",
+            "writeOnly": true
           },
           "params": {
             "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
@@ -2068,9 +2616,20 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the chart.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2080,6 +2639,7 @@
         "type": "object"
       },
       "ChartDataRollingOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "center": {
             "description": "Should the label be at the center of the window.Default: `false`",
@@ -2120,6 +2680,7 @@
             "type": "string"
           },
           "rolling_type_options": {
+            "additionalProperties": {},
             "description": "Optional options to pass to rolling method. Needed for e.g. quantile operation.",
             "example": {},
             "type": "object"
@@ -2148,17 +2709,27 @@
           "window": {
             "description": "Size of the rolling window in days.",
             "example": 7,
+            "maximum": 10000,
+            "minimum": 1,
             "type": "integer"
           }
         },
-        "required": ["rolling_type", "window"],
+        "required": [
+          "rolling_type",
+          "window"
+        ],
         "type": "object"
       },
       "ChartDataSelectOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "columns": {
             "description": "Columns which to select from the input data, in the desired order. If columns are renamed, the original column name should be referenced here.",
-            "example": ["country", "gender", "age"],
+            "example": [
+              "country",
+              "gender",
+              "age"
+            ],
             "items": {
               "type": "string"
             },
@@ -2166,7 +2737,9 @@
           },
           "exclude": {
             "description": "Columns to exclude from selection.",
-            "example": ["my_temp_column"],
+            "example": [
+              "my_temp_column"
+            ],
             "items": {
               "type": "string"
             },
@@ -2180,6 +2753,7 @@
               }
             ],
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -2188,8 +2762,10 @@
         "type": "object"
       },
       "ChartDataSortOptionsSchema": {
+        "additionalProperties": false,
         "properties": {
           "aggregates": {
+            "additionalProperties": {},
             "description": "The keys are the name of the aggregate column to be created, and the values specify the details of how to apply the aggregation. If an operator requires additional options, these can be passed here to be unpacked in the operator call. The following numpy operators are supported: average, argmin, argmax, cumsum, cumprod, max, mean, median, nansum, nanmin, nanmax, nanmean, nanmedian, min, percentile, prod, product, std, sum, var. Any options required by the operator can be passed to the `options` object.\n\nIn the example, a new column `first_quantile` is created based on values in the column `my_col` using the `percentile` operator with the `q=0.25` parameter.",
             "example": {
               "first_quantile": {
@@ -2203,6 +2779,7 @@
             "type": "object"
           },
           "columns": {
+            "additionalProperties": {},
             "description": "columns by by which to sort. The key specifies the column name, value specifies if sorting in ascending order.",
             "example": {
               "country": true,
@@ -2211,10 +2788,32 @@
             "type": "object"
           }
         },
-        "required": ["columns"],
+        "required": [
+          "columns"
+        ],
+        "type": "object"
+      },
+      "ChartDataTiming": {
+        "additionalProperties": false,
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/ChartDataQueryTiming"
+          },
+          "version": {
+            "enum": [
+              1
+            ],
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query",
+          "version"
+        ],
         "type": "object"
       },
       "ChartEntityResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2242,6 +2841,7 @@
             "type": "string"
           },
           "form_data": {
+            "additionalProperties": {},
             "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
           },
@@ -2261,6 +2861,7 @@
         "type": "object"
       },
       "ChartFavStarResponseResult": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "The Chart id",
@@ -2274,6 +2875,7 @@
         "type": "object"
       },
       "ChartGetDatasourceObjectDataResponse": {
+        "additionalProperties": false,
         "properties": {
           "datasource_id": {
             "description": "The datasource identifier",
@@ -2287,6 +2889,7 @@
         "type": "object"
       },
       "ChartGetDatasourceObjectResponse": {
+        "additionalProperties": false,
         "properties": {
           "label": {
             "description": "The name of the datasource",
@@ -2299,6 +2902,7 @@
         "type": "object"
       },
       "ChartGetDatasourceResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of datasources",
@@ -2311,6 +2915,7 @@
         "type": "object"
       },
       "ChartGetResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "type": "string"
@@ -2349,18 +2954,18 @@
           "description": {
             "type": "string"
           },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          },
           "id": {
             "description": "The id of the chart.",
             "type": "integer"
           },
           "is_managed_externally": {
             "type": "boolean"
-          },
-          "owners": {
-            "items": {
-              "$ref": "#/components/schemas/User"
-            },
-            "type": "array"
           },
           "params": {
             "type": "string"
@@ -2387,6 +2992,12 @@
             "format": "uuid",
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "type": "string"
           }
@@ -2394,6 +3005,7 @@
         "type": "object"
       },
       "ChartRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2402,6 +3014,7 @@
         "type": "object"
       },
       "ChartRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "nullable": true,
@@ -2440,7 +3053,10 @@
             "readOnly": true
           },
           "dashboards": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
+            "items": {
+              "$ref": "#/components/schemas/ChartRestApi.get_list.Dashboard"
+            },
+            "type": "array"
           },
           "datasource_id": {
             "nullable": true,
@@ -2467,6 +3083,12 @@
           "edit_url": {
             "readOnly": true
           },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/ChartRestApi.get_list.Subject"
+            },
+            "type": "array"
+          },
           "form_data": {
             "readOnly": true
           },
@@ -2484,9 +3106,6 @@
           "last_saved_by": {
             "$ref": "#/components/schemas/ChartRestApi.get_list.User2"
           },
-          "owners": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.User3"
-          },
           "params": {
             "nullable": true,
             "type": "string"
@@ -2503,7 +3122,10 @@
             "$ref": "#/components/schemas/ChartRestApi.get_list.SqlaTable"
           },
           "tags": {
-            "$ref": "#/components/schemas/ChartRestApi.get_list.Tag"
+            "items": {
+              "$ref": "#/components/schemas/ChartRestApi.get_list.Tag"
+            },
+            "type": "array"
           },
           "thumbnail_url": {
             "readOnly": true
@@ -2516,6 +3138,12 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "$ref": "#/components/schemas/ChartRestApi.get_list.Subject1"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "maxLength": 250,
             "nullable": true,
@@ -2525,6 +3153,7 @@
         "type": "object"
       },
       "ChartRestApi.get_list.Dashboard": {
+        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -2538,6 +3167,7 @@
         "type": "object"
       },
       "ChartRestApi.get_list.SqlaTable": {
+        "additionalProperties": false,
         "properties": {
           "default_endpoint": {
             "nullable": true,
@@ -2548,10 +3178,53 @@
             "type": "string"
           }
         },
-        "required": ["table_name"],
+        "required": [
+          "table_name"
+        ],
+        "type": "object"
+      },
+      "ChartRestApi.get_list.Subject": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ChartRestApi.get_list.Subject1": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.Tag": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -2562,12 +3235,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "ChartRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2581,10 +3260,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2598,10 +3281,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.get_list.User2": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2615,27 +3302,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ChartRestApi.get_list.User3": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2670,13 +3344,27 @@
           },
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           },
           "description": {
             "description": "A description of the chart propose.",
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the chart.",
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -2685,13 +3373,6 @@
           "is_managed_externally": {
             "nullable": true,
             "type": "boolean"
-          },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "type": "integer"
-            },
-            "type": "array"
           },
           "params": {
             "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
@@ -2719,18 +3400,34 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the chart.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "slice_name"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "slice_name"
+        ],
         "type": "object"
       },
       "ChartRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart. Note this defaults to the datasource/table timeout if undefined.",
@@ -2761,7 +3458,15 @@
           },
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
-            "enum": ["table", "dataset", "query", "saved_query", "view", null],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view",
+              null
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -2769,6 +3474,13 @@
             "description": "A description of the chart propose.",
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the chart.",
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -2778,12 +3490,34 @@
             "nullable": true,
             "type": "boolean"
           },
-          "owners": {
+          "normalization_changes": {
+            "description": "Optional advisory Explore hydration transitions used only to remove exact automatic normalization changes from human-readable version history. Invalid metadata is ignored.",
             "items": {
-              "description": "Owner are users ids allowed to delete or change this chart. If left empty you will be one of the owners of the chart.",
-              "type": "integer"
+              "properties": {
+                "control": {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                "from_present": {
+                  "type": "boolean"
+                },
+                "from_value": {},
+                "to_present": {
+                  "type": "boolean"
+                },
+                "to_value": {}
+              },
+              "required": [
+                "control",
+                "from_present",
+                "to_present"
+              ],
+              "type": "object"
             },
-            "type": "array"
+            "maxItems": 256,
+            "nullable": true,
+            "type": "array",
+            "writeOnly": true
           },
           "params": {
             "description": "Parameters are generated dynamically when clicking the save or overwrite button in the explore view. This JSON object for power users who may want to alter specific parameters.",
@@ -2819,9 +3553,20 @@
             "nullable": true,
             "type": "string"
           },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the chart.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "viz_type": {
             "description": "The type of chart visualization used.",
-            "example": ["bar", "area", "table"],
+            "example": [
+              "bar",
+              "area",
+              "table"
+            ],
             "maxLength": 250,
             "minLength": 0,
             "nullable": true,
@@ -2831,6 +3576,7 @@
         "type": "object"
       },
       "CssTemplateRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get.User"
@@ -2857,6 +3603,7 @@
         "type": "object"
       },
       "CssTemplateRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2870,10 +3617,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2887,10 +3638,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/CssTemplateRestApi.get_list.User"
@@ -2922,6 +3677,7 @@
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2935,10 +3691,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -2952,10 +3712,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "CssTemplateRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "css": {
             "nullable": true,
@@ -2970,6 +3734,7 @@
         "type": "object"
       },
       "CssTemplateRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "css": {
             "nullable": true,
@@ -2984,7 +3749,13 @@
         "type": "object"
       },
       "CurrentUserPutSchema": {
+        "additionalProperties": false,
         "properties": {
+          "current_password": {
+            "description": "The current user's existing password",
+            "type": "string",
+            "writeOnly": true
+          },
           "first_name": {
             "description": "The current user's first name",
             "maxLength": 64,
@@ -3005,6 +3776,7 @@
         "type": "object"
       },
       "Dashboard": {
+        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "type": "string"
@@ -3019,6 +3791,7 @@
         "type": "object"
       },
       "DashboardCacheScreenshotResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "cache_key": {
             "description": "The cache key",
@@ -3043,7 +3816,59 @@
         },
         "type": "object"
       },
+      "DashboardChartCustomizationsConfigUpdateSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "deleted": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modified": {
+            "items": {},
+            "type": "array"
+          },
+          "reordered": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DashboardColorsConfigUpdateSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "color_namespace": {
+            "nullable": true,
+            "type": "string"
+          },
+          "color_scheme": {
+            "nullable": true,
+            "type": "string"
+          },
+          "color_scheme_domain": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "label_colors": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "map_label_colors": {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          "shared_label_colors": {}
+        },
+        "type": "object"
+      },
       "DashboardCopySchema": {
+        "additionalProperties": false,
         "properties": {
           "css": {
             "description": "Override CSS for the dashboard.",
@@ -3065,10 +3890,13 @@
             "type": "string"
           }
         },
-        "required": ["json_metadata"],
+        "required": [
+          "json_metadata"
+        ],
         "type": "object"
       },
       "DashboardDatasetSchema": {
+        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "type": "boolean"
@@ -3077,6 +3905,7 @@
             "type": "integer"
           },
           "column_formats": {
+            "additionalProperties": {},
             "type": "object"
           },
           "column_names": {
@@ -3093,6 +3922,7 @@
           },
           "columns": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -3111,6 +3941,12 @@
           },
           "edit_url": {
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
           },
           "fetch_values_predicate": {
             "type": "string"
@@ -3144,6 +3980,7 @@
           },
           "metrics": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -3163,12 +4000,6 @@
                 "type": "string"
               },
               "type": "array"
-            },
-            "type": "array"
-          },
-          "owners": {
-            "items": {
-              "type": "object"
             },
             "type": "array"
           },
@@ -3217,7 +4048,82 @@
         },
         "type": "object"
       },
+      "DashboardExportXlsxPostSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "active_data_mask": {
+            "additionalProperties": {
+              "additionalProperties": {},
+              "type": "object"
+            },
+            "description": "Live dashboard filter state keyed by native filter id, each carrying an extraFormData object.",
+            "type": "object"
+          },
+          "mode": {
+            "default": "data",
+            "description": "Export mode: 'data' streams each chart's tabular result (default); 'images' embeds non-table charts as rendered images and keeps table charts tabular.",
+            "enum": [
+              "data",
+              "images"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DashboardExportXlsxResponseSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "job_id": {
+            "description": "Correlation id for the async export task",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DashboardFilterInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "column": {
+            "description": "Target column name for the filter",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "The native filter ID",
+            "type": "string"
+          },
+          "name": {
+            "description": "The native filter name",
+            "type": "string"
+          },
+          "status": {
+            "description": "Filter status: 'applied' (default value was included in the query), 'not_applied' (filter had no default value and was omitted, matching dashboard initial-load behavior), or 'not_applied_uses_default_to_first_item_prequery' (filter uses defaultToFirstItem which requires a pre-query to resolve and cannot be applied server-side)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status"
+        ],
+        "type": "object"
+      },
+      "DashboardFiltersResponseSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "filters": {
+            "description": "Metadata about each in-scope dashboard native filter and whether its default value was applied to the query",
+            "items": {
+              "$ref": "#/components/schemas/DashboardFilterInfo"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "DashboardGetResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -3228,7 +4134,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User"
           },
           "changed_by_name": {
             "type": "string"
@@ -3248,7 +4154,7 @@
             "type": "array"
           },
           "created_by": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User"
           },
           "created_on_delta_humanized": {
             "type": "string"
@@ -3267,6 +4173,16 @@
             "description": "A title for the dashboard.",
             "type": "string"
           },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          },
           "id": {
             "type": "integer"
           },
@@ -3278,24 +4194,12 @@
             "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
             "type": "string"
           },
-          "owners": {
-            "items": {
-              "$ref": "#/components/schemas/User1"
-            },
-            "type": "array"
-          },
           "position_json": {
             "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
             "type": "string"
           },
           "published": {
             "type": "boolean"
-          },
-          "roles": {
-            "items": {
-              "$ref": "#/components/schemas/Roles"
-            },
-            "type": "array"
           },
           "slug": {
             "type": "string"
@@ -3307,12 +4211,15 @@
             "type": "array"
           },
           "theme": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/Theme"
               }
-            ],
-            "nullable": true
+            ]
           },
           "thumbnail_url": {
             "nullable": true,
@@ -3325,15 +4232,45 @@
             "format": "uuid",
             "nullable": true,
             "type": "string"
+          },
+          "viewers": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "DashboardNativeFiltersConfigUpdateSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "deleted": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modified": {
+            "items": {},
+            "type": "array"
+          },
+          "reordered": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "type": "object"
       },
       "DashboardPermalinkStateSchema": {
+        "additionalProperties": false,
         "properties": {
           "activeTabs": {
             "description": "Current active dashboard tabs",
             "items": {
+              "nullable": true,
               "type": "string"
             },
             "nullable": true,
@@ -3345,11 +4282,13 @@
             "type": "string"
           },
           "chartStates": {
+            "additionalProperties": {},
             "description": "Chart-level state for stateful tables (column order, sorting, filtering)",
             "nullable": true,
             "type": "object"
           },
           "dataMask": {
+            "additionalProperties": {},
             "description": "Data mask used for native filter state",
             "nullable": true,
             "type": "object"
@@ -3367,6 +4306,7 @@
         "type": "object"
       },
       "DashboardRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3375,6 +4315,7 @@
         "type": "object"
       },
       "DashboardRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "nullable": true,
@@ -3459,6 +4400,7 @@
         "type": "object"
       },
       "DashboardRestApi.get_list.Subject": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3471,10 +4413,14 @@
             "type": "integer"
           }
         },
-        "required": ["label", "type"],
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.Subject1": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3487,10 +4433,14 @@
             "type": "integer"
           }
         },
-        "required": ["label", "type"],
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.Tag": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3501,12 +4451,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "DashboardRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3520,10 +4476,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -3537,10 +4497,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DashboardRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -3563,6 +4527,18 @@
             "nullable": true,
             "type": "string"
           },
+          "description": {
+            "description": "A description for the dashboard.",
+            "nullable": true,
+            "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the dashboard.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "external_url": {
             "nullable": true,
             "type": "string"
@@ -3575,13 +4551,6 @@
             "description": "This JSON object is generated dynamically when clicking the save or overwrite button in the dashboard view. It is exposed here for reference and for power users who may want to alter  specific parameters.",
             "type": "string"
           },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "position_json": {
             "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
             "type": "string"
@@ -3589,13 +4558,6 @@
           "published": {
             "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
             "type": "boolean"
-          },
-          "roles": {
-            "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "type": "integer"
-            },
-            "type": "array"
           },
           "slug": {
             "description": "Unique identifying part for the web address of the dashboard.",
@@ -3613,11 +4575,19 @@
             "format": "uuid",
             "nullable": true,
             "type": "string"
+          },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the dashboard.",
+              "type": "integer"
+            },
+            "type": "array"
           }
         },
         "type": "object"
       },
       "DashboardRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "certification_details": {
             "description": "Details of the certification",
@@ -3641,6 +4611,19 @@
             "nullable": true,
             "type": "string"
           },
+          "description": {
+            "description": "A description for the dashboard.",
+            "nullable": true,
+            "type": "string"
+          },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the dashboard.",
+              "nullable": true,
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "external_url": {
             "nullable": true,
             "type": "string"
@@ -3654,14 +4637,6 @@
             "nullable": true,
             "type": "string"
           },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this dashboard. If left empty you will be one of the owners of the dashboard.",
-              "nullable": true,
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "position_json": {
             "description": "This json object describes the positioning of the widgets in the dashboard. It is dynamically generated when adjusting the widgets size and positions by using drag & drop in the dashboard view",
             "nullable": true,
@@ -3671,14 +4646,6 @@
             "description": "Determines whether or not this dashboard is visible in the list of all dashboards.",
             "nullable": true,
             "type": "boolean"
-          },
-          "roles": {
-            "items": {
-              "description": "Roles is a list which defines access to the dashboard. These roles are always applied in addition to restrictions on dataset level access. If no roles defined then the dashboard is available to all roles.",
-              "nullable": true,
-              "type": "integer"
-            },
-            "type": "array"
           },
           "slug": {
             "description": "Unique identifying part for the web address of the dashboard.",
@@ -3704,11 +4671,20 @@
             "format": "uuid",
             "nullable": true,
             "type": "string"
+          },
+          "viewers": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can view the dashboard.",
+              "nullable": true,
+              "type": "integer"
+            },
+            "type": "array"
           }
         },
         "type": "object"
       },
       "DashboardScreenshotPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "activeTabs": {
             "description": "A list representing active tabs.",
@@ -3735,6 +4711,7 @@
         "type": "object"
       },
       "Database": {
+        "additionalProperties": false,
         "properties": {
           "allow_multi_catalog": {
             "type": "boolean"
@@ -3770,6 +4747,7 @@
         "type": "object"
       },
       "Database1": {
+        "additionalProperties": false,
         "properties": {
           "database_name": {
             "type": "string"
@@ -3778,6 +4756,7 @@
         "type": "object"
       },
       "DatabaseConnectionSchema": {
+        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "description": "Allow CREATE TABLE AS option in SQL Lab",
@@ -3805,7 +4784,8 @@
             "type": "string"
           },
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires, and -1 bypasses the cache. Note this defaults to the global timeout if undefined.",
+            "minimum": -1,
             "nullable": true,
             "type": "integer"
           },
@@ -3833,7 +4813,7 @@
             "type": "boolean"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.<br>7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or not drill to detail is disabled for the database.<br>8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.<br>9. The <code>disable_sampling_read_limit_override</code> field is a boolean specifying whether system-generated sampling queries (filter values, samples/preview, datetime format detection) that an engine rejects with a read-limit error should fail outright instead of being retried once with the engine's bounded-read override. Only affects engines that implement such an override.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -3882,12 +4862,15 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
-            "nullable": true
+            ]
           },
           "uuid": {
             "type": "string"
@@ -3896,6 +4879,7 @@
         "type": "object"
       },
       "DatabaseFunctionNamesResponse": {
+        "additionalProperties": false,
         "properties": {
           "function_names": {
             "items": {
@@ -3907,6 +4891,7 @@
         "type": "object"
       },
       "DatabaseRelatedChart": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -3921,6 +4906,7 @@
         "type": "object"
       },
       "DatabaseRelatedCharts": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Chart count",
@@ -3937,11 +4923,13 @@
         "type": "object"
       },
       "DatabaseRelatedDashboard": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
           },
           "json_metadata": {
+            "additionalProperties": {},
             "type": "object"
           },
           "slug": {
@@ -3954,6 +4942,7 @@
         "type": "object"
       },
       "DatabaseRelatedDashboards": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Dashboard count",
@@ -3970,6 +4959,7 @@
         "type": "object"
       },
       "DatabaseRelatedObjectsResponse": {
+        "additionalProperties": false,
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatabaseRelatedCharts"
@@ -3981,6 +4971,7 @@
         "type": "object"
       },
       "DatabaseRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "nullable": true,
@@ -4049,10 +5040,13 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "allow_ctas": {
             "nullable": true,
@@ -4146,10 +5140,13 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -4160,10 +5157,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -4174,7 +5175,10 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.post": {
@@ -4200,14 +5204,18 @@
             "type": "boolean"
           },
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires, and -1 bypasses the cache. Note this defaults to the global timeout if undefined.",
+            "minimum": -1,
             "nullable": true,
             "type": "integer"
           },
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4234,7 +5242,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.<br>7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or not drill to detail is disabled for the database.<br>8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.<br>9. The <code>disable_sampling_read_limit_override</code> field is a boolean specifying whether system-generated sampling queries (filter values, samples/preview, datetime format detection) that an engine rejects with a read-limit error should fail outright instead of being retried once with the engine's bounded-read override. Only affects engines that implement such an override.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -4274,18 +5282,23 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
-            "nullable": true
+            ]
           },
           "uuid": {
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatabaseRestApi.put": {
@@ -4311,14 +5324,18 @@
             "type": "boolean"
           },
           "cache_timeout": {
-            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires. Note this defaults to the global timeout if undefined.",
+            "description": "Duration (in seconds) of the caching timeout for charts of this database. A timeout of 0 indicates that the cache never expires, and -1 bypasses the cache. Note this defaults to the global timeout if undefined.",
+            "minimum": -1,
             "nullable": true,
             "type": "integer"
           },
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4346,7 +5363,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.<br>7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or not drill to detail is disabled for the database.<br>8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.<br>9. The <code>disable_sampling_read_limit_override</code> field is a boolean specifying whether system-generated sampling queries (filter values, samples/preview, datetime format detection) that an engine rejects with a read-limit error should fail outright instead of being retried once with the engine's bounded-read override. Only affects engines that implement such an override.</p>",
             "type": "string"
           },
           "force_ctas_schema": {
@@ -4386,12 +5403,15 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
-            "nullable": true
+            ]
           },
           "uuid": {
             "type": "string"
@@ -4400,6 +5420,7 @@
         "type": "object"
       },
       "DatabaseSSHTunnel": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "description": "SSH Tunnel ID (for updates)",
@@ -4407,15 +5428,26 @@
             "type": "integer"
           },
           "password": {
-            "type": "string"
+            "type": "string",
+            "writeOnly": true
           },
           "private_key": {
-            "type": "string"
+            "type": "string",
+            "writeOnly": true
           },
           "private_key_password": {
-            "type": "string"
+            "type": "string",
+            "writeOnly": true
           },
           "server_address": {
+            "maxLength": 256,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9._:\\-\\[\\]]+$",
+            "type": "string"
+          },
+          "server_host_key": {
+            "description": "Expected SSH server host key in authorized-key form (e.g. 'ssh-ed25519 AAAA...'). When set, the server's host key is verified against it before the tunnel is opened.",
+            "nullable": true,
             "type": "string"
           },
           "server_port": {
@@ -4427,7 +5459,47 @@
         },
         "type": "object"
       },
+      "DatabaseSSHTunnelValidation": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "SSH Tunnel ID (for updates)",
+            "nullable": true,
+            "type": "integer"
+          },
+          "password": {
+            "nullable": true,
+            "type": "string"
+          },
+          "private_key": {
+            "nullable": true,
+            "type": "string"
+          },
+          "private_key_password": {
+            "nullable": true,
+            "type": "string"
+          },
+          "server_address": {
+            "nullable": true,
+            "type": "string"
+          },
+          "server_host_key": {
+            "nullable": true,
+            "type": "string"
+          },
+          "server_port": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "username": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "DatabaseSchemaAccessForFileUploadResponse": {
+        "additionalProperties": false,
         "properties": {
           "schemas": {
             "description": "The list of schemas allowed for the database to upload information",
@@ -4440,8 +5512,10 @@
         "type": "object"
       },
       "DatabaseTablesResponse": {
+        "additionalProperties": false,
         "properties": {
           "extra": {
+            "additionalProperties": {},
             "description": "Extra data used to specify column metadata",
             "type": "object"
           },
@@ -4457,11 +5531,15 @@
         "type": "object"
       },
       "DatabaseTestConnectionSchema": {
+        "additionalProperties": false,
         "properties": {
           "configuration_method": {
             "default": "sqlalchemy_form",
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4481,7 +5559,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.<br>7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or not drill to detail is disabled for the database.<br>8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.<br>9. The <code>disable_sampling_read_limit_override</code> field is a boolean specifying whether system-generated sampling queries (filter values, samples/preview, datetime format detection) that an engine rejects with a read-limit error should fail outright instead of being retried once with the engine's bounded-read override. Only affects engines that implement such an override.</p>",
             "type": "string"
           },
           "impersonate_user": {
@@ -4510,12 +5588,15 @@
             "type": "string"
           },
           "ssh_tunnel": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/DatabaseSSHTunnel"
               }
-            ],
-            "nullable": true
+            ]
           }
         },
         "type": "object"
@@ -4531,7 +5612,10 @@
           },
           "configuration_method": {
             "description": "Configuration_method is used on the frontend to inform the backend whether to explode parameters or to provide only a sqlalchemy_uri.",
-            "enum": ["sqlalchemy_form", "dynamic_form"]
+            "enum": [
+              "sqlalchemy_form",
+              "dynamic_form"
+            ]
           },
           "database_name": {
             "description": "A database name to identify this connection.",
@@ -4550,7 +5634,7 @@
             "type": "string"
           },
           "extra": {
-            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or notdrill to detail is disabled for the database.8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.</p>",
+            "description": "<p>JSON string containing extra configuration elements.<br>1. The <code>engine_params</code> object gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine\" rel=\"noopener noreferrer\">sqlalchemy.create_engine</a> call, while the <code>metadata_params</code> gets unpacked into the <a href=\"https://docs.sqlalchemy.org/en/rel_1_0/core/metadata.html#sqlalchemy.schema.MetaData\" rel=\"noopener noreferrer\">sqlalchemy.MetaData</a> call.<br>2. The <code>metadata_cache_timeout</code> is a cache timeout setting in seconds for metadata fetch of this database. Specify it as <strong>\"metadata_cache_timeout\": {\"schema_cache_timeout\": 600, \"table_cache_timeout\": 600}</strong>. If unset, cache will not be enabled for the functionality. A timeout of 0 indicates that the cache never expires.<br>3. The <code>schemas_allowed_for_file_upload</code> is a comma separated list of schemas that CSVs are allowed to upload to. Specify it as <strong>\"schemas_allowed_for_file_upload\": [\"public\", \"csv_upload\"]</strong>. If database flavor does not support schema or any schema is allowed to be accessed, just leave the list empty<br>4. The <code>version</code> field is a string specifying the this db's version. This should be used with Presto DBs so that the syntax is correct<br>5. The <code>allows_virtual_table_explore</code> field is a boolean specifying whether or not the Explore button in SQL Lab results is shown.<br>6. The <code>disable_data_preview</code> field is a boolean specifying whether or not data preview queries will be run when fetching table metadata in SQL Lab.<br>7. The <code>disable_drill_to_detail</code> field is a boolean specifying whether or not drill to detail is disabled for the database.<br>8. The <code>allow_multi_catalog</code> indicates if the database allows changing the default catalog when running queries and creating datasets.<br>9. The <code>disable_sampling_read_limit_override</code> field is a boolean specifying whether system-generated sampling queries (filter values, samples/preview, datetime format detection) that an engine rejects with a read-limit error should fail outright instead of being retried once with the engine's bounded-read override. Only affects engines that implement such an override.</p>",
             "type": "string"
           },
           "id": {
@@ -4578,29 +5662,47 @@
             "description": "<p>Optional CA_BUNDLE contents to validate HTTPS requests. Only available on certain database engines.</p>",
             "nullable": true,
             "type": "string"
+          },
+          "ssh_tunnel": {
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/DatabaseSSHTunnelValidation"
+              }
+            ]
           }
         },
-        "required": ["configuration_method", "engine"],
+        "required": [
+          "configuration_method",
+          "engine"
+        ],
         "type": "object"
       },
       "Dataset": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this dataset.",
             "type": "integer"
           },
           "column_formats": {
+            "additionalProperties": {},
             "description": "Column formats.",
             "type": "object"
           },
           "columns": {
             "description": "Columns metadata.",
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "database": {
+            "additionalProperties": {},
             "description": "Database associated with the dataset.",
             "type": "object"
           },
@@ -4620,7 +5722,15 @@
             "description": "The URL for editing the dataset.",
             "type": "string"
           },
+          "editors": {
+            "description": "List of editors",
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          },
           "extra": {
+            "additionalProperties": {},
             "description": "JSON string containing extra configuration elements.",
             "type": "object"
           },
@@ -4640,6 +5750,7 @@
             "description": "Name of temporal column used for time filtering for SQL datasources. This field is deprecated, use `granularity` instead.",
             "items": {
               "items": {
+                "additionalProperties": {},
                 "type": "object"
               },
               "type": "array"
@@ -4665,6 +5776,7 @@
           "metrics": {
             "description": "Dataset metrics.",
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -4687,20 +5799,22 @@
             },
             "type": "array"
           },
-          "owners": {
-            "description": "List of owners identifiers",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "params": {
+            "additionalProperties": {},
             "description": "Extra params for the dataset.",
             "type": "object"
           },
           "perm": {
             "description": "Permission expression.",
             "type": "string"
+          },
+          "rls_filters": {
+            "default": [],
+            "description": "Row-level security filters applied to this dataset.",
+            "items": {
+              "$ref": "#/components/schemas/RlsFilter"
+            },
+            "type": "array"
           },
           "schema": {
             "description": "Dataset schema.",
@@ -4719,6 +5833,7 @@
             "type": "string"
           },
           "template_params": {
+            "additionalProperties": {},
             "description": "Table template params.",
             "type": "object"
           },
@@ -4741,6 +5856,7 @@
             "type": "string"
           },
           "verbose_map": {
+            "additionalProperties": {},
             "description": "Mapping from raw name to verbose name.",
             "type": "object"
           }
@@ -4748,6 +5864,7 @@
         "type": "object"
       },
       "DatasetCacheWarmUpRequestSchema": {
+        "additionalProperties": false,
         "properties": {
           "dashboard_id": {
             "description": "The ID of the dashboard to get filters for when warming cache",
@@ -4766,10 +5883,14 @@
             "type": "string"
           }
         },
-        "required": ["db_name", "table_name"],
+        "required": [
+          "db_name",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetCacheWarmUpResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of each chart's warmup status and errors if any",
@@ -4782,6 +5903,7 @@
         "type": "object"
       },
       "DatasetCacheWarmUpResponseSingle": {
+        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The ID of the chart the status belongs to",
@@ -4799,6 +5921,7 @@
         "type": "object"
       },
       "DatasetColumnsPut": {
+        "additionalProperties": false,
         "properties": {
           "advanced_data_type": {
             "maxLength": 255,
@@ -4866,10 +5989,13 @@
             "type": "string"
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetColumnsRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4878,6 +6004,7 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4886,6 +6013,7 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4894,6 +6022,7 @@
         "type": "object"
       },
       "DatasetColumnsRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4902,6 +6031,7 @@
         "type": "object"
       },
       "DatasetDuplicateSchema": {
+        "additionalProperties": false,
         "properties": {
           "base_model_id": {
             "type": "integer"
@@ -4912,10 +6042,14 @@
             "type": "string"
           }
         },
-        "required": ["base_model_id", "table_name"],
+        "required": [
+          "base_model_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetMetricCurrencyPut": {
+        "additionalProperties": false,
         "properties": {
           "symbol": {
             "maxLength": 128,
@@ -4931,6 +6065,7 @@
         "type": "object"
       },
       "DatasetMetricRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4939,6 +6074,7 @@
         "type": "object"
       },
       "DatasetMetricRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4947,6 +6083,7 @@
         "type": "object"
       },
       "DatasetMetricRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4955,6 +6092,7 @@
         "type": "object"
       },
       "DatasetMetricRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -4963,14 +6101,18 @@
         "type": "object"
       },
       "DatasetMetricsPut": {
+        "additionalProperties": false,
         "properties": {
           "currency": {
-            "allOf": [
+            "anyOf": [
+              {
+                "nullable": true,
+                "type": "object"
+              },
               {
                 "$ref": "#/components/schemas/DatasetMetricCurrencyPut"
               }
-            ],
-            "nullable": true
+            ]
           },
           "d3format": {
             "maxLength": 128,
@@ -5017,10 +6159,14 @@
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
         "type": "object"
       },
       "DatasetRelatedChart": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -5035,6 +6181,7 @@
         "type": "object"
       },
       "DatasetRelatedCharts": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Chart count",
@@ -5051,11 +6198,13 @@
         "type": "object"
       },
       "DatasetRelatedDashboard": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
           },
           "json_metadata": {
+            "additionalProperties": {},
             "type": "object"
           },
           "slug": {
@@ -5068,6 +6217,7 @@
         "type": "object"
       },
       "DatasetRelatedDashboards": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "Dashboard count",
@@ -5084,6 +6234,7 @@
         "type": "object"
       },
       "DatasetRelatedObjectsResponse": {
+        "additionalProperties": false,
         "properties": {
           "charts": {
             "$ref": "#/components/schemas/DatasetRelatedCharts"
@@ -5095,6 +6246,7 @@
         "type": "object"
       },
       "DatasetRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "nullable": true,
@@ -5109,7 +6261,7 @@
             "type": "string"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User2"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -5123,10 +6275,13 @@
             "readOnly": true
           },
           "columns": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
+            "items": {
+              "$ref": "#/components/schemas/DatasetRestApi.get.TableColumn"
+            },
+            "type": "array"
           },
           "created_by": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User1"
+            "$ref": "#/components/schemas/DatasetRestApi.get.User"
           },
           "created_on": {
             "format": "date-time",
@@ -5157,6 +6312,12 @@
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRestApi.get.Subject"
+            },
+            "type": "array"
           },
           "extra": {
             "nullable": true,
@@ -5195,7 +6356,10 @@
             "type": "string"
           },
           "metrics": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.SqlMetric"
+            "items": {
+              "$ref": "#/components/schemas/DatasetRestApi.get.SqlMetric"
+            },
+            "type": "array"
           },
           "name": {
             "readOnly": true
@@ -5210,9 +6374,6 @@
           },
           "order_by_choices": {
             "readOnly": true
-          },
-          "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get.User"
           },
           "schema": {
             "maxLength": 255,
@@ -5252,10 +6413,16 @@
             "readOnly": true
           }
         },
-        "required": ["columns", "database", "metrics", "table_name"],
+        "required": [
+          "columns",
+          "database",
+          "metrics",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.Database": {
+        "additionalProperties": false,
         "properties": {
           "allow_multi_catalog": {
             "readOnly": true
@@ -5276,11 +6443,20 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.SqlMetric": {
+        "additionalProperties": false,
         "properties": {
+          "certification_details": {
+            "readOnly": true
+          },
+          "certified_by": {
+            "readOnly": true
+          },
           "changed_on": {
             "format": "date-time",
             "nullable": true,
@@ -5313,6 +6489,9 @@
           "id": {
             "type": "integer"
           },
+          "is_certified": {
+            "readOnly": true
+          },
           "metric_name": {
             "maxLength": 255,
             "type": "string"
@@ -5332,20 +6511,53 @@
             "nullable": true,
             "type": "string"
           },
+          "warning_markdown": {
+            "readOnly": true
+          },
           "warning_text": {
             "nullable": true,
             "type": "string"
           }
         },
-        "required": ["expression", "metric_name"],
+        "required": [
+          "expression",
+          "metric_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get.Subject": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.TableColumn": {
+        "additionalProperties": false,
         "properties": {
           "advanced_data_type": {
             "maxLength": 255,
             "nullable": true,
             "type": "string"
+          },
+          "certification_details": {
+            "readOnly": true
+          },
+          "certified_by": {
+            "readOnly": true
           },
           "changed_on": {
             "format": "date-time",
@@ -5388,6 +6600,9 @@
             "nullable": true,
             "type": "boolean"
           },
+          "is_certified": {
+            "readOnly": true
+          },
           "is_dttm": {
             "nullable": true,
             "type": "boolean"
@@ -5413,29 +6628,36 @@
             "maxLength": 1024,
             "nullable": true,
             "type": "string"
+          },
+          "warning_markdown": {
+            "readOnly": true
           }
         },
-        "required": ["column_name"],
+        "required": [
+          "column_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
             "type": "string"
-          },
-          "id": {
-            "type": "integer"
           },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -5446,24 +6668,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "DatasetRestApi.get.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -5496,6 +6708,12 @@
             "nullable": true,
             "type": "string"
           },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetRestApi.get_list.Subject"
+            },
+            "type": "array"
+          },
           "explore_url": {
             "readOnly": true
           },
@@ -5508,9 +6726,6 @@
           },
           "kind": {
             "readOnly": true
-          },
-          "owners": {
-            "$ref": "#/components/schemas/DatasetRestApi.get_list.User1"
           },
           "schema": {
             "maxLength": 255,
@@ -5531,10 +6746,14 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.Database": {
+        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -5549,10 +6768,33 @@
             "type": "string"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
+        "type": "object"
+      },
+      "DatasetRestApi.get_list.Subject": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "DatasetRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -5566,27 +6808,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "DatasetRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -5598,8 +6827,20 @@
             "nullable": true,
             "type": "string"
           },
+          "currency_code_column": {
+            "maxLength": 250,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
           "database": {
             "type": "integer"
+          },
+          "editors": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -5612,12 +6853,6 @@
           "normalize_columns": {
             "default": false,
             "type": "boolean"
-          },
-          "owners": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
           },
           "schema": {
             "maxLength": 250,
@@ -5644,10 +6879,14 @@
             "type": "string"
           }
         },
-        "required": ["database", "table_name"],
+        "required": [
+          "database",
+          "table_name"
+        ],
         "type": "object"
       },
       "DatasetRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -5685,6 +6924,12 @@
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
           },
           "external_url": {
             "nullable": true,
@@ -5736,12 +6981,6 @@
             "nullable": true,
             "type": "integer"
           },
-          "owners": {
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "schema": {
             "maxLength": 255,
             "minLength": 0,
@@ -5771,6 +7010,7 @@
         "type": "object"
       },
       "Datasource": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "description": "Datasource catalog",
@@ -5787,7 +7027,14 @@
           },
           "datasource_type": {
             "description": "The type of dataset/datasource identified on `datasource_id`.",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           },
           "schema": {
@@ -5795,10 +7042,13 @@
             "type": "string"
           }
         },
-        "required": ["datasource_type"],
+        "required": [
+          "datasource_type"
+        ],
         "type": "object"
       },
       "DistincResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of distinct values",
@@ -5814,6 +7064,7 @@
         "type": "object"
       },
       "DistinctResultResponse": {
+        "additionalProperties": false,
         "properties": {
           "text": {
             "description": "The distinct item",
@@ -5823,6 +7074,7 @@
         "type": "object"
       },
       "EmbeddedDashboardConfig": {
+        "additionalProperties": false,
         "properties": {
           "allowed_domains": {
             "items": {
@@ -5831,10 +7083,13 @@
             "type": "array"
           }
         },
-        "required": ["allowed_domains"],
+        "required": [
+          "allowed_domains"
+        ],
         "type": "object"
       },
       "EmbeddedDashboardResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "allowed_domains": {
             "items": {
@@ -5843,7 +7098,7 @@
             "type": "array"
           },
           "changed_by": {
-            "$ref": "#/components/schemas/User2"
+            "$ref": "#/components/schemas/User1"
           },
           "changed_on": {
             "format": "date-time",
@@ -5859,6 +7114,7 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -5868,6 +7124,7 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -5877,6 +7134,7 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -5886,6 +7144,7 @@
         "type": "object"
       },
       "EmbeddedDashboardRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "uuid": {
             "format": "uuid",
@@ -5895,10 +7154,19 @@
         "type": "object"
       },
       "EngineInformation": {
+        "additionalProperties": false,
         "properties": {
           "disable_ssh_tunneling": {
             "description": "SSH tunnel is not available to the database",
             "type": "boolean"
+          },
+          "identifier_quote": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdentifierQuote"
+              }
+            ],
+            "description": "Characters used to quote identifiers for this dialect"
           },
           "supports_dynamic_catalog": {
             "description": "The database supports multiple catalogs in a single connection",
@@ -5911,11 +7179,20 @@
           "supports_oauth2": {
             "description": "The database supports OAuth2",
             "type": "boolean"
+          },
+          "supports_offset": {
+            "description": "The database supports OFFSET in SQL queries. Engines like Elasticsearch SQL return False.",
+            "type": "boolean"
+          },
+          "supports_schemas": {
+            "description": "The database uses schemas to organize tables",
+            "type": "boolean"
           }
         },
         "type": "object"
       },
       "EstimateQueryCostSchema": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "description": "The database catalog",
@@ -5936,14 +7213,19 @@
             "type": "string"
           },
           "template_params": {
+            "additionalProperties": {},
             "description": "The SQL query template params",
             "type": "object"
           }
         },
-        "required": ["database_id", "sql"],
+        "required": [
+          "database_id",
+          "sql"
+        ],
         "type": "object"
       },
       "ExecutePayloadSchema": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "nullable": true,
@@ -5997,18 +7279,24 @@
           },
           "tmp_table_name": {
             "nullable": true,
+            "pattern": "^([A-Za-z_][A-Za-z0-9_]*)?\\Z",
             "type": "string"
           }
         },
-        "required": ["database_id", "sql"],
+        "required": [
+          "database_id",
+          "sql"
+        ],
         "type": "object"
       },
       "ExploreContextSchema": {
+        "additionalProperties": false,
         "properties": {
           "dataset": {
             "$ref": "#/components/schemas/Dataset"
           },
           "form_data": {
+            "additionalProperties": {},
             "description": "Form data from the Explore controls used to form the chart's data query.",
             "type": "object"
           },
@@ -6023,8 +7311,16 @@
         "type": "object"
       },
       "ExplorePermalinkStateSchema": {
+        "additionalProperties": false,
         "properties": {
+          "chartState": {
+            "additionalProperties": {},
+            "description": "Chart-level state for stateful tables (column filters, sorting, column order)",
+            "nullable": true,
+            "type": "object"
+          },
           "formData": {
+            "additionalProperties": {},
             "description": "Chart form data",
             "type": "object"
           },
@@ -6038,10 +7334,13 @@
             "type": "array"
           }
         },
-        "required": ["formData"],
+        "required": [
+          "formData"
+        ],
         "type": "object"
       },
       "Folder": {
+        "additionalProperties": false,
         "properties": {
           "children": {
             "items": {
@@ -6062,7 +7361,11 @@
             "type": "string"
           },
           "type": {
-            "enum": ["metric", "column", "folder"],
+            "enum": [
+              "metric",
+              "column",
+              "folder"
+            ],
             "type": "string"
           },
           "uuid": {
@@ -6070,10 +7373,13 @@
             "type": "string"
           }
         },
-        "required": ["uuid"],
+        "required": [
+          "uuid"
+        ],
         "type": "object"
       },
       "FormDataPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The chart ID",
@@ -6085,7 +7391,14 @@
           },
           "datasource_type": {
             "description": "The datasource type",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           },
           "form_data": {
@@ -6093,10 +7406,15 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "FormDataPutSchema": {
+        "additionalProperties": false,
         "properties": {
           "chart_id": {
             "description": "The chart ID",
@@ -6108,7 +7426,14 @@
           },
           "datasource_type": {
             "description": "The datasource type",
-            "enum": ["table", "dataset", "query", "saved_query", "view"],
+            "enum": [
+              "table",
+              "dataset",
+              "query",
+              "saved_query",
+              "view",
+              "semantic_view"
+            ],
             "type": "string"
           },
           "form_data": {
@@ -6116,10 +7441,15 @@
             "type": "string"
           }
         },
-        "required": ["datasource_id", "datasource_type", "form_data"],
+        "required": [
+          "datasource_id",
+          "datasource_type",
+          "form_data"
+        ],
         "type": "object"
       },
       "FormatQueryPayloadSchema": {
+        "additionalProperties": false,
         "properties": {
           "database_id": {
             "description": "The database id",
@@ -6139,10 +7469,13 @@
             "type": "string"
           }
         },
-        "required": ["sql"],
+        "required": [
+          "sql"
+        ],
         "type": "object"
       },
       "GetFavStarIdsSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of results for each corresponding chart in the request",
@@ -6155,6 +7488,7 @@
         "type": "object"
       },
       "GetOrCreateDatasetSchema": {
+        "additionalProperties": false,
         "properties": {
           "always_filter_main_dttm": {
             "default": false,
@@ -6191,199 +7525,14 @@
             "type": "string"
           }
         },
-        "required": ["database_id", "table_name"],
-        "type": "object"
-      },
-      "GroupApi.get": {
-        "properties": {
-          "description": {
-            "maxLength": 512,
-            "nullable": true,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "label": {
-            "maxLength": 150,
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "maxLength": 100,
-            "type": "string"
-          },
-          "roles": {
-            "$ref": "#/components/schemas/GroupApi.get.Role"
-          },
-          "users": {
-            "$ref": "#/components/schemas/GroupApi.get.User"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "GroupApi.get.Role": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "GroupApi.get.User": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "username": {
-            "maxLength": 128,
-            "type": "string"
-          }
-        },
-        "required": ["username"],
-        "type": "object"
-      },
-      "GroupApi.get_list": {
-        "properties": {
-          "description": {
-            "maxLength": 512,
-            "nullable": true,
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "label": {
-            "maxLength": 150,
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "maxLength": 100,
-            "type": "string"
-          },
-          "roles": {
-            "$ref": "#/components/schemas/GroupApi.get_list.Role"
-          },
-          "users": {
-            "$ref": "#/components/schemas/GroupApi.get_list.User"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "GroupApi.get_list.Role": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "GroupApi.get_list.User": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "username": {
-            "maxLength": 128,
-            "type": "string"
-          }
-        },
-        "required": ["username"],
-        "type": "object"
-      },
-      "GroupApi.post": {
-        "properties": {
-          "description": {
-            "description": "Group description",
-            "maxLength": 512,
-            "minLength": 0,
-            "nullable": true,
-            "type": "string"
-          },
-          "label": {
-            "description": "Group label",
-            "maxLength": 150,
-            "minLength": 0,
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "description": "Group name",
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string"
-          },
-          "roles": {
-            "description": "Group roles",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          },
-          "users": {
-            "description": "Group users",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "GroupApi.put": {
-        "properties": {
-          "description": {
-            "description": "Group description",
-            "maxLength": 512,
-            "minLength": 0,
-            "nullable": true,
-            "type": "string"
-          },
-          "label": {
-            "description": "Group label",
-            "maxLength": 150,
-            "minLength": 0,
-            "nullable": true,
-            "type": "string"
-          },
-          "name": {
-            "description": "Group name",
-            "maxLength": 100,
-            "minLength": 1,
-            "type": "string"
-          },
-          "roles": {
-            "description": "Group roles",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          },
-          "users": {
-            "description": "Group users",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          }
-        },
+        "required": [
+          "database_id",
+          "table_name"
+        ],
         "type": "object"
       },
       "GroupPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -6420,10 +7569,13 @@
             "type": "array"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "GroupPutSchema": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "description": "Group description",
@@ -6464,6 +7616,15 @@
       },
       "GuestTokenCreate": {
         "properties": {
+          "datasets": {
+            "default": null,
+            "description": "Optional allowlist of dataset IDs the guest may access. When omitted all datasets linked to the embedded dashboard are accessible, preserving the default behaviour.",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          },
           "resources": {
             "items": {
               "$ref": "#/components/schemas/Resource"
@@ -6477,143 +7638,35 @@
             "type": "array"
           },
           "user": {
-            "$ref": "#/components/schemas/User3"
+            "$ref": "#/components/schemas/User2"
           }
         },
-        "required": ["resources", "rls"],
+        "required": [
+          "resources",
+          "rls"
+        ],
         "type": "object"
       },
-      "ImportV1Database": {
+      "IdentifierQuote": {
+        "additionalProperties": false,
         "properties": {
-          "allow_csv_upload": {
-            "type": "boolean"
-          },
-          "allow_ctas": {
-            "type": "boolean"
-          },
-          "allow_cvas": {
-            "type": "boolean"
-          },
-          "allow_dml": {
-            "type": "boolean"
-          },
-          "allow_run_async": {
-            "type": "boolean"
-          },
-          "cache_timeout": {
-            "nullable": true,
-            "type": "integer"
-          },
-          "configuration_method": {
-            "default": "sqlalchemy_form",
-            "enum": ["sqlalchemy_form", "dynamic_form", null],
-            "nullable": true
-          },
-          "database_name": {
+          "end": {
+            "description": "Character that closes a quoted identifier",
             "type": "string"
           },
-          "encrypted_extra": {
-            "nullable": true,
-            "type": "string"
-          },
-          "expose_in_sqllab": {
+          "escape_by_doubling": {
+            "description": "Whether an embedded closing-quote character is escaped by doubling it (True) or with a backslash escape (False, e.g. BigQuery's GoogleSQL backtick identifiers)",
             "type": "boolean"
           },
-          "external_url": {
-            "nullable": true,
-            "type": "string"
-          },
-          "extra": {
-            "$ref": "#/components/schemas/ImportV1DatabaseExtra"
-          },
-          "impersonate_user": {
-            "type": "boolean"
-          },
-          "is_managed_externally": {
-            "nullable": true,
-            "type": "boolean"
-          },
-          "password": {
-            "nullable": true,
-            "type": "string"
-          },
-          "sqlalchemy_uri": {
-            "type": "string"
-          },
-          "ssh_tunnel": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DatabaseSSHTunnel"
-              }
-            ],
-            "nullable": true
-          },
-          "uuid": {
-            "format": "uuid",
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          }
-        },
-        "required": ["database_name", "sqlalchemy_uri", "uuid", "version"],
-        "type": "object"
-      },
-      "ImportV1DatabaseExtra": {
-        "properties": {
-          "allow_multi_catalog": {
-            "type": "boolean"
-          },
-          "allows_virtual_table_explore": {
-            "type": "boolean"
-          },
-          "cancel_query_on_windows_unload": {
-            "type": "boolean"
-          },
-          "cost_estimate_enabled": {
-            "type": "boolean"
-          },
-          "disable_data_preview": {
-            "type": "boolean"
-          },
-          "disable_drill_to_detail": {
-            "type": "boolean"
-          },
-          "engine_params": {
-            "additionalProperties": {},
-            "type": "object"
-          },
-          "metadata_cache_timeout": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "type": "object"
-          },
-          "metadata_params": {
-            "additionalProperties": {},
-            "type": "object"
-          },
-          "per_user_caching": {
-            "type": "boolean"
-          },
-          "schema_options": {
-            "additionalProperties": {},
-            "type": "object"
-          },
-          "schemas_allowed_for_csv_upload": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "version": {
-            "nullable": true,
+          "start": {
+            "description": "Character that opens a quoted identifier",
             "type": "string"
           }
         },
         "type": "object"
       },
       "LogRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -6649,11 +7702,15 @@
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get.User"
           },
-          "user_id": {}
+          "user_id": {
+            "default": null,
+            "nullable": true
+          }
         },
         "type": "object"
       },
       "LogRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -6668,10 +7725,15 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -6707,11 +7769,15 @@
           "user": {
             "$ref": "#/components/schemas/LogRestApi.get_list.User"
           },
-          "user_id": {}
+          "user_id": {
+            "default": null,
+            "nullable": true
+          }
         },
         "type": "object"
       },
       "LogRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -6726,10 +7792,15 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name", "username"],
+        "required": [
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "LogRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6738,6 +7809,7 @@
         "type": "object"
       },
       "LogRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "maxLength": 512,
@@ -6760,6 +7832,7 @@
         "type": "object"
       },
       "PermissionApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6769,10 +7842,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "PermissionApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -6782,127 +7858,57 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "PermissionApi.post": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "PermissionApi.put": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 100,
             "type": "string"
           }
         },
-        "required": ["name"],
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "permission": {
-            "$ref": "#/components/schemas/PermissionViewMenuApi.get.Permission"
-          },
-          "view_menu": {
-            "$ref": "#/components/schemas/PermissionViewMenuApi.get.ViewMenu"
-          }
-        },
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get.Permission": {
-        "properties": {
-          "name": {
-            "maxLength": 100,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get.ViewMenu": {
-        "properties": {
-          "name": {
-            "maxLength": 250,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get_list": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "permission": {
-            "$ref": "#/components/schemas/PermissionViewMenuApi.get_list.Permission"
-          },
-          "view_menu": {
-            "$ref": "#/components/schemas/PermissionViewMenuApi.get_list.ViewMenu"
-          }
-        },
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get_list.Permission": {
-        "properties": {
-          "name": {
-            "maxLength": 100,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "PermissionViewMenuApi.get_list.ViewMenu": {
-        "properties": {
-          "name": {
-            "maxLength": 250,
-            "type": "string"
-          }
-        },
-        "required": ["name"],
-        "type": "object"
-      },
-      "PermissionViewMenuApi.post": {
-        "properties": {
-          "permission_id": {},
-          "view_menu_id": {}
-        },
-        "type": "object"
-      },
-      "PermissionViewMenuApi.put": {
-        "properties": {
-          "permission_id": {},
-          "view_menu_id": {}
-        },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "QueryExecutionResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "columns": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "data": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
           },
           "expanded_columns": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -6915,6 +7921,7 @@
           },
           "selected_columns": {
             "items": {
+              "additionalProperties": {},
               "type": "object"
             },
             "type": "array"
@@ -6926,6 +7933,7 @@
         "type": "object"
       },
       "QueryRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -7033,10 +8041,14 @@
             "readOnly": true
           }
         },
-        "required": ["client_id", "database"],
+        "required": [
+          "client_id",
+          "database"
+        ],
         "type": "object"
       },
       "QueryRestApi.get.Database": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7045,6 +8057,7 @@
         "type": "object"
       },
       "QueryRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -7074,6 +8087,9 @@
           "sql_tables": {
             "readOnly": true
           },
+          "start_running_time": {
+            "type": "number"
+          },
           "start_time": {
             "type": "number"
           },
@@ -7090,12 +8106,13 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User"
           }
         },
         "type": "object"
       },
       "QueryRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7104,6 +8121,7 @@
         "type": "object"
       },
       "QueryRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7112,6 +8130,7 @@
         "type": "object"
       },
       "QueryResult": {
+        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
@@ -7137,6 +8156,7 @@
             "type": "string"
           },
           "extra": {
+            "additionalProperties": {},
             "type": "object"
           },
           "id": {
@@ -7203,6 +8223,7 @@
         "type": "object"
       },
       "RLSRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -7214,7 +8235,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -7229,9 +8253,9 @@
             "description": "name_description",
             "type": "string"
           },
-          "roles": {
+          "subjects": {
             "items": {
-              "$ref": "#/components/schemas/Roles1"
+              "$ref": "#/components/schemas/SubjectResponse"
             },
             "type": "array"
           },
@@ -7245,9 +8269,10 @@
         "type": "object"
       },
       "RLSRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User"
           },
           "changed_on_delta_humanized": {
             "readOnly": true
@@ -7262,7 +8287,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -7277,9 +8305,9 @@
             "description": "name_description",
             "type": "string"
           },
-          "roles": {
+          "subjects": {
             "items": {
-              "$ref": "#/components/schemas/Roles1"
+              "$ref": "#/components/schemas/SubjectResponse"
             },
             "type": "array"
           },
@@ -7293,6 +8321,7 @@
         "type": "object"
       },
       "RLSRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -7305,7 +8334,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -7319,8 +8351,8 @@
             "minLength": 1,
             "type": "string"
           },
-          "roles": {
-            "description": "roles_description",
+          "subjects": {
+            "description": "Subjects (users, roles, groups) associated with this RLS rule. For regular filters, the rule applies to these subjects. For base filters, these subjects are excluded from the filter.",
             "items": {
               "type": "integer"
             },
@@ -7335,10 +8367,16 @@
             "type": "array"
           }
         },
-        "required": ["clause", "filter_type", "name", "roles", "tables"],
+        "required": [
+          "clause",
+          "filter_type",
+          "name",
+          "tables"
+        ],
         "type": "object"
       },
       "RLSRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "clause": {
             "description": "clause_description",
@@ -7351,7 +8389,10 @@
           },
           "filter_type": {
             "description": "filter_type_description",
-            "enum": ["Regular", "Base"],
+            "enum": [
+              "Regular",
+              "Base"
+            ],
             "type": "string"
           },
           "group_key": {
@@ -7365,8 +8406,8 @@
             "minLength": 1,
             "type": "string"
           },
-          "roles": {
-            "description": "roles_description",
+          "subjects": {
+            "description": "Subjects (users, roles, groups) associated with this RLS rule. For regular filters, the rule applies to these subjects. For base filters, these subjects are excluded from the filter.",
             "items": {
               "type": "integer"
             },
@@ -7377,12 +8418,14 @@
             "items": {
               "type": "integer"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
         "type": "object"
       },
       "RecentActivity": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "description": "Action taken describing type of activity",
@@ -7412,6 +8455,7 @@
         "type": "object"
       },
       "RecentActivityResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "A list of recent activity objects",
@@ -7424,6 +8468,7 @@
         "type": "object"
       },
       "RecentActivitySchema": {
+        "additionalProperties": false,
         "properties": {
           "action": {
             "description": "Action taken describing type of activity",
@@ -7453,6 +8498,7 @@
         "type": "object"
       },
       "RelatedResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "count": {
             "description": "The total number of related values",
@@ -7468,8 +8514,10 @@
         "type": "object"
       },
       "RelatedResultResponse": {
+        "additionalProperties": false,
         "properties": {
           "extra": {
+            "additionalProperties": {},
             "description": "The extra metadata for related item",
             "type": "object"
           },
@@ -7485,6 +8533,7 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -7525,10 +8574,14 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "end_dttm": {
             "format": "date-time",
@@ -7569,10 +8622,14 @@
             "type": "string"
           }
         },
-        "required": ["scheduled_dttm", "state"],
+        "required": [
+          "scheduled_dttm",
+          "state"
+        ],
         "type": "object"
       },
       "ReportExecutionLogRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7581,6 +8638,7 @@
         "type": "object"
       },
       "ReportExecutionLogRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7589,20 +8647,29 @@
         "type": "object"
       },
       "ReportRecipient": {
+        "additionalProperties": false,
         "properties": {
           "recipient_config_json": {
             "$ref": "#/components/schemas/ReportRecipientConfigJSON"
           },
           "type": {
             "description": "The recipient type, check spec for valid options",
-            "enum": ["Email", "Slack", "SlackV2", "Webhook"],
+            "enum": [
+              "Email",
+              "Slack",
+              "SlackV2",
+              "Webhook"
+            ],
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportRecipientConfigJSON": {
+        "additionalProperties": false,
         "properties": {
           "bccTarget": {
             "type": "string"
@@ -7617,6 +8684,7 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -7652,6 +8720,12 @@
             "nullable": true,
             "type": "string"
           },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/ReportScheduleRestApi.get.Subject"
+            },
+            "type": "array"
+          },
           "email_subject": {
             "maxLength": 255,
             "nullable": true,
@@ -7670,6 +8744,10 @@
           },
           "id": {
             "type": "integer"
+          },
+          "include_cta": {
+            "nullable": true,
+            "type": "boolean"
           },
           "last_eval_dttm": {
             "format": "date-time",
@@ -7697,16 +8775,31 @@
             "maxLength": 150,
             "type": "string"
           },
-          "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get.User"
-          },
           "recipients": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get.ReportRecipients"
+            "items": {
+              "$ref": "#/components/schemas/ReportScheduleRestApi.get.ReportRecipients"
+            },
+            "type": "array"
           },
           "report_format": {
             "maxLength": 50,
             "nullable": true,
             "type": "string"
+          },
+          "retry_max_attempts": {
+            "type": "integer"
+          },
+          "retry_notify_owners": {
+            "type": "boolean"
+          },
+          "retry_notify_recipients": {
+            "type": "boolean"
+          },
+          "retry_on_failure": {
+            "type": "boolean"
+          },
+          "send_failed_reports": {
+            "type": "boolean"
           },
           "sql": {
             "nullable": true,
@@ -7734,10 +8827,16 @@
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Dashboard": {
+        "additionalProperties": false,
         "properties": {
           "dashboard_title": {
             "maxLength": 500,
@@ -7751,6 +8850,7 @@
         "type": "object"
       },
       "ReportScheduleRestApi.get.Database": {
+        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -7760,10 +8860,13 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.ReportRecipients": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7777,10 +8880,13 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get.Slice": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7798,24 +8904,28 @@
         },
         "type": "object"
       },
-      "ReportScheduleRestApi.get.User": {
+      "ReportScheduleRestApi.get.Subject": {
+        "additionalProperties": false,
         "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
           "id": {
             "type": "integer"
           },
-          "last_name": {
-            "maxLength": 64,
+          "label": {
+            "maxLength": 255,
             "type": "string"
+          },
+          "type": {
+            "type": "integer"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "label",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -7832,7 +8942,10 @@
           "changed_on_delta_humanized": {
             "readOnly": true
           },
-          "chart_id": {},
+          "chart_id": {
+            "default": null,
+            "nullable": true
+          },
           "created_by": {
             "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User1"
           },
@@ -7853,10 +8966,19 @@
           "crontab_humanized": {
             "readOnly": true
           },
-          "dashboard_id": {},
+          "dashboard_id": {
+            "default": null,
+            "nullable": true
+          },
           "description": {
             "nullable": true,
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.Subject"
+            },
+            "type": "array"
           },
           "extra": {
             "readOnly": true
@@ -7878,11 +9000,26 @@
             "maxLength": 150,
             "type": "string"
           },
-          "owners": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.User2"
-          },
           "recipients": {
-            "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
+            "items": {
+              "$ref": "#/components/schemas/ReportScheduleRestApi.get_list.ReportRecipients"
+            },
+            "type": "array"
+          },
+          "retry_max_attempts": {
+            "type": "integer"
+          },
+          "retry_notify_owners": {
+            "type": "boolean"
+          },
+          "retry_notify_recipients": {
+            "type": "boolean"
+          },
+          "retry_on_failure": {
+            "type": "boolean"
+          },
+          "send_failed_reports": {
+            "type": "boolean"
           },
           "timezone": {
             "maxLength": 100,
@@ -7893,10 +9030,16 @@
             "type": "string"
           }
         },
-        "required": ["crontab", "name", "recipients", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "recipients",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.get_list.ReportRecipients": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -7906,55 +9049,69 @@
             "type": "string"
           }
         },
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
-      "ReportScheduleRestApi.get_list.User": {
+      "ReportScheduleRestApi.get_list.Subject": {
+        "additionalProperties": false,
         "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ReportScheduleRestApi.get_list.User1": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
-          "last_name": {
-            "maxLength": 64,
-            "type": "string"
-          }
-        },
-        "required": ["first_name", "last_name"],
-        "type": "object"
-      },
-      "ReportScheduleRestApi.get_list.User2": {
-        "properties": {
-          "first_name": {
-            "maxLength": 64,
-            "type": "string"
-          },
           "id": {
             "type": "integer"
           },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ReportScheduleRestApi.get_list.User": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
           "last_name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "ReportScheduleRestApi.get_list.User1": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -7970,7 +9127,11 @@
           },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
-            "enum": ["charts", "dashboards", "alerts_reports"]
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports"
+            ]
           },
           "crontab": {
             "description": "A CRON expression.[Crontab Guru](https://crontab.guru/) is a helpful resource that can help you craft a CRON expression.",
@@ -7998,6 +9159,13 @@
             "nullable": true,
             "type": "string"
           },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the report.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "email_subject": {
             "description": "The report schedule subject line",
             "example": "[Report]  Report name: Dashboard or chart name",
@@ -8005,6 +9173,7 @@
             "type": "string"
           },
           "extra": {
+            "additionalProperties": {},
             "type": "object"
           },
           "force_screenshot": {
@@ -8015,6 +9184,11 @@
             "example": 14400,
             "minimum": 1,
             "type": "integer"
+          },
+          "include_cta": {
+            "description": "Whether to include the call-to-action link back to Superset (e.g. 'Explore in Superset') in the delivered notifications",
+            "nullable": true,
+            "type": "boolean"
           },
           "log_retention": {
             "description": "How long to keep the logs around for this report (in days)",
@@ -8029,13 +9203,6 @@
             "minLength": 1,
             "type": "string"
           },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
@@ -8043,15 +9210,42 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PDF", "PNG", "CSV", "TEXT"],
+            "enum": [
+              "PDF",
+              "PNG",
+              "CSV",
+              "XLSX",
+              "TEXT"
+            ],
             "type": "string"
           },
-          "selected_tabs": {
-            "items": {
-              "type": "integer"
-            },
-            "nullable": true,
-            "type": "array"
+          "retry_max_attempts": {
+            "default": 3,
+            "description": "Maximum number of retry attempts (1\u201310)",
+            "example": 3,
+            "maximum": 10,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "retry_notify_owners": {
+            "default": true,
+            "description": "Notify report owners on each retry attempt",
+            "type": "boolean"
+          },
+          "retry_notify_recipients": {
+            "default": false,
+            "description": "Notify report recipients on each retry attempt",
+            "type": "boolean"
+          },
+          "retry_on_failure": {
+            "default": false,
+            "description": "Enable automatic retries on report failure",
+            "type": "boolean"
+          },
+          "send_failed_reports": {
+            "default": false,
+            "description": "Send the failed report to all recipients after retries are exhausted",
+            "type": "boolean"
           },
           "sql": {
             "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
@@ -8663,7 +9857,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -8671,7 +9868,10 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator"],
+            "enum": [
+              "not null",
+              "operator"
+            ],
             "type": "string"
           },
           "working_timeout": {
@@ -8681,10 +9881,15 @@
             "type": "integer"
           }
         },
-        "required": ["crontab", "name", "type"],
+        "required": [
+          "crontab",
+          "name",
+          "type"
+        ],
         "type": "object"
       },
       "ReportScheduleRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -8700,7 +9905,12 @@
           },
           "creation_method": {
             "description": "Creation method is used to inform the frontend whether the report/alert was created in the dashboard, chart, or alerts and reports UI.",
-            "enum": ["charts", "dashboards", "alerts_reports", null],
+            "enum": [
+              "charts",
+              "dashboards",
+              "alerts_reports",
+              null
+            ],
             "nullable": true
           },
           "crontab": {
@@ -8720,6 +9930,7 @@
             "type": "integer"
           },
           "database": {
+            "nullable": true,
             "type": "integer"
           },
           "description": {
@@ -8728,6 +9939,13 @@
             "nullable": true,
             "type": "string"
           },
+          "editors": {
+            "items": {
+              "description": "A list of subject IDs (users, roles, or groups) that can alter the report.",
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "email_subject": {
             "description": "The report schedule subject line",
             "example": "[Report]  Report name: Dashboard or chart name",
@@ -8735,6 +9953,7 @@
             "type": "string"
           },
           "extra": {
+            "additionalProperties": {},
             "type": "object"
           },
           "force_screenshot": {
@@ -8745,6 +9964,11 @@
             "example": 14400,
             "minimum": 1,
             "type": "integer"
+          },
+          "include_cta": {
+            "description": "Whether to include the call-to-action link back to Superset (e.g. 'Explore in Superset') in the delivered notifications",
+            "nullable": true,
+            "type": "boolean"
           },
           "log_retention": {
             "description": "How long to keep the logs around for this report (in days)",
@@ -8758,13 +9982,6 @@
             "minLength": 1,
             "type": "string"
           },
-          "owners": {
-            "items": {
-              "description": "Owner are users ids allowed to delete or change this report. If left empty you will be one of the owners of the report.",
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "recipients": {
             "items": {
               "$ref": "#/components/schemas/ReportRecipient"
@@ -8772,8 +9989,37 @@
             "type": "array"
           },
           "report_format": {
-            "enum": ["PDF", "PNG", "CSV", "TEXT"],
+            "enum": [
+              "PDF",
+              "PNG",
+              "CSV",
+              "XLSX",
+              "TEXT"
+            ],
             "type": "string"
+          },
+          "retry_max_attempts": {
+            "description": "Maximum number of retry attempts (1\u201310)",
+            "example": 3,
+            "maximum": 10,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "retry_notify_owners": {
+            "description": "Notify report owners on each retry attempt",
+            "type": "boolean"
+          },
+          "retry_notify_recipients": {
+            "description": "Notify report recipients on each retry attempt",
+            "type": "boolean"
+          },
+          "retry_on_failure": {
+            "description": "Enable automatic retries on report failure",
+            "type": "boolean"
+          },
+          "send_failed_reports": {
+            "description": "Send the failed report to all recipients after retries are exhausted",
+            "type": "boolean"
           },
           "sql": {
             "description": "A SQL statement that defines whether the alert should get triggered or not. The query is expected to return either NULL or a number value.",
@@ -9386,7 +10632,10 @@
           },
           "type": {
             "description": "The report schedule type",
-            "enum": ["Alert", "Report"],
+            "enum": [
+              "Alert",
+              "Report"
+            ],
             "type": "string"
           },
           "validator_config_json": {
@@ -9394,7 +10643,11 @@
           },
           "validator_type": {
             "description": "Determines when to trigger alert based off value from alert query. Alerts will be triggered with these validator types:\n- Not Null - When the return value is Not NULL, Empty, or 0\n- Operator - When `sql_return_value comparison_operator threshold` is True e.g. `50 <= 75`<br>Supports the comparison operators <, <=, >, >=, ==, and !=",
-            "enum": ["not null", "operator", null],
+            "enum": [
+              "not null",
+              "operator",
+              null
+            ],
             "nullable": true,
             "type": "string"
           },
@@ -9414,25 +10667,91 @@
             "type": "string"
           },
           "type": {
-            "enum": ["dashboard"]
+            "enum": [
+              "dashboard"
+            ]
           }
         },
-        "required": ["id", "type"],
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "RlsFilter": {
+        "additionalProperties": false,
+        "properties": {
+          "clause": {
+            "description": "RLS filter clause.",
+            "nullable": true,
+            "type": "string"
+          },
+          "filter_type": {
+            "description": "RLS filter type.",
+            "nullable": true,
+            "type": "string"
+          },
+          "group_key": {
+            "description": "RLS filter group key.",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "RLS filter ID.",
+            "type": "integer"
+          },
+          "inherited": {
+            "default": false,
+            "description": "If the filter is inherited from underlying physical tables.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "RLS filter name.",
+            "type": "string"
+          },
+          "roles": {
+            "default": [],
+            "description": "Roles associated with the RLS filter.",
+            "items": {
+              "$ref": "#/components/schemas/RlsRole"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "RlsRole": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Role ID.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Role name.",
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "RlsRule": {
+        "additionalProperties": false,
         "properties": {
           "clause": {
             "type": "string"
           },
           "dataset": {
+            "minimum": 1,
             "type": "integer"
           }
         },
-        "required": ["clause"],
+        "required": [
+          "clause"
+        ],
         "type": "object"
       },
       "RoleGroupPutSchema": {
+        "additionalProperties": false,
         "properties": {
           "group_ids": {
             "description": "List of group ids",
@@ -9442,10 +10761,13 @@
             "type": "array"
           }
         },
-        "required": ["group_ids"],
+        "required": [
+          "group_ids"
+        ],
         "type": "object"
       },
       "RolePermissionListSchema": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9460,6 +10782,7 @@
         "type": "object"
       },
       "RolePermissionPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "permission_view_menu_ids": {
             "description": "List of permission view menu id",
@@ -9469,7 +10792,9 @@
             "type": "array"
           }
         },
-        "required": ["permission_view_menu_ids"],
+        "required": [
+          "permission_view_menu_ids"
+        ],
         "type": "object"
       },
       "RoleResponseSchema": {
@@ -9496,6 +10821,7 @@
         "type": "object"
       },
       "RoleUserPutSchema": {
+        "additionalProperties": false,
         "properties": {
           "user_ids": {
             "description": "List of user ids",
@@ -9505,29 +10831,9 @@
             "type": "array"
           }
         },
-        "required": ["user_ids"],
-        "type": "object"
-      },
-      "Roles": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "Roles1": {
-        "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
+        "required": [
+          "user_ids"
+        ],
         "type": "object"
       },
       "RolesResponseSchema": {
@@ -9550,14 +10856,82 @@
         },
         "type": "object"
       },
+      "SQLLabBootstrapDatabase": {
+        "additionalProperties": false,
+        "properties": {
+          "allow_ctas": {
+            "type": "boolean"
+          },
+          "allow_cvas": {
+            "type": "boolean"
+          },
+          "allow_dml": {
+            "type": "boolean"
+          },
+          "allow_file_upload": {
+            "type": "boolean"
+          },
+          "allow_multi_catalog": {
+            "type": "boolean"
+          },
+          "allow_run_async": {
+            "type": "boolean"
+          },
+          "allows_cost_estimate": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "allows_subquery": {
+            "type": "boolean"
+          },
+          "allows_virtual_table_explore": {
+            "type": "boolean"
+          },
+          "backend": {
+            "description": "The database backend",
+            "type": "string"
+          },
+          "database_name": {
+            "description": "The database name",
+            "type": "string"
+          },
+          "disable_data_preview": {
+            "type": "boolean"
+          },
+          "disable_drill_to_detail": {
+            "type": "boolean"
+          },
+          "engine_information": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EngineInformation"
+              }
+            ],
+            "description": "Dialect capabilities, including identifier_quote"
+          },
+          "expose_in_sqllab": {
+            "type": "boolean"
+          },
+          "force_ctas_schema": {
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "The database id",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "SQLLabBootstrapSchema": {
+        "additionalProperties": false,
         "properties": {
           "active_tab": {
             "$ref": "#/components/schemas/TabState"
           },
           "databases": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/ImportV1Database"
+              "$ref": "#/components/schemas/SQLLabBootstrapDatabase"
             },
             "type": "object"
           },
@@ -9577,6 +10951,7 @@
         "type": "object"
       },
       "SavedQueryRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -9632,6 +11007,7 @@
         "type": "object"
       },
       "SavedQueryRestApi.get.Database": {
+        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -9641,10 +11017,13 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9658,10 +11037,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9675,10 +11058,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
@@ -9707,7 +11094,10 @@
           "database": {
             "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Database"
           },
-          "db_id": {},
+          "db_id": {
+            "default": null,
+            "nullable": true
+          },
           "description": {
             "nullable": true,
             "type": "string"
@@ -9743,12 +11133,16 @@
             "readOnly": true
           },
           "tags": {
-            "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Tag"
+            "items": {
+              "$ref": "#/components/schemas/SavedQueryRestApi.get_list.Tag"
+            },
+            "type": "array"
           }
         },
         "type": "object"
       },
       "SavedQueryRestApi.get_list.Database": {
+        "additionalProperties": false,
         "properties": {
           "database_name": {
             "maxLength": 250,
@@ -9758,10 +11152,13 @@
             "type": "integer"
           }
         },
-        "required": ["database_name"],
+        "required": [
+          "database_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list.Tag": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -9772,12 +11169,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "SavedQueryRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9791,10 +11194,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -9808,17 +11215,24 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "SavedQueryRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
             "nullable": true,
             "type": "string"
           },
-          "db_id": {},
+          "db_id": {
+            "default": null,
+            "nullable": true
+          },
           "description": {
             "nullable": true,
             "type": "string"
@@ -9849,13 +11263,17 @@
         "type": "object"
       },
       "SavedQueryRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "maxLength": 256,
             "nullable": true,
             "type": "string"
           },
-          "db_id": {},
+          "db_id": {
+            "default": null,
+            "nullable": true
+          },
           "description": {
             "nullable": true,
             "type": "string"
@@ -9886,6 +11304,7 @@
         "type": "object"
       },
       "SchemasResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "items": {
@@ -9898,6 +11317,7 @@
         "type": "object"
       },
       "SelectStarResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "description": "SQL select star",
@@ -9906,7 +11326,49 @@
         },
         "type": "object"
       },
+      "SemanticViewRestApi.get": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SemanticViewRestApi.get_list": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SemanticViewRestApi.post": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SemanticViewRestApi.put": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_timeout": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "description": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "Slice": {
+        "additionalProperties": false,
         "properties": {
           "cache_timeout": {
             "description": "Duration (in seconds) of the caching timeout for this chart.",
@@ -9945,7 +11407,15 @@
             "description": "The URL for editing the slice.",
             "type": "string"
           },
+          "editors": {
+            "description": "List of editors",
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
+          },
           "form_data": {
+            "additionalProperties": {},
             "description": "Form data associated with the slice.",
             "type": "object"
           },
@@ -9957,14 +11427,8 @@
             "description": "Last modification in human readable form.",
             "type": "string"
           },
-          "owners": {
-            "description": "Owners identifiers.",
-            "items": {
-              "type": "integer"
-            },
-            "type": "array"
-          },
           "query_context": {
+            "additionalProperties": {},
             "description": "The context associated with the query.",
             "type": "object"
           },
@@ -9984,6 +11448,7 @@
         "type": "object"
       },
       "SqlLabPermalinkSchema": {
+        "additionalProperties": false,
         "properties": {
           "autorun": {
             "type": "boolean"
@@ -10016,10 +11481,15 @@
             "type": "string"
           }
         },
-        "required": ["dbId", "name", "sql"],
+        "required": [
+          "dbId",
+          "name",
+          "sql"
+        ],
         "type": "object"
       },
       "StopQuerySchema": {
+        "additionalProperties": false,
         "properties": {
           "client_id": {
             "type": "string"
@@ -10027,7 +11497,131 @@
         },
         "type": "object"
       },
-      "SupersetRoleApi.get": {
+      "SubjectResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "img": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "secondary_label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SubjectRestApi.get": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "changed_by": {
+            "$ref": "#/components/schemas/SubjectRestApi.get.User1"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "extra_search": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "group": {
+            "$ref": "#/components/schemas/SubjectRestApi.get.Group"
+          },
+          "group_id": {
+            "default": null,
+            "nullable": true
+          },
+          "id": {
+            "type": "integer"
+          },
+          "img": {
+            "readOnly": true
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/SubjectRestApi.get.Role"
+          },
+          "role_id": {
+            "default": null,
+            "nullable": true
+          },
+          "secondary_label": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          },
+          "user": {
+            "$ref": "#/components/schemas/SubjectRestApi.get.User"
+          },
+          "user_id": {
+            "default": null,
+            "nullable": true
+          },
+          "uuid": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get.Group": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 150,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get.Role": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10037,10 +11631,526 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get.User": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "email": {
+            "maxLength": 320,
+            "type": "string"
+          },
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "username": {
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get.User1": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get_list": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "changed_by": {
+            "$ref": "#/components/schemas/SubjectRestApi.get_list.User"
+          },
+          "changed_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "created_on": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "extra_search": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "group_id": {
+            "default": null,
+            "nullable": true
+          },
+          "id": {
+            "type": "integer"
+          },
+          "img": {
+            "readOnly": true
+          },
+          "label": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "role_id": {
+            "default": null,
+            "nullable": true
+          },
+          "secondary_label": {
+            "maxLength": 255,
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "type": "integer"
+          },
+          "user_id": {
+            "default": null,
+            "nullable": true
+          },
+          "uuid": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "type"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.get_list.User": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "last_name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "first_name",
+          "last_name"
+        ],
+        "type": "object"
+      },
+      "SubjectRestApi.post": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SubjectRestApi.put": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SupersetGroupApi.get": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 150,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/SupersetGroupApi.get.Role"
+            },
+            "type": "array"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/SupersetGroupApi.get.User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.get.Role": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.get.User": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.get_list": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "label": {
+            "maxLength": 150,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/SupersetGroupApi.get_list.Role"
+            },
+            "type": "array"
+          },
+          "users": {
+            "items": {
+              "$ref": "#/components/schemas/SupersetGroupApi.get_list.User"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.get_list.Role": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.get_list.User": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "username": {
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.post": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Group description",
+            "maxLength": 512,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "label": {
+            "description": "Group label",
+            "maxLength": 150,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Group name",
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "Group roles",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "users": {
+            "description": "Group users",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetGroupApi.put": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Group description",
+            "maxLength": 512,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "label": {
+            "description": "Group label",
+            "maxLength": 150,
+            "minLength": 0,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Group name",
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "roles": {
+            "description": "Group roles",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "users": {
+            "description": "Group users",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get.Permission"
+          },
+          "view_menu": {
+            "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get.ViewMenu"
+          }
+        },
+        "required": [
+          "permission",
+          "view_menu"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get.Permission": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get.ViewMenu": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "maxLength": 250,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get_list": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get_list.Permission"
+          },
+          "view_menu": {
+            "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get_list.ViewMenu"
+          }
+        },
+        "required": [
+          "permission",
+          "view_menu"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get_list.Permission": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.get_list.ViewMenu": {
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "maxLength": 250,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.post": {
+        "additionalProperties": false,
+        "properties": {
+          "permission_id": {
+            "default": null,
+            "nullable": true
+          },
+          "view_menu_id": {
+            "default": null,
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "SupersetPermissionViewMenuApi.put": {
+        "additionalProperties": false,
+        "properties": {
+          "permission_id": {
+            "default": null,
+            "nullable": true
+          },
+          "view_menu_id": {
+            "default": null,
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "SupersetRoleApi.get": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "maxLength": 64,
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetRoleApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10050,30 +12160,39 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetRoleApi.post": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetRoleApi.put": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 64,
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -10108,7 +12227,10 @@
             "type": "string"
           },
           "groups": {
-            "$ref": "#/components/schemas/SupersetUserApi.get.Group"
+            "items": {
+              "$ref": "#/components/schemas/SupersetUserApi.get.Group"
+            },
+            "type": "array"
           },
           "id": {
             "type": "integer"
@@ -10127,17 +12249,26 @@
             "type": "integer"
           },
           "roles": {
-            "$ref": "#/components/schemas/SupersetUserApi.get.Role"
+            "items": {
+              "$ref": "#/components/schemas/SupersetUserApi.get.Role"
+            },
+            "type": "array"
           },
           "username": {
             "maxLength": 128,
             "type": "string"
           }
         },
-        "required": ["email", "first_name", "last_name", "username"],
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get.Group": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -10157,10 +12288,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get.Role": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10170,10 +12304,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10182,6 +12319,7 @@
         "type": "object"
       },
       "SupersetUserApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10190,6 +12328,7 @@
         "type": "object"
       },
       "SupersetUserApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "nullable": true,
@@ -10224,7 +12363,10 @@
             "type": "string"
           },
           "groups": {
-            "$ref": "#/components/schemas/SupersetUserApi.get_list.Group"
+            "items": {
+              "$ref": "#/components/schemas/SupersetUserApi.get_list.Group"
+            },
+            "type": "array"
           },
           "id": {
             "type": "integer"
@@ -10243,17 +12385,26 @@
             "type": "integer"
           },
           "roles": {
-            "$ref": "#/components/schemas/SupersetUserApi.get_list.Role"
+            "items": {
+              "$ref": "#/components/schemas/SupersetUserApi.get_list.Role"
+            },
+            "type": "array"
           },
           "username": {
             "maxLength": 128,
             "type": "string"
           }
         },
-        "required": ["email", "first_name", "last_name", "username"],
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get_list.Group": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "maxLength": 512,
@@ -10273,10 +12424,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get_list.Role": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10286,10 +12440,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "SupersetUserApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10298,6 +12455,7 @@
         "type": "object"
       },
       "SupersetUserApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10306,6 +12464,7 @@
         "type": "object"
       },
       "SupersetUserApi.post": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "description": "Is user active?It's not a good policy to remove a user, just make it inactive",
@@ -10358,6 +12517,7 @@
         "type": "object"
       },
       "SupersetUserApi.put": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "description": "Is user active?It's not a good policy to remove a user, just make it inactive",
@@ -10403,6 +12563,7 @@
         "type": "object"
       },
       "Tab": {
+        "additionalProperties": false,
         "properties": {
           "children": {
             "items": {
@@ -10426,6 +12587,7 @@
         "type": "object"
       },
       "TabState": {
+        "additionalProperties": false,
         "properties": {
           "active": {
             "type": "boolean"
@@ -10437,6 +12599,7 @@
             "type": "integer"
           },
           "extra_json": {
+            "additionalProperties": {},
             "type": "object"
           },
           "hide_left_bar": {
@@ -10455,6 +12618,7 @@
             "type": "integer"
           },
           "saved_query": {
+            "additionalProperties": {},
             "nullable": true,
             "type": "object"
           },
@@ -10477,6 +12641,7 @@
         "type": "object"
       },
       "Table": {
+        "additionalProperties": false,
         "properties": {
           "database_id": {
             "type": "integer"
@@ -10503,20 +12668,25 @@
         "type": "object"
       },
       "TableExtraMetadataResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "clustering": {
+            "additionalProperties": {},
             "type": "object"
           },
           "metadata": {
+            "additionalProperties": {},
             "type": "object"
           },
           "partitions": {
+            "additionalProperties": {},
             "type": "object"
           }
         },
         "type": "object"
       },
       "TableMetadataColumnsResponse": {
+        "additionalProperties": false,
         "properties": {
           "duplicates_constraint": {
             "type": "string"
@@ -10544,6 +12714,7 @@
         "type": "object"
       },
       "TableMetadataForeignKeysIndexesResponse": {
+        "additionalProperties": false,
         "properties": {
           "column_names": {
             "items": {
@@ -10578,6 +12749,7 @@
         "type": "object"
       },
       "TableMetadataOptionsResponse": {
+        "additionalProperties": false,
         "properties": {
           "deferrable": {
             "type": "boolean"
@@ -10598,6 +12770,7 @@
         "type": "object"
       },
       "TableMetadataPrimaryKeyResponse": {
+        "additionalProperties": false,
         "properties": {
           "column_names": {
             "items": {
@@ -10617,6 +12790,7 @@
         "type": "object"
       },
       "TableMetadataResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "columns": {
             "description": "A list of columns and their metadata",
@@ -10659,6 +12833,7 @@
         "type": "object"
       },
       "Tables": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10673,6 +12848,7 @@
         "type": "object"
       },
       "TabsPayloadSchema": {
+        "additionalProperties": false,
         "properties": {
           "all_tabs": {
             "additionalProperties": {
@@ -10690,6 +12866,7 @@
         "type": "object"
       },
       "Tag": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10698,12 +12875,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "Tag1": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10712,12 +12895,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "TagGetResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -10732,6 +12921,7 @@
         "type": "object"
       },
       "TagObject": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -10750,6 +12940,7 @@
         "type": "object"
       },
       "TagPostBulkResponseObject": {
+        "additionalProperties": false,
         "properties": {
           "objects_skipped": {
             "description": "Objects to tag",
@@ -10765,6 +12956,7 @@
         "type": "object"
       },
       "TagPostBulkResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "result": {
             "$ref": "#/components/schemas/TagPostBulkResponseObject"
@@ -10773,6 +12965,7 @@
         "type": "object"
       },
       "TagPostBulkSchema": {
+        "additionalProperties": false,
         "properties": {
           "tags": {
             "items": {
@@ -10784,6 +12977,7 @@
         "type": "object"
       },
       "TagRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/TagRestApi.get.User"
@@ -10810,12 +13004,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "TagRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -10826,10 +13026,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -10840,10 +13044,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/TagRestApi.get_list.User"
@@ -10870,12 +13078,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [1, 2, 3, 4]
+            "enum": [
+              1,
+              2,
+              3,
+              4
+            ]
           }
         },
         "type": "object"
       },
       "TagRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -10886,10 +13100,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -10900,10 +13118,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "TagRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -10922,6 +13144,7 @@
         "type": "object"
       },
       "TagRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "nullable": true,
@@ -10940,28 +13163,29 @@
         "type": "object"
       },
       "TaggedObjectEntityResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "changed_on": {
             "format": "date-time",
             "type": "string"
           },
           "created_by": {
-            "$ref": "#/components/schemas/User1"
+            "$ref": "#/components/schemas/User"
           },
           "creator": {
             "type": "string"
+          },
+          "editors": {
+            "items": {
+              "$ref": "#/components/schemas/SubjectResponse"
+            },
+            "type": "array"
           },
           "id": {
             "type": "integer"
           },
           "name": {
             "type": "string"
-          },
-          "owners": {
-            "items": {
-              "$ref": "#/components/schemas/User2"
-            },
-            "type": "array"
           },
           "tags": {
             "items": {
@@ -10979,26 +13203,33 @@
         "type": "object"
       },
       "TemporaryCachePostSchema": {
+        "additionalProperties": false,
         "properties": {
           "value": {
             "description": "Any type of JSON supported text.",
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object"
       },
       "TemporaryCachePutSchema": {
+        "additionalProperties": false,
         "properties": {
           "value": {
             "description": "Any type of JSON supported text.",
             "type": "string"
           }
         },
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object"
       },
       "Theme": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11013,6 +13244,7 @@
         "type": "object"
       },
       "ThemeRestApi.get": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/ThemeRestApi.get.User"
@@ -11053,6 +13285,7 @@
         "type": "object"
       },
       "ThemeRestApi.get.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11066,10 +13299,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ThemeRestApi.get.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11083,10 +13320,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ThemeRestApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "changed_by": {
             "$ref": "#/components/schemas/ThemeRestApi.get_list.User"
@@ -11135,6 +13376,7 @@
         "type": "object"
       },
       "ThemeRestApi.get_list.User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11148,10 +13390,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ThemeRestApi.get_list.User1": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "maxLength": 64,
@@ -11165,10 +13411,14 @@
             "type": "string"
           }
         },
-        "required": ["first_name", "last_name"],
+        "required": [
+          "first_name",
+          "last_name"
+        ],
         "type": "object"
       },
       "ThemeRestApi.post": {
+        "additionalProperties": false,
         "properties": {
           "json_data": {
             "type": "string"
@@ -11177,10 +13427,14 @@
             "type": "string"
           }
         },
-        "required": ["json_data", "theme_name"],
+        "required": [
+          "json_data",
+          "theme_name"
+        ],
         "type": "object"
       },
       "ThemeRestApi.put": {
+        "additionalProperties": false,
         "properties": {
           "json_data": {
             "type": "string"
@@ -11189,10 +13443,14 @@
             "type": "string"
           }
         },
-        "required": ["json_data", "theme_name"],
+        "required": [
+          "json_data",
+          "theme_name"
+        ],
         "type": "object"
       },
       "UploadFileMetadata": {
+        "additionalProperties": false,
         "properties": {
           "items": {
             "items": {
@@ -11204,6 +13462,7 @@
         "type": "object"
       },
       "UploadFileMetadataItem": {
+        "additionalProperties": false,
         "properties": {
           "column_names": {
             "description": "A list of columns names in the sheet",
@@ -11220,6 +13479,7 @@
         "type": "object"
       },
       "UploadFileMetadataPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "delimiter": {
             "description": "The character used to separate values in the CSV file (e.g., a comma, semicolon, or tab).",
@@ -11236,18 +13496,30 @@
           },
           "type": {
             "description": "File type to upload",
-            "enum": ["csv", "excel", "columnar"]
+            "enum": [
+              "csv",
+              "excel",
+              "columnar"
+            ]
           }
         },
-        "required": ["file", "type"],
+        "required": [
+          "file",
+          "type"
+        ],
         "type": "object"
       },
       "UploadPostSchema": {
+        "additionalProperties": false,
         "properties": {
           "already_exists": {
             "default": "fail",
             "description": "What to do if the table already exists accepts: fail, replace, append",
-            "enum": ["fail", "replace", "append"],
+            "enum": [
+              "fail",
+              "replace",
+              "append"
+            ],
             "type": "string"
           },
           "column_data_types": {
@@ -11342,13 +13614,22 @@
           },
           "type": {
             "description": "File type to upload",
-            "enum": ["csv", "excel", "columnar"]
+            "enum": [
+              "csv",
+              "excel",
+              "columnar"
+            ]
           }
         },
-        "required": ["file", "table_name", "type"],
+        "required": [
+          "file",
+          "table_name",
+          "type"
+        ],
         "type": "object"
       },
       "User": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -11363,20 +13644,7 @@
         "type": "object"
       },
       "User1": {
-        "properties": {
-          "first_name": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer"
-          },
-          "last_name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "User2": {
+        "additionalProperties": false,
         "properties": {
           "first_name": {
             "type": "string"
@@ -11393,7 +13661,7 @@
         },
         "type": "object"
       },
-      "User3": {
+      "User2": {
         "properties": {
           "attributes": {
             "additionalProperties": {
@@ -11414,7 +13682,20 @@
         },
         "type": "object"
       },
+      "UserGroup": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "UserRegistrationsRestAPI.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11423,6 +13704,7 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.get_list": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "maxLength": 320,
@@ -11444,20 +13726,21 @@
             "nullable": true,
             "type": "string"
           },
-          "registration_hash": {
-            "maxLength": 256,
-            "nullable": true,
-            "type": "string"
-          },
           "username": {
             "maxLength": 128,
             "type": "string"
           }
         },
-        "required": ["email", "first_name", "last_name", "username"],
+        "required": [
+          "email",
+          "first_name",
+          "last_name",
+          "username"
+        ],
         "type": "object"
       },
       "UserRegistrationsRestAPI.post": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11466,6 +13749,7 @@
         "type": "object"
       },
       "UserRegistrationsRestAPI.put": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11474,12 +13758,19 @@
         "type": "object"
       },
       "UserResponseSchema": {
+        "additionalProperties": false,
         "properties": {
           "email": {
             "type": "string"
           },
           "first_name": {
             "type": "string"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/UserGroup"
+            },
+            "type": "array"
           },
           "id": {
             "type": "integer"
@@ -11503,6 +13794,7 @@
         "type": "object"
       },
       "ValidateSQLRequest": {
+        "additionalProperties": false,
         "properties": {
           "catalog": {
             "nullable": true,
@@ -11517,14 +13809,18 @@
             "type": "string"
           },
           "template_params": {
+            "additionalProperties": {},
             "nullable": true,
             "type": "object"
           }
         },
-        "required": ["sql"],
+        "required": [
+          "sql"
+        ],
         "type": "object"
       },
       "ValidateSQLResponse": {
+        "additionalProperties": false,
         "properties": {
           "end_column": {
             "type": "integer"
@@ -11542,10 +13838,18 @@
         "type": "object"
       },
       "ValidatorConfigJSON": {
+        "additionalProperties": false,
         "properties": {
           "op": {
             "description": "The operation to compare with a threshold to apply to the SQL output\n",
-            "enum": ["<", "<=", ">", ">=", "==", "!="],
+            "enum": [
+              "<",
+              "<=",
+              ">",
+              ">=",
+              "==",
+              "!="
+            ],
             "type": "string"
           },
           "threshold": {
@@ -11554,7 +13858,95 @@
         },
         "type": "object"
       },
+      "VersionChangeRecord": {
+        "additionalProperties": false,
+        "properties": {
+          "from_value": {
+            "description": "Value at path before the save; null when the field did not exist.",
+            "nullable": true
+          },
+          "kind": {
+            "description": "Semantic category of the change. First-class values in V1: 'filter', 'metric', 'dimension', 'column', 'chart', 'time_range', 'color_palette'. Falls back to 'field' for generic scalar changes that don't map to a named kind.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "The verb for this change: 'add', 'remove', 'move', 'edit', 'update' (a collapsed-summary record for a field whose per-leaf changes exceeded the cap), or 'announce' (a synthetic headline record). Surfaced explicitly so consumers need not infer the verb from from_value/to_value null-tests \u2014 'move' in particular cannot be derived that way.",
+            "type": "string"
+          },
+          "path": {
+            "description": "Array of segments locating the change in the entity's state. Example: ['params', 'adhoc_filters', 'country']."
+          },
+          "to_value": {
+            "description": "Value at path after the save; null when the field was removed.",
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "VersionChangedBy": {
+        "additionalProperties": false,
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "last_name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "VersionListItemSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "changed_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VersionChangedBy"
+              },
+              {
+                "nullable": true,
+                "type": "object"
+              }
+            ],
+            "description": "User who produced the version, or null when the commit had no authenticated Flask user (CLI, Celery, import)."
+          },
+          "changes": {
+            "description": "Structured diff records describing the atomic field-level changes at this version, ordered by emission sequence. Empty for baseline (op=0) transactions per spec M4.",
+            "items": {
+              "$ref": "#/components/schemas/VersionChangeRecord"
+            },
+            "type": "array"
+          },
+          "issued_at": {
+            "description": "UTC timestamp of the commit that produced the row",
+            "format": "date-time",
+            "type": "string"
+          },
+          "operation_type": {
+            "description": "One of 'baseline', 'update', or 'delete', derived from the Continuum integer constant. Restore is not a distinct operation_type: a restore surfaces as 'update' carrying ``action_kind='restore'`` (see ACTIVITY_ACTION_KINDS).",
+            "type": "string"
+          },
+          "transaction_id": {
+            "description": "Underlying Continuum transaction id",
+            "type": "integer"
+          },
+          "version_number": {
+            "description": "0-based position in the history, oldest first",
+            "type": "integer"
+          },
+          "version_uuid": {
+            "description": "Deterministic UUIDv5 derived from the entity UUID and the Continuum transaction id \u2014 stable across replicas and retention pruning. The handle accepted by the get/restore version endpoints.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ViewMenuApi.get": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11564,10 +13956,13 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "ViewMenuApi.get_list": {
+        "additionalProperties": false,
         "properties": {
           "id": {
             "type": "integer"
@@ -11577,27 +13972,35 @@
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "ViewMenuApi.post": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "ViewMenuApi.put": {
+        "additionalProperties": false,
         "properties": {
           "name": {
             "maxLength": 250,
             "type": "string"
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object"
       },
       "advanced_data_type_convert_schema": {
@@ -11614,7 +14017,10 @@
             "type": "array"
           }
         },
-        "required": ["type", "values"],
+        "required": [
+          "type",
+          "values"
+        ],
         "type": "object"
       },
       "database_catalogs_query_schema": {
@@ -11651,7 +14057,9 @@
             "type": "string"
           }
         },
-        "required": ["schema_name"],
+        "required": [
+          "schema_name"
+        ],
         "type": "object"
       },
       "delete_tags_schema": {
@@ -11661,18 +14069,33 @@
         "type": "array"
       },
       "get_delete_ids_schema": {
+        "example": [
+          1,
+          2,
+          3
+        ],
         "items": {
           "type": "integer"
         },
         "type": "array"
       },
       "get_export_ids_schema": {
+        "example": [
+          1,
+          2,
+          3
+        ],
         "items": {
           "type": "integer"
         },
         "type": "array"
       },
       "get_fav_star_ids_schema": {
+        "example": [
+          1,
+          2,
+          3
+        ],
         "items": {
           "type": "integer"
         },
@@ -11797,7 +14220,11 @@
                   ]
                 }
               },
-              "required": ["col", "opr", "value"],
+              "required": [
+                "col",
+                "opr",
+                "value"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -11820,7 +14247,10 @@
             "type": "string"
           },
           "order_direction": {
-            "enum": ["asc", "desc"],
+            "enum": [
+              "asc",
+              "desc"
+            ],
             "type": "string"
           },
           "page": {
@@ -11878,13 +14308,47 @@
         },
         "type": "object"
       },
+      "get_slack_channels_schema": {
+        "properties": {
+          "exact_match": {
+            "type": "boolean"
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "page": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "page_size": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "search_string": {
+            "type": "string"
+          },
+          "types": {
+            "items": {
+              "enum": [
+                "public_channel",
+                "private_channel"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "queries_get_updated_since_schema": {
         "properties": {
           "last_updated_ms": {
             "type": "number"
           }
         },
-        "required": ["last_updated_ms"],
+        "required": [
+          "last_updated_ms"
+        ],
         "type": "object"
       },
       "screenshot_query_schema": {
@@ -11913,7 +14377,9 @@
             "type": "string"
           }
         },
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "type": "object"
       },
       "thumbnail_query_schema": {
@@ -11923,125 +14389,15 @@
           }
         },
         "type": "object"
-      },
-      "DashboardNativeFiltersConfigUpdateSchema": {
-        "type": "object",
-        "properties": {
-          "deleted": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of deleted filter IDs."
-          },
-          "modified": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            },
-            "description": "List of modified filter configurations."
-          },
-          "reordered": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of filter IDs in new order."
-          }
-        }
-      },
-      "DashboardColorsConfigUpdateSchema": {
-        "type": "object",
-        "properties": {
-          "color_namespace": {
-            "type": "string",
-            "nullable": true,
-            "description": "The color namespace."
-          },
-          "color_scheme": {
-            "type": "string",
-            "nullable": true,
-            "description": "The color scheme name."
-          },
-          "map_label_colors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Mapping of labels to colors."
-          },
-          "shared_label_colors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Shared label colors across charts."
-          },
-          "label_colors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "description": "Label to color mapping."
-          },
-          "color_scheme_domain": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Color scheme domain values."
-          }
-        }
-      },
-      "get_slack_channels_schema": {
-        "type": "object",
-        "properties": {
-          "search_string": {
-            "type": "string",
-            "description": "String to search for in channel names."
-          },
-          "types": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": ["public_channel", "private_channel"]
-            },
-            "description": "Types of channels to search."
-          },
-          "exact_match": {
-            "type": "boolean",
-            "description": "Whether to match channel names exactly."
-          }
-        }
-      },
-      "DashboardChartCustomizationsConfigUpdateSchema": {
-        "type": "object",
-        "properties": {
-          "deleted": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of deleted chart customization IDs."
-          },
-          "modified": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            },
-            "description": "List of modified chart customization configurations."
-          },
-          "reordered": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of chart customization IDs in new order."
-          }
-        }
       }
     },
     "securitySchemes": {
+      "api_key": {
+        "bearerFormat": "API Key",
+        "description": "API key authentication using Bearer token",
+        "scheme": "bearer",
+        "type": "http"
+      },
       "jwt": {
         "bearerFormat": "JWT",
         "scheme": "bearer",
@@ -12083,12 +14439,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AdvancedDataTypeSchema"
-                },
-                "example": {
-                  "display_value": "string",
-                  "error_message": "string",
-                  "valid_filter_operators": ["string"],
-                  "values": ["string"]
                 }
               }
             },
@@ -12113,26 +14463,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Return an AdvancedDataTypeResponse",
-        "tags": ["Advanced Data Type"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/advanced_data_type/convert\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/advanced_data_type/convert\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/advanced_data_type/convert\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Advanced Data Type"
         ]
       }
     },
@@ -12152,9 +14490,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": ["string"]
                 }
               }
             },
@@ -12176,26 +14511,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Return a list of available advanced data types",
-        "tags": ["Advanced Data Type"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/advanced_data_type/types\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/advanced_data_type/types\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/advanced_data_type/types\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Advanced Data Type"
         ]
       }
     },
@@ -12225,9 +14548,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -12249,26 +14569,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete multiple annotation layers in a bulk operation",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "get": {
@@ -12351,20 +14659,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -12386,26 +14680,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a list of annotation layers (annotation-layer)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a list of annotation layers",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "post": {
@@ -12414,10 +14696,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.post"
-              },
-              "example": {
-                "descr": "string",
-                "name": "string"
               }
             }
           },
@@ -12438,13 +14716,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "descr": "string",
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -12466,26 +14737,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Create an annotation layer (annotation-layer)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/annotation_layer/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/annotation_layer/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Create an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -12547,14 +14806,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -12576,26 +14827,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (annotation-layer--info)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -12628,10 +14867,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -12643,6 +14878,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -12653,26 +14891,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (annotation-layer-related-column-name)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -12700,9 +14926,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -12721,26 +14944,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Delete annotation layer (annotation-layer-pk)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Delete annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "get": {
@@ -12813,22 +15024,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "descr": "string",
-                    "id": 1,
-                    "name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -12853,26 +15048,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get an annotation layer (annotation-layer-pk)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "put": {
@@ -12892,10 +15075,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationLayerRestApi.put"
-              },
-              "example": {
-                "descr": "string",
-                "name": "string"
               }
             }
           },
@@ -12916,13 +15095,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "descr": "string",
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -12944,26 +15116,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Update an annotation layer (annotation-layer-pk)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/annotation_layer/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/annotation_layer/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Update an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -13002,9 +15162,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -13026,26 +15183,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete annotation layers",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "get": {
@@ -13098,11 +15243,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "ids": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -13124,26 +15264,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a list of annotation layers (annotation-layer-pk-annotation)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a list of annotation layers",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "post": {
@@ -13163,13 +15291,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationRestApi.post"
-              },
-              "example": {
-                "end_dttm": "2024-01-15T10:30:00Z",
-                "json_metadata": "string",
-                "long_descr": "string",
-                "short_descr": "string",
-                "start_dttm": "2024-01-15T10:30:00Z"
               }
             }
           },
@@ -13190,16 +15311,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "end_dttm": "2024-01-15T10:30:00Z",
-                    "json_metadata": "string",
-                    "long_descr": "string",
-                    "short_descr": "string",
-                    "start_dttm": "2024-01-15T10:30:00Z"
-                  }
                 }
               }
             },
@@ -13221,26 +15332,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Create an annotation layer (annotation-layer-pk-annotation)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Create an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -13277,9 +15376,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -13298,26 +15394,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Delete annotation layer (annotation-layer-pk-annotation-annotation-id)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Delete annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "get": {
@@ -13367,17 +15451,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "end_dttm": "2024-01-15T10:30:00Z",
-                    "id": 1,
-                    "json_metadata": "string",
-                    "long_descr": "string",
-                    "short_descr": "string",
-                    "start_dttm": "2024-01-15T10:30:00Z"
-                  }
                 }
               }
             },
@@ -13402,26 +15475,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get an annotation layer (annotation-layer-pk-annotation-annotation-id)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       },
       "put": {
@@ -13450,13 +15511,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/AnnotationRestApi.put"
-              },
-              "example": {
-                "end_dttm": "2024-01-15T10:30:00Z",
-                "json_metadata": "string",
-                "long_descr": "string",
-                "short_descr": "string",
-                "start_dttm": "2024-01-15T10:30:00Z"
               }
             }
           },
@@ -13477,16 +15531,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "end_dttm": "2024-01-15T10:30:00Z",
-                    "json_metadata": "string",
-                    "long_descr": "string",
-                    "short_descr": "string",
-                    "start_dttm": "2024-01-15T10:30:00Z"
-                  }
                 }
               }
             },
@@ -13508,26 +15552,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Update an annotation layer (annotation-layer-pk-annotation-annotation-id)",
-        "tags": ["Annotation Layers"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/annotation_layer/1/annotation/{annotation_id}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Update an annotation layer",
+        "tags": [
+          "Annotation Layers"
         ]
       }
     },
@@ -13559,26 +15591,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Export all assets",
-        "tags": ["Import/export"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/assets/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/assets/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/assets/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Import/export"
         ]
       }
     },
@@ -13593,6 +15613,14 @@
                     "description": "upload file (ZIP or JSON)",
                     "format": "binary",
                     "type": "string"
+                  },
+                  "encrypted_extra_secrets": {
+                    "description": "JSON map of secret values for masked encrypted_extra fields. Each key is a database file path and the value is a map of JSONPath expressions to secret values. For example: `{\"databases/db.yaml\": {\"$.credentials_info.secret\": \"foo\"}}`.",
+                    "type": "string"
+                  },
+                  "overwrite": {
+                    "description": "overwrite existing assets? Defaults to ``true`` for backwards compatibility. When ``false``, the import fails if any of the assets already exist.",
+                    "type": "boolean"
                   },
                   "passwords": {
                     "description": "JSON map of passwords for each featured database in the ZIP file. If the ZIP includes a database config in the path `databases/MyDatabase.yaml`, the password should be provided in the following format: `{\"databases/MyDatabase.yaml\": \"my_password\"}`.",
@@ -13632,9 +15660,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -13656,26 +15681,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import multiple assets",
-        "tags": ["Import/export"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/assets/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/assets/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/assets/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Import/export"
         ]
       }
     },
@@ -13732,19 +15745,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [
-                    {
-                      "channel_id": "string",
-                      "errors": [],
-                      "id": "string",
-                      "job_id": "string",
-                      "result_url": "string",
-                      "status": "string",
-                      "user_id": 1
-                    }
-                  ]
                 }
               }
             },
@@ -13760,26 +15760,82 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Read off of the Redis events stream",
-        "tags": ["AsyncEventsRestApi"],
-        "x-codeSamples": [
+        "tags": [
+          "AsyncEventsRestApi"
+        ]
+      }
+    },
+    "/api/v1/async_event/{job_id}/cancel": {
+      "post": {
+        "description": "Revokes the Celery task backing an in-flight async query. The caller is authorized against the job's original owner (channel and user), both resolved server-side from the request, so a client cannot cancel a job it did not submit.",
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/async_event/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/async_event/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/async_event/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "description": "The job ID returned when the async query was submitted",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "properties": {
+                        "job_id": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Job cancelled"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Cancel a running async query job",
+        "tags": [
+          "AsyncEventsRestApi"
         ]
       }
     },
@@ -13796,11 +15852,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "domains": []
-                  }
                 }
               }
             },
@@ -13816,26 +15867,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get all available domains",
-        "tags": ["Available Domains"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/available_domains/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/available_domains/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/available_domains/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Available Domains"
         ]
       }
     },
@@ -13847,10 +15886,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CacheInvalidationRequestSchema"
-              },
-              "example": {
-                "datasource_uids": ["string"],
-                "datasources": [{}]
               }
             }
           },
@@ -13871,26 +15906,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Invalidate cache records and remove the database records",
-        "tags": ["CacheRestApi"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/cachekey/invalidate\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/cachekey/invalidate\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/cachekey/invalidate\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "CacheRestApi"
         ]
       }
     },
@@ -13920,9 +15943,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -13947,26 +15967,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Bulk delete charts",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Bulk delete charts (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Charts"
         ]
       },
       "get": {
@@ -14049,20 +16057,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -14084,26 +16078,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of charts",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       },
       "post": {
@@ -14112,25 +16094,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartRestApi.post"
-              },
-              "example": {
-                "cache_timeout": 1,
-                "certification_details": "string",
-                "certified_by": "string",
-                "dashboards": [1],
-                "datasource_id": 1,
-                "datasource_name": "string",
-                "datasource_type": "table",
-                "description": "string",
-                "external_url": "string",
-                "is_managed_externally": true,
-                "owners": [1],
-                "params": "string",
-                "query_context": "string",
-                "query_context_generation": true,
-                "slice_name": "string",
-                "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                "viz_type": ["bar", "area", "table"]
               }
             }
           },
@@ -14151,28 +16114,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "cache_timeout": 1,
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "dashboards": [],
-                    "datasource_id": 1,
-                    "datasource_name": "string",
-                    "datasource_type": "table",
-                    "description": "string",
-                    "external_url": "string",
-                    "is_managed_externally": true,
-                    "owners": [],
-                    "params": "string",
-                    "query_context": "string",
-                    "query_context_generation": true,
-                    "slice_name": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "viz_type": ["bar", "area", "table"]
-                  }
                 }
               }
             },
@@ -14197,26 +16138,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new chart",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14278,14 +16207,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -14307,26 +16228,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (chart--info)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14338,18 +16247,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartDataQueryContextSchema"
-              },
-              "example": {
-                "custom_cache_timeout": 1,
-                "datasource": {
-                  "id": {},
-                  "type": "table"
-                },
-                "force": true,
-                "form_data": {},
-                "queries": [{}],
-                "result_format": {},
-                "result_type": {}
               }
             }
           },
@@ -14362,9 +16259,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -14375,13 +16269,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
-                },
-                "example": {
-                  "channel_id": "string",
-                  "job_id": "string",
-                  "result_url": "string",
-                  "status": "string",
-                  "user_id": "string"
                 }
               }
             },
@@ -14393,6 +16280,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
@@ -14400,26 +16290,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Return payload data response for the given query (chart-data)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/data\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/data\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/data\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Return payload data response for the given query",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14442,9 +16320,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -14455,6 +16330,9 @@
           },
           "401": {
             "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
           },
           "404": {
             "$ref": "#/components/responses/404"
@@ -14469,26 +16347,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Return payload data response for the given query (chart-data-cache-key)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/data/{cache_key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/data/{cache_key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/data/{cache_key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Return payload data response for the given query",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14535,26 +16401,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download multiple charts as YAML files",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14579,9 +16433,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -14603,26 +16454,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Check favorited charts for current user",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14676,9 +16515,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -14700,32 +16536,20 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import chart(s) with associated datasets and databases",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
     "/api/v1/chart/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a chart. Use `owners` has the `column_name` parameter",
+        "description": "Get a list of all possible related entities for a chart. Use `editors` as the `column_name` parameter",
         "parameters": [
           {
             "in": "path",
@@ -14753,10 +16577,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -14768,6 +16588,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -14778,42 +16601,25 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (chart-related-column-name)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Charts"
         ]
       }
     },
     "/api/v1/chart/warm_up_cache": {
       "put": {
-        "description": "Warms up the cache for the chart. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore_json` action.",
+        "description": "Warms up the cache for the chart. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore` action.",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartCacheWarmUpRequestSchema"
-              },
-              "example": {
-                "chart_id": 1,
-                "dashboard_id": 1,
-                "extra_filters": "string"
               }
             }
           },
@@ -14826,9 +16632,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheWarmUpResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -14847,26 +16650,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Warm up the cache for the chart",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/chart/warm_up_cache\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/chart/warm_up_cache\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/warm_up_cache\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14895,32 +16686,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "cache_timeout": "string",
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "changed_on_delta_humanized": "string",
-                    "dashboards": [],
-                    "datasource_id": 1,
-                    "datasource_name_text": {},
-                    "datasource_type": "string",
-                    "datasource_url": {},
-                    "datasource_uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "description": "string",
-                    "id": 1,
-                    "is_managed_externally": true,
-                    "owners": [],
-                    "params": "string",
-                    "query_context": "string",
-                    "slice_name": "string",
-                    "tags": [],
-                    "thumbnail_url": "string",
-                    "url": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "viz_type": "string"
-                  }
                 }
               }
             },
@@ -14942,26 +16707,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a chart detail information",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/{id_or_uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/{id_or_uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/{id_or_uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -14988,9 +16741,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -15015,26 +16765,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Delete a chart",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Delete a chart (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Charts"
         ]
       },
       "put": {
@@ -15053,25 +16791,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ChartRestApi.put"
-              },
-              "example": {
-                "cache_timeout": 1,
-                "certification_details": "string",
-                "certified_by": "string",
-                "dashboards": [1],
-                "datasource_id": 1,
-                "datasource_type": "table",
-                "description": "string",
-                "external_url": "string",
-                "is_managed_externally": true,
-                "owners": [1],
-                "params": "string",
-                "query_context": "string",
-                "query_context_generation": true,
-                "slice_name": "string",
-                "tags": [1],
-                "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                "viz_type": ["bar", "area", "table"]
               }
             }
           },
@@ -15087,33 +16806,43 @@
                     "id": {
                       "type": "number"
                     },
+                    "new_transaction_id": {
+                      "description": "Continuum transaction_id of the live row after this update. Differs from old_transaction_id when the update produced a new version row.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version": {
+                      "description": "0-based version_number of the newly-live row after this update. Can equal old_version when no versioned column changed, or when retention pruning dropped an older closed row in the same commit.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row after this update. Null when version capture is disabled.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "old_transaction_id": {
+                      "description": "Continuum transaction_id of the live row before this update. Stable across pruning.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version": {
+                      "description": "0-based version_number of the live row before this update. Unstable under retention pruning \u2014 see old_transaction_id for a stable identifier.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row before this update. Null when version capture is disabled or the entity has no version rows yet.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "result": {
                       "$ref": "#/components/schemas/ChartRestApi.put"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "cache_timeout": 1,
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "dashboards": [],
-                    "datasource_id": 1,
-                    "datasource_type": "table",
-                    "description": "string",
-                    "external_url": "string",
-                    "is_managed_externally": true,
-                    "owners": [],
-                    "params": "string",
-                    "query_context": "string",
-                    "query_context_generation": true,
-                    "slice_name": "string",
-                    "tags": [],
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "viz_type": ["bar", "area", "table"]
-                  }
                 }
               }
             },
@@ -15141,26 +16870,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a chart",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/chart/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/chart/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -15193,13 +16910,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
-                },
-                "example": {
-                  "cache_key": "string",
-                  "chart_url": "string",
-                  "image_url": "string",
-                  "task_status": "string",
-                  "task_updated_at": "string"
                 }
               }
             },
@@ -15210,13 +16920,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartCacheScreenshotResponseSchema"
-                },
-                "example": {
-                  "cache_key": "string",
-                  "chart_url": "string",
-                  "image_url": "string",
-                  "task_status": "string",
-                  "task_updated_at": "string"
                 }
               }
             },
@@ -15238,32 +16941,20 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Compute and cache a screenshot (chart-pk-cache-screenshot)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/cache_screenshot/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Compute and cache a screenshot",
+        "tags": [
+          "Charts"
         ]
       }
     },
     "/api/v1/chart/{pk}/data/": {
       "get": {
-        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response.",
+        "description": "Takes a chart ID and uses the query context stored when the chart was saved to return payload data response. When filters_dashboard_id is provided, the chart's compiled SQL includes in scope dashboard filter default values.",
         "parameters": [
           {
             "description": "The chart ID",
@@ -15297,6 +16988,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "description": "Dashboard ID whose filter defaults should be applied to the chart's query context. The chart must belong to the specified dashboard. Only in scope filters with static default values are applied; filters that require a database query (I.E. defaultToFirstItem) or have no default are reported in the dashboard_filters response metadata.",
+            "in": "query",
+            "name": "filters_dashboard_id",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -15305,9 +17004,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -15318,13 +17014,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
-                },
-                "example": {
-                  "channel_id": "string",
-                  "job_id": "string",
-                  "result_url": "string",
-                  "status": "string",
-                  "user_id": "string"
                 }
               }
             },
@@ -15336,6 +17025,12 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
@@ -15343,26 +17038,91 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Return payload data response for a chart",
-        "tags": ["Charts"],
-        "x-codeSamples": [
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{pk}/deck_layers/": {
+      "get": {
+        "description": "Multiple Layers charts (viz_type \"deck_multi\") reference other saved charts as layers via their `deck_slices` config, but those layer charts typically sit on no dashboard of their own, so a per-layer `GET /api/v1/chart/<id>` can 404 for a principal (e.g. an embedded guest) who is only entitled to the container. This endpoint gates on the container chart and resolves the layers it declares, mirroring the access the legacy explore_json pipeline granted server-side.",
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/data/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/data/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/data/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "description": "The id of the Multiple Layers container chart",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "items": {
+                        "properties": {
+                          "datasource_id": {
+                            "type": "integer"
+                          },
+                          "datasource_type": {
+                            "type": "string"
+                          },
+                          "params": {
+                            "type": "string"
+                          },
+                          "slice_id": {
+                            "type": "integer"
+                          },
+                          "viz_type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The container's declared layer charts"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get the sub-layer charts declared by a deck.gl Multiple Layers chart",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -15389,9 +17149,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -15410,26 +17167,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Remove the chart from the user favorite list",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/chart/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/chart/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Charts"
         ]
       },
       "post": {
@@ -15454,9 +17199,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -15475,26 +17217,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Mark the chart as favorite for the current user",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/chart/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/chart/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -15546,26 +17276,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a computed screenshot from cache (chart-pk-screenshot-digest)",
-        "tags": ["Charts"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/screenshot/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a computed screenshot from cache",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -15622,26 +17340,447 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get chart thumbnail",
-        "tags": ["Charts"],
-        "x-codeSamples": [
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid_str}/activity/": {
+      "get": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+            "description": "Chart UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
           },
           {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/chart/1/thumbnail/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "default": "all",
+              "enum": [
+                "self",
+                "related",
+                "all"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Case-insensitive search over the full history (summary, entity name, kind, path, values) \u2014 applied before pagination, so `count` reflects the matches.",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            },
+            "description": "Activity stream ordered newest-first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Activity stream \u2014 chart own edits + datasets the chart pointed at during association",
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid_str}/versions/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Chart UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "integer"
+                    },
+                    "result": {
+                      "items": {
+                        "$ref": "#/components/schemas/VersionListItemSchema"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Version history ordered by oldest first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Return the version history for a chart",
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid_str}/versions/{version_uuid_str}/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Chart UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list endpoint",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "description": "The chart's scalar fields at the target version (entity-specific keys), plus a `_version` block with the version-level metadata.",
+                      "properties": {
+                        "_version": {
+                          "$ref": "#/components/schemas/VersionListItemSchema"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Snapshot of the chart at the target version"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Read-only snapshot of the chart at a given version",
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid_str}/versions/{version_uuid_str}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Chart UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list-versions endpoint. Stable across retention pruning.",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart was restored"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Revert a chart to an earlier version (non-destructive)",
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid}/purge": {
+      "post": {
+        "description": "Irreversibly remove an archived chart and its dependents. Limited to owners and admins (same audience as restore).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart permanently deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Permanently delete a soft-deleted chart",
+        "tags": [
+          "Charts"
+        ]
+      }
+    },
+    "/api/v1/chart/{uuid}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Chart restored"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Restore a soft-deleted chart",
+        "tags": [
+          "Charts"
         ]
       }
     },
@@ -15671,9 +17810,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -15695,26 +17831,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete CSS templates",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       },
       "get": {
@@ -15797,20 +17921,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -15832,26 +17942,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of CSS templates",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       },
       "post": {
@@ -15860,10 +17958,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CssTemplateRestApi.post"
-              },
-              "example": {
-                "css": "string",
-                "template_name": "string"
               }
             }
           },
@@ -15884,13 +17978,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "css": "string",
-                    "template_name": "string"
-                  }
                 }
               }
             },
@@ -15912,26 +17999,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a CSS template",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/css_template/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/css_template/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       }
     },
@@ -15993,14 +18068,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -16022,26 +18089,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (css-template--info)",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "CSS Templates"
         ]
       }
     },
@@ -16074,10 +18129,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -16089,6 +18140,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -16099,26 +18153,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (css-template-related-column-name)",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "CSS Templates"
         ]
       }
     },
@@ -16145,9 +18187,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -16166,26 +18205,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a CSS template",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       },
       "get": {
@@ -16258,23 +18285,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "changed_on_delta_humanized": {},
-                    "css": "string",
-                    "id": 1,
-                    "template_name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -16299,26 +18309,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a CSS template",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       },
       "put": {
@@ -16337,10 +18335,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CssTemplateRestApi.put"
-              },
-              "example": {
-                "css": "string",
-                "template_name": "string"
               }
             }
           },
@@ -16358,12 +18352,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "css": "string",
-                    "template_name": "string"
-                  }
                 }
               }
             },
@@ -16388,26 +18376,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a CSS template",
-        "tags": ["CSS Templates"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/css_template/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/css_template/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/css_template/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "CSS Templates"
         ]
       }
     },
@@ -16437,9 +18413,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -16464,26 +18437,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Bulk delete dashboards",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Bulk delete dashboards (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Dashboards"
         ]
       },
       "get": {
@@ -16524,11 +18485,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1,
-                  "ids": [1],
-                  "result": [{}]
                 }
               }
             },
@@ -16550,26 +18506,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of dashboards",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       },
       "post": {
@@ -16578,22 +18522,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardRestApi.post"
-              },
-              "example": {
-                "certification_details": "string",
-                "certified_by": "string",
-                "css": "string",
-                "dashboard_title": "string",
-                "external_url": "string",
-                "is_managed_externally": true,
-                "json_metadata": "string",
-                "owners": [1],
-                "position_json": "string",
-                "published": true,
-                "roles": [1],
-                "slug": "string",
-                "theme_id": 1,
-                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -16614,25 +18542,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "css": "string",
-                    "dashboard_title": "string",
-                    "external_url": "string",
-                    "is_managed_externally": true,
-                    "json_metadata": "string",
-                    "owners": [],
-                    "position_json": "string",
-                    "published": true,
-                    "roles": [],
-                    "slug": "string",
-                    "theme_id": 1,
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  }
                 }
               }
             },
@@ -16654,26 +18563,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new dashboard",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -16735,14 +18632,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -16764,26 +18653,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (dashboard--info)",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -16832,26 +18709,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download multiple dashboards as YAML files",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -16876,9 +18741,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -16900,26 +18762,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Check favorited dashboards for current user",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -16937,6 +18787,10 @@
                   },
                   "overwrite": {
                     "description": "overwrite existing dashboards?",
+                    "type": "boolean"
+                  },
+                  "overwrite_all": {
+                    "description": "overwrite all existing assets within the dashboard?",
                     "type": "boolean"
                   },
                   "passwords": {
@@ -16973,9 +18827,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -16997,26 +18848,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import dashboard(s) with associated charts/datasets/databases",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17044,9 +18883,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "state": {}
                 }
               }
             },
@@ -17071,32 +18907,20 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get dashboard's permanent link state",
-        "tags": ["Dashboard Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboard Permanent Link"
         ]
       }
     },
     "/api/v1/dashboard/related/{column_name}": {
       "get": {
-        "description": "Get a list of all possible owners for a dashboard.",
+        "description": "Get a list of all possible related entities for a dashboard",
         "parameters": [
           {
             "in": "path",
@@ -17124,10 +18948,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -17139,6 +18959,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -17149,26 +18972,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (dashboard-related-column-name)",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17183,6 +18994,17 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_item_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
           }
         ],
         "responses": {
@@ -17196,33 +19018,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "changed_by_name": "string",
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "changed_on_delta_humanized": "string",
-                    "charts": [],
-                    "created_on_delta_humanized": "string",
-                    "css": "string",
-                    "custom_tags": [],
-                    "dashboard_title": "string",
-                    "id": 1,
-                    "is_managed_externally": true,
-                    "json_metadata": "string",
-                    "owners": [],
-                    "position_json": "string",
-                    "published": true,
-                    "roles": [],
-                    "slug": "string",
-                    "tags": [],
-                    "theme": {},
-                    "thumbnail_url": "string",
-                    "url": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  }
                 }
               }
             },
@@ -17244,26 +19039,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a dashboard detail information",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17293,9 +19076,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -17317,26 +19097,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a dashboard's chart definitions.",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/charts\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/charts\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/charts\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17358,12 +19126,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardCopySchema"
-              },
-              "example": {
-                "css": "string",
-                "dashboard_title": "string",
-                "duplicate_slices": true,
-                "json_metadata": "string"
               }
             }
           },
@@ -17383,10 +19145,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "last_modified_time": 1.0
                 }
               }
             },
@@ -17411,26 +19169,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a copy of an existing dashboard",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/copy/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/copy/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/copy/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17462,9 +19208,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -17486,26 +19229,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get dashboard's datasets",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/datasets\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/datasets\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/datasets\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17533,9 +19264,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -17551,26 +19279,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a dashboard's embedded configuration",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       },
       "get": {
@@ -17596,14 +19312,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "allowed_domains": [],
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "dashboard_id": "string",
-                    "uuid": "string"
-                  }
                 }
               }
             },
@@ -17619,26 +19327,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the dashboard's embedded configuration",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       },
       "post": {
@@ -17658,9 +19354,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
-              },
-              "example": {
-                "allowed_domains": ["string"]
               }
             }
           },
@@ -17678,14 +19371,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "allowed_domains": [],
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "dashboard_id": "string",
-                    "uuid": "string"
-                  }
                 }
               }
             },
@@ -17701,26 +19386,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Set a dashboard's embedded configuration",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       },
       "put": {
@@ -17741,9 +19414,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EmbeddedDashboardConfig"
-              },
-              "example": {
-                "allowed_domains": ["string"]
               }
             }
           },
@@ -17761,14 +19431,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "allowed_domains": [],
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "dashboard_id": "string",
-                    "uuid": "string"
-                  }
                 }
               }
             },
@@ -17784,27 +19446,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Dashboards"],
-        "operationId": "update_dashboard_by_id_or_slug_embedded",
-        "summary": "Update dashboard by id_or_slug embedded",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/embedded\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/embedded\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17836,9 +19484,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -17860,26 +19505,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get dashboard's tabs",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/tabs\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/tabs\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/tabs\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -17906,9 +19539,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -17933,26 +19563,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Delete a dashboard",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Delete a dashboard (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Dashboards"
         ]
       },
       "put": {
@@ -17971,23 +19589,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardRestApi.put"
-              },
-              "example": {
-                "certification_details": "string",
-                "certified_by": "string",
-                "css": "string",
-                "dashboard_title": "string",
-                "external_url": "string",
-                "is_managed_externally": true,
-                "json_metadata": "string",
-                "owners": [1],
-                "position_json": "string",
-                "published": true,
-                "roles": [1],
-                "slug": "string",
-                "tags": [1],
-                "theme_id": 1,
-                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -18006,32 +19607,43 @@
                     "last_modified_time": {
                       "type": "number"
                     },
+                    "new_transaction_id": {
+                      "description": "Continuum transaction_id of the live row after this update. Differs from old_transaction_id when the update produced a new version row.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version": {
+                      "description": "0-based version_number of the newly-live row after this update. Can equal old_version when no versioned column changed, or when retention pruning dropped an older closed row in the same commit.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row after this update. Null when version capture is disabled.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "old_transaction_id": {
+                      "description": "Continuum transaction_id of the live row before this update. Stable across pruning.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version": {
+                      "description": "0-based version_number of the live row before this update. Unstable under retention pruning \u2014 see old_transaction_id for a stable identifier.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row before this update. Null when version capture is disabled or the entity has no version rows yet.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DashboardRestApi.put"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "last_modified_time": 1.0,
-                  "result": {
-                    "certification_details": "string",
-                    "certified_by": "string",
-                    "css": "string",
-                    "dashboard_title": "string",
-                    "external_url": "string",
-                    "is_managed_externally": true,
-                    "json_metadata": "string",
-                    "owners": [],
-                    "position_json": "string",
-                    "published": true,
-                    "roles": [],
-                    "slug": "string",
-                    "tags": [],
-                    "theme_id": 1,
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  }
                 }
               }
             },
@@ -18059,26 +19671,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a dashboard",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18099,12 +19699,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardScreenshotPostSchema"
-              },
-              "example": {
-                "activeTabs": ["string"],
-                "anchor": "string",
-                "dataMask": {},
-                "urlParams": []
               }
             }
           }
@@ -18115,13 +19709,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DashboardCacheScreenshotResponseSchema"
-                },
-                "example": {
-                  "cache_key": "string",
-                  "dashboard_url": "string",
-                  "image_url": "string",
-                  "task_status": "string",
-                  "task_updated_at": "string"
                 }
               }
             },
@@ -18143,26 +19730,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Compute and cache a screenshot (dashboard-pk-cache-dashboard-screenshot)",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/cache_dashboard_screenshot/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Compute and cache a screenshot",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18183,11 +19758,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardChartCustomizationsConfigUpdateSchema"
-              },
-              "example": {
-                "deleted": ["string"],
-                "modified": [{}],
-                "reordered": ["string"]
               }
             }
           },
@@ -18205,9 +19775,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -18235,26 +19802,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update chart customizations configuration for a dashboard.",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/chart_customizations\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18283,20 +19838,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardColorsConfigUpdateSchema"
-              },
-              "example": {
-                "color_namespace": "string",
-                "color_scheme": "string",
-                "map_label_colors": {
-                  "key": "value"
-                },
-                "shared_label_colors": {
-                  "key": "value"
-                },
-                "label_colors": {
-                  "key": "value"
-                },
-                "color_scheme_domain": ["string"]
               }
             }
           },
@@ -18314,9 +19855,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -18344,26 +19882,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update colors configuration for a dashboard.",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/colors\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/colors\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/colors\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18426,26 +19952,81 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Export dashboard as example bundle",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{pk}/export_xlsx/": {
+      "post": {
+        "description": "Enqueues an async task that writes each chart's data to its own worksheet, uploads the .xlsx to S3, and emails the requesting user a pre-signed download link. Returns immediately with a job id.",
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/export_as_example/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "description": "The dashboard id",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardExportXlsxPostSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardExportXlsxResponseSchema"
+                }
+              }
+            },
+            "description": "Export task accepted"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          },
+          "501": {
+            "description": "Excel export is not configured on this server"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Export dashboard chart data to Excel",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18472,9 +20053,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -18493,26 +20071,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Remove the dashboard from the user favorite list",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       },
       "post": {
@@ -18537,9 +20103,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -18558,26 +20121,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Mark the dashboard as favorite for the current user",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -18613,18 +20164,25 @@
                         {
                           "col": "tz_offset",
                           "op": ">=",
-                          "val": [1000]
+                          "val": [
+                            1000
+                          ]
                         },
                         {
                           "col": "tz_offset",
                           "op": "<=",
-                          "val": [2000]
+                          "val": [
+                            2000
+                          ]
                         }
                       ]
                     },
                     "filterState": {
                       "label": "1000 <= x <= 2000",
-                      "value": [1000, 2000]
+                      "value": [
+                        1000,
+                        2000
+                      ]
                     },
                     "id": "NATIVE_FILTER_ID"
                   }
@@ -18638,7 +20196,9 @@
                     },
                     "filterState": {
                       "label": "Week ending Saturday",
-                      "value": ["P1W/1970-01-03T00:00:00Z"]
+                      "value": [
+                        "P1W/1970-01-03T00:00:00Z"
+                      ]
                     },
                     "id": "NATIVE_FILTER_ID"
                   }
@@ -18664,7 +20224,9 @@
                       "granularity_sqla": "order_date"
                     },
                     "filterState": {
-                      "value": ["order_date"]
+                      "value": [
+                        "order_date"
+                      ]
                     },
                     "id": "NATIVE_FILTER_ID"
                   }
@@ -18678,12 +20240,16 @@
                         {
                           "col": "real_name",
                           "op": "IN",
-                          "val": ["John Doe"]
+                          "val": [
+                            "John Doe"
+                          ]
                         }
                       ]
                     },
                     "filterState": {
-                      "value": ["John Doe"]
+                      "value": [
+                        "John Doe"
+                      ]
                     },
                     "id": "NATIVE_FILTER_ID"
                   }
@@ -18691,9 +20257,6 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/TemporaryCachePostSchema"
-              },
-              "example": {
-                "value": "string"
               }
             }
           },
@@ -18711,9 +20274,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string"
                 }
               }
             },
@@ -18735,26 +20295,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a dashboard's filter state",
-        "tags": ["Dashboard Filter State"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/filter_state\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboard Filter State"
         ]
       }
     },
@@ -18791,9 +20339,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -18818,26 +20363,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a dashboard's filter state value",
-        "tags": ["Dashboard Filter State"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Dashboard Filter State"
         ]
       },
       "get": {
@@ -18871,9 +20404,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "value": "string"
                 }
               }
             },
@@ -18898,26 +20428,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a dashboard's filter state value",
-        "tags": ["Dashboard Filter State"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboard Filter State"
         ]
       },
       "put": {
@@ -18951,9 +20469,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TemporaryCachePutSchema"
-              },
-              "example": {
-                "value": "string"
               }
             }
           },
@@ -18971,9 +20486,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string"
                 }
               }
             },
@@ -18998,26 +20510,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a dashboard's filter state value",
-        "tags": ["Dashboard Filter State"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filter_state/{key}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboard Filter State"
         ]
       }
     },
@@ -19038,11 +20538,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DashboardNativeFiltersConfigUpdateSchema"
-              },
-              "example": {
-                "deleted": ["string"],
-                "modified": [{}],
-                "reordered": ["string"]
               }
             }
           },
@@ -19060,9 +20555,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -19090,26 +20582,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update native filters configuration for a dashboard.",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dashboard/1/filters\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dashboard/1/filters\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/filters\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -19138,18 +20618,25 @@
                           {
                             "col": "tz_offset",
                             "op": ">=",
-                            "val": [1000]
+                            "val": [
+                              1000
+                            ]
                           },
                           {
                             "col": "tz_offset",
                             "op": "<=",
-                            "val": [2000]
+                            "val": [
+                              2000
+                            ]
                           }
                         ]
                       },
                       "filterState": {
                         "label": "1000 <= x <= 200",
-                        "value": [1000, 2000]
+                        "value": [
+                          1000,
+                          2000
+                        ]
                       },
                       "id": "NATIVE_FILTER_ID"
                     }
@@ -19164,7 +20651,9 @@
                       },
                       "filterState": {
                         "label": "Week ending Saturday",
-                        "value": ["P1W/1970-01-03T00:00:00Z"]
+                        "value": [
+                          "P1W/1970-01-03T00:00:00Z"
+                        ]
                       },
                       "id": "NATIVE_FILTER_ID"
                     }
@@ -19192,7 +20681,9 @@
                         "granularity_sqla": "order_date"
                       },
                       "filterState": {
-                        "value": ["order_date"]
+                        "value": [
+                          "order_date"
+                        ]
                       },
                       "id": "NATIVE_FILTER_ID"
                     }
@@ -19207,12 +20698,16 @@
                           {
                             "col": "real_name",
                             "op": "IN",
-                            "val": ["John Doe"]
+                            "val": [
+                              "John Doe"
+                            ]
                           }
                         ]
                       },
                       "filterState": {
-                        "value": ["John Doe"]
+                        "value": [
+                          "John Doe"
+                        ]
                       },
                       "id": "NATIVE_FILTER_ID"
                     }
@@ -19221,13 +20716,6 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/DashboardPermalinkStateSchema"
-              },
-              "example": {
-                "activeTabs": ["string"],
-                "anchor": "string",
-                "chartStates": {},
-                "dataMask": {},
-                "urlParams": [{}]
               }
             }
           },
@@ -19249,10 +20737,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string",
-                  "url": "string"
                 }
               }
             },
@@ -19274,26 +20758,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new dashboard's permanent link",
-        "tags": ["Dashboard Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dashboard/1/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dashboard/1/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Dashboard Permanent Link"
         ]
       }
     },
@@ -19320,7 +20792,10 @@
             "in": "query",
             "name": "download_format",
             "schema": {
-              "enum": ["png", "pdf"],
+              "enum": [
+                "png",
+                "pdf"
+              ],
               "type": "string"
             }
           }
@@ -19353,26 +20828,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a computed screenshot from cache (dashboard-pk-screenshot-digest)",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/screenshot/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a computed screenshot from cache",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -19420,9 +20883,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -19447,26 +20907,449 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get dashboard's thumbnail",
-        "tags": ["Dashboards"],
-        "x-codeSamples": [
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid_str}/activity/": {
+      "get": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+            "description": "Dashboard UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+            "description": "Lower bound on issued_at (ISO 8601, UTC)",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
           },
           {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dashboard/1/thumbnail/{digest}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "description": "Upper bound on issued_at (ISO 8601, UTC)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "default": "all",
+              "enum": [
+                "self",
+                "related",
+                "all"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Case-insensitive search over the full history (summary, entity name, kind, path, values) \u2014 applied before pagination, so `count` reflects the matches.",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            },
+            "description": "Activity stream ordered newest-first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Activity stream \u2014 dashboard own edits + transitive chart-on-dashboard and dataset-via-chart edits, time-bounded by association windows",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid_str}/versions/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Dashboard UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "integer"
+                    },
+                    "result": {
+                      "items": {
+                        "$ref": "#/components/schemas/VersionListItemSchema"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Version history ordered by oldest first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Return the version history for a dashboard",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid_str}/versions/{version_uuid_str}/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Dashboard UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list endpoint",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "description": "The dashboard's scalar fields at the target version (entity-specific keys), plus a `_version` block with the version-level metadata.",
+                      "properties": {
+                        "_version": {
+                          "$ref": "#/components/schemas/VersionListItemSchema"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Snapshot of the dashboard at the target version"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Read-only snapshot of the dashboard at a given version",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid_str}/versions/{version_uuid_str}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Dashboard UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list-versions endpoint. Stable across retention pruning.",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard was restored"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Revert a dashboard to an earlier version (non-destructive)",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid}/purge": {
+      "post": {
+        "description": "Irreversibly remove an archived dashboard and its dependents. Limited to owners and admins (same audience as restore).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard permanently deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Permanently delete a soft-deleted dashboard",
+        "tags": [
+          "Dashboards"
+        ]
+      }
+    },
+    "/api/v1/dashboard/{uuid}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard restored"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Restore a soft-deleted dashboard",
+        "tags": [
+          "Dashboards"
         ]
       }
     },
@@ -19551,20 +21434,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -19586,26 +21455,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of databases",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       },
       "post": {
@@ -19614,30 +21471,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseRestApi.post"
-              },
-              "example": {
-                "allow_ctas": true,
-                "allow_cvas": true,
-                "allow_dml": true,
-                "allow_file_upload": true,
-                "allow_run_async": true,
-                "cache_timeout": 1,
-                "configuration_method": {},
-                "database_name": "string",
-                "driver": "string",
-                "engine": "string",
-                "expose_in_sqllab": true,
-                "external_url": "string",
-                "extra": "string",
-                "force_ctas_schema": "string",
-                "impersonate_user": true,
-                "is_managed_externally": true,
-                "masked_encrypted_extra": "string",
-                "parameters": {},
-                "server_cert": "string",
-                "sqlalchemy_uri": "string",
-                "ssh_tunnel": {},
-                "uuid": "string"
               }
             }
           },
@@ -19658,33 +21491,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "allow_ctas": true,
-                    "allow_cvas": true,
-                    "allow_dml": true,
-                    "allow_file_upload": true,
-                    "allow_run_async": true,
-                    "cache_timeout": 1,
-                    "configuration_method": {},
-                    "database_name": "string",
-                    "driver": "string",
-                    "engine": "string",
-                    "expose_in_sqllab": true,
-                    "external_url": "string",
-                    "extra": "string",
-                    "force_ctas_schema": "string",
-                    "impersonate_user": true,
-                    "is_managed_externally": true,
-                    "masked_encrypted_extra": "string",
-                    "parameters": {},
-                    "server_cert": "string",
-                    "sqlalchemy_uri": "string",
-                    "ssh_tunnel": {},
-                    "uuid": "string"
-                  }
                 }
               }
             },
@@ -19706,26 +21512,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -19787,14 +21581,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -19816,26 +21602,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (database--info)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -19897,22 +21671,7 @@
                     "type": "object"
                   },
                   "type": "array"
-                },
-                "example": [
-                  {
-                    "available_drivers": ["string"],
-                    "default_driver": "string",
-                    "engine": "string",
-                    "engine_information": {
-                      "disable_ssh_tunneling": true,
-                      "supports_file_upload": true
-                    },
-                    "name": "string",
-                    "parameters": {},
-                    "preferred": true,
-                    "sqlalchemy_uri_placeholder": "string"
-                  }
-                ]
+                }
               }
             },
             "description": "Database names"
@@ -19927,26 +21686,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get names of databases currently available",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/available/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/available/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/available/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -19990,26 +21737,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download database(s) and associated dataset(s) as a zip file",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20020,6 +21755,10 @@
             "multipart/form-data": {
               "schema": {
                 "properties": {
+                  "encrypted_extra_secrets": {
+                    "description": "JSON map of sensitive values for masked_encrypted_extra fields. Keys are file paths (e.g., \"databases/db.yaml\") and values are JSON objects mapping JSONPath expressions to secrets. (e.g., `{\"databases/MyDatabase.yaml\": {\"$.credentials_info.private_key\": \"actual_key\"}}`).",
+                    "type": "string"
+                  },
                   "formData": {
                     "description": "upload file (ZIP)",
                     "format": "binary",
@@ -20063,9 +21802,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -20087,26 +21823,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import database(s) with associated datasets",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20167,26 +21891,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Receive personal access tokens from OAuth2",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/oauth2/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/oauth2/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/oauth2/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20219,10 +21931,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -20234,6 +21942,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -20244,26 +21955,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (database-related-column-name)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20274,19 +21973,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseTestConnectionSchema"
-              },
-              "example": {
-                "configuration_method": {},
-                "database_name": "string",
-                "driver": "string",
-                "engine": "string",
-                "extra": "string",
-                "impersonate_user": true,
-                "masked_encrypted_extra": "string",
-                "parameters": {},
-                "server_cert": "string",
-                "sqlalchemy_uri": "string",
-                "ssh_tunnel": {}
               }
             }
           },
@@ -20304,9 +21990,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -20325,26 +22008,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Test a database connection",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/test_connection/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/test_connection/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/test_connection/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20371,11 +22042,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "items": []
-                  }
                 }
               }
             },
@@ -20390,6 +22056,21 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Payload too large, file exceeds the maximum allowed size"
+          },
           "500": {
             "$ref": "#/components/responses/500"
           }
@@ -20397,26 +22078,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Upload a file and returns file metadata",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/upload_metadata/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/upload_metadata/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/upload_metadata/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20427,23 +22096,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseValidateParametersSchema"
-              },
-              "example": {
-                "catalog": {
-                  "key": "value"
-                },
-                "configuration_method": {},
-                "database_name": "string",
-                "driver": "string",
-                "engine": "string",
-                "extra": "string",
-                "id": 1,
-                "impersonate_user": true,
-                "masked_encrypted_extra": "string",
-                "parameters": {
-                  "key": "value"
-                },
-                "server_cert": "string"
               }
             }
           },
@@ -20461,9 +22113,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -20482,26 +22131,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Validate database connection parameters",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/validate_parameters/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/validate_parameters/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/validate_parameters/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20528,9 +22165,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -20555,26 +22189,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Database"
         ]
       },
       "get": {
@@ -20616,26 +22238,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       },
       "put": {
@@ -20654,30 +22264,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatabaseRestApi.put"
-              },
-              "example": {
-                "allow_ctas": true,
-                "allow_cvas": true,
-                "allow_dml": true,
-                "allow_file_upload": true,
-                "allow_run_async": true,
-                "cache_timeout": 1,
-                "configuration_method": {},
-                "database_name": "string",
-                "driver": "string",
-                "engine": "string",
-                "expose_in_sqllab": true,
-                "external_url": "string",
-                "extra": "string",
-                "force_ctas_schema": "string",
-                "impersonate_user": true,
-                "is_managed_externally": true,
-                "masked_encrypted_extra": "string",
-                "parameters": {},
-                "server_cert": "string",
-                "sqlalchemy_uri": "string",
-                "ssh_tunnel": {},
-                "uuid": "string"
               }
             }
           },
@@ -20698,33 +22284,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "allow_ctas": true,
-                    "allow_cvas": true,
-                    "allow_dml": true,
-                    "allow_file_upload": true,
-                    "allow_run_async": true,
-                    "cache_timeout": 1,
-                    "configuration_method": {},
-                    "database_name": "string",
-                    "driver": "string",
-                    "engine": "string",
-                    "expose_in_sqllab": true,
-                    "external_url": "string",
-                    "extra": "string",
-                    "force_ctas_schema": "string",
-                    "impersonate_user": true,
-                    "is_managed_externally": true,
-                    "masked_encrypted_extra": "string",
-                    "parameters": {},
-                    "server_cert": "string",
-                    "sqlalchemy_uri": "string",
-                    "ssh_tunnel": {},
-                    "uuid": "string"
-                  }
                 }
               }
             },
@@ -20752,26 +22311,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Change a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/database/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/database/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20805,9 +22352,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CatalogsResponseSchema"
-                },
-                "example": {
-                  "result": ["string"]
                 }
               }
             },
@@ -20829,26 +22373,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get all catalogs from a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/catalogs/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/catalogs/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/catalogs/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20871,32 +22403,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseConnectionSchema"
-                },
-                "example": {
-                  "allow_ctas": true,
-                  "allow_cvas": true,
-                  "allow_dml": true,
-                  "allow_file_upload": true,
-                  "allow_run_async": true,
-                  "backend": "string",
-                  "cache_timeout": 1,
-                  "configuration_method": "string",
-                  "database_name": "string",
-                  "driver": "string",
-                  "engine_information": {},
-                  "expose_in_sqllab": true,
-                  "extra": "string",
-                  "force_ctas_schema": "string",
-                  "id": 1,
-                  "impersonate_user": true,
-                  "is_managed_externally": true,
-                  "masked_encrypted_extra": "string",
-                  "parameters": {},
-                  "parameters_schema": {},
-                  "server_cert": "string",
-                  "sqlalchemy_uri": "string",
-                  "ssh_tunnel": {},
-                  "uuid": "string"
                 }
               }
             },
@@ -20918,26 +22424,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a database connection info",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/connection\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/connection\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/connection\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -20959,9 +22453,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseFunctionNamesResponse"
-                },
-                "example": {
-                  "function_names": ["string"]
                 }
               }
             },
@@ -20980,26 +22471,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get function names supported by a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/function_names/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/function_names/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/function_names/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21021,10 +22500,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseRelatedObjectsResponse"
-                },
-                "example": {
-                  "charts": {},
-                  "dashboards": {}
                 }
               }
             },
@@ -21043,26 +22518,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get charts and dashboards count associated to a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/related_objects/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/related_objects/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/related_objects/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21096,9 +22559,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SchemasResponseSchema"
-                },
-                "example": {
-                  "result": ["string"]
                 }
               }
             },
@@ -21120,26 +22580,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get all schemas from a database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/schemas/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/schemas/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/schemas/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21161,9 +22609,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatabaseSchemaAccessForFileUploadResponse"
-                },
-                "example": {
-                  "schemas": ["string"]
                 }
               }
             },
@@ -21182,26 +22627,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "The list of the database schemas where to upload information",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/schemas_access_for_file_upload/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21242,9 +22675,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -21269,26 +22699,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get database select star for table (database-pk-select-star-table-name)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get database select star for table",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21329,9 +22747,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SelectStarResponseSchema"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -21356,26 +22771,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get database select star for table (database-pk-select-star-table-name-schema-name)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/select_star/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get database select star for table",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21403,9 +22806,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -21427,26 +22827,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Re-sync all permissions for a database connection",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/sync_permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/sync_permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/sync_permissions/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21487,14 +22875,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableMetadataResponseSchema"
-                },
-                "example": {
-                  "columns": [],
-                  "foreignKeys": [],
-                  "indexes": [],
-                  "name": "string",
-                  "primaryKey": {},
-                  "selectStar": "string"
                 }
               }
             },
@@ -21519,26 +22899,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get database table metadata",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21580,11 +22948,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
-                },
-                "example": {
-                  "clustering": {},
-                  "metadata": {},
-                  "partitions": {}
                 }
               }
             },
@@ -21609,26 +22972,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get table extra metadata (database-pk-table-extra-table-name-schema-name)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_extra/{table_name}/{schema_name}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get table extra metadata",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21677,11 +23028,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
-                },
-                "example": {
-                  "clustering": {},
-                  "metadata": {},
-                  "partitions": {}
                 }
               }
             },
@@ -21700,26 +23046,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get table metadata",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_metadata/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_metadata/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_metadata/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21768,11 +23102,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TableExtraMetadataResponseSchema"
-                },
-                "example": {
-                  "clustering": {},
-                  "metadata": {},
-                  "partitions": {}
                 }
               }
             },
@@ -21791,26 +23120,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get table extra metadata (database-pk-table-metadata-extra)",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/table_metadata/extra/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get table extra metadata",
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21856,10 +23173,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1,
-                  "result": [{}]
                 }
               }
             },
@@ -21884,26 +23197,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of tables for given database",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/database/1/tables/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/database/1/tables/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/tables/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -21940,9 +23241,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -21957,6 +23255,21 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Payload too large, file exceeds the maximum allowed size"
+          },
           "422": {
             "$ref": "#/components/responses/422"
           },
@@ -21967,26 +23280,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Upload a file to a database table",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/upload/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/upload/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/upload/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -22008,12 +23309,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ValidateSQLRequest"
-              },
-              "example": {
-                "catalog": "string",
-                "schema": "string",
-                "sql": "string",
-                "template_params": {}
               }
             }
           },
@@ -22035,9 +23330,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -22059,26 +23351,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Validate arbitrary SQL",
-        "tags": ["Database"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/database/1/validate_sql/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/database/1/validate_sql/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/database/1/validate_sql/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Database"
         ]
       }
     },
@@ -22108,9 +23388,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -22138,26 +23415,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Bulk delete datasets",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Bulk delete datasets (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Datasets"
         ]
       },
       "get": {
@@ -22240,20 +23505,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -22275,26 +23526,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of datasets",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       },
       "post": {
@@ -22303,20 +23542,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetRestApi.post"
-              },
-              "example": {
-                "always_filter_main_dttm": true,
-                "catalog": "string",
-                "database": 1,
-                "external_url": "string",
-                "is_managed_externally": true,
-                "normalize_columns": true,
-                "owners": [1],
-                "schema": "string",
-                "sql": "string",
-                "table_name": "string",
-                "template_params": "string",
-                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -22337,23 +23562,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "always_filter_main_dttm": true,
-                    "catalog": "string",
-                    "database": 1,
-                    "external_url": "string",
-                    "is_managed_externally": true,
-                    "normalize_columns": true,
-                    "owners": [],
-                    "schema": "string",
-                    "sql": "string",
-                    "table_name": "string",
-                    "template_params": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  }
                 }
               }
             },
@@ -22375,26 +23583,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22456,14 +23652,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -22485,26 +23673,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (dataset--info)",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22537,10 +23713,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -22562,26 +23734,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get distinct values from field data (dataset-distinct-column-name)",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22592,10 +23752,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetDuplicateSchema"
-              },
-              "example": {
-                "base_model_id": 1,
-                "table_name": "string"
               }
             }
           },
@@ -22616,13 +23772,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "base_model_id": 1,
-                    "table_name": "string"
-                  }
                 }
               }
             },
@@ -22650,26 +23799,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Duplicate a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/duplicate\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/duplicate\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/duplicate\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22715,26 +23852,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download multiple datasets as YAML files",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22745,15 +23870,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GetOrCreateDatasetSchema"
-              },
-              "example": {
-                "always_filter_main_dttm": true,
-                "catalog": "string",
-                "database_id": 1,
-                "normalize_columns": true,
-                "schema": "string",
-                "table_name": "string",
-                "template_params": "string"
               }
             }
           },
@@ -22775,11 +23891,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "table_id": 1
-                  }
                 }
               }
             },
@@ -22801,26 +23912,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Retrieve a table by name, or create it if it does not exist",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/get_or_create/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/get_or_create/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/get_or_create/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22882,9 +23981,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -22906,26 +24002,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import dataset(s) with associated databases",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/dataset/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/dataset/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -22958,10 +24042,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -22973,6 +24053,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -22983,43 +24066,25 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (dataset-related-column-name)",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Datasets"
         ]
       }
     },
     "/api/v1/dataset/warm_up_cache": {
       "put": {
-        "description": "Warms up the cache for the table. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore_json` action.",
+        "description": "Warms up the cache for the table. Note for slices a force refresh occurs. In terms of the `extra_filters` these can be obtained from records in the JSON encoded `logs.json` column associated with the `explore` action.",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetCacheWarmUpRequestSchema"
-              },
-              "example": {
-                "dashboard_id": 1,
-                "db_name": "string",
-                "extra_filters": "string",
-                "table_name": "string"
               }
             }
           },
@@ -23032,9 +24097,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetCacheWarmUpResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -23053,26 +24115,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Warm up the cache for each chart powered by the given table",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/warm_up_cache\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/warm_up_cache\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/warm_up_cache\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23124,48 +24174,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "always_filter_main_dttm": true,
-                    "cache_timeout": {},
-                    "catalog": "string",
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "changed_on_humanized": {},
-                    "column_formats": {},
-                    "created_on": "2024-01-15T10:30:00Z",
-                    "created_on_humanized": {},
-                    "currency_code_column": "string",
-                    "datasource_name": {},
-                    "datasource_type": {},
-                    "default_endpoint": "string",
-                    "description": "string",
-                    "extra": "string",
-                    "fetch_values_predicate": "string",
-                    "filter_select_enabled": true,
-                    "folders": {},
-                    "granularity_sqla": {},
-                    "id": 1,
-                    "is_managed_externally": true,
-                    "is_sqllab_view": true,
-                    "kind": {},
-                    "main_dttm_col": "string",
-                    "name": {},
-                    "normalize_columns": true,
-                    "offset": 1,
-                    "order_by_choices": {},
-                    "schema": "string",
-                    "select_star": {},
-                    "sql": "string",
-                    "table_name": "string",
-                    "template_params": "string",
-                    "time_grain_sqla": {},
-                    "uid": {},
-                    "url": {},
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "verbose_map": {}
-                  }
                 }
               }
             },
@@ -23187,26 +24195,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/{id_or_uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23228,10 +24224,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetRelatedObjectsResponse"
-                },
-                "example": {
-                  "charts": {},
-                  "dashboards": {}
                 }
               }
             },
@@ -23250,26 +24242,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get charts and dashboards count associated to a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/{id_or_uuid}/related_objects\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23296,9 +24276,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -23323,26 +24300,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Delete a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "summary": "Delete a dataset (soft delete, recoverable via restore, when the SOFT_DELETE feature flag is enabled; permanent otherwise)",
+        "tags": [
+          "Datasets"
         ]
       },
       "put": {
@@ -23361,6 +24326,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "description": "Optional optimistic-concurrency guard. Pass the ``ETag`` returned by a prior read of this dataset; the update is rejected with 412 if the dataset has changed since.",
+            "in": "header",
+            "name": "If-Match",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -23368,33 +24341,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DatasetRestApi.put"
-              },
-              "example": {
-                "always_filter_main_dttm": true,
-                "cache_timeout": 1,
-                "catalog": "string",
-                "columns": [{}],
-                "currency_code_column": "string",
-                "database_id": 1,
-                "default_endpoint": "string",
-                "description": "string",
-                "external_url": "string",
-                "extra": "string",
-                "fetch_values_predicate": "string",
-                "filter_select_enabled": true,
-                "folders": [{}],
-                "is_managed_externally": true,
-                "is_sqllab_view": true,
-                "main_dttm_col": "string",
-                "metrics": [{}],
-                "normalize_columns": true,
-                "offset": 1,
-                "owners": [1],
-                "schema": "string",
-                "sql": "string",
-                "table_name": "string",
-                "template_params": "string",
-                "uuid": "550e8400-e29b-41d4-a716-446655440000"
               }
             }
           },
@@ -23410,41 +24356,43 @@
                     "id": {
                       "type": "number"
                     },
+                    "new_transaction_id": {
+                      "description": "Continuum transaction_id of the live row after this update. When this differs from ``old_transaction_id`` the update produced a new version row (regardless of whether ``new_version`` changed).",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version": {
+                      "description": "0-based version_number of the newly-live row after this update. Can equal ``old_version`` when no versioned column changed, or when retention pruning dropped an older closed row in the same commit.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "new_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row after this update. Null when version capture is disabled.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "old_transaction_id": {
+                      "description": "Continuum transaction_id of the live row before this update. Stable across retention pruning.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version": {
+                      "description": "0-based version_number of the live row before this update (null if the dataset had no prior history). Matches the ``version_number`` field of the list versions endpoint. Unstable under retention pruning \u2014 see ``old_transaction_id`` for a stable identifier.",
+                      "nullable": true,
+                      "type": "integer"
+                    },
+                    "old_version_uuid": {
+                      "description": "Deterministic version_uuid of the live row before this update. Null when version capture is disabled or the dataset has no version rows yet.",
+                      "format": "uuid",
+                      "nullable": true,
+                      "type": "string"
+                    },
                     "result": {
                       "$ref": "#/components/schemas/DatasetRestApi.put"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "always_filter_main_dttm": true,
-                    "cache_timeout": 1,
-                    "catalog": "string",
-                    "columns": [],
-                    "currency_code_column": "string",
-                    "database_id": 1,
-                    "default_endpoint": "string",
-                    "description": "string",
-                    "external_url": "string",
-                    "extra": "string",
-                    "fetch_values_predicate": "string",
-                    "filter_select_enabled": true,
-                    "folders": [],
-                    "is_managed_externally": true,
-                    "is_sqllab_view": true,
-                    "main_dttm_col": "string",
-                    "metrics": [],
-                    "normalize_columns": true,
-                    "offset": 1,
-                    "owners": [],
-                    "schema": "string",
-                    "sql": "string",
-                    "table_name": "string",
-                    "template_params": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  }
                 }
               }
             },
@@ -23462,6 +24410,21 @@
           "404": {
             "$ref": "#/components/responses/404"
           },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The dataset changed since the version identified by the request's ``If-Match`` header; the update was not applied."
+          },
           "422": {
             "$ref": "#/components/responses/422"
           },
@@ -23472,26 +24435,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23528,9 +24479,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -23555,26 +24503,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a dataset column",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/column/{column_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23602,9 +24538,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -23629,26 +24562,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get dataset drill info",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/dataset/1/drill_info/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/dataset/1/drill_info/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/drill_info/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23685,9 +24606,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -23712,26 +24630,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a dataset metric",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/metric/{metric_id}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Datasets"
         ]
       }
     },
@@ -23758,9 +24664,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -23785,26 +24688,491 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Refresh and update columns of a dataset",
-        "tags": ["Datasets"],
-        "x-codeSamples": [
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid_str}/activity/": {
+      "get": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/dataset/1/refresh\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+            "description": "Dataset UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
           },
           {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/dataset/1/refresh\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
           },
           {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/dataset/1/refresh\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "default": "all",
+              "enum": [
+                "self",
+                "related",
+                "all"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Case-insensitive search over the full history (summary, entity name, kind, path, values) \u2014 applied before pagination, so `count` reflects the matches.",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 25,
+              "maximum": 200,
+              "minimum": 1,
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            },
+            "description": "Activity stream ordered newest-first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Activity stream \u2014 dataset's own edits only. Datasets have no transitive layer in V2 \u2014 chart and dashboard edits that touch this dataset do NOT appear here. ``?include=self`` and ``?include=all`` return the dataset's own edits; ``?include=related`` returns an empty stream (a dataset has no related entities to fan out to).",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid_str}/versions/": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Dataset UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "integer"
+                    },
+                    "result": {
+                      "items": {
+                        "$ref": "#/components/schemas/VersionListItemSchema"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Version history ordered by oldest first"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Return the version history for a dataset",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid_str}/versions/{version_uuid_str}/": {
+      "get": {
+        "description": "Returns the dataset's scalar fields plus reconstructed ``columns`` and ``metrics`` lists as they were at the target version. Does not modify live state.",
+        "parameters": [
+          {
+            "description": "Dataset UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list endpoint",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "description": "The dataset's scalar fields at the target version (entity-specific keys), plus `columns` / `metrics` as they were at that version, plus a `_version` block with the version-level metadata.",
+                      "properties": {
+                        "_version": {
+                          "$ref": "#/components/schemas/VersionListItemSchema"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Snapshot of the dataset at the target version"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Read-only snapshot of the dataset at a given version",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid_str}/versions/{version_uuid_str}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Dataset UUID",
+            "in": "path",
+            "name": "uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version UUID as returned by the list-versions endpoint. Stable across retention pruning.",
+            "in": "path",
+            "name": "version_uuid_str",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dataset was restored"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Revert a dataset to an earlier version (non-destructive)",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid}/purge": {
+      "post": {
+        "description": "Irreversibly remove an archived dataset and its dependents. Limited to owners and admins (same audience as restore).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dataset permanently deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Permanently delete a soft-deleted dataset",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid}/restore": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dataset restored"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Restore a soft-deleted dataset",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/datasource/": {
+      "get": {
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Combined list of datasets and semantic views"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "List datasets and semantic views combined",
+        "tags": [
+          "Datasources"
         ]
       }
     },
@@ -23834,6 +25202,14 @@
             "in": "path",
             "name": "column_name",
             "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional case-insensitive substring; only values containing it are returned. Lets the client search the full column rather than the truncated first page.",
+            "in": "query",
+            "name": "q",
             "schema": {
               "type": "string"
             }
@@ -23869,9 +25245,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -23896,26 +25269,115 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get possible values for a datasource column",
-        "tags": ["Datasources"],
-        "x-codeSamples": [
+        "tags": [
+          "Datasources"
+        ]
+      }
+    },
+    "/api/v1/datasource/{datasource_type}/{datasource_id}/compatible": {
+      "post": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+            "in": "path",
+            "name": "datasource_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/column/{column_name}/values/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "in": "path",
+            "name": "datasource_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "selected_dimensions": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "selected_metrics": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "properties": {
+                        "compatible_dimensions": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "compatible_metrics": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Compatible metrics and dimensions"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get compatible metrics and dimensions",
+        "tags": [
+          "Datasources"
         ]
       }
     },
@@ -23948,7 +25410,10 @@
                 "properties": {
                   "clause": {
                     "description": "SQL clause type for filter expressions",
-                    "enum": ["WHERE", "HAVING"],
+                    "enum": [
+                      "WHERE",
+                      "HAVING"
+                    ],
                     "type": "string"
                   },
                   "expression": {
@@ -23958,17 +25423,19 @@
                   "expression_type": {
                     "default": "where",
                     "description": "The type of SQL expression",
-                    "enum": ["column", "metric", "where", "having"],
+                    "enum": [
+                      "column",
+                      "metric",
+                      "where",
+                      "having"
+                    ],
                     "type": "string"
                   }
                 },
-                "required": ["expression"],
+                "required": [
+                  "expression"
+                ],
                 "type": "object"
-              },
-              "example": {
-                "clause": "WHERE",
-                "expression": "string",
-                "expression_type": "column"
               }
             }
           },
@@ -24003,16 +25470,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [
-                    {
-                      "end_column": 1,
-                      "line_number": 1,
-                      "message": "string",
-                      "start_column": 1
-                    }
-                  ]
                 }
               }
             },
@@ -24037,26 +25494,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Validate a SQL expression against a datasource",
-        "tags": ["Datasources"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/datasource/{datasource_type}/{datasource_id}/validate_expression/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Datasources"
         ]
       }
     },
@@ -24124,14 +25569,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "allowed_domains": [],
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "dashboard_id": "string",
-                    "uuid": "string"
-                  }
                 }
               },
               "text/html": {
@@ -24155,26 +25592,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a report schedule log (embedded-dashboard-uuid)",
-        "tags": ["Embedded Dashboard"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/embedded_dashboard/{uuid}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a report schedule log",
+        "tags": [
+          "Embedded Dashboard"
         ]
       }
     },
@@ -24224,12 +25649,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExploreContextSchema"
-                },
-                "example": {
-                  "dataset": {},
-                  "form_data": {},
-                  "message": "string",
-                  "slice": {}
                 }
               }
             },
@@ -24254,26 +25673,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Assemble Explore related information in a single endpoint",
-        "tags": ["Explore"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Explore"
         ]
       }
     },
@@ -24293,12 +25700,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormDataPostSchema"
-              },
-              "example": {
-                "chart_id": 1,
-                "datasource_id": 1,
-                "datasource_type": "table",
-                "form_data": "string"
               }
             }
           },
@@ -24316,9 +25717,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string"
                 }
               }
             },
@@ -24340,26 +25738,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new form_data",
-        "tags": ["Explore Form Data"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/explore/form_data\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/explore/form_data\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Explore Form Data"
         ]
       }
     },
@@ -24388,9 +25774,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -24415,26 +25798,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a form_data",
-        "tags": ["Explore Form Data"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Explore Form Data"
         ]
       },
       "get": {
@@ -24460,9 +25831,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "form_data": "string"
                 }
               }
             },
@@ -24487,26 +25855,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a form_data",
-        "tags": ["Explore Form Data"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Explore Form Data"
         ]
       },
       "put": {
@@ -24532,12 +25888,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormDataPutSchema"
-              },
-              "example": {
-                "chart_id": 1,
-                "datasource_id": 1,
-                "datasource_type": "table",
-                "form_data": "string"
               }
             }
           },
@@ -24555,9 +25905,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string"
                 }
               }
             },
@@ -24582,26 +25929,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update an existing form_data",
-        "tags": ["Explore Form Data"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/explore/form_data/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/form_data/{key}\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Explore Form Data"
         ]
       }
     },
@@ -24612,10 +25947,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExplorePermalinkStateSchema"
-              },
-              "example": {
-                "formData": {},
-                "urlParams": [{}]
               }
             }
           },
@@ -24637,10 +25968,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string",
-                  "url": "string"
                 }
               }
             },
@@ -24662,26 +25989,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Create a new permanent link (explore-permalink)",
-        "tags": ["Explore Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/explore/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/explore/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Create a new permanent link",
+        "tags": [
+          "Explore Permanent Link"
         ]
       }
     },
@@ -24709,9 +26024,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "state": {}
                 }
               }
             },
@@ -24736,26 +26048,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get chart's permanent link state",
-        "tags": ["Explore Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/explore/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/explore/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/explore/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Explore Permanent Link"
         ]
       }
     },
@@ -24840,20 +26140,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -24875,26 +26161,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of logs",
-        "tags": ["LogRestApi"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "LogRestApi"
         ]
       },
       "post": {
@@ -24903,9 +26177,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/LogRestApi.post"
-              },
-              "example": {
-                "id": 1
               }
             }
           },
@@ -24926,12 +26197,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "id": 1
-                  }
                 }
               }
             },
@@ -24953,27 +26218,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["LogRestApi"],
-        "operationId": "create_log",
-        "summary": "Create log",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "LogRestApi"
         ]
       }
     },
@@ -25007,9 +26258,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RecentActivityResponseSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -25031,26 +26279,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get recent activity data for a user",
-        "tags": ["LogRestApi"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/log/recent_activity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/recent_activity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/recent_activity/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "LogRestApi"
         ]
       }
     },
@@ -25125,27 +26361,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "action": "string",
-                    "dashboard_id": 1,
-                    "dttm": "2024-01-15T10:30:00Z",
-                    "duration_ms": 1,
-                    "json": "string",
-                    "referrer": "string",
-                    "slice_id": 1,
-                    "user_id": {}
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -25170,26 +26385,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a log detail information",
-        "tags": ["LogRestApi"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/log/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/log/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/log/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "LogRestApi"
         ]
       }
     },
@@ -25207,18 +26410,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "email": "string",
-                    "first_name": "string",
-                    "id": 1,
-                    "is_active": true,
-                    "is_anonymous": true,
-                    "last_name": "string",
-                    "login_count": 1,
-                    "username": "string"
-                  }
                 }
               }
             },
@@ -25231,26 +26422,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the user object",
-        "tags": ["Current User"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/me/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/me/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Current User"
         ]
       },
       "put": {
@@ -25260,11 +26439,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CurrentUserPutSchema"
-              },
-              "example": {
-                "first_name": "string",
-                "last_name": "string",
-                "password": "string"
               }
             }
           },
@@ -25281,18 +26455,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "email": "string",
-                    "first_name": "string",
-                    "id": 1,
-                    "is_active": true,
-                    "is_anonymous": true,
-                    "last_name": "string",
-                    "login_count": 1,
-                    "username": "string"
-                  }
                 }
               }
             },
@@ -25308,26 +26470,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update the current user",
-        "tags": ["Current User"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/me/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/me/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Current User"
         ]
       }
     },
@@ -25345,18 +26495,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "email": "string",
-                    "first_name": "string",
-                    "id": 1,
-                    "is_active": true,
-                    "is_anonymous": true,
-                    "last_name": "string",
-                    "login_count": 1,
-                    "username": "string"
-                  }
                 }
               }
             },
@@ -25369,26 +26507,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the user roles",
-        "tags": ["Current User"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/me/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/me/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/me/roles/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Current User"
         ]
       }
     },
@@ -25434,17 +26560,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [
-                    {
-                      "childs": [],
-                      "icon": "string",
-                      "label": "string",
-                      "name": "string",
-                      "url": "string"
-                    }
-                  ]
                 }
               }
             },
@@ -25457,27 +26572,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Menu"],
-        "operationId": "get_menu",
-        "summary": "Get menu",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/menu/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/menu/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/menu/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Menu"
         ]
       }
     },
@@ -25562,20 +26663,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -25597,26 +26684,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of queries",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -25649,10 +26724,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -25674,26 +26745,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get distinct values from field data (query-distinct-column-name)",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/query/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -25726,10 +26785,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -25741,6 +26796,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -25751,26 +26809,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (query-related-column-name)",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/query/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -25781,9 +26827,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/StopQuerySchema"
-              },
-              "example": {
-                "client_id": "string"
               }
             }
           },
@@ -25801,9 +26844,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -25825,26 +26865,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Manually stop a query with client_id",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/query/stop\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/query/stop\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/stop\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -25878,9 +26906,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -25902,26 +26927,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of queries that changed after last_updated_ms",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/query/updated_since\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/updated_since\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/updated_since\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -25996,43 +27009,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "client_id": "string",
-                    "end_result_backend_time": 1.0,
-                    "end_time": 1.0,
-                    "error_message": "string",
-                    "executed_sql": "string",
-                    "id": 1,
-                    "limit": 1,
-                    "progress": 1,
-                    "results_key": "string",
-                    "rows": 1,
-                    "schema": "string",
-                    "select_as_cta": true,
-                    "select_as_cta_used": true,
-                    "select_sql": "string",
-                    "sql": "string",
-                    "sql_editor_id": "string",
-                    "start_running_time": 1.0,
-                    "start_time": 1.0,
-                    "status": "string",
-                    "tab_name": "string",
-                    "tmp_schema_name": "string",
-                    "tmp_table_name": "string",
-                    "tracking_url": {}
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -26057,26 +27033,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get query detail information",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/query/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -26106,9 +27070,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -26133,26 +27094,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete report schedules",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       },
       "get": {
@@ -26235,20 +27184,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -26270,26 +27205,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of report schedules",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       },
       "post": {
@@ -26298,36 +27221,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReportScheduleRestApi.post"
-              },
-              "example": {
-                "active": true,
-                "chart": 1,
-                "context_markdown": "string",
-                "creation_method": {},
-                "crontab": "*/5 * * * *",
-                "custom_width": 1000,
-                "dashboard": 1,
-                "database": 1,
-                "description": "Daily sales dashboard to marketing",
-                "email_subject": "[Report]  Report name: Dashboard or chart name",
-                "extra": {},
-                "force_screenshot": true,
-                "grace_period": 14400,
-                "log_retention": 90,
-                "name": "Daily dashboard email",
-                "owners": [1],
-                "recipients": [{}],
-                "report_format": "PDF",
-                "selected_tabs": [1],
-                "sql": "SELECT value FROM time_series_table",
-                "timezone": "Africa/Abidjan",
-                "type": "Alert",
-                "validator_config_json": {
-                  "op": "<",
-                  "threshold": 1.0
-                },
-                "validator_type": "not null",
-                "working_timeout": 3600
               }
             }
           },
@@ -26348,35 +27241,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "active": true,
-                    "chart": 1,
-                    "context_markdown": "string",
-                    "creation_method": {},
-                    "crontab": "*/5 * * * *",
-                    "custom_width": 1000,
-                    "dashboard": 1,
-                    "database": 1,
-                    "description": "Daily sales dashboard to marketing",
-                    "email_subject": "[Report]  Report name: Dashboard or chart name",
-                    "extra": {},
-                    "force_screenshot": true,
-                    "grace_period": 14400,
-                    "log_retention": 90,
-                    "name": "Daily dashboard email",
-                    "owners": [],
-                    "recipients": [],
-                    "report_format": "PDF",
-                    "selected_tabs": [],
-                    "sql": "SELECT value FROM time_series_table",
-                    "timezone": "Africa/Abidjan",
-                    "type": "Alert",
-                    "validator_type": "not null",
-                    "working_timeout": 3600
-                  }
                 }
               }
             },
@@ -26401,26 +27265,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a report schedule",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/report/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/report/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -26482,14 +27334,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -26511,26 +27355,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (report--info)",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -26563,10 +27395,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -26578,6 +27406,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -26588,26 +27419,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (report-related-column-name)",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -26649,14 +27468,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [
-                    {
-                      "id": "string",
-                      "name": "string"
-                    }
-                  ]
                 }
               }
             },
@@ -26681,26 +27492,74 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get slack channels",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/slack_channels/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
+        "tags": [
+          "Report Schedules"
+        ]
+      }
+    },
+    "/api/v1/report/subscribe": {
+      "post": {
+        "description": "Creates a report schedule locked to the authenticated user's email. ``creation_method`` is derived server-side from the payload (chart \u2192 charts, dashboard \u2192 dashboards). ``recipients`` are not accepted and are always set to the requesting user's email address.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportScheduleRestApi.post"
+              }
+            }
           },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/slack_channels/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
+          "description": "Report schedule subscription schema",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ReportScheduleRestApi.post"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Report schedule subscription created"
           },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/slack_channels/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
           }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Subscribe to a chart or dashboard report",
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -26728,9 +27587,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -26752,26 +27608,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a report schedule",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       },
       "get": {
@@ -26844,43 +27688,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "active": true,
-                    "context_markdown": "string",
-                    "creation_method": "string",
-                    "crontab": "string",
-                    "custom_width": 1,
-                    "description": "string",
-                    "email_subject": "string",
-                    "extra": {},
-                    "force_screenshot": true,
-                    "grace_period": 1,
-                    "id": 1,
-                    "last_eval_dttm": "2024-01-15T10:30:00Z",
-                    "last_state": "string",
-                    "last_value": 1.0,
-                    "last_value_row_json": "string",
-                    "log_retention": 1,
-                    "name": "string",
-                    "report_format": "string",
-                    "sql": "string",
-                    "timezone": "string",
-                    "type": "string",
-                    "validator_config_json": "string",
-                    "validator_type": "string",
-                    "working_timeout": 1
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -26905,26 +27712,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a report schedule",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       },
       "put": {
@@ -26944,35 +27739,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReportScheduleRestApi.put"
-              },
-              "example": {
-                "active": true,
-                "chart": 1,
-                "context_markdown": "string",
-                "creation_method": {},
-                "crontab": "string",
-                "custom_width": 1000,
-                "dashboard": 1,
-                "database": 1,
-                "description": "Daily sales dashboard to marketing",
-                "email_subject": "[Report]  Report name: Dashboard or chart name",
-                "extra": {},
-                "force_screenshot": true,
-                "grace_period": 14400,
-                "log_retention": 90,
-                "name": "string",
-                "owners": [1],
-                "recipients": [{}],
-                "report_format": "PDF",
-                "sql": "SELECT value FROM time_series_table",
-                "timezone": "Africa/Abidjan",
-                "type": "Alert",
-                "validator_config_json": {
-                  "op": "<",
-                  "threshold": 1.0
-                },
-                "validator_type": "not null",
-                "working_timeout": 3600
               }
             }
           },
@@ -26993,34 +27759,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "active": true,
-                    "chart": 1,
-                    "context_markdown": "string",
-                    "creation_method": {},
-                    "crontab": "string",
-                    "custom_width": 1000,
-                    "dashboard": 1,
-                    "database": 1,
-                    "description": "Daily sales dashboard to marketing",
-                    "email_subject": "[Report]  Report name: Dashboard or chart name",
-                    "extra": {},
-                    "force_screenshot": true,
-                    "grace_period": 14400,
-                    "log_retention": 90,
-                    "name": "string",
-                    "owners": [],
-                    "recipients": [],
-                    "report_format": "PDF",
-                    "sql": "SELECT value FROM time_series_table",
-                    "timezone": "Africa/Abidjan",
-                    "type": "Alert",
-                    "validator_type": "not null",
-                    "working_timeout": 3600
-                  }
                 }
               }
             },
@@ -27048,26 +27786,78 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a report schedule",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
+        "tags": [
+          "Report Schedules"
+        ]
+      }
+    },
+    "/api/v1/report/{pk}/execute": {
+      "post": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/report/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/report/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "description": "The report schedule pk",
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "execution_id": {
+                      "description": "UUID to track the execution status",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "Success message",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Report schedule execution started"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          },
+          "503": {
+            "description": "Celery backend not configured"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Execute a report schedule immediately",
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -27122,11 +27912,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "ids": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -27148,26 +27933,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of report schedule logs",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1/log/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1/log/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1/log/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -27219,20 +27992,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "end_dttm": "2024-01-15T10:30:00Z",
-                    "error_message": "string",
-                    "id": 1,
-                    "scheduled_dttm": "2024-01-15T10:30:00Z",
-                    "start_dttm": "2024-01-15T10:30:00Z",
-                    "state": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000",
-                    "value": 1.0,
-                    "value_row_json": "string"
-                  }
                 }
               }
             },
@@ -27257,26 +28016,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get a report schedule log (report-pk-log-log-id)",
-        "tags": ["Report Schedules"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/report/1/log/{log_id}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/report/1/log/{log_id}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/report/1/log/{log_id}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get a report schedule log",
+        "tags": [
+          "Report Schedules"
         ]
       }
     },
@@ -27306,9 +28053,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -27333,26 +28077,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete RLS rules",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       },
       "get": {
@@ -27435,20 +28167,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -27470,26 +28188,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of RLS",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       },
       "post": {
@@ -27498,15 +28204,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RLSRestApi.post"
-              },
-              "example": {
-                "clause": "string",
-                "description": "string",
-                "filter_type": "Regular",
-                "group_key": "string",
-                "name": "string",
-                "roles": [1],
-                "tables": [1]
               }
             }
           },
@@ -27527,18 +28224,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "clause": "string",
-                    "description": "string",
-                    "filter_type": "Regular",
-                    "group_key": "string",
-                    "name": "string",
-                    "roles": [],
-                    "tables": []
-                  }
                 }
               }
             },
@@ -27549,6 +28234,9 @@
           },
           "401": {
             "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
           },
           "404": {
             "$ref": "#/components/responses/404"
@@ -27563,26 +28251,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a new RLS rule",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/rowlevelsecurity/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       }
     },
@@ -27644,14 +28320,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -27673,26 +28341,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (rowlevelsecurity--info)",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Row Level Security"
         ]
       }
     },
@@ -27725,10 +28381,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -27740,6 +28392,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -27750,26 +28405,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (rowlevelsecurity-related-column-name)",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Row Level Security"
         ]
       }
     },
@@ -27796,9 +28439,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -27817,26 +28457,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete an RLS",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       },
       "get": {
@@ -27909,27 +28537,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "clause": "string",
-                    "description": "string",
-                    "filter_type": "Regular",
-                    "group_key": "string",
-                    "id": 1,
-                    "name": "string",
-                    "roles": [],
-                    "tables": []
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -27954,26 +28561,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get an RLS",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       },
       "put": {
@@ -27993,15 +28588,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RLSRestApi.put"
-              },
-              "example": {
-                "clause": "string",
-                "description": "string",
-                "filter_type": "Regular",
-                "group_key": "string",
-                "name": "string",
-                "roles": [1],
-                "tables": [1]
               }
             }
           },
@@ -28022,18 +28608,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "clause": "string",
-                    "description": "string",
-                    "filter_type": "Regular",
-                    "group_key": "string",
-                    "name": "string",
-                    "roles": [],
-                    "tables": []
-                  }
                 }
               }
             },
@@ -28061,26 +28635,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update an RLS rule",
-        "tags": ["Row Level Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/rowlevelsecurity/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/rowlevelsecurity/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Row Level Security"
         ]
       }
     },
@@ -28110,9 +28672,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -28134,26 +28693,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete saved queries",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Queries"
         ]
       },
       "get": {
@@ -28236,20 +28783,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -28271,26 +28804,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of saved queries",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       },
       "post": {
@@ -28299,16 +28820,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SavedQueryRestApi.post"
-              },
-              "example": {
-                "catalog": "string",
-                "db_id": {},
-                "description": "string",
-                "extra_json": "string",
-                "label": "string",
-                "schema": "string",
-                "sql": "string",
-                "template_parameters": "string"
               }
             }
           },
@@ -28329,19 +28840,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "catalog": "string",
-                    "db_id": {},
-                    "description": "string",
-                    "extra_json": "string",
-                    "label": "string",
-                    "schema": "string",
-                    "sql": "string",
-                    "template_parameters": "string"
-                  }
                 }
               }
             },
@@ -28363,26 +28861,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a saved query",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/saved_query/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/saved_query/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28444,14 +28930,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -28473,26 +28951,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (saved-query--info)",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28525,10 +28991,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DistincResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -28550,26 +29012,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get distinct values from field data (saved-query-distinct-column-name)",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get distinct values from field data",
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28616,26 +29066,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download multiple saved queries as YAML files",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28689,9 +29127,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -28713,26 +29148,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import saved queries with associated databases",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/saved_query/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/saved_query/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28765,10 +29188,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -28780,6 +29199,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -28790,26 +29212,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (saved-query-related-column-name)",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -28836,9 +29246,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -28857,26 +29264,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a saved query",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Queries"
         ]
       },
       "get": {
@@ -28949,29 +29344,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "catalog": "string",
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "changed_on_delta_humanized": {},
-                    "description": "string",
-                    "id": 1,
-                    "label": "string",
-                    "schema": "string",
-                    "sql": "string",
-                    "sql_tables": {},
-                    "template_parameters": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -28996,26 +29368,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a saved query",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       },
       "put": {
@@ -29034,16 +29394,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SavedQueryRestApi.put"
-              },
-              "example": {
-                "catalog": "string",
-                "db_id": {},
-                "description": "string",
-                "extra_json": "string",
-                "label": "string",
-                "schema": "string",
-                "sql": "string",
-                "template_parameters": "string"
               }
             }
           },
@@ -29061,18 +29411,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "catalog": "string",
-                    "db_id": {},
-                    "description": "string",
-                    "extra_json": "string",
-                    "label": "string",
-                    "schema": "string",
-                    "sql": "string",
-                    "template_parameters": "string"
-                  }
                 }
               }
             },
@@ -29097,26 +29435,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a saved query",
-        "tags": ["Queries"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/saved_query/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/saved_query/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/saved_query/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Queries"
         ]
       }
     },
@@ -29133,9 +29459,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -29151,26 +29474,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the CSRF token",
-        "tags": ["Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/csrf_token/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/csrf_token/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/csrf_token/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security"
         ]
       }
     },
@@ -29249,26 +29560,12 @@
                     "result": {
                       "description": "The result from the get list query",
                       "items": {
-                        "$ref": "#/components/schemas/GroupApi.get_list"
+                        "$ref": "#/components/schemas/SupersetGroupApi.get_list"
                       },
                       "type": "array"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -29290,110 +29587,37 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "get_security_groups",
-        "summary": "Get security groups",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       },
       "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupPostSchema"
-              },
-              "example": {
-                "description": "string",
-                "label": "string",
-                "name": "string",
-                "roles": [1],
-                "users": [1]
-              }
-            }
-          },
-          "description": "Model schema",
-          "required": true
-        },
         "responses": {
           "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "$ref": "#/components/schemas/GroupPostSchema"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "description": "string",
-                    "label": "string",
-                    "name": "string",
-                    "roles": [],
-                    "users": []
-                  }
-                }
-              }
-            },
             "description": "Group created"
           },
           "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
+            "description": "Bad request"
           },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Server error"
           }
         },
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "create_security_groups",
-        "summary": "Create security groups",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/groups/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/groups/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       }
     },
@@ -29455,14 +29679,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -29484,27 +29700,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "get_security_groups__info",
-        "summary": "Get security groups  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       }
     },
@@ -29531,9 +29733,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -29552,27 +29751,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "delete_security_groups_by_pk",
-        "summary": "Delete security groups by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       },
       "get": {
@@ -29629,7 +29814,7 @@
                       "type": "object"
                     },
                     "result": {
-                      "$ref": "#/components/schemas/GroupApi.get"
+                      "$ref": "#/components/schemas/SupersetGroupApi.get"
                     },
                     "show_columns": {
                       "description": "A list of columns",
@@ -29645,23 +29830,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "description": "string",
-                    "id": 1,
-                    "label": "string",
-                    "name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -29686,27 +29854,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "get_security_groups_by_pk",
-        "summary": "Get security groups by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       },
       "put": {
@@ -29720,89 +29874,30 @@
             }
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GroupPutSchema"
-              },
-              "example": {
-                "description": "string",
-                "label": "string",
-                "name": "string",
-                "roles": [1],
-                "users": [1]
-              }
-            }
-          },
-          "description": "Model schema",
-          "required": true
-        },
         "responses": {
           "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "$ref": "#/components/schemas/GroupPutSchema"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "description": "string",
-                    "label": "string",
-                    "name": "string",
-                    "roles": [],
-                    "users": []
-                  }
-                }
-              }
-            },
             "description": "Group updated"
           },
           "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
+            "description": "Bad request"
           },
           "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
+            "description": "Not found"
           },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Server error"
           }
         },
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Groups"],
-        "operationId": "update_security_groups_by_pk",
-        "summary": "Update security groups by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/groups/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/groups/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/groups/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Groups"
         ]
       }
     },
@@ -29813,15 +29908,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/GuestTokenCreate"
-              },
-              "example": {
-                "resources": [{}],
-                "rls": [{}],
-                "user": {
-                  "first_name": "string",
-                  "last_name": "string",
-                  "username": "string"
-                }
               }
             }
           },
@@ -29839,9 +29925,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "token": "string"
                 }
               }
             },
@@ -29860,26 +29943,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a guest token",
-        "tags": ["Security"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/guest_token/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/guest_token/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/guest_token/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security"
         ]
       }
     },
@@ -29898,7 +29969,10 @@
                   },
                   "provider": {
                     "description": "Choose an authentication provider",
-                    "enum": ["db", "ldap"],
+                    "enum": [
+                      "db",
+                      "ldap"
+                    ],
                     "example": "db",
                     "type": "string"
                   },
@@ -29914,12 +29988,6 @@
                   }
                 },
                 "type": "object"
-              },
-              "example": {
-                "password": "complex-password",
-                "provider": "db",
-                "refresh": true,
-                "username": "admin"
               }
             }
           },
@@ -29939,10 +30007,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "access_token": "string",
-                  "refresh_token": "string"
                 }
               }
             },
@@ -29958,25 +30022,8 @@
             "$ref": "#/components/responses/500"
           }
         },
-        "tags": ["Security"],
-        "operationId": "create_security_login",
-        "summary": "Create security login",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/login\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/login\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/login\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security"
         ]
       }
     },
@@ -30055,26 +30102,12 @@
                     "result": {
                       "description": "The result from the get list query",
                       "items": {
-                        "$ref": "#/components/schemas/PermissionViewMenuApi.get_list"
+                        "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get_list"
                       },
                       "type": "array"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -30096,27 +30129,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "get_security_permissions_resources",
-        "summary": "Get security permissions resources",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       },
       "post": {
@@ -30124,11 +30143,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PermissionViewMenuApi.post"
-              },
-              "example": {
-                "permission_id": {},
-                "view_menu_id": {}
+                "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.post"
               }
             }
           },
@@ -30145,17 +30160,10 @@
                       "type": "string"
                     },
                     "result": {
-                      "$ref": "#/components/schemas/PermissionViewMenuApi.post"
+                      "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.post"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "permission_id": {},
-                    "view_menu_id": {}
-                  }
                 }
               }
             },
@@ -30177,27 +30185,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "create_security_permissions_resources",
-        "summary": "Create security permissions resources",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/permissions-resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/permissions-resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       }
     },
@@ -30259,14 +30253,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -30288,27 +30274,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "get_security_permissions_resources__info",
-        "summary": "Get security permissions resources  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       }
     },
@@ -30335,9 +30307,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -30356,27 +30325,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "delete_security_permissions_resources_by_pk",
-        "summary": "Delete security permissions resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       },
       "get": {
@@ -30433,7 +30388,7 @@
                       "type": "object"
                     },
                     "result": {
-                      "$ref": "#/components/schemas/PermissionViewMenuApi.get"
+                      "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.get"
                     },
                     "show_columns": {
                       "description": "A list of columns",
@@ -30449,20 +30404,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "id": 1
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -30487,27 +30428,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "get_security_permissions_resources_by_pk",
-        "summary": "Get security permissions resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       },
       "put": {
@@ -30525,11 +30452,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PermissionViewMenuApi.put"
-              },
-              "example": {
-                "permission_id": {},
-                "view_menu_id": {}
+                "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.put"
               }
             }
           },
@@ -30543,16 +30466,10 @@
                 "schema": {
                   "properties": {
                     "result": {
-                      "$ref": "#/components/schemas/PermissionViewMenuApi.put"
+                      "$ref": "#/components/schemas/SupersetPermissionViewMenuApi.put"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "permission_id": {},
-                    "view_menu_id": {}
-                  }
                 }
               }
             },
@@ -30577,27 +30494,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions on Resources (View Menus)"],
-        "operationId": "update_security_permissions_resources_by_pk",
-        "summary": "Update security permissions resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/permissions-resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions-resources/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions on Resources (View Menus)"
         ]
       }
     },
@@ -30682,20 +30585,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -30717,27 +30606,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions"],
-        "operationId": "get_security_permissions",
-        "summary": "Get security permissions",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions"
         ]
       }
     },
@@ -30799,14 +30674,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -30828,27 +30695,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions"],
-        "operationId": "get_security_permissions__info",
-        "summary": "Get security permissions  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions"
         ]
       }
     },
@@ -30923,21 +30776,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "id": 1,
-                    "name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -30962,27 +30800,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Permissions"],
-        "operationId": "get_security_permissions_by_pk",
-        "summary": "Get security permissions by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/permissions/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/permissions/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/permissions/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Permissions"
         ]
       }
     },
@@ -31001,9 +30825,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "access_token": "string"
                 }
               }
             },
@@ -31021,25 +30842,8 @@
             "jwt_refresh": []
           }
         ],
-        "tags": ["Security"],
-        "operationId": "create_security_refresh",
-        "summary": "Create security refresh",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/refresh\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/refresh\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/refresh\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security"
         ]
       }
     },
@@ -31124,20 +30928,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -31159,27 +30949,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "get_security_resources",
-        "summary": "Get security resources",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       },
       "post": {
@@ -31188,9 +30964,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ViewMenuApi.post"
-              },
-              "example": {
-                "name": "string"
               }
             }
           },
@@ -31211,12 +30984,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -31238,27 +31005,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "create_security_resources",
-        "summary": "Create security resources",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/resources/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/resources/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       }
     },
@@ -31320,14 +31073,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -31349,27 +31094,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "get_security_resources__info",
-        "summary": "Get security resources  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       }
     },
@@ -31396,9 +31127,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -31417,27 +31145,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "delete_security_resources_by_pk",
-        "summary": "Delete security resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       },
       "get": {
@@ -31510,21 +31224,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "id": 1,
-                    "name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -31549,27 +31248,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "get_security_resources_by_pk",
-        "summary": "Get security resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       },
       "put": {
@@ -31588,9 +31273,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ViewMenuApi.put"
-              },
-              "example": {
-                "name": "string"
               }
             }
           },
@@ -31608,11 +31290,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -31637,27 +31314,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Resources (View Menus)"],
-        "operationId": "update_security_resources_by_pk",
-        "summary": "Update security resources by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/resources/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/resources/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/resources/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Resources (View Menus)"
         ]
       }
     },
@@ -31742,20 +31405,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -31777,27 +31426,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "get_security_roles",
-        "summary": "Get security roles",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       },
       "post": {
@@ -31806,9 +31441,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetRoleApi.post"
-              },
-              "example": {
-                "name": "string"
               }
             }
           },
@@ -31829,12 +31461,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -31856,27 +31482,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "create_security_roles",
-        "summary": "Create security roles",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/roles/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/roles/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -31938,14 +31550,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -31967,27 +31571,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "get_security_roles__info",
-        "summary": "Get security roles  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32004,7 +31594,11 @@
                   "items": {
                     "properties": {
                       "col": {
-                        "enum": ["user_ids", "permission_ids", "name"],
+                        "enum": [
+                          "user_ids",
+                          "permission_ids",
+                          "name"
+                        ],
                         "type": "string"
                       },
                       "value": {
@@ -32017,12 +31611,18 @@
                 },
                 "order_column": {
                   "default": "id",
-                  "enum": ["id", "name"],
+                  "enum": [
+                    "id",
+                    "name"
+                  ],
                   "type": "string"
                 },
                 "order_direction": {
                   "default": "asc",
-                  "enum": ["asc", "desc"],
+                  "enum": [
+                    "asc",
+                    "desc"
+                  ],
                   "type": "string"
                 },
                 "page": {
@@ -32044,11 +31644,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RolesResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "ids": [1],
-                  "result": []
                 }
               }
             },
@@ -32064,9 +31659,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "error": "string"
                 }
               }
             },
@@ -32082,9 +31674,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "error": "string"
                 }
               }
             },
@@ -32094,26 +31683,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "List roles",
-        "tags": ["Security Roles"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/search/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/search/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/search/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32140,9 +31717,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -32161,27 +31735,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "delete_security_roles_by_pk",
-        "summary": "Delete security roles by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       },
       "get": {
@@ -32254,21 +31814,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "id": 1,
-                    "name": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -32293,27 +31838,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "get_security_roles_by_pk",
-        "summary": "Get security roles by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       },
       "put": {
@@ -32332,9 +31863,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SupersetRoleApi.put"
-              },
-              "example": {
-                "name": "string"
               }
             }
           },
@@ -32352,11 +31880,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "name": "string"
-                  }
                 }
               }
             },
@@ -32381,27 +31904,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "update_security_roles_by_pk",
-        "summary": "Update security roles by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32422,9 +31931,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RoleGroupPutSchema"
-              },
-              "example": {
-                "group_ids": [1]
               }
             }
           },
@@ -32442,11 +31948,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "group_ids": []
-                  }
                 }
               }
             },
@@ -32471,27 +31972,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "update_security_roles_by_role_id_groups",
-        "summary": "Update security roles by role_id groups",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/groups\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32512,9 +31999,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RolePermissionPostSchema"
-              },
-              "example": {
-                "permission_view_menu_ids": [1]
               }
             }
           },
@@ -32532,11 +32016,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "permission_view_menu_ids": []
-                  }
                 }
               }
             },
@@ -32561,27 +32040,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "create_security_roles_by_role_id_permissions",
-        "summary": "Create security roles by role_id permissions",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32611,9 +32076,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -32638,27 +32100,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "get_security_roles_by_role_id_permissions",
-        "summary": "Get security roles by role_id permissions",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/permissions/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Roles"
         ]
       }
     },
@@ -32679,9 +32127,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RoleUserPutSchema"
-              },
-              "example": {
-                "user_ids": [1]
               }
             }
           },
@@ -32699,11 +32144,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "user_ids": []
-                  }
                 }
               }
             },
@@ -32728,27 +32168,322 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Roles"],
-        "operationId": "update_security_roles_by_role_id_users",
-        "summary": "Update security roles by role_id users",
-        "x-codeSamples": [
+        "tags": [
+          "Security Roles"
+        ]
+      }
+    },
+    "/api/v1/security/subject/": {
+      "get": {
+        "description": "Gets a list of Subjects, use Rison or JSON query parameters for filtering, sorting, pagination and for selecting specific columns and metadata.",
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/roles/{role_id}/users\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/roles/{role_id}/users\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/roles/{role_id}/users\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "description": "The total record count on the backend",
+                      "type": "number"
+                    },
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "ids": {
+                      "description": "A list of item ids, useful when you don't know the column id",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "list_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "list_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "List Items",
+                      "type": "string"
+                    },
+                    "order_columns": {
+                      "description": "A list of allowed columns to sort",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "result": {
+                      "description": "The result from the get list query",
+                      "items": {
+                        "$ref": "#/components/schemas/SubjectRestApi.get_list"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Items from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get a list of Subjects",
+        "tags": [
+          "Security Subjects"
+        ]
+      }
+    },
+    "/api/v1/security/subject/_info": {
+      "get": {
+        "description": "Get metadata information about this API resource",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_info_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "add_columns": {
+                      "type": "object"
+                    },
+                    "edit_columns": {
+                      "type": "object"
+                    },
+                    "filters": {
+                      "properties": {
+                        "column_name": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "description": "The filter name. Will be translated by babel",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "The filter operation key to use on list filters",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "permissions": {
+                      "description": "The user permissions for this API resource",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Security Subjects"
+        ]
+      }
+    },
+    "/api/v1/security/subject/{pk}": {
+      "get": {
+        "description": "Get an item model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_item_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "description_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The description for the column name. Will be translated by babel",
+                          "example": "A Nice description for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "id": {
+                      "description": "The item id",
+                      "type": "string"
+                    },
+                    "label_columns": {
+                      "properties": {
+                        "column_name": {
+                          "description": "The label for the column name. Will be translated by babel",
+                          "example": "A Nice label for the column",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/SubjectRestApi.get"
+                    },
+                    "show_columns": {
+                      "description": "A list of columns",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "show_title": {
+                      "description": "A title to render. Will be translated by babel",
+                      "example": "Show Item Details",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Item from Model"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get a Subject",
+        "tags": [
+          "Security Subjects"
         ]
       }
     },
@@ -32833,20 +32568,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -32868,106 +32589,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "get_security_user_registrations",
-        "summary": "Get security user registrations",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      },
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserRegistrationsRestAPI.post"
-              },
-              "example": {
-                "id": 1
-              }
-            }
-          },
-          "description": "Model schema",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UserRegistrationsRestAPI.post"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "id": "string",
-                  "result": {
-                    "id": 1
-                  }
-                }
-              }
-            },
-            "description": "Item inserted"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "create_security_user_registrations",
-        "summary": "Create security user registrations",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/user_registrations/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/user_registrations/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "UserRegistrationsRestAPI"
         ]
       }
     },
@@ -33029,14 +32657,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -33058,181 +32678,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "get_security_user_registrations__info",
-        "summary": "Get security user registrations  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      }
-    },
-    "/api/v1/security/user_registrations/distinct/{column_name}": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_related_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DistincResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
-                }
-              }
-            },
-            "description": "Distinct field data"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "summary": "Get distinct values from field data (security-user-registrations-distinct-column-name)",
-        "tags": ["UserRegistrationsRestAPI"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/distinct/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      }
-    },
-    "/api/v1/security/user_registrations/related/{column_name}": {
-      "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "column_name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/get_related_schema"
-                }
-              }
-            },
-            "in": "query",
-            "name": "q"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
-                }
-              }
-            },
-            "description": "Related column data"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "summary": "Get related fields data (security-user-registrations-related-column-name)",
-        "tags": ["UserRegistrationsRestAPI"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "UserRegistrationsRestAPI"
         ]
       }
     },
@@ -33259,9 +32711,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -33280,27 +32729,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "delete_security_user_registrations_by_pk",
-        "summary": "Delete security user registrations by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "UserRegistrationsRestAPI"
         ]
       },
       "get": {
@@ -33373,20 +32808,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "id": 1
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -33411,115 +32832,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "get_security_user_registrations_by_pk",
-        "summary": "Get security user registrations by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      },
-      "put": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "pk",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserRegistrationsRestAPI.put"
-              },
-              "example": {
-                "id": 1
-              }
-            }
-          },
-          "description": "Model schema",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "$ref": "#/components/schemas/UserRegistrationsRestAPI.put"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "id": 1
-                  }
-                }
-              }
-            },
-            "description": "Item changed"
-          },
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "tags": ["UserRegistrationsRestAPI"],
-        "operationId": "update_security_user_registrations_by_pk",
-        "summary": "Update security user registrations by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/user_registrations/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/user_registrations/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/user_registrations/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "UserRegistrationsRestAPI"
         ]
       }
     },
@@ -33604,20 +32923,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -33639,119 +32944,37 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "get_security_users",
-        "summary": "Get security users",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Users"
         ]
       },
       "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SupersetUserApi.post"
-              },
-              "example": {
-                "active": true,
-                "email": "string",
-                "first_name": "string",
-                "groups": [1],
-                "last_name": "string",
-                "password": "string",
-                "roles": [1],
-                "username": "string"
-              }
-            }
-          },
-          "description": "Model schema",
-          "required": true
-        },
         "responses": {
           "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "$ref": "#/components/schemas/SupersetUserApi.post"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "active": true,
-                    "email": "string",
-                    "first_name": "string",
-                    "groups": [],
-                    "last_name": "string",
-                    "password": "string",
-                    "roles": [],
-                    "username": "string"
-                  }
-                }
-              }
-            },
-            "description": "Item changed"
+            "description": "User created"
           },
           "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "422": {
-            "$ref": "#/components/responses/422"
+            "description": "Bad request"
           },
           "500": {
-            "$ref": "#/components/responses/500"
+            "description": "Server error"
           }
         },
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "create_security_users",
-        "summary": "Create security users",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/security/users/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/security/users/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Users"
         ]
       }
     },
@@ -33813,14 +33036,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -33842,27 +33057,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "get_security_users__info",
-        "summary": "Get security users  info",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Security Users"
         ]
       }
     },
@@ -33889,9 +33090,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -33910,27 +33108,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "delete_security_users_by_pk",
-        "summary": "Delete security users by pk",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Security Users"
         ]
       },
       "get": {
@@ -34003,30 +33187,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "active": true,
-                    "changed_on": "2024-01-15T10:30:00Z",
-                    "created_on": "2024-01-15T10:30:00Z",
-                    "email": "string",
-                    "fail_login_count": 1,
-                    "first_name": "string",
-                    "id": 1,
-                    "last_login": "2024-01-15T10:30:00Z",
-                    "last_name": "string",
-                    "login_count": 1,
-                    "username": "string"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -34051,27 +33211,695 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "get_security_users_by_pk",
-        "summary": "Get security users by pk",
-        "x-codeSamples": [
+        "tags": [
+          "Security Users"
+        ]
+      },
+      "put": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "description": "User updated"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Security Users"
+        ]
+      }
+    },
+    "/api/v1/security/users/{pk}/sessions": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sessions terminated"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Security Users"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "A list of semantic layers"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "List all semantic layers",
+        "tags": [
+          "Semantic Layers"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cache_timeout": {
+                    "type": "integer"
+                  },
+                  "configuration": {
+                    "type": "object"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Semantic layer created"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Create a semantic layer",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/connections/": {
+      "get": {
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_list_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Combined list of databases and semantic layers"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "List databases and semantic layers combined",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/schema/configuration": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "configuration": {
+                    "type": "object"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Configuration JSON Schema"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get configuration schema for a semantic layer type",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/types": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "A list of semantic layer types"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "List available semantic layer types",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/{uuid}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Semantic layer deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Delete a semantic layer",
+        "tags": [
+          "Semantic Layers"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A semantic layer"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get a semantic layer by UUID",
+        "tags": [
+          "Semantic Layers"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "cache_timeout": {
+                    "type": "integer"
+                  },
+                  "configuration": {
+                    "type": "object"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Semantic layer updated"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Update a semantic layer",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/{uuid}/schema/runtime": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "runtime_data": {
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Runtime JSON Schema"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get runtime schema for a semantic layer",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_layer/{uuid}/views": {
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "runtime_data": {
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Available views"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "List available views from a semantic layer",
+        "tags": [
+          "Semantic Layers"
+        ]
+      }
+    },
+    "/api/v1/semantic_view/": {
+      "delete": {
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_delete_ids_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Semantic views deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Bulk delete semantic views",
+        "tags": [
+          "SemanticViewRestApi"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "views": {
+                    "items": {
+                      "properties": {
+                        "cache_timeout": {
+                          "type": "integer"
+                        },
+                        "configuration": {
+                          "type": "object"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "semantic_layer_uuid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Semantic views created"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Create semantic views",
+        "tags": [
+          "SemanticViewRestApi"
+        ]
+      }
+    },
+    "/api/v1/semantic_view/{pk}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Semantic view deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Delete a semantic view",
+        "tags": [
+          "SemanticViewRestApi"
         ]
       },
       "put": {
@@ -34089,21 +33917,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SupersetUserApi.put"
-              },
-              "example": {
-                "active": true,
-                "email": "string",
-                "first_name": "string",
-                "groups": [1],
-                "last_name": "string",
-                "password": "string",
-                "roles": [1],
-                "username": "string"
+                "$ref": "#/components/schemas/SemanticViewRestApi.put"
               }
             }
           },
-          "description": "Model schema",
+          "description": "Semantic view schema",
           "required": true
         },
         "responses": {
@@ -34112,33 +33930,27 @@
               "application/json": {
                 "schema": {
                   "properties": {
+                    "id": {
+                      "type": "number"
+                    },
                     "result": {
-                      "$ref": "#/components/schemas/SupersetUserApi.put"
+                      "$ref": "#/components/schemas/SemanticViewRestApi.put"
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {
-                    "active": true,
-                    "email": "string",
-                    "first_name": "string",
-                    "groups": [],
-                    "last_name": "string",
-                    "password": "string",
-                    "roles": [],
-                    "username": "string"
-                  }
                 }
               }
             },
-            "description": "Item changed"
+            "description": "Semantic view changed"
           },
           "400": {
             "$ref": "#/components/responses/400"
           },
           "401": {
             "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
           },
           "404": {
             "$ref": "#/components/responses/404"
@@ -34153,27 +33965,57 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Security Users"],
-        "operationId": "update_security_users_by_pk",
-        "summary": "Update security users by pk",
-        "x-codeSamples": [
+        "summary": "Update a semantic view",
+        "tags": [
+          "SemanticViewRestApi"
+        ]
+      }
+    },
+    "/api/v1/semantic_view/{pk}/structure": {
+      "get": {
+        "parameters": [
           {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/security/users/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/security/users/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/security/users/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
+            "in": "path",
+            "name": "pk",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
           }
+        ],
+        "responses": {
+          "200": {
+            "description": "Semantic view structure"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "422": {
+            "$ref": "#/components/responses/422"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get semantic view structure",
+        "tags": [
+          "SemanticViewRestApi"
         ]
       }
     },
@@ -34186,16 +34028,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SQLLabBootstrapSchema"
-                },
-                "example": {
-                  "active_tab": {},
-                  "databases": {
-                    "key": "value"
-                  },
-                  "queries": {
-                    "key": "value"
-                  },
-                  "tab_state_ids": ["string"]
                 }
               }
             },
@@ -34217,26 +34049,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the bootstrap data for SqlLab page",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34247,13 +34067,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/EstimateQueryCostSchema"
-              },
-              "example": {
-                "catalog": "string",
-                "database_id": 1,
-                "schema": "string",
-                "sql": "string",
-                "template_params": {}
               }
             }
           },
@@ -34271,9 +34084,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -34295,26 +34105,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Estimate the SQL query execution cost",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/estimate/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/estimate/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/estimate/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34325,22 +34123,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExecutePayloadSchema"
-              },
-              "example": {
-                "catalog": "string",
-                "client_id": "string",
-                "ctas_method": "string",
-                "database_id": 1,
-                "expand_data": true,
-                "queryLimit": 1,
-                "runAsync": true,
-                "schema": "string",
-                "select_as_cta": true,
-                "sql": "string",
-                "sql_editor_id": "string",
-                "tab": "string",
-                "templateParams": "string",
-                "tmp_table_name": "string"
               }
             }
           },
@@ -34353,15 +34135,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
-                },
-                "example": {
-                  "columns": [{}],
-                  "data": [{}],
-                  "expanded_columns": [{}],
-                  "query": {},
-                  "query_id": 1,
-                  "selected_columns": [{}],
-                  "status": "string"
                 }
               }
             },
@@ -34372,15 +34145,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
-                },
-                "example": {
-                  "columns": [{}],
-                  "data": [{}],
-                  "expanded_columns": [{}],
-                  "query": {},
-                  "query_id": 1,
-                  "selected_columns": [{}],
-                  "status": "string"
                 }
               }
             },
@@ -34405,26 +34169,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Execute a SQL query",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/execute/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/execute/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/execute/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34471,26 +34223,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Export the SQL query results to a CSV",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/export/{client_id}/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34551,26 +34291,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Export SQL query results to CSV with streaming",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/export_streaming/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/export_streaming/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/export_streaming/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34581,12 +34309,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/FormatQueryPayloadSchema"
-              },
-              "example": {
-                "database_id": 1,
-                "engine": "string",
-                "sql": "string",
-                "template_params": "string"
               }
             }
           },
@@ -34604,9 +34326,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -34628,26 +34347,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Format SQL code",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/format_sql/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/format_sql/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/format_sql/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34658,10 +34365,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ExplorePermalinkStateSchema"
-              },
-              "example": {
-                "formData": {},
-                "urlParams": [{}]
               }
             }
           },
@@ -34683,10 +34386,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "key": "string",
-                  "url": "string"
                 }
               }
             },
@@ -34708,26 +34407,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Create a new permanent link (sqllab-permalink)",
-        "tags": ["SQL Lab Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/sqllab/permalink\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/sqllab/permalink\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/permalink\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Create a new permanent link",
+        "tags": [
+          "SQL Lab Permanent Link"
         ]
       }
     },
@@ -34755,9 +34442,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "state": {}
                 }
               }
             },
@@ -34782,26 +34466,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get permanent link state for SQLLab editor.",
-        "tags": ["SQL Lab Permanent Link"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/permalink/{key}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/permalink/{key}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/permalink/{key}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab Permanent Link"
         ]
       }
     },
@@ -34826,15 +34498,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryExecutionResponseSchema"
-                },
-                "example": {
-                  "columns": [{}],
-                  "data": [{}],
-                  "expanded_columns": [{}],
-                  "query": {},
-                  "query_id": 1,
-                  "selected_columns": [{}],
-                  "status": "string"
                 }
               }
             },
@@ -34862,26 +34525,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get the result of a SQL query execution",
-        "tags": ["SQL Lab"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/sqllab/results/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/sqllab/results/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/sqllab/results/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "SQL Lab"
         ]
       }
     },
@@ -34912,9 +34563,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -34939,26 +34587,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete tags",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Tags"
         ]
       },
       "get": {
@@ -35041,20 +34677,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -35076,26 +34698,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of tags",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       },
       "post": {
@@ -35105,11 +34715,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagRestApi.post"
-              },
-              "example": {
-                "description": "string",
-                "name": "string",
-                "objects_to_tag": []
               }
             }
           },
@@ -35130,14 +34735,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "description": "string",
-                    "name": "string",
-                    "objects_to_tag": []
-                  }
                 }
               }
             },
@@ -35159,26 +34756,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a tag",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35240,14 +34825,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -35269,26 +34846,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get metadata information about tag API endpoints",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35299,9 +34864,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagPostBulkSchema"
-              },
-              "example": {
-                "tags": [{}]
               }
             }
           },
@@ -35314,9 +34876,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TagPostBulkResponseSchema"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -35341,26 +34900,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk create tags and tagged objects",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/bulk_create\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/bulk_create\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/bulk_create\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35386,9 +34933,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetFavStarIdsSchema"
-                },
-                "example": {
-                  "result": []
                 }
               }
             },
@@ -35410,39 +34954,48 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Tags"],
-        "operationId": "get_tag_favorite_status",
-        "summary": "Get tag favorite status",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/favorite_status/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/favorite_status/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/favorite_status/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
     "/api/v1/tag/get_objects/": {
       "get": {
+        "description": "Get all objects associated with a tag. If tagIds is set, tags will be ignored.",
         "parameters": [
           {
-            "in": "path",
-            "name": "tag_id",
-            "required": true,
+            "in": "query",
+            "name": "tagIds",
             "schema": {
-              "type": "integer"
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tags",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "types",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           }
         ],
@@ -35460,9 +35013,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": [{}]
                 }
               }
             },
@@ -35487,26 +35037,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get all objects associated with a tag",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/get_objects/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/get_objects/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/get_objects/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35539,10 +35077,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -35554,6 +35088,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -35564,26 +35101,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (tag-related-column-name)",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35622,9 +35147,6 @@
                   }
                 },
                 "type": "object"
-              },
-              "example": {
-                "tags": ["string"]
               }
             }
           },
@@ -35654,26 +35176,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Add tags to an object",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -35716,9 +35226,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -35743,31 +35250,20 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a tagged object",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/{object_type}/{object_id}/{tag}/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
     "/api/v1/tag/{pk}": {
       "delete": {
+        "description": "Delete a Tag by id. This will remove all tagged objects with this tag.",
         "parameters": [
           {
             "in": "path",
@@ -35789,13 +35285,16 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
-            "description": "Item deleted"
+            "description": "Tag deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
           },
           "404": {
             "$ref": "#/components/responses/404"
@@ -35810,26 +35309,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a tag",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Tags"
         ]
       },
       "get": {
@@ -35902,25 +35389,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "changed_on_delta_humanized": {},
-                    "created_on_delta_humanized": {},
-                    "description": "string",
-                    "id": 1,
-                    "name": "string",
-                    "type": {}
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -35945,26 +35413,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a tag detail information",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       },
       "put": {
@@ -35984,11 +35440,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TagRestApi.put"
-              },
-              "example": {
-                "description": "string",
-                "name": "string",
-                "objects_to_tag": []
               }
             }
           },
@@ -36009,14 +35460,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "description": "string",
-                    "name": "string",
-                    "objects_to_tag": []
-                  }
                 }
               }
             },
@@ -36044,26 +35487,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a tag",
-        "tags": ["Tags"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/tag/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/tag/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -36091,9 +35522,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -36115,27 +35543,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Tags"],
-        "operationId": "delete_tag_by_pk_favorites",
-        "summary": "Delete tag by pk favorites",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/tag/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/tag/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1/favorites/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Tags"
         ]
       },
       "post": {
@@ -36161,9 +35575,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": {}
                 }
               }
             },
@@ -36185,27 +35596,13 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["Tags"],
-        "operationId": "create_tag_by_pk_favorites",
-        "summary": "Create tag by pk favorites",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/tag/1/favorites/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/tag/1/favorites/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/tag/1/favorites/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Tags"
         ]
       }
     },
@@ -36235,9 +35632,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -36259,26 +35653,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Bulk delete themes",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Themes"
         ]
       },
       "get": {
@@ -36361,20 +35743,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "count": 1.0,
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "ids": ["string"],
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "list_columns": ["string"],
-                  "list_title": "List Items",
-                  "order_columns": ["string"],
-                  "result": [{}]
                 }
               }
             },
@@ -36396,26 +35764,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a list of themes",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       },
       "post": {
@@ -36424,10 +35780,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ThemeRestApi.post"
-              },
-              "example": {
-                "json_data": "string",
-                "theme_name": "string"
               }
             }
           },
@@ -36448,13 +35800,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "json_data": "string",
-                    "theme_name": "string"
-                  }
                 }
               }
             },
@@ -36476,26 +35821,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Create a theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/theme/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/theme/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36557,14 +35890,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "add_columns": {},
-                  "edit_columns": {},
-                  "filters": {
-                    "column_name": [{}]
-                  },
-                  "permissions": ["string"]
                 }
               }
             },
@@ -36586,26 +35911,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get metadata information about this API resource (theme--info)",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/_info\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/_info\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/_info\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get metadata information about this API resource",
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36655,26 +35968,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Download multiple themes as YAML files",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/export/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/export/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/export/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36710,9 +36011,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -36734,26 +36032,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Import themes from a ZIP file",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X POST \"http://localhost:8088/api/v1/theme/import/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.post(\n    \"http://localhost:8088/api/v1/theme/import/\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/import/\",\n  {\n    method: \"POST\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36786,10 +36072,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RelatedResponseSchema"
-                },
-                "example": {
-                  "count": 1,
-                  "result": []
                 }
               }
             },
@@ -36801,6 +36083,9 @@
           "401": {
             "$ref": "#/components/responses/401"
           },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
           "404": {
             "$ref": "#/components/responses/404"
           },
@@ -36811,26 +36096,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "summary": "Get related fields data (theme-related-column-name)",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/related/{column_name}\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/related/{column_name}\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/related/{column_name}\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get related fields data",
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36847,9 +36120,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -36868,26 +36138,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Clear the system dark theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/unset_system_dark\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/unset_system_dark\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/unset_system_dark\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36904,9 +36162,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "result": "string"
                 }
               }
             },
@@ -36925,26 +36180,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Clear the system default theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/unset_system_default\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/unset_system_default\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/unset_system_default\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -36971,9 +36214,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "message": "string"
                 }
               }
             },
@@ -36998,26 +36238,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Delete a theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X DELETE \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.delete(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.status_code)"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    method: \"DELETE\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconsole.log(response.status);"
-          }
+        "tags": [
+          "Themes"
         ]
       },
       "get": {
@@ -37090,27 +36318,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "description_columns": {
-                    "column_name": "A Nice description for the column"
-                  },
-                  "id": "string",
-                  "label_columns": {
-                    "column_name": "A Nice label for the column"
-                  },
-                  "result": {
-                    "changed_on_delta_humanized": {},
-                    "id": 1,
-                    "is_system": true,
-                    "is_system_dark": true,
-                    "is_system_default": true,
-                    "json_data": "string",
-                    "theme_name": "string",
-                    "uuid": "550e8400-e29b-41d4-a716-446655440000"
-                  },
-                  "show_columns": ["string"],
-                  "show_title": "Show Item Details"
                 }
               }
             },
@@ -37135,26 +36342,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Get a theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       },
       "put": {
@@ -37173,10 +36368,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ThemeRestApi.put"
-              },
-              "example": {
-                "json_data": "string",
-                "theme_name": "string"
               }
             }
           },
@@ -37197,13 +36388,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1.0,
-                  "result": {
-                    "json_data": "string",
-                    "theme_name": "string"
-                  }
                 }
               }
             },
@@ -37231,26 +36415,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Update a theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"key\": \"value\"}'"
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -37281,10 +36453,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1,
-                  "result": "string"
                 }
               }
             },
@@ -37312,26 +36480,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Set a theme as the system dark theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1/set_system_dark\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1/set_system_dark\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1/set_system_dark\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -37362,10 +36518,6 @@
                     }
                   },
                   "type": "object"
-                },
-                "example": {
-                  "id": 1,
-                  "result": "string"
                 }
               }
             },
@@ -37393,26 +36545,14 @@
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
         "summary": "Set a theme as the system default theme",
-        "tags": ["Themes"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X PUT \"http://localhost:8088/api/v1/theme/1/set_system_default\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.put(\n    \"http://localhost:8088/api/v1/theme/1/set_system_default\",\n    headers={\"Authorization\": \"Bearer \" + access_token},\n    json={\"key\": \"value\"}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/theme/1/set_system_default\",\n  {\n    method: \"PUT\",\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`,\n      \"Content-Type\": \"application/json\"\n    },\n    body: JSON.stringify({ key: \"value\" })\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "tags": [
+          "Themes"
         ]
       }
     },
@@ -37441,263 +36581,24 @@
             "$ref": "#/components/responses/404"
           }
         },
-        "summary": "Get the user avatar",
-        "tags": ["User"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/user/{user_id}/avatar.png\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      }
-    },
-    "/api/{version}/_openapi": {
-      "get": {
-        "description": "Get the OpenAPI spec for a specific API version",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            },
-            "description": "The OpenAPI spec"
-          },
-          "404": {
-            "$ref": "#/components/responses/404"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
         "security": [
           {
             "jwt": []
+          },
+          {
+            "api_key": []
           }
         ],
-        "tags": ["OpenApi"],
-        "operationId": "get_api_by_version__openapi",
-        "summary": "Get api by version  openapi",
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/{version}/_openapi\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/{version}/_openapi\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/{version}/_openapi\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
+        "summary": "Get the user avatar",
+        "tags": [
+          "User"
         ]
       }
     }
   },
   "servers": [
     {
-      "url": "http://localhost:8088",
-      "description": "Local development server"
-    },
-    {
-      "url": "{protocol}://{host}:{port}",
-      "description": "Custom server",
-      "variables": {
-        "protocol": {
-          "default": "http",
-          "enum": ["http", "https"],
-          "description": "HTTP protocol"
-        },
-        "host": {
-          "default": "localhost",
-          "description": "Server hostname or IP"
-        },
-        "port": {
-          "default": "8088",
-          "description": "Server port"
-        }
-      }
-    }
-  ],
-  "tags": [
-    {
-      "name": "Advanced Data Type",
-      "description": "Advanced data type operations and conversions."
-    },
-    {
-      "name": "Annotation Layers",
-      "description": "Manage annotation layers and annotations for charts."
-    },
-    {
-      "name": "AsyncEventsRestApi",
-      "description": "Real-time event streaming via Server-Sent Events (SSE)."
-    },
-    {
-      "name": "Available Domains",
-      "description": "Get available domains for the Superset instance."
-    },
-    {
-      "name": "CSS Templates",
-      "description": "Manage CSS templates for custom dashboard styling."
-    },
-    {
-      "name": "CacheRestApi",
-      "description": "Cache management and invalidation operations."
-    },
-    {
-      "name": "Charts",
-      "description": "Create, read, update, and delete charts (slices)."
-    },
-    {
-      "name": "Current User",
-      "description": "Get information about the authenticated user."
-    },
-    {
-      "name": "Dashboard Filter State",
-      "description": "Manage temporary filter state for dashboards."
-    },
-    {
-      "name": "Dashboard Permanent Link",
-      "description": "Permanent links to dashboard states."
-    },
-    {
-      "name": "Dashboards",
-      "description": "Create, read, update, and delete dashboards."
-    },
-    {
-      "name": "Database",
-      "description": "Manage database connections and metadata."
-    },
-    {
-      "name": "Datasets",
-      "description": "Manage datasets (tables) used for building charts."
-    },
-    {
-      "name": "Datasources",
-      "description": "Query datasource metadata and column values."
-    },
-    {
-      "name": "Embedded Dashboard",
-      "description": "Configure embedded dashboard settings."
-    },
-    {
-      "name": "Explore",
-      "description": "Chart exploration and data querying endpoints."
-    },
-    {
-      "name": "Explore Form Data",
-      "description": "Manage temporary form data for chart exploration."
-    },
-    {
-      "name": "Explore Permanent Link",
-      "description": "Permanent links to chart explore states."
-    },
-    {
-      "name": "Import/export",
-      "description": "Import and export Superset assets."
-    },
-    {
-      "name": "LogRestApi",
-      "description": "Access audit logs and activity history."
-    },
-    {
-      "name": "Menu",
-      "description": "Get the Superset menu structure."
-    },
-    {
-      "name": "OpenApi",
-      "description": "Access the OpenAPI specification."
-    },
-    {
-      "name": "Queries",
-      "description": "View and manage SQL Lab query history."
-    },
-    {
-      "name": "Report Schedules",
-      "description": "Configure scheduled reports and alerts."
-    },
-    {
-      "name": "Row Level Security",
-      "description": "Manage row-level security rules for data access."
-    },
-    {
-      "name": "SQL Lab",
-      "description": "Execute SQL queries and manage SQL Lab sessions."
-    },
-    {
-      "name": "SQL Lab Permanent Link",
-      "description": "Permanent links to SQL Lab states."
-    },
-    {
-      "name": "Security",
-      "description": "Authentication and token management."
-    },
-    {
-      "name": "Security Groups",
-      "description": "Endpoints related to Security Groups."
-    },
-    {
-      "name": "Security Permissions",
-      "description": "View available permissions."
-    },
-    {
-      "name": "Security Permissions on Resources (View Menus)",
-      "description": "Permission-resource mappings."
-    },
-    {
-      "name": "Security Resources (View Menus)",
-      "description": "Manage security resources (view menus)."
-    },
-    {
-      "name": "Security Roles",
-      "description": "Manage security roles and their permissions."
-    },
-    {
-      "name": "Security Users",
-      "description": "Manage user accounts."
-    },
-    {
-      "name": "Tags",
-      "description": "Organize assets with tags."
-    },
-    {
-      "name": "Themes",
-      "description": "Manage UI themes for customizing Superset's appearance."
-    },
-    {
-      "name": "User",
-      "description": "User profile and preferences."
-    },
-    {
-      "name": "UserRegistrationsRestAPI",
-      "description": "Endpoints related to UserRegistrationsRestAPI."
+      "url": "http://localhost:8088"
     }
   ]
 }

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -6171,6 +6171,90 @@
         ],
         "type": "object"
       },
+      "DatasetPurgeImpactCollection": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "restricted_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "result": {
+            "items": {
+              "$ref": "#/components/schemas/DatasetPurgeImpactObject"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "count",
+          "restricted_count",
+          "result"
+        ],
+        "type": "object"
+      },
+      "DatasetPurgeImpactObject": {
+        "additionalProperties": false,
+        "properties": {
+          "archived": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "nullable": true,
+            "type": "string"
+          },
+          "uuid": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "archived",
+          "name",
+          "url",
+          "uuid"
+        ],
+        "type": "object"
+      },
+      "DatasetPurgeImpactSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "charts": {
+            "$ref": "#/components/schemas/DatasetPurgeImpactCollection"
+          },
+          "dashboards": {
+            "$ref": "#/components/schemas/DatasetPurgeImpactCollection"
+          },
+          "impact_token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "charts",
+          "dashboards",
+          "impact_token"
+        ],
+        "type": "object"
+      },
+      "DatasetPurgeRequestSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "confirmed_impact_token": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "confirmed_impact_token"
+        ],
+        "type": "object"
+      },
       "DatasetRelatedChart": {
         "additionalProperties": false,
         "properties": {
@@ -25139,6 +25223,17 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetPurgeRequestSchema"
+              }
+            }
+          },
+          "description": "Confirmed dependency impact",
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
@@ -25155,6 +25250,9 @@
             },
             "description": "Dataset permanently deleted"
           },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
           "401": {
             "$ref": "#/components/responses/401"
           },
@@ -25163,6 +25261,35 @@
           },
           "404": {
             "$ref": "#/components/responses/404"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "impact": {
+                      "$ref": "#/components/schemas/DatasetPurgeImpactSchema"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "enum": [
+                        "purge_impact_changed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "reason",
+                    "impact"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dataset dependency impact changed"
           },
           "422": {
             "$ref": "#/components/responses/422"
@@ -25180,6 +25307,58 @@
           }
         ],
         "summary": "Permanently delete a soft-deleted dataset",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/{uuid}/purge-impact": {
+      "get": {
+        "description": "Report the charts and dashboards that depend on an archived dataset, with an impact token that must be echoed back on the purge request. Limited to owners and admins (same audience as restore).",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uuid",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetPurgeImpactSchema"
+                }
+              }
+            },
+            "description": "Dependency impact of purging the dataset"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "403": {
+            "$ref": "#/components/responses/403"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Preview the dependency impact of purging an archived dataset",
         "tags": [
           "Datasets"
         ]

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -584,6 +584,9 @@ class DashboardRestApi(
         EmbeddedDashboardResponseSchema,
         DashboardScreenshotPostSchema,
         VersionListItemSchema,
+        DashboardChartCustomizationsConfigUpdateSchema,
+        DashboardColorsConfigUpdateSchema,
+        DashboardNativeFiltersConfigUpdateSchema,
     )
     apispec_parameter_schemas = {
         "get_delete_ids_schema": get_delete_ids_schema,

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -218,7 +218,9 @@ class DashboardJSONMetadataSchema(Schema):
     color_namespace = fields.Str(allow_none=True)
     positions = fields.Dict(allow_none=True)
     label_colors = fields.Dict()
-    shared_label_colors = SharedLabelsColorsField()
+    shared_label_colors = SharedLabelsColorsField(
+        metadata={"type": "array", "items": {"type": "string"}}
+    )
     map_label_colors = fields.Dict()
     color_scheme_domain = fields.List(fields.Str())
     cross_filters_enabled = fields.Boolean(dump_default=True)
@@ -546,7 +548,9 @@ class DashboardColorsConfigUpdateSchema(BaseDashboardSchema):
     color_namespace = fields.String(allow_none=True)
     color_scheme = fields.String(allow_none=True)
     map_label_colors = fields.Dict(allow_none=False)
-    shared_label_colors = SharedLabelsColorsField()
+    shared_label_colors = SharedLabelsColorsField(
+        metadata={"type": "array", "items": {"type": "string"}}
+    )
     label_colors = fields.Dict(allow_none=False)
     color_scheme_domain = fields.List(fields.String(), allow_none=False)
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -2153,11 +2153,12 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         """Return the activity stream for a dataset.
         ---
         get:
-          summary: Activity stream — dataset's own edits only.
-            Datasets have no transitive layer in V2 — chart and
-            dashboard edits that touch this dataset do NOT appear here.
-            ``?include=self`` and ``?include=all`` return the dataset's
-            own edits; ``?include=related`` returns an empty stream
+          summary: Get a dataset's activity stream
+          description: >-
+            A dataset's own edits only. Datasets have no transitive layer in
+            V2 — chart and dashboard edits that touch this dataset do NOT
+            appear here. ``?include=self`` and ``?include=all`` return the
+            dataset's own edits; ``?include=related`` returns an empty stream
             (a dataset has no related entities to fan out to).
           parameters:
           - in: path

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -297,6 +297,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
 
     apispec_parameter_schemas = {
         "get_delete_ids_schema": get_delete_ids_schema,
+        "get_slack_channels_schema": get_slack_channels_schema,
     }
     openapi_spec_tag = "Report Schedules"
     openapi_spec_methods = openapi_spec_methods_override


### PR DESCRIPTION
### SUMMARY

The committed OpenAPI snapshot has drifted well behind the code. Regenerating with
`superset update-api-docs` documents **39 endpoints** that were missing, and removes two that no
longer exist: `UserRegistrationsRestAPI.include_route_methods` excludes `RELATED` and `DISTINCT`, so
`/api/v1/security/user_registrations/{distinct,related}/{column_name}` are documented but return 404.

Regenerating also surfaced four schemas that route docstrings `$ref` but nothing declares, which made
`update-api-docs` emit dangling references. This registers them — the three dashboard config update
schemas via `openapi_spec_component_schemas`, and `get_slack_channels_schema` via
`apispec_parameter_schemas`. The regenerated spec now resolves every `$ref`.

Most of the diff is reordering rather than content. The snapshot predates the current serializer,
which writes sorted keys, so regeneration rewrites the file even where nothing changed. Output is
deterministic: regenerating twice produces an identical file.

### TESTING INSTRUCTIONS

```bash
superset update-api-docs
git diff --stat docs/static/resources/openapi.json   # expect no further change
```

To confirm the two removed routes are genuinely gone:

```python
[r.rule for r in app.url_map.iter_rules() if "user_registrations" in r.rule]
# -> only /, /_info, /<pk>
```

To confirm no dangling references remain, load the spec and check that every
`#/components/schemas/...` reference resolves against `components.schemas`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
