### PR TITLE
fix(table): hide the Time Grain control in raw records mode

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -247,6 +247,12 @@ const config: ControlPanelConfig = {
             config: {
               ...sharedControls.time_grain_sqla,
               visibility: ({ controls }) => {
+                // Time grain only applies to the aggregate query, so the
+                // control must follow the query mode like its siblings do.
+                if (!isAggMode({ controls })) {
+                  return false;
+                }
+
                 const dttmLookup = Object.fromEntries(
                   ensureIsArray(controls?.groupby?.options).map(option => [
                     (option.column_name || '').toLowerCase(),

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
@@ -18,6 +18,7 @@ import {
   CustomControlItem,
   isCustomControlItem,
 } from '@superset-ui/chart-controls';
+import { QueryMode } from '@superset-ui/core';
 import config from '../src/controlPanel';
 
 type VisibilityFn = (
@@ -68,6 +69,16 @@ function mkProps(
   } as unknown as ControlPanelsContainerProps;
 }
 
+function withControls(
+  props: ControlPanelsContainerProps,
+  controls: Record<string, unknown>,
+): ControlPanelsContainerProps {
+  return {
+    ...props,
+    controls: { ...props.controls, ...controls },
+  } as unknown as ControlPanelsContainerProps;
+}
+
 test('time_grain_sqla visibility should be case-insensitive', () => {
   const vis = getVisibility(config, 'time_grain_sqla');
   const controlState = {} as ControlState;
@@ -75,6 +86,68 @@ test('time_grain_sqla visibility should be case-insensitive', () => {
   expect(vis(mkProps(['orderdate']), controlState)).toBe(true);
   expect(vis(mkProps(['ORDERDATE']), controlState)).toBe(true);
   expect(vis(mkProps(['some_other_col']), controlState)).toBe(false);
+});
+
+test('time_grain_sqla is hidden in raw records mode', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+  const temporalGroupby = mkProps(['ORDERDATE']);
+
+  expect(
+    vis(
+      withControls(temporalGroupby, {
+        query_mode: { value: QueryMode.Aggregate },
+      }),
+      controlState,
+    ),
+  ).toBe(true);
+
+  // `groupby` is kept when the query mode switches to raw records, both in the
+  // control state and in a saved chart's form data, so a temporal dimension on
+  // its own must not bring the control back.
+  expect(
+    vis(
+      withControls(temporalGroupby, { query_mode: { value: QueryMode.Raw } }),
+      controlState,
+    ),
+  ).toBe(false);
+
+  // Charts saved before the query mode control existed are inferred as raw
+  // records from their columns.
+  expect(
+    vis(
+      withControls(temporalGroupby, { all_columns: { value: ['name'] } }),
+      controlState,
+    ),
+  ).toBe(false);
+});
+
+test('time_grain_sqla is hidden in raw records mode for an adhoc dimension', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+
+  // An adhoc column reports temporal without the lookup, so it needs the guard too.
+  const adhocGroupby = withControls(mkProps([]), {
+    groupby: {
+      value: [{ sqlExpression: 'ds', label: 'ds', expressionType: 'SQL' }],
+      options: [],
+    },
+  });
+
+  expect(
+    vis(
+      withControls(adhocGroupby, {
+        query_mode: { value: QueryMode.Aggregate },
+      }),
+      controlState,
+    ),
+  ).toBe(true);
+  expect(
+    vis(
+      withControls(adhocGroupby, { query_mode: { value: QueryMode.Raw } }),
+      controlState,
+    ),
+  ).toBe(false);
 });
 
 test('show_totals renders in the customize tab atop visual formatting', () => {

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -270,6 +270,12 @@ const config: ControlPanelConfig = {
             config: {
               ...sharedControls.time_grain_sqla,
               visibility: ({ controls }) => {
+                // Time grain only applies to the aggregate query, so the
+                // control must follow the query mode like its siblings do.
+                if (!isAggMode({ controls })) {
+                  return false;
+                }
+
                 const dttmLookup = Object.fromEntries(
                   ensureIsArray(controls?.groupby?.options).map(option => [
                     (option.column_name || '').toLowerCase(),

--- a/superset-frontend/plugins/plugin-chart-table/test/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/controlPanel.test.ts
@@ -17,6 +17,7 @@ import {
   ControlState,
   CustomControlItem,
 } from '@superset-ui/chart-controls';
+import { QueryMode } from '@superset-ui/core';
 import config from '../src/controlPanel';
 
 type VisibilityFn = (
@@ -67,6 +68,16 @@ function mkProps(
   } as unknown as ControlPanelsContainerProps;
 }
 
+function withControls(
+  props: ControlPanelsContainerProps,
+  controls: Record<string, unknown>,
+): ControlPanelsContainerProps {
+  return {
+    ...props,
+    controls: { ...props.controls, ...controls },
+  } as unknown as ControlPanelsContainerProps;
+}
+
 test('time_grain_sqla visibility should be case-insensitive', () => {
   const vis = getVisibility(config, 'time_grain_sqla');
   const controlState = {} as ControlState;
@@ -74,4 +85,66 @@ test('time_grain_sqla visibility should be case-insensitive', () => {
   expect(vis(mkProps(['orderdate']), controlState)).toBe(true);
   expect(vis(mkProps(['ORDERDATE']), controlState)).toBe(true);
   expect(vis(mkProps(['some_other_col']), controlState)).toBe(false);
+});
+
+test('time_grain_sqla is hidden in raw records mode', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+  const temporalGroupby = mkProps(['ORDERDATE']);
+
+  expect(
+    vis(
+      withControls(temporalGroupby, {
+        query_mode: { value: QueryMode.Aggregate },
+      }),
+      controlState,
+    ),
+  ).toBe(true);
+
+  // `groupby` is kept when the query mode switches to raw records, both in the
+  // control state and in a saved chart's form data, so a temporal dimension on
+  // its own must not bring the control back.
+  expect(
+    vis(
+      withControls(temporalGroupby, { query_mode: { value: QueryMode.Raw } }),
+      controlState,
+    ),
+  ).toBe(false);
+
+  // Charts saved before the query mode control existed are inferred as raw
+  // records from their columns.
+  expect(
+    vis(
+      withControls(temporalGroupby, { all_columns: { value: ['name'] } }),
+      controlState,
+    ),
+  ).toBe(false);
+});
+
+test('time_grain_sqla is hidden in raw records mode for an adhoc dimension', () => {
+  const vis = getVisibility(config, 'time_grain_sqla');
+  const controlState = {} as ControlState;
+
+  // An adhoc column reports temporal without the lookup, so it needs the guard too.
+  const adhocGroupby = withControls(mkProps([]), {
+    groupby: {
+      value: [{ sqlExpression: 'ds', label: 'ds', expressionType: 'SQL' }],
+      options: [],
+    },
+  });
+
+  expect(
+    vis(
+      withControls(adhocGroupby, {
+        query_mode: { value: QueryMode.Aggregate },
+      }),
+      controlState,
+    ),
+  ).toBe(true);
+  expect(
+    vis(
+      withControls(adhocGroupby, { query_mode: { value: QueryMode.Raw } }),
+      controlState,
+    ),
+  ).toBe(false);
 });


### PR DESCRIPTION
### SUMMARY

Time Grain is an aggregate only concept, and `buildQuery` already ignores it outside aggregate mode, but the control kept rendering in **Raw Records**. Its visibility check in both table control panels only asked whether a temporal column was picked as a dimension:

```ts
visibility: ({ controls }) => {
  const dttmLookup = ...;   // does any `groupby` selection resolve to a temporal column?
}
```

`groupby` survives a switch to raw records, in the control state and in a saved chart's form data alike, so the combobox reappeared under a "Raw records" query mode, both right after the switch and after reloading a chart saved that way. Every other aggregate only control in the same panels (`metrics`, `percent_metrics`, `timeseries_limit_metric`, the groupby control itself) already gates on `isAggMode`. (`show_totals` gates on it in `plugin-chart-table` only; the ag-grid panel leaves it ungated on purpose so totals also render in raw records mode.)

This gates the check on the query mode first, matching those siblings. The control still behaves exactly as before in aggregate mode.

The same panel exists in two plugins, `plugin-chart-table` and `plugin-chart-ag-grid-table`, and both had the identical predicate, so both are fixed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before, on a chart with a temporal dimension and query mode set to Raw records, the Time Grain combobox renders alongside the "Raw records" radio. After, it is gone, while aggregate mode is unchanged.

### TESTING INSTRUCTIONS

1. Create a Table chart on a dataset with a temporal column (for example `birth_names`).
2. In **Aggregate** mode, add the temporal column as a dimension and set a **Time Grain** (for example Month). Save.
3. Switch **Query mode** to **Raw records**. Save.
4. Hard reload the Explore page.
5. The Time Grain control is not rendered. On master it reappears after the reload. Switching back to Aggregate shows it again.
6. Unit coverage:

   ```bash
   npx jest plugins/plugin-chart-table/test/controlPanel.test.ts plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
   ```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
