### PR TITLE
fix(alerts): resolve async chart data when loading report filter values

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -58,6 +58,7 @@ jest.mock('src/features/databases/state.ts', () => ({
 }));
 
 const mockGetChartDataRequest = jest.fn().mockResolvedValue({
+  response: { status: 200 },
   json: { result: [{ data: [] }] },
 });
 jest.mock('src/components/Chart/chartAction', () => ({
@@ -324,6 +325,7 @@ afterEach(() => {
   // Reset chartData mock so stale resolved values don't leak
   mockGetChartDataRequest.mockReset();
   mockGetChartDataRequest.mockResolvedValue({
+    response: { status: 200 },
     json: { result: [{ data: [] }] },
   });
 });
@@ -2744,6 +2746,7 @@ test('selecting filter triggers chart data request with correct params', async (
   fetchMock.get(tabsEndpoint, tabsWithFilters, { name: tabsEndpoint });
 
   mockGetChartDataRequest.mockResolvedValue({
+    response: { status: 200 },
     json: { result: [{ data: [{ country: 'US' }, { country: 'UK' }] }] },
   });
 
@@ -2783,6 +2786,7 @@ test('selected filter excluded from other row dropdowns', async () => {
   fetchMock.get(tabsEndpoint, tabsWithFilters, { name: tabsEndpoint });
 
   mockGetChartDataRequest.mockResolvedValue({
+    response: { status: 200 },
     json: { result: [{ data: [{ country: 'US' }] }] },
   });
 

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -102,7 +102,10 @@ import { StatusMessage } from 'src/filters/components/common';
 import { useSelector } from 'react-redux';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import getBootstrapData from 'src/utils/getBootstrapData';
-import { getChartDataRequest } from 'src/components/Chart/chartAction';
+import {
+  getChartDataRequest,
+  handleChartDataResponse,
+} from 'src/components/Chart/chartAction';
 import DateFilterControl from 'src/explore/components/controls/DateFilterControl';
 import { Icons } from '@superset-ui/core/components/Icons';
 import { StandardModal, ModalFormField } from 'src/components/Modal';
@@ -759,35 +762,35 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       ownState: {},
     };
 
-    const data = await getChartDataRequest(filterValues).then(response => {
-      const rawData = response.json.result[0].data;
-      let filteredData = rawData;
+    const { response, json } = await getChartDataRequest(filterValues);
+    const queriesResponse = await handleChartDataResponse(response, json);
+    const rawData = queriesResponse[0].data;
+    let filteredData = rawData;
 
-      if (vizType === 'filter_timecolumn') {
-        // filter for time columns types
-        filteredData = rawData.filter((item: any) => item.dtype === 2);
+    if (vizType === 'filter_timecolumn') {
+      // filter for time columns types
+      filteredData = rawData.filter((item: any) => item.dtype === 2);
+    }
+
+    const data = filteredData.map((item: any) => {
+      if (vizType === 'filter_timegrain') {
+        return {
+          value: item.duration,
+          label: item.name,
+        };
       }
 
-      return filteredData.map((item: any) => {
-        if (vizType === 'filter_timegrain') {
-          return {
-            value: item.duration,
-            label: item.name,
-          };
-        }
-
-        if (vizType === 'filter_timecolumn') {
-          return {
-            value: item.column_name,
-            label: item.verbose_name || item.column_name,
-          };
-        }
-
+      if (vizType === 'filter_timecolumn') {
         return {
-          value: item[columnName],
-          label: item[columnName],
+          value: item.column_name,
+          label: item.verbose_name || item.column_name,
         };
-      });
+      }
+
+      return {
+        value: item[columnName],
+        label: item[columnName],
+      };
     });
 
     // eslint-disable-next-line consistent-return
@@ -1584,29 +1587,34 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       return;
     }
 
-    getChartDataRequest(filterValues).then(response => {
-      const newFilterValues = response.json.result[0].data.map((item: any) => ({
-        value: item[columnName],
-        label: item[columnName],
-      }));
+    getChartDataRequest(filterValues)
+      .then(({ response, json }) => handleChartDataResponse(response, json))
+      .then(queriesResponse => {
+        const newFilterValues = queriesResponse[0].data.map((item: any) => ({
+          value: item[columnName],
+          label: item[columnName],
+        }));
 
-      setNativeFilterData(
-        nativeFilterData.map((filter, index) =>
-          index === idx
-            ? {
-                ...filter,
-                filterName,
-                filterType,
-                nativeFilterId,
-                columnLabel,
-                columnName,
-                optionFilterValues: newFilterValues,
-                filterValues: [], // reset filter values on filter change
-              }
-            : filter,
-        ),
-      );
-    });
+        setNativeFilterData(
+          nativeFilterData.map((filter, index) =>
+            index === idx
+              ? {
+                  ...filter,
+                  filterName,
+                  filterType,
+                  nativeFilterId,
+                  columnLabel,
+                  columnName,
+                  optionFilterValues: newFilterValues,
+                  filterValues: [], // reset filter values on filter change
+                }
+              : filter,
+          ),
+        );
+      })
+      .catch(() => {
+        addDangerToast(t('Failed to load dashboard filter values.'));
+      });
   };
 
   const onChangeDashboardFilterValue = (


### PR DESCRIPTION
### SUMMARY

When `GLOBAL_ASYNC_QUERIES` is enabled, `/api/v1/chart/data` often returns **HTTP 202** with a job id instead of synchronous `result[0].data`.

`AlertReportModal` was reading `response.json.result[0].data` directly from `getChartDataRequest`, so selecting a **Dashboard Filter** never populated `optionFilterValues` and the **Value** control stayed disabled/greyed out.

This change routes those responses through `handleChartDataResponse` (same pattern as Drill By), which awaits async results via `waitForAsyncData` when status is 202.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (behavior fix; Value dropdown enables after filter options load)

### TESTING INSTRUCTIONS

1. Enable feature flags:
   - `ALERT_REPORTS=True`
   - `ALERT_REPORTS_FILTER=True`
   - `GLOBAL_ASYNC_QUERIES=True`
2. Open **Alerts & Reports** → create/edit a report
3. Content type = **Dashboard**, pick a dashboard with native filters
4. Select a dashboard filter
5. Confirm **Value** becomes enabled and lists options (may take a moment for the async query)
6. Also smoke-test with `GLOBAL_ASYNC_QUERIES=False` to confirm sync path still works

Unit tests: update `getChartDataRequest` mocks to include `response: { status: 200 }` so the GAQ branch of `handleChartDataResponse` is satisfied under the suite's `isFeatureEnabled: () => true` mock.

### ADDITIONAL INFORMATION

- [x] Has associated issue: discovered while enabling `ALERT_REPORTS_FILTER` with GAQ on Superset 6.1.0
- [ ] Required feature flags: `ALERT_REPORTS`, `ALERT_REPORTS_FILTER` (bug only surfaces with `GLOBAL_ASYNC_QUERIES`)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API


Made with [Cursor](https://cursor.com)