### PR TITLE
feat(gtf): gate the websocket transport on Redis-subscription health

### DIFF
--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -194,6 +194,36 @@ describe('server', () => {
       expect(endMock).toHaveBeenCalledTimes(1);
       expect(endMock).toHaveBeenLastCalledWith('Not Found');
     });
+
+    const readyResponse = () => {
+      const endMock = vi.fn();
+      const writeHeadMock = vi.fn();
+      server.httpRequest(
+        {
+          url: '/ready',
+          method: 'GET',
+          headers: { host: 'example.com' },
+        } as unknown as http.IncomingMessage,
+        {
+          writeHead: writeHeadMock,
+          end: endMock,
+        } as unknown as http.ServerResponse<http.IncomingMessage>,
+      );
+      return { writeHeadMock, endMock };
+    };
+
+    test('readiness is 200 while the subscriber is healthy', () => {
+      // resetState() (beforeEach) leaves the server healthy.
+      const { writeHeadMock } = readyResponse();
+      expect(writeHeadMock).toHaveBeenLastCalledWith(200);
+    });
+
+    test('readiness is 503 while the subscriber is unhealthy', () => {
+      server.markSubscriberUnhealthy('test drop');
+      const { writeHeadMock, endMock } = readyResponse();
+      expect(writeHeadMock).toHaveBeenLastCalledWith(503);
+      expect(endMock).toHaveBeenLastCalledWith('SUBSCRIBER_UNAVAILABLE');
+    });
   });
 
   describe('redisUrlFromConfig', () => {

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -1039,6 +1039,71 @@ describe('server', () => {
     });
   });
 
+  describe('subscriber health', () => {
+    test('markSubscriberUnhealthy closes open sockets with a retryable code', () => {
+      // resetState() leaves the server healthy; open a socket, then drop the
+      // subscriber and assert the socket is closed so the client reconnects.
+      const ws = new wsMock('localhost');
+      const closeSpy = vi.spyOn(ws, 'close');
+      trackSocket(channelId, ws);
+
+      server.markSubscriberUnhealthy('test drop');
+
+      expect(server.subscriberHealthy).toBe(false);
+      expect(closeSpy).toHaveBeenCalledWith(1012, expect.any(String));
+    });
+
+    test('markSubscriberUnhealthy is a no-op when already unhealthy (edge only)', () => {
+      server.markSubscriberUnhealthy('first');
+      const ws = new wsMock('localhost');
+      const closeSpy = vi.spyOn(ws, 'close');
+      trackSocket(channelId, ws);
+
+      server.markSubscriberUnhealthy('second'); // already unhealthy
+
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    test('httpUpgrade is refused with 503 while the subscriber is unhealthy', () => {
+      server.markSubscriberUnhealthy('test drop');
+      const socket = new net.Socket();
+      const destroySpy = vi.spyOn(socket, 'destroy');
+      const writeSpy = vi.spyOn(socket, 'write');
+      const upgradeSpy = vi.spyOn(server.wss, 'handleUpgrade');
+
+      server.httpUpgrade(
+        makeRequest({ token: signRealtimeToken() }),
+        socket,
+        Buffer.alloc(5),
+      );
+
+      expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('503'));
+      expect(destroySpy).toHaveBeenCalled();
+      expect(upgradeSpy).not.toHaveBeenCalled();
+      expect(statsdIncrementMock).toHaveBeenCalledWith('ws_upgrade_rejected');
+      upgradeSpy.mockRestore();
+    });
+
+    test('markSubscriberHealthy restores the transport so upgrades proceed', () => {
+      server.markSubscriberUnhealthy('test drop');
+      server.markSubscriberHealthy();
+
+      const socket = new net.Socket();
+      const destroySpy = vi.spyOn(socket, 'destroy');
+      const upgradeSpy = vi.spyOn(server.wss, 'handleUpgrade');
+
+      server.httpUpgrade(
+        makeRequest({ token: signRealtimeToken() }),
+        socket,
+        Buffer.alloc(5),
+      );
+
+      expect(destroySpy).not.toHaveBeenCalled();
+      expect(upgradeSpy).toHaveBeenCalled();
+      upgradeSpy.mockRestore();
+    });
+  });
+
   describe('isOriginAllowed', () => {
     afterEach(() => {
       server.opts.allowedOrigins = [];

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -736,8 +736,21 @@ export const httpRequest = (
   const headers = request.headers || {};
   const url = new URL(rawUrl as string, `http://${headers.host}`);
   if (url.pathname === '/health' && ['GET', 'HEAD'].includes(method)) {
+    // Liveness: the process is up. Deliberately independent of subscriber health
+    // (see /ready) so a transient Redis blip doesn't get the pod restarted.
     response.writeHead(200);
     response.end('OK');
+  } else if (url.pathname === '/ready' && ['GET', 'HEAD'].includes(method)) {
+    // Readiness: healthy only while the Redis subscriber is connected+subscribed,
+    // so a load balancer can drain a pod whose transport is degraded (upgrade
+    // refusal + socket close still cover correctness on their own).
+    if (subscriberHealthy) {
+      response.writeHead(200);
+      response.end('OK');
+    } else {
+      response.writeHead(503);
+      response.end('SUBSCRIBER_UNAVAILABLE');
+    }
   } else {
     logger.info(`Received unexpected request: ${method} ${rawUrl}`);
     response.writeHead(404);

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -222,6 +222,51 @@ export let sockets: Record<string, SocketInstance> = {};
 // connection limit has been reached (1013 = "Try Again Later").
 const CONNECTION_LIMIT_CLOSE_CODE = 1013;
 
+// The Redis Pub/Sub subscriber is the server's only source of realtime messages.
+// If it drops, a browser socket can stay open while the server silently misses
+// messages, so subscriber health gates the transport: while unhealthy, new
+// upgrades are refused and existing sockets are closed with a retryable code
+// (1012 = "Service Restart") so clients reconnect and run their status_changes
+// catch-up once the subscriber is healthy again. (Left off /health, which is a
+// liveness probe — coupling it to a transient Redis blip would churn pods.)
+const SUBSCRIBER_UNHEALTHY_CLOSE_CODE = 1012;
+export let subscriberHealthy = false;
+
+export const markSubscriberHealthy = (): void => {
+  if (subscriberHealthy) return;
+  subscriberHealthy = true;
+  logger.info('Redis subscriber healthy; realtime transport available');
+};
+
+export const markSubscriberUnhealthy = (reason: string): void => {
+  if (!subscriberHealthy) return; // act only on the healthy -> unhealthy edge
+  subscriberHealthy = false;
+  logger.warn(
+    `Redis subscriber unhealthy (${reason}); refusing upgrades and closing ` +
+      `sockets so clients reconnect and catch up`,
+  );
+  // Snapshot ids first: ws.close triggers the 'close' handler, which deletes from
+  // `sockets` — mutating the object mid-iteration.
+  Object.keys(sockets).forEach(socketId => {
+    try {
+      sockets[socketId]?.ws.close(
+        SUBSCRIBER_UNHEALTHY_CLOSE_CODE,
+        'realtime backend unavailable',
+      );
+    } catch (err) {
+      logger.error(
+        `Failed to close socket ${socketId} on subscriber loss: ${err}`,
+      );
+    }
+  });
+};
+
+// A dropped/ended subscriber connection means missed messages; ioredis
+// auto-reconnects (and re-subscribes), and the 'ready' handler below reconfirms
+// the subscription and flips back to healthy.
+redisSubscriber.on('close', () => markSubscriberUnhealthy('connection closed'));
+redisSubscriber.on('end', () => markSubscriberUnhealthy('connection ended'));
+
 /**
  * Returns whether the socket with the given id is currently active, i.e. it is
  * still registered and its underlying connection is in an active readyState.
@@ -520,6 +565,7 @@ export const subscribeToChannels = async (): Promise<void> => {
   }
   try {
     await redisSubscriber.subscribe(REALTIME_CHANNEL);
+    markSubscriberHealthy();
     logger.info(`Subscribed to Redis channel: ${REALTIME_CHANNEL}`);
   } catch (err) {
     logger.error(
@@ -529,6 +575,13 @@ export const subscribeToChannels = async (): Promise<void> => {
     setTimeout(subscribeToChannels, SUBSCRIBE_RETRY_MS);
   }
 };
+
+// After a reconnect ioredis re-subscribes automatically; reconfirm the
+// subscription (idempotent) so the healthy flag flips back on. Wired here, after
+// subscribeToChannels is defined, to avoid a use-before-define reference.
+redisSubscriber.on('ready', () => {
+  subscribeToChannels();
+});
 
 /**
  * Verify and parse a realtime JWT cookie from an HTTP request.
@@ -737,6 +790,18 @@ export const httpUpgrade = (
     return;
   }
 
+  // Refuse upgrades while the Redis subscriber is unhealthy: a socket accepted now
+  // would silently miss messages until the subscription recovers. Reply 503 so the
+  // client backs off and retries (its reconnect then runs the status_changes
+  // catch-up against a healthy server).
+  if (!subscriberHealthy) {
+    statsd.increment('ws_upgrade_rejected');
+    logger.warn('Rejecting WebSocket upgrade: Redis subscriber unhealthy');
+    socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+
   let identity: SocketIdentity;
   try {
     identity = readSocketIdentity(request);
@@ -879,4 +944,7 @@ export const resetState = () => {
   channels = {};
   sockets = {};
   messageBound = false;
+  // A reset server is a clean, running (subscribed) server, so tests start from a
+  // healthy transport; a test drives the unhealthy edge with markSubscriberUnhealthy.
+  subscriberHealthy = true;
 };


### PR DESCRIPTION
### SUMMARY

Follow-up to #43782 (reviewer-requested): treat the `superset-websocket` server's Redis Pub/Sub subscriber health as part of the transport's readiness.

The server's Redis subscriber is its **only** source of realtime messages. If that subscriber connection drops, a browser socket can stay **open** while the server silently misses every message published during the gap (until ioredis reconnects and re-subscribes) — a blind spot no client-side catch-up covers, because the client has no signal that anything went wrong and so never reconnects to run its `status_changes` reconciliation.

This gates the transport on subscriber health:

- **Health tracking.** `subscriberHealthy` flips **healthy** after a successful `subscribe(realtime)` — and on the subscriber connection's `ready` event, which fires after ioredis auto-reconnects and re-subscribes — and **unhealthy** on its `close`/`end`.
- **Close sockets on the unhealthy edge.** When the subscriber drops, open sockets are closed with a retryable code (`1012` "Service Restart") so clients reconnect. The frontend already runs a `status_changes` catch-up on reconnect (from #43696 / #43782), so a server-initiated close plugs straight into existing recovery — no new client code.
- **Refuse upgrades while unhealthy.** New upgrades get `503` so a client can't attach to a server that would miss its messages; the client's reconnect backoff retries until the server is healthy again.
- **`/health` stays liveness; `/ready` reflects transport health.** `/health` is deliberately *not* gated on subscriber health — coupling liveness to a transient Redis blip would churn pods. A separate `/ready` returns 200 only while the subscriber is connected+subscribed (else 503), so a load balancer can drain a pod whose transport is degraded. The correctness guarantee still comes from upgrade-refusal + socket-close; `/ready` just lets infra route around a bad pod.

Node-only change (`superset-websocket`); no frontend or Python changes.

### TESTING INSTRUCTIONS

```bash
npm --prefix superset-websocket run lint   # eslint + tsc
npm --prefix superset-websocket test       # vitest (84 passing, incl. 6 new)
```

New tests cover: the unhealthy edge closes open sockets with `1012`; repeated unhealthy transitions are a no-op (edge-only); upgrades are refused with `503` while unhealthy; recovery (`markSubscriberHealthy`) lets upgrades proceed again; and `/ready` is 200 when healthy / 503 when unhealthy.

Manual: with `WEBSOCKET_ENABLE` on and a chart loading, bounce Redis (or block the ws server's Redis connection): open sockets close and the browser reconnects; while Redis is down, new upgrades get `503`; once Redis returns, the socket reconnects and the chart resolves via the catch-up.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `WEBSOCKET_ENABLE` (realtime transport)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

