### PR TITLE
docs(gtf): align async API docs/schema with GTF; fix stale doc comments

### DIFF
--- a/docs/developer_docs/api.mdx
+++ b/docs/developer_docs/api.mdx
@@ -571,15 +571,6 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 </details>
 
 <details>
-<summary><strong>AsyncEventsRestApi</strong> (1 endpoints) — Real-time event streaming via Server-Sent Events (SSE).</summary>
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | [Read off of the Redis events stream](/developer-docs/api/read-off-of-the-redis-events-stream) | `/api/v1/async_event/` |
-
-</details>
-
-<details>
 <summary><strong>OpenApi</strong> (1 endpoints) — Access the OpenAPI specification.</summary>
 
 | Method | Endpoint | Description |

--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -152,7 +152,7 @@ Use the tuple format `(current, total)` whenever possible. It provides the riche
 
 #### Payload
 
-The `payload` parameter stores custom metadata that can help users understand what the task is doing. Each call to `update_task()` replaces the previous payload completely.
+The `payload` parameter stores custom metadata that can help users understand what the task is doing. Each call to `update_task()` merges into the existing payload (top-level keys are added or overwritten; keys you don't pass are preserved), so a task can build up its payload incrementally across calls.
 
 In the Task List UI, when a payload is defined, an info icon appears in the **Details** column. Users can hover over it to see the JSON content.
 

--- a/docs/scripts/fix-openapi-spec.py
+++ b/docs/scripts/fix-openapi-spec.py
@@ -287,7 +287,6 @@ def add_missing_operation_ids(spec: dict[str, Any]) -> int:
 TAG_DESCRIPTIONS = {
     "Advanced Data Type": "Advanced data type operations and conversions.",
     "Annotation Layers": "Manage annotation layers and annotations for charts.",
-    "AsyncEventsRestApi": "Real-time event streaming via Server-Sent Events (SSE).",
     "Available Domains": "Get available domains for the Superset instance.",
     "CSS Templates": "Manage CSS templates for custom dashboard styling.",
     "CacheRestApi": "Cache management and invalidation operations.",

--- a/docs/scripts/generate-api-index.mjs
+++ b/docs/scripts/generate-api-index.mjs
@@ -93,7 +93,6 @@ const CATEGORY_GROUPS = {
     'User',
     'Menu',
     'Available Domains',
-    'AsyncEventsRestApi',
     'OpenApi',
   ],
 };

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -821,24 +821,19 @@
       },
       "ChartDataAsyncResponseSchema": {
         "properties": {
-          "channel_id": {
-            "description": "Unique session async channel ID",
+          "task_ids": {
+            "description": "UUIDs of the scheduled GTF tasks (one per QueryObject that missed the cache), in query order. The client polls `/api/v1/task/status_changes`, aggregates these tasks' statuses, and re-issues this request once they all succeed.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cursor": {
+            "description": "Status-changes recovery cursor captured before any task was created. The client polls `/api/v1/task/status_changes` from it and is guaranteed to observe each task's completion.",
             "type": "string"
           },
-          "job_id": {
-            "description": "Unique async job ID",
-            "type": "string"
-          },
-          "result_url": {
-            "description": "Unique result URL for fetching async query data",
-            "type": "string"
-          },
-          "status": {
-            "description": "Status value for async job",
-            "type": "string"
-          },
-          "user_id": {
-            "description": "Requesting user ID",
+          "tab_id": {
+            "description": "The per-client (e.g. browser-tab) id echoed back when the caller advertised one, so a later cancel detaches exactly that client. Absent when the caller supplied none.",
             "nullable": true,
             "type": "string"
           }
@@ -13679,110 +13674,6 @@
         ]
       }
     },
-    "/api/v1/async_event/": {
-      "get": {
-        "description": "Reads off of the Redis events stream, using the user's JWT token and optional query params for last event received.",
-        "parameters": [
-          {
-            "description": "Last ID received by the client",
-            "in": "query",
-            "name": "last_id",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "result": {
-                      "items": {
-                        "properties": {
-                          "channel_id": {
-                            "type": "string"
-                          },
-                          "errors": {
-                            "items": {
-                              "type": "object"
-                            },
-                            "type": "array"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "job_id": {
-                            "type": "string"
-                          },
-                          "result_url": {
-                            "type": "string"
-                          },
-                          "status": {
-                            "type": "string"
-                          },
-                          "user_id": {
-                            "type": "integer"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "type": "object"
-                },
-                "example": {
-                  "result": [
-                    {
-                      "channel_id": "string",
-                      "errors": [],
-                      "id": "string",
-                      "job_id": "string",
-                      "result_url": "string",
-                      "status": "string",
-                      "user_id": 1
-                    }
-                  ]
-                }
-              }
-            },
-            "description": "Async event results"
-          },
-          "401": {
-            "$ref": "#/components/responses/401"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        },
-        "security": [
-          {
-            "jwt": []
-          }
-        ],
-        "summary": "Read off of the Redis events stream",
-        "tags": ["AsyncEventsRestApi"],
-        "x-codeSamples": [
-          {
-            "lang": "cURL",
-            "label": "cURL",
-            "source": "curl -X GET \"http://localhost:8088/api/v1/async_event/\" \\\n  -H \"Authorization: Bearer $ACCESS_TOKEN\""
-          },
-          {
-            "lang": "Python",
-            "label": "Python",
-            "source": "import requests\n\nresponse = requests.get(\n    \"http://localhost:8088/api/v1/async_event/\",\n    headers={\"Authorization\": \"Bearer \" + access_token}\n)\nprint(response.json())"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "JavaScript",
-            "source": "const response = await fetch(\n  \"http://localhost:8088/api/v1/async_event/\",\n  {\n    headers: {\n      \"Authorization\": `Bearer ${accessToken}`\n    }\n  }\n);\nconst data = await response.json();\nconsole.log(data);"
-          }
-        ]
-      }
-    },
     "/api/v1/available_domains/": {
       "get": {
         "responses": {
@@ -14377,11 +14268,9 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 },
                 "example": {
-                  "channel_id": "string",
-                  "job_id": "string",
-                  "result_url": "string",
-                  "status": "string",
-                  "user_id": "string"
+                  "task_ids": ["string"],
+                  "cursor": "string",
+                  "tab_id": "string"
                 }
               }
             },
@@ -15320,11 +15209,9 @@
                   "$ref": "#/components/schemas/ChartDataAsyncResponseSchema"
                 },
                 "example": {
-                  "channel_id": "string",
-                  "job_id": "string",
-                  "result_url": "string",
-                  "status": "string",
-                  "user_id": "string"
+                  "task_ids": ["string"],
+                  "cursor": "string",
+                  "tab_id": "string"
                 }
               }
             },
@@ -37554,10 +37441,6 @@
     {
       "name": "Annotation Layers",
       "description": "Manage annotation layers and annotations for charts."
-    },
-    {
-      "name": "AsyncEventsRestApi",
-      "description": "Real-time event streaming via Server-Sent Events (SSE)."
     },
     {
       "name": "Available Domains",

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -181,9 +181,10 @@ const fetchStatusChanges = makeApi<
 });
 
 const cancelTask = (taskId: string, tabId: string) => {
-  // Best-effort task abort/unsubscribe. This can prevent pending work from
-  // starting, but chart tasks do not cancel an underlying warehouse query after
-  // execution starts. Failures are non-fatal: the client has stopped waiting.
+  // Best-effort task abort/unsubscribe. This prevents pending work from starting
+  // and, once execution has begun, cancels the underlying warehouse query on a
+  // best-effort, engine-dependent basis (engines that expose a pre-execution
+  // cancel id). Failures are non-fatal: the client has stopped waiting.
   //
   // Send the tab id captured at submit time (not read fresh here) so the backend
   // detaches exactly the tab that subscribed: if another tab of the same user is

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -307,7 +307,7 @@ docker compose --profile websocket up superset-websocket
 
 ## Health check
 
-The WebSocket server supports health checks via one of:
+The WebSocket server supports liveness checks via one of:
 
 ```text
 GET /health
@@ -318,6 +318,20 @@ OR
 ```text
 HEAD /health
 ```
+
+`/health` is a pure liveness probe: it returns `200` whenever the process is up,
+so a transient Redis blip does not churn pods.
+
+For load-balancer draining, use the **readiness** endpoint instead:
+
+```text
+GET /ready
+```
+
+`/ready` returns `200` only while the server's Redis Pub/Sub subscriber is
+connected and subscribed, and `503` when that subscriber has dropped (the server
+can't deliver messages until it reconnects). Wire connection draining to `/ready`,
+not `/health`, so a degraded pod stops receiving new connections while it recovers.
 
 ## Containerization
 

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -1877,25 +1877,32 @@ class ChartDataResponseSchema(Schema):
 
 
 class ChartDataAsyncResponseSchema(Schema):
-    channel_id = fields.String(
-        metadata={"description": "Unique session async channel ID"},
+    task_ids = fields.List(
+        fields.String(),
+        metadata={
+            "description": "UUIDs of the scheduled GTF tasks (one per QueryObject "
+            "that missed the cache), in query order. The client polls "
+            "`/api/v1/task/status_changes`, aggregates these tasks' statuses, and "
+            "re-issues this request once they all succeed."
+        },
         allow_none=False,
     )
-    job_id = fields.String(
-        metadata={"description": "Unique async job ID"},
+    cursor = fields.String(
+        metadata={
+            "description": "Status-changes recovery cursor captured before any task "
+            "was created. The client polls `/api/v1/task/status_changes` from it and "
+            "is guaranteed to observe each task's completion."
+        },
         allow_none=False,
     )
-    user_id = fields.String(
-        metadata={"description": "Requesting user ID"},
+    tab_id = fields.String(
+        metadata={
+            "description": "The per-client (e.g. browser-tab) id echoed back when the "
+            "caller advertised one, so a later cancel detaches exactly that client. "
+            "Absent when the caller supplied none."
+        },
+        required=False,
         allow_none=True,
-    )
-    status = fields.String(
-        metadata={"description": "Status value for async job"},
-        allow_none=False,
-    )
-    result_url = fields.String(
-        metadata={"description": "Unique result URL for fetching async query data"},
-        allow_none=False,
     )
 
 


### PR DESCRIPTION
### SUMMARY

Documentation and OpenAPI-schema follow-ups from a final review of the `gaq-to-gtf` epic (#43407). All findings were P2/P3; **no runtime behavior changes**.

**P2 — async chart-data OpenAPI advertised the removed GAQ response shape.**
The async endpoint returns `{task_ids, cursor, tab_id}` from GTF submission (`submit_chart_data_query_tasks`), but `ChartDataAsyncResponseSchema` still exposed `channel_id`, `job_id`, `user_id`, `status`, and `result_url`.
- Rewrote the marshmallow schema (which drives the live `/swagger/v1`) to `task_ids` / `cursor` / `tab_id`.
- Updated the committed docs snapshot `docs/static/resources/openapi.json` — the schema component and both chart-data `202` examples — to match.

**P2 — generated API docs still listed the removed async-events endpoint.**
`/api/v1/async_event/` and `AsyncEventsRestApi` were removed from the backend but still published in the docs. Removed the path, tag, and `202` schema from the docs snapshot and the generated `docs/developer_docs/api.mdx`, and dropped the hard-coded `AsyncEventsRestApi` entries from the generators (`generate-api-index.mjs`, `fix-openapi-spec.py`) so a regeneration doesn't re-add them. The frozen `version-6.1.0` versioned docs are intentionally left untouched (they document a released version).

**P3 — stale frontend cancellation comment.** `asyncEvent.ts` said chart tasks "do not cancel an underlying warehouse query after execution starts." The worker now registers engine-level abort handlers (`_capture_query_cancellation`), so this is reworded as best-effort / engine-dependent.

**P3 — websocket operator docs omitted `/ready`.** The `superset-websocket` README health-check section only listed `/health`. Documented `/ready` (readiness — `200` only while the Redis subscriber is connected/subscribed, `503` otherwise) for load-balancer draining, and clarified `/health` as pure liveness.

**P3 — extension task-payload semantics.** The extension docs said `update_task()` "replaces the previous payload completely"; the code merges (top-level keys). Corrected to describe incremental merge semantics.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (docs/schema only).

### TESTING INSTRUCTIONS

- `python -c "import json; json.load(open('docs/static/resources/openapi.json'))"` — snapshot is valid JSON.
- Load `/swagger/v1` and confirm the chart-data `202` response documents `task_ids`/`cursor`/`tab_id` and that `AsyncEventsRestApi` / `/api/v1/async_event/` are gone.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---
Part of the GAQ → GTF migration epic (#43407).
