### PR TITLE
fix(gtf): publish completion on abort-to-terminal; gate guest async on Task read

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -75,6 +75,15 @@ resolves the `async_mode` it sends from a policy chain — per-dashboard overrid
 deployment default `GLOBAL_ASYNC_QUERIES_DEFAULT` (default `true`) → the feature
 flag — so the UI keeps its existing async behavior by default.
 
+**Embedded (guest token) async requires explicit role grants.** Async chart-data
+completion is observed through `GET /api/v1/task/status_changes` (gated by
+`can_read Task`) and, when the WebSocket transport is enabled, over the socket
+(gated by `can_read Realtime`). An authenticated Gamma user has `can_read Task` by
+default; the default guest role (`Public`) does **not**. So an embedded guest only
+runs async when the operator grants its role `can_read Task` (and `can_read
+Realtime` for the socket) — otherwise the request transparently falls back to the
+synchronous `200` flow rather than returning a `202` the guest could never resolve.
+
 Enabling the realtime WebSocket transport (optional; when enabled it becomes the
 completion transport for async chart-data — see the note on the interval poll):
 

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -367,9 +367,17 @@ class ChartDataRestApi(ChartRestApi):
         per-principal subscription (see ``superset.tasks.subscription``). A fully
         anonymous request (public dashboard viewed directly, no login and no guest
         token) has no principal, so it would schedule a task it could never poll
-        or cancel; those requests run synchronously instead. Public async delivery
-        is supported via guest tokens (embedded dashboards), which do have a
-        principal.
+        or cancel; those requests run synchronously instead.
+
+        The principal must also be able to *observe* task state: chart completion is
+        read from ``GET /api/v1/task/status_changes``, which is gated by
+        ``can_read Task`` (the websocket transport is likewise gated by
+        ``can_read Realtime``). An authenticated Gamma user has ``Task`` by default;
+        an embedded guest on the default ``Public`` role does not, so guest async
+        works only when the operator grants the guest role ``can_read Task`` — and
+        otherwise falls back to sync rather than returning a 202 the guest can never
+        resolve. See ``UPDATING.md`` for the guest-role grants required to enable
+        embedded async.
 
         The eligibility check reads :meth:`QueryContext.get_cache_timeout`, which
         only resolves the explicitly configured chart/dataset/database TTL. That is
@@ -389,6 +397,10 @@ class ChartDataRestApi(ChartRestApi):
                 get_user_id() is not None
                 or get_current_guest_subscriber_key() is not None
             )
+            # The client must be able to read task status to observe completion;
+            # otherwise the 202 is unresolvable (e.g. a guest on the default Public
+            # role). Fall back to sync when it can't.
+            and security_manager.can_access("can_read", "Task")
         )
 
     def _run_async(

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1602,12 +1602,13 @@ class ChartDataQueryContextSchema(Schema):
 
     force_nonce = fields.String(
         metadata={
-            "description": "Idempotency token for a forced refresh. Set once per "
-            "user-initiated force refresh and sent on every request of that "
-            "refresh (the async submit and the follow-up read-back). The first "
-            "execution recomputes and records a marker; later requests carrying "
-            "the same nonce read the freshly-cached result instead of recomputing "
-            "it. Ignored when `force` is false."
+            "description": "Forced-refresh idempotency token for a single-query "
+            "request: the async task's UUID (as returned in the 202 `task_ids`). "
+            "Sent on the synchronous read-back of a forced refresh so it reads the "
+            "result the task warmed instead of recomputing; concurrent refreshes "
+            "joining the same shared task read back under the same token. Multi-query "
+            "requests set the per-query `force_nonce` on each query instead. Ignored "
+            "when `force` is false."
         },
         required=False,
         allow_none=True,

--- a/superset/commands/tasks/cancel.py
+++ b/superset/commands/tasks/cancel.py
@@ -33,6 +33,7 @@ from superset.commands.tasks.exceptions import (
 )
 from superset.extensions import security_manager
 from superset.stats_logger import BaseStatsLogger
+from superset.tasks.constants import TERMINAL_STATES
 from superset.tasks.guest import get_guest_subscriber_key_for
 from superset.tasks.locks import task_lock
 from superset.tasks.registry import TaskRegistry
@@ -85,6 +86,12 @@ class CancelTaskCommand(BaseCommand):
             "cancelled"  # Will be set to 'aborted', 'unsubscribed', or 'detached'
         )
         self._should_publish_abort: bool = False
+        # Set to the terminal status when this cancel drove the task straight to a
+        # terminal state (a queued PENDING task aborts directly to ABORTED, without
+        # a worker to finalize it). Published as completion post-commit so waiters
+        # wake; None when the task only reached ABORTING (the worker finalizes and
+        # publishes completion) or was unsubscribed/detached (still running).
+        self._completed_status: str | None = None
 
     def run(self) -> "Task":
         """
@@ -126,6 +133,15 @@ class CancelTaskCommand(BaseCommand):
         # This prevents race conditions where listeners check DB before commit
         if self._should_publish_abort:
             TaskManager.publish_abort(self._task_uuid)
+
+        # A cancel that drove the task straight to a terminal state (queued
+        # PENDING → ABORTED) has no worker to finalize it, so it must publish
+        # completion itself — otherwise a websocket-mode waiter (which does not
+        # poll) only learns of the cancellation at the stale-timeout give-up.
+        # The ABORTING case is handled by the worker's own completion publish
+        # once its abort handlers finish.
+        if self._completed_status is not None:
+            TaskManager.publish_completion(self._task_uuid, self._completed_status)
 
         # Nudge realtime list views of the abort/cancel state change (post-commit).
         # Abort transitions (→ABORTING/ABORTED) don't go through
@@ -303,6 +319,10 @@ class CancelTaskCommand(BaseCommand):
         # Track if we need to publish abort after commit
         if TaskStatus(result.status) == TaskStatus.ABORTING:
             self._should_publish_abort = True
+        elif result.status in TERMINAL_STATES:
+            # Aborted straight to terminal (queued PENDING task): no worker will
+            # publish completion, so run() must after commit.
+            self._completed_status = result.status
 
         # Emit stats metric
         stats_logger: BaseStatsLogger = current_app.config["STATS_LOGGER"]
@@ -369,6 +389,8 @@ class CancelTaskCommand(BaseCommand):
         """
         Get the action that was taken.
 
-        :returns: 'aborted' or 'unsubscribed'
+        :returns: 'aborted' (task terminated), 'unsubscribed' (principal removed
+            from a shared task that keeps running), or 'detached' (one client of the
+            principal detached while the principal's other clients keep it running)
         """
         return self._action_taken

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -363,6 +363,8 @@ class TaskRestApi(BaseSupersetModelRestApi):
             The `action` field in the response indicates what happened:
             - `aborted`: Task was terminated
             - `unsubscribed`: User was removed from task (task continues)
+            - `detached`: One client of the user detached (e.g. a browser tab); the
+              task continues for the user's other clients
           parameters:
           - in: path
             schema:

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -347,8 +347,9 @@ def submit_chart_data_query_tasks(
     cursor (the recovery watermark for polling/catch-up), and the tab id the
     subscription policy recorded for this request (echoed so a later cancel detaches
     exactly this tab; omitted when the caller supplied none). Client aborts may
-    unsubscribe from shared work or abort pending work; engine-level query
-    cancellation is outside this chart async path.
+    unsubscribe from shared work or abort pending work; a running query is also
+    cancelled at the engine level on engines that expose a pre-execution cancel id
+    (see ``_capture_query_cancellation``).
     """
     guest_user = security_manager.get_current_guest_user_if_guest()
     guest_token = guest_user.guest_token if guest_user else None

--- a/superset/tasks/decorators.py
+++ b/superset/tasks/decorators.py
@@ -508,12 +508,17 @@ class TaskWrapper(Generic[P]):
             task.uuid,
         )
         # Ensure status is ABORTED (not just ABORTING)
-        InternalStatusTransitionCommand(
+        transitioned = InternalStatusTransitionCommand(
             task_uuid=task.uuid,
             new_status=TaskStatus.ABORTED,
             expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
             set_ended_at=True,
         ).run()
+        # Wake waiters (websocket-mode clients don't poll), but only when this path
+        # performed the transition, so a cancel that already published completion
+        # isn't echoed. Mirrors the async pre-execution check in ``scheduler.py``.
+        if transitioned:
+            TaskManager.publish_completion(task.uuid, TaskStatus.ABORTED.value)
         refreshed = TaskDAO.find_one_or_none(uuid=task.uuid, skip_base_filter=True)
         return refreshed if refreshed else task
 

--- a/superset/tasks/scheduler.py
+++ b/superset/tasks/scheduler.py
@@ -410,12 +410,17 @@ def execute_task(
             task_type,
             task_uuid,
         )
-        InternalStatusTransitionCommand(
+        transitioned = InternalStatusTransitionCommand(
             task_uuid=native_uuid,
             new_status=TaskStatus.ABORTED,
             expected_status=[TaskStatus.PENDING, TaskStatus.ABORTING],
             set_ended_at=True,
         ).run()
+        # Wake waiters (websocket-mode chart clients don't poll). Only when this
+        # path performed the transition, so a cancel that already published
+        # completion for the same task isn't echoed.
+        if transitioned:
+            TaskManager.publish_completion(native_uuid, TaskStatus.ABORTED.value)
         return {"status": TaskStatus.ABORTED.value, "task_uuid": task_uuid}
 
     # DAG gate (non-blocking): defer via Celery retry until every prerequisite is

--- a/tests/integration_tests/tasks/commands/test_cancel.py
+++ b/tests/integration_tests/tasks/commands/test_cancel.py
@@ -50,7 +50,12 @@ def test_cancel_pending_task_aborts(app_context, get_user) -> None:
 
     try:
         # Cancel the pending task with admin user context
-        with override_user(admin):
+        with (
+            override_user(admin),
+            patch(
+                "superset.tasks.manager.TaskManager.publish_completion"
+            ) as publish_completion,
+        ):
             command = CancelTaskCommand(task_uuid=task.uuid)
             result = command.run()
 
@@ -58,6 +63,11 @@ def test_cancel_pending_task_aborts(app_context, get_user) -> None:
         assert result.uuid == task.uuid
         assert result.status == TaskStatus.ABORTED.value
         assert command.action_taken == "aborted"
+
+        # A queued task aborts straight to a terminal state with no worker to
+        # finalize it, so the command must publish completion itself — otherwise a
+        # websocket-mode waiter (which does not poll) hangs until the give-up.
+        publish_completion.assert_called_once_with(task.uuid, TaskStatus.ABORTED.value)
 
         # Verify in database
         db.session.refresh(task)
@@ -89,6 +99,9 @@ def test_cancel_in_progress_abortable_task_sets_aborting(app_context, get_user) 
         with (
             override_user(admin),
             patch("superset.tasks.manager.TaskManager.publish_abort"),
+            patch(
+                "superset.tasks.manager.TaskManager.publish_completion"
+            ) as publish_completion,
         ):
             command = CancelTaskCommand(task_uuid=task.uuid)
             result = command.run()
@@ -97,6 +110,10 @@ def test_cancel_in_progress_abortable_task_sets_aborting(app_context, get_user) 
         assert result.uuid == task.uuid
         assert result.status == TaskStatus.ABORTING.value
         assert command.action_taken == "aborted"
+
+        # Only ABORTING here: the worker finalizes ABORTED and publishes completion
+        # once its abort handlers run, so the command must not publish it early.
+        publish_completion.assert_not_called()
 
         # Verify in database
         db.session.refresh(task)

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -96,6 +96,11 @@ def test_should_run_async_requires_async_mode_flag() -> None:
             "superset.charts.data.api.get_current_guest_subscriber_key",
             return_value=None,
         ),
+        # The principal can read task status (covered on its own below).
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ),
     ):
         # A real (non-null) DATA cache backend so async is viable.
         cache_manager.data_cache.cache = MagicMock()
@@ -144,6 +149,11 @@ def test_should_run_async_requires_subscribeable_identity() -> None:
     with (
         patch("superset.charts.data.api.is_feature_enabled", return_value=True),
         patch("superset.charts.data.api.cache_manager") as cache_manager,
+        # The principal can read task status (covered on its own below).
+        patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ),
     ):
         cache_manager.data_cache.cache = MagicMock()
 
@@ -176,6 +186,48 @@ def test_should_run_async_requires_subscribeable_identity() -> None:
             ),
         ):
             assert api._should_run_async({"async_mode": True}, qc) is True
+
+
+def test_should_run_async_requires_task_read_permission() -> None:
+    """Async needs a principal that can observe task status.
+
+    Completion is read from ``status_changes`` (``can_read Task``); a principal that
+    can't — e.g. an embedded guest on the default ``Public`` role — would get a 202
+    it could never resolve, so it falls back to sync. An authenticated Gamma user
+    has ``can_read Task`` by default and keeps async.
+    """
+    api = ChartDataRestApi()
+    qc = MagicMock()
+    qc.result_format = ChartDataResultFormat.JSON
+    qc.result_type = ChartDataResultType.FULL
+    qc.get_cache_timeout.return_value = 300
+
+    with (
+        patch("superset.charts.data.api.is_feature_enabled", return_value=True),
+        patch("superset.charts.data.api.cache_manager") as cache_manager,
+        # An embedded guest has a subscribe-able identity...
+        patch("superset.charts.data.api.get_user_id", return_value=None),
+        patch(
+            "superset.charts.data.api.get_current_guest_subscriber_key",
+            return_value="guest:abc",
+        ),
+    ):
+        cache_manager.data_cache.cache = MagicMock()
+
+        # ...but without `can_read Task` it can't observe completion → sync.
+        with patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=False,
+        ):
+            assert api._should_run_async({"async_mode": True}, qc) is False
+
+        # With the grant → async.
+        with patch(
+            "superset.charts.data.api.security_manager.can_access",
+            return_value=True,
+        ) as can_access:
+            assert api._should_run_async({"async_mode": True}, qc) is True
+            can_access.assert_called_with("can_read", "Task")
 
 
 def test_get_data_sets_g_form_data_without_dashboard_filter() -> None:


### PR DESCRIPTION
### SUMMARY

Follow-ups from a full re-review of the `gaq-to-gtf` epic (#43407). Three findings; no in-scope security-boundary violation under `SECURITY.md`.

**1. High — queued-task aborts didn't wake websocket-mode waiters.**
`TaskManager.publish_completion()` is the only producer of the targeted `task.status` message a chart waiter observes, but **no abort→terminal transition called it**:
- `TaskDAO.abort_task()` moves a `PENDING` task straight to `ABORTED`.
- The pre-claim `InternalStatusTransitionCommand(ABORTED)` in `scheduler.py` and the inline decorator (`_abort_if_preaborted`) emit only `entity.changed`/required-by nudges.

With the websocket enabled the client does **not** run a recurring poll (`asyncEvent.ts`), so cancelling a *queued* chart task, a last-tab cancel, or an admin force-cancel left the waiting chart unaware until the ~10-minute stale/give-up reconciliation.

Fix:
- `CancelTaskCommand` publishes completion when a cancel aborts straight to a terminal state (`PENDING → ABORTED`). The `ABORTING` case is unchanged — the worker finalizes `ABORTED` and publishes completion once its abort handlers run.
- The two pre-claim executor paths (`scheduler.execute_task`, `decorators._abort_if_preaborted`) publish completion **when they performed the transition** (guarded on the CAS result, so a cancel that already published for the same task isn't echoed).

**2. High/conditional — embedded guest async could return a 202 the guest can't resolve.**
`_should_run_async()` treated a guest subscriber key as sufficient async eligibility, but completion is observed through `GET /api/v1/task/status_changes` (gated by `can_read Task`) and, when enabled, the websocket JWT (gated by `can_read Realtime`). The default guest role (`Public`, `PUBLIC_ROLE_PERMISSIONS`) has neither, so an embedded guest got a `202` it could never poll or observe. (An authenticated Gamma user has `can_read Task` by default — it's neither admin-only nor Gamma-excluded — so this is guest-specific.)

Fix: gate async eligibility on `security_manager.can_access("can_read", "Task")` so a principal that can't observe completion transparently falls back to the synchronous `200` flow. Documented the guest-role grants required to enable embedded async in `UPDATING.md`.

**3. Low — stale docs after hardening.**
- `async_queries.py` docstring said engine-level query cancellation is "outside this chart async path", though the worker registers `ctx.on_abort(_cancel)` via `_capture_query_cancellation`.
- The cancel command's `action_taken` property and the cancel API docstring listed only `aborted`/`unsubscribed`, omitting `detached`.
- The top-level `force_nonce` schema description still described the pre-task-UUID one-nonce-per-refresh model (the per-query field already documents the task-UUID semantics).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/charts/test_chart_data_api.py -k should_run_async`
- `pytest tests/integration_tests/tasks/commands/test_cancel.py -k "pending_task_aborts or in_progress_abortable"` (requires the integration test DB)
- Manual: with `GLOBAL_ASYNC_QUERIES` + `WEBSOCKET_ENABLE`, submit a slow async chart, cancel it (or admin force-cancel) while still `PENDING`, and confirm the chart resolves to a cancelled/error state immediately rather than hanging.
- Manual: open an embedded dashboard as a guest on the default `Public` role with async enabled and confirm chart data returns synchronously (no unresolved 202); grant the guest role `can_read Task` and confirm it goes async.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---
Part of the GAQ → GTF migration epic (#43407).
