### PR TITLE
fix(gtf): forced async read-back keeps force_nonce; fix duplicate-tab id race

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
@@ -750,6 +750,80 @@ test('resolves async (202) responses via the injected handleAsyncChartData hook'
   });
 });
 
+test('forced async read-back re-sends force with per-query task ids as nonces', async () => {
+  mockChartClient.client.post
+    .mockResolvedValueOnce({
+      response: { status: 202 } as Response,
+      json: { task_ids: ['task-1', 'task-2'] },
+    })
+    .mockResolvedValueOnce({
+      response: { status: 200 } as Response,
+      json: [{ data: 'cached' }],
+    });
+  // The handler resolves by re-issuing the request with the task ids (the
+  // force nonces), mirroring how the app-level async middleware calls refetch.
+  const handleAsyncChartData = jest.fn(
+    async (
+      _response: Response,
+      _json: unknown,
+      refetch: (nonces?: string[]) => Promise<QueryData[]>,
+    ) => refetch(['task-1', 'task-2']),
+  );
+
+  render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      force
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(2);
+  });
+  const { jsonPayload } = mockChartClient.client.post.mock.calls[1][0];
+  // Read-back re-forces so the marker can suppress recompute, stamps each query
+  // with its task id, and resolves inline (no async_mode).
+  expect(jsonPayload.force).toBe(true);
+  expect(jsonPayload.queries[0].force_nonce).toBe('task-1');
+  expect(jsonPayload.async_mode).toBeUndefined();
+});
+
+test('non-forced async read-back carries neither force nor a nonce', async () => {
+  mockChartClient.client.post
+    .mockResolvedValueOnce({
+      response: { status: 202 } as Response,
+      json: { task_ids: ['task-1'] },
+    })
+    .mockResolvedValueOnce({
+      response: { status: 200 } as Response,
+      json: [{ data: 'cached' }],
+    });
+  const handleAsyncChartData = jest.fn(
+    async (
+      _response: Response,
+      _json: unknown,
+      refetch: (nonces?: string[]) => Promise<QueryData[]>,
+    ) => refetch(['task-1']),
+  );
+
+  render(
+    <StatefulChart
+      formData={mockFormData}
+      chartType="test_chart"
+      hooks={{ handleAsyncChartData }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(2);
+  });
+  const { jsonPayload } = mockChartClient.client.post.mock.calls[1][0];
+  expect(jsonPayload.force).not.toBe(true);
+  expect(jsonPayload.queries[0].force_nonce).toBeUndefined();
+});
+
 test('requests async_mode and the tab id when opting in and 202 is handled', async () => {
   mockChartClient.client.post.mockResolvedValue({
     response: { status: 200 } as Response,

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -353,11 +353,33 @@ export default function StatefulChart(props: StatefulChartProps) {
               'the async handler or disable GLOBAL_ASYNC_QUERIES for this chart.',
           );
         }
-        // Re-issue from the warm per-query cache (force off) and extract rows.
-        const refetch = async (): Promise<QueryData[]> => {
+        // Re-issue synchronously from the warm per-query cache and extract rows.
+        // A forced request re-sends `force: true` and stamps each query's task id
+        // (passed by the async handler) as its `force_nonce`, so the backend serves
+        // the result that task cached rather than recomputing — and re-forces
+        // (instead of serving stale) if that result was not persisted. Non-forced
+        // reads carry neither. `async_mode` is intentionally omitted so the read-back
+        // resolves inline instead of returning another 202.
+        const refetch = async (
+          queryForceNonces?: string[],
+        ): Promise<QueryData[]> => {
+          const nonces = force ? queryForceNonces : undefined;
+          const readBackContext = nonces?.length
+            ? {
+                ...queryContext,
+                queries: queryContext.queries.map((query, index) =>
+                  nonces[index]
+                    ? { ...query, force_nonce: nonces[index] }
+                    : query,
+                ),
+              }
+            : queryContext;
           const cached = await chartClientRef.current!.client.post({
             ...requestConfig,
-            jsonPayload: queryContext,
+            jsonPayload: {
+              ...readBackContext,
+              ...(force && { force: true }),
+            },
           });
           return extractRows(cached.json);
         };

--- a/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/models/ChartProps.ts
@@ -71,12 +71,16 @@ export type Hooks = {
    * Injected by the app so components in this package (e.g. Matrixify's
    * StatefulChart) can await async results without importing app-level
    * async-event middleware. `refetch` re-issues the request synchronously once
-   * the query tasks have succeeded. Returns the resolved query results.
+   * the query tasks have succeeded; it receives the per-query task ids, which
+   * double as forced-refresh idempotency nonces (see `requestChartDataResolved`)
+   * so a forced read-back reads the result its task cached instead of recomputing
+   * — and does not serve stale data if that result was not persisted. Returns the
+   * resolved query results.
    */
   handleAsyncChartData?: (
     response: Response,
     json: JsonObject,
-    refetch: () => Promise<QueryData[]>,
+    refetch: (queryForceNonces?: string[]) => Promise<QueryData[]>,
     signal?: AbortSignal,
   ) => Promise<QueryData[]> | QueryData[];
   /**

--- a/superset-frontend/src/hooks/useTabId.test.ts
+++ b/superset-frontend/src/hooks/useTabId.test.ts
@@ -17,13 +17,57 @@
  * under the License.
  */
 
+import { renderHook, act } from '@testing-library/react';
+
+// --- Fake BroadcastChannel ---
+//
+// jsdom has no cross-tab BroadcastChannel delivery, so a test drives the hook's
+// listener directly by dispatching on the channel the hook created. Installed on
+// the global before the hook module loads (getChannel constructs lazily, once).
+type ChannelMessage = { type: string; tabId: string };
+
+class FakeBroadcastChannel extends EventTarget {
+  static instances: FakeBroadcastChannel[] = [];
+
+  posted: ChannelMessage[] = [];
+
+  constructor(public name: string) {
+    super();
+    FakeBroadcastChannel.instances.push(this);
+  }
+
+  postMessage(message: ChannelMessage) {
+    this.posted.push(message);
+  }
+
+  close() {}
+}
+
+(global as unknown as { BroadcastChannel: unknown }).BroadcastChannel =
+  FakeBroadcastChannel;
+
 // The global test shim mocks 'src/hooks/useTabId' (BroadcastChannel leaks in
-// jest); use the real implementation here to exercise getTabId itself.
-const { getTabId } = jest.requireActual('src/hooks/useTabId');
+// jest); use the real implementation here. Loaded once so the hook, its helpers,
+// and RTL all share a single React instance (resetModules would fork React).
+const { getTabId, useTabId, subscribeTabIdChange } =
+  jest.requireActual('src/hooks/useTabId');
+
+// The hook's channel is a per-module singleton (constructed on first mount), so a
+// single FakeBroadcastChannel instance is reused across tests; reference it here.
+function channel(): FakeBroadcastChannel {
+  return FakeBroadcastChannel.instances[0];
+}
+
+function emit(message: ChannelMessage) {
+  act(() => {
+    channel().dispatchEvent(new MessageEvent('message', { data: message }));
+  });
+}
 
 beforeEach(() => {
   window.sessionStorage.clear();
   window.localStorage.clear();
+  channel()?.posted.splice(0);
 });
 
 test('getTabId returns a stable id within the tab', () => {
@@ -39,4 +83,71 @@ test('getTabId reuses an id already stored by the useTabId hook', () => {
   // id so a tab is identified consistently everywhere.
   window.sessionStorage.setItem('tab_id', '42');
   expect(getTabId()).toBe('42');
+});
+
+test('useTabId claims a fresh id and broadcasts a request for a stored one', () => {
+  window.sessionStorage.setItem('tab_id', '5');
+
+  const { result } = renderHook(() => useTabId());
+
+  expect(result.current).toBe('5');
+  // A tab that reloads (id already in sessionStorage) asks peers whether the id
+  // is a duplicate, so a genuinely duplicated tab can be told to reassign.
+  expect(channel().posted).toContainEqual({
+    type: 'REQUESTING_TAB_ID',
+    tabId: '5',
+  });
+});
+
+test('useTabId denies a peer that claims this tab’s id', () => {
+  window.sessionStorage.setItem('tab_id', '5');
+
+  renderHook(() => useTabId());
+  channel().posted.splice(0);
+
+  // A duplicated tab announces the same id; this tab (the incumbent) denies it.
+  emit({ type: 'REQUESTING_TAB_ID', tabId: '5' });
+
+  expect(channel().posted).toContainEqual({
+    type: 'TAB_ID_DENIED',
+    tabId: '5',
+  });
+});
+
+test('useTabId reassigns and notifies subscribers when its id is denied', () => {
+  const onChange = jest.fn();
+  const unsubscribe = subscribeTabIdChange(onChange);
+
+  const { result } = renderHook(() => useTabId());
+  // Empty storage -> claims the first id without asking.
+  expect(result.current).toBe('1');
+
+  // A denial for the id this tab currently holds forces a reassignment, even
+  // though it can arrive before React commits the initial state — the handler
+  // compares against a live local id, not the render-captured state.
+  emit({ type: 'TAB_ID_DENIED', tabId: '1' });
+
+  expect(result.current).toBe('2');
+  // Consumers that pinned the old id (e.g. the realtime socket channel) re-sync.
+  expect(onChange).toHaveBeenCalledTimes(1);
+  unsubscribe();
+});
+
+test('useTabId ignores channel messages addressed to other tabs', () => {
+  const { result } = renderHook(() => useTabId());
+  expect(result.current).toBe('1');
+
+  emit({ type: 'TAB_ID_DENIED', tabId: '999' });
+
+  expect(result.current).toBe('1');
+});
+
+test('useTabId removes its channel listener on unmount', () => {
+  const { result, unmount } = renderHook(() => useTabId());
+  expect(result.current).toBe('1');
+  unmount();
+
+  // After unmount a denial must not reach the (torn-down) handler.
+  emit({ type: 'TAB_ID_DENIED', tabId: '1' });
+  expect(result.current).toBe('1');
 });

--- a/superset-frontend/src/hooks/useTabId.ts
+++ b/superset-frontend/src/hooks/useTabId.ts
@@ -122,11 +122,34 @@ export function useTabId() {
 
   useEffect(() => {
     if (!isStorageAvailable()) {
-      if (!tabId) {
-        setTabId(getTabId());
-      }
-      return;
+      setTabId(prev => prev ?? getTabId());
+      return undefined;
     }
+
+    const channel = getChannel();
+    // The id this tab currently claims. A mutable local (not the render-captured
+    // `tabId` state) so the message handler always compares against the live value
+    // — otherwise a TAB_ID_DENIED that arrives before the state/effect updates
+    // (e.g. on the very first render, when `tabId` is still undefined) is dropped,
+    // leaving two tabs sharing an id and colliding on the backend per-tab consumer
+    // key (`<principal>:<tab_id>`).
+    let currentId: string | undefined;
+
+    const handler = (messageEvent: MessageEvent<TabIdChannelMessage>) => {
+      if (messageEvent.data.tabId !== currentId) return;
+      if (messageEvent.data.type === 'REQUESTING_TAB_ID') {
+        channel.postMessage({ type: 'TAB_ID_DENIED', tabId: currentId });
+      } else if (messageEvent.data.type === 'TAB_ID_DENIED') {
+        currentId = createTabId();
+        setTabId(currentId);
+        // The id was reassigned; tell consumers that pinned the old one (e.g. the
+        // realtime socket's per-tab channel) to re-sync.
+        notifyTabIdChange();
+      }
+    };
+    // Install the listener BEFORE broadcasting, so a peer's immediate denial of a
+    // duplicated id can't race ahead of us subscribing.
+    channel.addEventListener('message', handler);
 
     let storedTabId;
     try {
@@ -135,32 +158,16 @@ export function useTabId() {
       // continue regardless of error
     }
     if (storedTabId) {
-      getChannel().postMessage({
-        type: 'REQUESTING_TAB_ID',
-        tabId: storedTabId,
-      });
+      currentId = storedTabId;
       setTabId(storedTabId);
+      channel.postMessage({ type: 'REQUESTING_TAB_ID', tabId: storedTabId });
     } else {
-      setTabId(createTabId());
+      currentId = createTabId();
+      setTabId(currentId);
     }
 
-    getChannel().onmessage = messageEvent => {
-      if (messageEvent.data.tabId === tabId) {
-        if (messageEvent.data.type === 'REQUESTING_TAB_ID') {
-          const message: TabIdChannelMessage = {
-            type: 'TAB_ID_DENIED',
-            tabId: messageEvent.data.tabId,
-          };
-          getChannel().postMessage(message);
-        } else if (messageEvent.data.type === 'TAB_ID_DENIED') {
-          setTabId(createTabId());
-          // The id was reassigned; tell consumers that pinned the old one (e.g.
-          // the realtime socket's per-tab channel) to re-sync.
-          notifyTabIdChange();
-        }
-      }
-    };
-  }, [tabId]);
+    return () => channel.removeEventListener('message', handler);
+  }, []);
 
   return tabId;
 }


### PR DESCRIPTION
### SUMMARY

Two follow-ups from an external review of the async chart-data / websocket work on the `gaq-to-gtf` epic (#43407). Both are correctness fixes on the frontend; no backend or schema changes.

**1. Forced async read-back dropped `force` and the per-query nonce (`StatefulChart`).**
The HTTP 202 async path in the `@apache-superset/core` package (`StatefulChart`, used by Matrixify) re-issued the `/chart/data` POST with a bare `refetch()` — no `force`, no nonce. So a *forced* refresh that ran as a GTF task would recompute on the web worker on read-back instead of reading the result its task had cached, and could even serve stale data if the forced result had not been persisted. This diverged from the Redux path, which already threads the per-query task ids as forced-refresh nonces.

Fix: widen the injected `handleAsyncChartData` refetch signature to `(queryForceNonces?: string[]) => Promise<QueryData[]>`, and on a forced read-back re-send `force: true` with each query stamped `queries[i].force_nonce = task_ids[i]` (the task UUID *is* the idempotency nonce). `async_mode` is intentionally omitted so the read-back resolves inline from the warm cache. Non-forced reads carry neither `force` nor a nonce.

**2. Duplicate-tab id race (`useTabId`).**
`useTabId` installed its `BroadcastChannel` message handler *after* broadcasting `REQUESTING_TAB_ID`, and the handler compared incoming denials against the render-captured `tabId` (which is `undefined` on the first render). A peer's immediate `TAB_ID_DENIED` for the just-claimed id could therefore be dropped, leaving two tabs sharing a tab id — which then collide on the backend's per-tab consumer key (`<principal>:<tab_id>`) used for async task fanout/cancel.

Fix: install the listener *before* broadcasting; compare against a live mutable local id (`currentId`) instead of the render-captured state; and use `addEventListener` + an effect cleanup (`removeEventListener`) instead of the shared singleton `onmessage`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (no visual change).

### TESTING INSTRUCTIONS

- `npm run test -- packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx src/hooks/useTabId.test.ts`
- Manual: with `GLOBAL_ASYNC_QUERIES` + websocket enabled, force-refresh a Matrixify chart — the read-back reads cached results (single execution), and a not-yet-persisted forced result re-forces rather than serving stale data.
- Manual: duplicate a browser tab (Ctrl/Cmd-click reload into a new tab of the same session) — the duplicate is reassigned a fresh tab id rather than silently sharing the incumbent's.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---
Part of the GAQ → GTF migration epic (#43407).
