### PR TITLE
fix(sql): close StarRocks SQL parsing and mutation-detection gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,9 @@ dependencies = [
     "sqlalchemy>=2.0.52, <2.1",
     "sqlalchemy-continuum>=1.6.0, <2.0.0",
     "sqlalchemy-utils>=0.42.1, <0.43", # expanding lowerbound to work with pydoris
+    # Dialect-specific gaps/bugs against this pin are worked around in
+    # superset/sql/dialects/ (e.g. starrocks.py); check there for anything
+    # that can be cleaned up when bumping
     "sqlglot>=30.17.0, <31", # 30.16.0 adds Trino inline UDF IF/CASE routine statement parsing
     # newer pandas needs 0.9+
     "tabulate>=0.10.0, <1.0",

--- a/superset/sql/dialects/__init__.py
+++ b/superset/sql/dialects/__init__.py
@@ -21,6 +21,7 @@ from .firebolt import Firebolt, FireboltOld
 from .hana import Hana
 from .opensearch import OpenSearch
 from .pinot import Pinot
+from .starrocks import StarRocks
 from .vertica import Vertica
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "Hana",
     "OpenSearch",
     "Pinot",
+    "StarRocks",
     "Vertica",
 ]

--- a/superset/sql/dialects/starrocks.py
+++ b/superset/sql/dialects/starrocks.py
@@ -1,0 +1,659 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+StarRocks dialect for Superset, extending sqlglot's built-in StarRocks dialect.
+
+sqlglot's StarRocks parser inherits almost all of its grammar from MySQL, which
+doesn't model a long tail of StarRocks-only syntax: catalog-qualified schema
+references, aggregate/primary-key column shorthand, admin/ops statements, and
+several ALTER/CREATE/SHOW clause variants. Each override below closes one gap
+found while auditing StarRocks' SQL reference against this dialect; see the
+docstring on each method for the specific construct it fixes.
+"""
+
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.dialects.starrocks import StarRocks as _StarRocks
+from sqlglot.errors import ParseError
+from sqlglot.helper import seq_get
+from sqlglot.parsers.starrocks import StarRocksParser as _StarRocksParser
+from sqlglot.tokens import TokenType
+
+# Head keywords for StarRocks statements that sqlglot's MySQL-derived grammar
+# doesn't model at all (no dedicated TokenType, no STATEMENT_PARSERS entry).
+# Without this, the parser tries to read them as a generic expression/alias
+# and raises a ParseError. Mapping them to TokenType.COMMAND opts them into
+# the same generic "slurp the rest of the statement as an opaque command"
+# fallback already used by CALL/EXPLAIN/OPTIMIZE/PREPARE/VACUUM, producing a
+# structured-enough `exp.Command` instead of crashing. This is safe only for
+# words that have no other meaning elsewhere in the grammar -- ADD and DELETE
+# are handled separately below because they're already meaningful keywords.
+_STARROCKS_COMMAND_KEYWORDS = (
+    "ADMIN",
+    "BACKUP",
+    "RESTORE",
+    "RECOVER",
+    "CANCEL",
+    "EXPORT",
+    "SUBMIT",
+    "PAUSE",
+    "RESUME",
+    "STOP",
+    "DEALLOCATE",
+)
+
+# Column-level aggregate-function markers on AGGREGATE KEY / UNIQUE KEY table
+# columns, e.g. `v2 INT SUM`. See
+# https://docs.starrocks.io/docs/table_design/table_types/aggregate_table/
+_STARROCKS_AGGREGATE_COLUMN_CONSTRAINTS = (
+    "SUM",
+    "MAX",
+    "MIN",
+    "REPLACE",
+    "REPLACE_IF_NOT_NULL",
+    "BITMAP_UNION",
+    "HLL_UNION",
+)
+
+
+class StarRocksParser(_StarRocksParser):
+    # StarRocks accepts a bare `AS <expr>` generated-column definition, not
+    # just the parenthesized `AS (<expr>)` form MySQL requires.
+    # https://docs.starrocks.io/docs/sql-reference/sql-statements/generated_columns/
+    WRAPPED_TRANSFORM_COLUMN_CONSTRAINT = False
+
+    FUNCTIONS = {
+        **_StarRocksParser.FUNCTIONS,
+        # StarRocks' 2-arg `time_slice(dt, INTERVAL n unit [, boundary])` packs
+        # the interval into a single argument, unlike sqlglot's generic
+        # TimeSlice(this, expression, unit, kind) shape, which expects the
+        # numeric amount and unit as separate positional arguments.
+        "TIME_SLICE": lambda args: exp.TimeSlice(
+            this=seq_get(args, 0),
+            expression=seq_get(args, 1).this
+            if isinstance(seq_get(args, 1), exp.Interval)
+            else seq_get(args, 1),
+            unit=seq_get(args, 1).args.get("unit")
+            if isinstance(seq_get(args, 1), exp.Interval)
+            else seq_get(args, 2),
+            kind=seq_get(args, 2)
+            if isinstance(seq_get(args, 1), exp.Interval)
+            else seq_get(args, 3),
+        ),
+    }
+
+    CONSTRAINT_PARSERS = {
+        **_StarRocksParser.CONSTRAINT_PARSERS,
+        **{
+            keyword: (lambda keyword: lambda self: exp.var(keyword))(keyword)
+            for keyword in _STARROCKS_AGGREGATE_COLUMN_CONSTRAINTS
+        },
+        # Overrides MySQL's "KEY" (always a named inline secondary index) to
+        # also accept StarRocks' bare `KEY` column attribute, which marks the
+        # column as part of the primary/duplicate key with no name or column
+        # list, e.g. `ADD COLUMN c INT KEY DEFAULT '0' FIRST`.
+        "KEY": lambda self: self._parse_starrocks_key_constraint(),
+    }
+
+    def _parse_starrocks_key_constraint(self) -> exp.Expr:
+        index = self._index
+
+        is_index_def = self._match(TokenType.L_PAREN, advance=False)
+        if not is_index_def and self._match_set(self.ID_VAR_TOKENS, advance=False):
+            self._advance()
+            self._match(TokenType.USING) and self._advance_any()
+            is_index_def = self._match(TokenType.L_PAREN, advance=False)
+            self._retreat(index)
+
+        if is_index_def:
+            return self._parse_index_constraint()
+
+        return exp.var("KEY")
+
+    def _parse_kill(self) -> exp.Kill:
+        # StarRocks additionally supports `KILL ANALYZE <task_id>` to cancel a
+        # running ANALYZE job, alongside MySQL's CONNECTION/QUERY forms.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/cbo_stats/KILL_ANALYZE/
+        kind = (
+            exp.var(self._prev.text)
+            if self._match_texts(("CONNECTION", "QUERY", "ANALYZE"))
+            else None
+        )
+        return self.expression(exp.Kill(this=self._parse_primary(), kind=kind))
+
+    def _parse_refresh(self) -> exp.Refresh | exp.Command:
+        # Extends sqlglot's generic REFRESH (EXTERNAL TABLE | TABLE |
+        # MATERIALIZED VIEW) with StarRocks' DICTIONARY and CONNECTIONS forms,
+        # and consumes (without modeling) the optional FORCE / PARTITION
+        # START(...) END(...) / WITH SYNC MODE clauses on
+        # REFRESH MATERIALIZED VIEW so they don't derail the statement. The
+        # base implementation is replicated (rather than delegated to) using
+        # `_parse_table_parts` instead of `_parse_table`, because the latter
+        # also tries to parse a trailing `FORCE`/`PARTITION` as a MySQL index
+        # hint and raises before this method ever sees those tokens.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_MATERIALIZED_VIEW/
+        if self._match_text_seq("DICTIONARY"):
+            return self.expression(
+                exp.Refresh(this=self._parse_table_parts(), kind="DICTIONARY")
+            )
+        if self._match_text_seq("CONNECTIONS"):
+            return self.expression(
+                exp.Refresh(this=exp.var("CONNECTIONS"), kind="CONNECTIONS")
+            )
+
+        if self._match_text_seq("EXTERNAL", "TABLE"):
+            kind = "EXTERNAL TABLE"
+        elif self._match(TokenType.TABLE):
+            kind = "TABLE"
+        elif self._match_text_seq("MATERIALIZED", "VIEW"):
+            kind = "MATERIALIZED VIEW"
+        else:
+            kind = ""
+
+        this = self._parse_string() or self._parse_table_parts()
+        if not kind and not isinstance(this, exp.Literal):
+            return self._parse_as_command(self._prev)
+
+        if kind == "MATERIALIZED VIEW":
+            self._match_text_seq("FORCE")
+            if self._match_text_seq("PARTITION", "START"):
+                self._parse_wrapped(self._parse_string)
+                self._match_text_seq("END")
+                self._parse_wrapped(self._parse_string)
+                self._match_text_seq("FORCE")
+            self._match_text_seq("WITH", "SYNC", "MODE")
+
+        return self.expression(exp.Refresh(this=this, kind=kind))
+
+    def _parse_show_mysql(
+        self,
+        this: str,
+        target: bool | str = False,
+        full: bool | None = None,
+        global_: bool | None = None,
+    ) -> exp.Show:
+        json = self._match_text_seq("JSON")
+
+        if target:
+            if isinstance(target, str):
+                self._match_text_seq(*target.split(" "))
+            target_id = self._parse_id_var()
+        else:
+            target_id = None
+
+        index = self._index
+        if self._match_text_seq("IN"):
+            log = self._parse_string()
+            if log is None:
+                self._retreat(index)
+        else:
+            log = None
+
+        if this in ("BINLOG EVENTS", "RELAYLOG EVENTS"):
+            position = self._parse_number() if self._match_text_seq("FROM") else None
+            db = None
+        else:
+            position = None
+            db = None
+
+            if self._match(TokenType.FROM) or self._match_text_seq("IN"):
+                db = self._parse_table_parts(is_db_reference=True)
+            elif self._match(TokenType.DOT):
+                db = target_id
+                target_id = self._parse_id_var()
+
+        # `SHOW CREATE FUNCTION`/`SHOW CREATE PROCEDURE` require a
+        # parenthesized argument-type list to disambiguate overloads,
+        # e.g. `SHOW CREATE FUNCTION db.my_add(BIGINT)`.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/Function/SHOW_CREATE_FUNCTION/
+        if this in ("CREATE FUNCTION", "CREATE PROCEDURE") and self._match(
+            TokenType.L_PAREN, advance=False
+        ):
+            self._parse_wrapped_csv(self._parse_types)
+
+        channel = (
+            self._parse_id_var() if self._match_text_seq("FOR", "CHANNEL") else None
+        )
+
+        like = self._parse_string() if self._match_text_seq("LIKE") else None
+        where = self._parse_where()
+
+        if this == "PROFILE":
+            types = self._parse_csv(
+                lambda: self._parse_var_from_options(self.PROFILE_TYPES)
+            )
+            query = (
+                self._parse_number() if self._match_text_seq("FOR", "QUERY") else None
+            )
+            offset = self._parse_number() if self._match_text_seq("OFFSET") else None
+            limit = self._parse_number() if self._match_text_seq("LIMIT") else None
+        else:
+            types, query = None, None
+            offset, limit = self._parse_oldstyle_limit()
+
+        mutex = True if self._match_text_seq("MUTEX") else None
+        mutex = False if self._match_text_seq("STATUS") else mutex
+
+        for_table = (
+            self._parse_id_var() if self._match_text_seq("FOR", "TABLE") else None
+        )
+        for_group = (
+            self._parse_string() if self._match_text_seq("FOR", "GROUP") else None
+        )
+        for_user = self._parse_string() if self._match_text_seq("FOR", "USER") else None
+        for_role = self._parse_string() if self._match_text_seq("FOR", "ROLE") else None
+        into_outfile = (
+            self._parse_string() if self._match_text_seq("INTO", "OUTFILE") else None
+        )
+
+        return self.expression(
+            exp.Show(
+                this=this,
+                target=target_id,
+                full=full,
+                log=log,
+                position=position,
+                db=db,
+                channel=channel,
+                like=like,
+                where=where,
+                types=types,
+                query=query,
+                offset=offset,
+                limit=limit,
+                mutex=mutex,
+                for_table=for_table,
+                for_group=for_group,
+                for_user=for_user,
+                for_role=for_role,
+                into_outfile=into_outfile,
+                json=json,
+                global_=global_,
+            )
+        )
+
+    def _parse_index_constraint(  # noqa: C901
+        self, kind: str | None = None
+    ) -> exp.IndexColumnConstraint:
+        if kind:
+            self._match_texts(("INDEX", "KEY"))
+
+        this = self._parse_id_var(any_token=False)
+        index_type = (
+            self._match(TokenType.USING) and self._advance_any() and self._prev.text
+        )
+        expressions = self._parse_wrapped_csv(self._parse_ordered)
+
+        options = []
+        while True:
+            if self._match_text_seq("KEY_BLOCK_SIZE"):
+                self._match(TokenType.EQ)
+                opt = exp.IndexConstraintOption(key_block_size=self._parse_number())
+            elif self._match(TokenType.USING):
+                opt = exp.IndexConstraintOption(
+                    using=self._advance_any() and self._prev.text
+                )
+                # StarRocks' GIN/NGRAM full-text indexes take an inline
+                # properties list after the index type, which MySQL's
+                # grammar doesn't expect: `USING GIN ('parser' = 'english')`.
+                # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX/
+                if self._match(TokenType.L_PAREN, advance=False):
+                    self._parse_wrapped_properties()
+            elif self._match_text_seq("WITH", "PARSER"):
+                opt = exp.IndexConstraintOption(parser=self._parse_var(any_token=True))
+            elif self._match(TokenType.COMMENT):
+                opt = exp.IndexConstraintOption(comment=self._parse_string())
+            elif self._match_text_seq("VISIBLE"):
+                opt = exp.IndexConstraintOption(visible=True)
+            elif self._match_text_seq("INVISIBLE"):
+                opt = exp.IndexConstraintOption(visible=False)
+            elif self._match_text_seq("ENGINE_ATTRIBUTE"):
+                self._match(TokenType.EQ)
+                opt = exp.IndexConstraintOption(engine_attr=self._parse_string())
+            elif self._match_text_seq("SECONDARY_ENGINE_ATTRIBUTE"):
+                self._match(TokenType.EQ)
+                opt = exp.IndexConstraintOption(
+                    secondary_engine_attr=self._parse_string()
+                )
+            else:
+                opt = None
+
+            if not opt:
+                break
+
+            options.append(opt)
+
+        return self.expression(
+            exp.IndexColumnConstraint(
+                this=this,
+                expressions=expressions,
+                kind=kind,
+                index_type=index_type,
+                options=options,
+            )
+        )
+
+    def _parse_drop(self, exists: bool = False) -> exp.Drop | exp.Command:
+        start = self._prev
+        temporary = self._match(TokenType.TEMPORARY)
+        materialized = self._match_text_seq("MATERIALIZED")
+        iceberg = self._match_text_seq("ICEBERG")
+
+        kind = self._match_set(self.CREATABLES) and self._prev.text.upper()
+        if not kind or (iceberg and kind and kind != "TABLE"):
+            return self._parse_as_command(start)
+
+        concurrently = self._match_text_seq("CONCURRENTLY")
+        if_exists = exists or self._parse_exists()
+
+        if kind == "COLUMN":
+            this = self._parse_column()
+        else:
+            this = self._parse_table_parts(
+                schema=True, is_db_reference=kind == "SCHEMA"
+            )
+
+        if kind == "INDEX" and self._match(TokenType.ON):
+            # MySQL's grammar treats `ON` after DROP INDEX as an "ON CLUSTER"
+            # style property (a bare id, optionally with a column list), but
+            # StarRocks' `DROP INDEX idx ON db.table` names a dotted table.
+            # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/DROP_INDEX/
+            cluster = self.expression(exp.OnProperty(this=self._parse_table_parts()))
+        else:
+            cluster = self._parse_on_property() if self._match(TokenType.ON) else None
+
+        if self._match(TokenType.L_PAREN, advance=False):
+            expressions = self._parse_wrapped_csv(self._parse_types)
+        else:
+            expressions = None
+
+        cascade_or_restrict = (
+            self._match_texts(("CASCADE", "RESTRICT")) and self._prev.text.upper()
+        )
+
+        return self.expression(
+            exp.Drop(
+                exists=if_exists,
+                this=this,
+                expressions=expressions,
+                kind=self.dialect.CREATABLE_KIND_MAPPING.get(kind) or kind,
+                temporary=temporary,
+                materialized=materialized,
+                cascade=cascade_or_restrict == "CASCADE",
+                restrict=cascade_or_restrict == "RESTRICT",
+                constraints=self._match_text_seq("CONSTRAINTS"),
+                purge=self._match_text_seq("PURGE"),
+                cluster=cluster,
+                concurrently=concurrently,
+                sync=self._match_text_seq("SYNC"),
+                iceberg=iceberg,
+                force=self._match_text_seq("FORCE"),
+            )
+        )
+
+    def _parse_delete(self) -> exp.Delete:
+        # `DELETE FROM t PARTITION p1 WHERE ...` -- StarRocks allows scoping a
+        # DELETE to a partition, which the base parser's DELETE target
+        # doesn't request (unlike ALTER TABLE, it doesn't pass
+        # parse_partition=True).
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/DELETE/
+        hint = self._parse_hint()
+
+        tables = None
+        if not self._match(TokenType.FROM, advance=False):
+            tables = self._parse_csv(self._parse_table) or None
+
+        returning = self._parse_returning()
+
+        return self.expression(
+            exp.Delete(
+                hint=hint,
+                tables=tables,
+                this=self._match(TokenType.FROM)
+                and self._parse_table(joins=True, parse_partition=True),
+                using=self._match(TokenType.USING)
+                and self._parse_csv(lambda: self._parse_table(joins=True)),
+                cluster=self._match(TokenType.ON) and self._parse_on_property(),
+                where=self._parse_where(),
+                returning=returning or self._parse_returning(),
+                order=self._parse_order(),
+                limit=self._parse_limit(),
+            )
+        )
+
+    def _parse_insert_table(self) -> exp.Expr | None:
+        # StarRocks' `WITH LABEL <name>` names the load job for an INSERT and
+        # can appear before an explicit target column list, which the base
+        # parser doesn't expect anywhere in the INSERT grammar:
+        #   INSERT OVERWRITE t PARTITION(p1) WITH LABEL `l1` SELECT ...
+        #   INSERT OVERWRITE t WITH LABEL `l1` (c1, c2) SELECT ...
+        # `schema=True` (the base default) is tried first since it already
+        # correctly resolves the common `t (c1, c2)` column-list form; it
+        # only fails for a table-function target like `INSERT INTO
+        # FILES(...)`, whose key=value call arguments don't fit a
+        # column-schema list. That's caught and retried with schema=False,
+        # parsing the target the same way a FROM-clause table reference
+        # would.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/loading_unloading/INSERT/
+        index = self._index
+        try:
+            this = self._parse_table(schema=True, parse_partition=True)
+        except ParseError:
+            self._retreat(index)
+            this = self._parse_table(schema=False, parse_partition=True)
+
+        # Unlike a FROM-clause table reference, `schema=True` doesn't parse a
+        # trailing alias itself (it would be ambiguous with the column-schema
+        # list), so it's handled explicitly here instead.
+        if isinstance(this, exp.Table) and self._match(TokenType.ALIAS, advance=False):
+            this.set("alias", self._parse_table_alias())
+
+        if self._match_text_seq("WITH", "LABEL"):
+            self._parse_id_var()
+
+        if isinstance(this, exp.Table) and self._match(
+            TokenType.L_PAREN, advance=False
+        ):
+            columns = self._parse_wrapped_id_vars()
+            this = self.expression(exp.Schema(this=this, expressions=columns))
+
+        return this
+
+    def _parse_alter_table_add(self) -> list[exp.Expr]:
+        # `ALTER TABLE t ADD ROLLUP r1(col1, col2) [FROM base_index] [PROPERTIES (...)]`
+        # is a distinct ALTER action from the CREATE-TABLE-level ROLLUP
+        # property (already handled by `_parse_rollup_property`).
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE/#rollup
+        if self._match_text_seq("ROLLUP"):
+            return self._parse_csv(self._parse_add_rollup_index)
+
+        # StarRocks accepts a parenthesized multi-column list after the
+        # singular `ADD COLUMN` (MySQL requires the plural `ADD COLUMNS` for
+        # that form): `ADD COLUMN (c1 INT DEFAULT '0', c2 INT DEFAULT '0')`.
+        index = self._index
+        if self._match_text_seq("COLUMN") and self._match(
+            TokenType.L_PAREN, advance=False
+        ):
+            schema = self._parse_schema()
+            if schema:
+                return [schema]
+        self._retreat(index)
+
+        return super()._parse_alter_table_add()
+
+    def _parse_add_rollup_index(self) -> exp.RollupIndex:
+        return self.expression(
+            exp.RollupIndex(
+                this=self._parse_id_var(),
+                expressions=self._parse_wrapped_id_vars(),
+                from_index=self._parse_id_var()
+                if self._match_text_seq("FROM")
+                else None,
+                properties=self.expression(
+                    exp.Properties(expressions=self._parse_wrapped_properties())
+                )
+                if self._match_text_seq("PROPERTIES")
+                else None,
+            )
+        )
+
+    def _parse_partition(self) -> exp.Partition | None:
+        # `ALTER TABLE t DROP PARTITION p1` / `DELETE FROM t PARTITION p1 ...`
+        # -- StarRocks also accepts a bare, unparenthesized single partition
+        # name, not just the parenthesized `PARTITION (p1, p2)` list form.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE/#drop-partition
+        if not self._match_texts(self.PARTITION_KEYWORDS):
+            return None
+
+        subpartition = self._prev.text.upper() == "SUBPARTITION"
+
+        if self._match(TokenType.L_PAREN, advance=False):
+            expressions = self._parse_wrapped_csv(self._parse_disjunction)
+        else:
+            expressions = [self._parse_disjunction()]
+
+        return self.expression(
+            exp.Partition(subpartition=subpartition, expressions=expressions)
+        )
+
+    def _parse_partition_range_value(self) -> exp.Expr | None:
+        self._match_text_seq("PARTITION")
+        name = self._parse_id_var()
+
+        if self._match_text_seq("VALUES", "LESS", "THAN"):
+            if self._match_text_seq("MAXVALUE"):
+                values: list[exp.Expr] = [exp.var("MAXVALUE")]
+            else:
+                values = self._parse_wrapped_csv(self._parse_expression)
+                if (
+                    len(values) == 1
+                    and isinstance(values[0], exp.Column)
+                    and values[0].name.upper() == "MAXVALUE"
+                ):
+                    values = [exp.var("MAXVALUE")]
+
+            part_range = self.expression(
+                exp.PartitionRange(this=name, expressions=values)
+            )
+            return self.expression(exp.Partition(expressions=[part_range]))
+
+        if self._match_text_seq("VALUES") and self._match(TokenType.L_BRACKET):
+            # Dual-bound range partition, e.g.
+            # `PARTITION p1 VALUES [("2021-01-01"), ("2021-01-31"))` -- the
+            # mismatched `[ ... )` denotes an inclusive-lower/exclusive-upper
+            # bound; both bounds are still ordinary parenthesized tuples.
+            # https://docs.starrocks.io/docs/table_design/data_distribution/#range-partitioning
+            lower = self._parse_wrapped_csv(self._parse_expression)
+            self._match(TokenType.COMMA)
+            upper = self._parse_wrapped_csv(self._parse_expression)
+            self._match(TokenType.R_PAREN)
+            part_range = self.expression(
+                exp.PartitionRange(
+                    this=name,
+                    expressions=[
+                        exp.Tuple(expressions=lower),
+                        exp.Tuple(expressions=upper),
+                    ],
+                )
+            )
+            return self.expression(exp.Partition(expressions=[part_range]))
+
+        return name
+
+    def _parse_refresh_property(self) -> exp.RefreshTriggerProperty:
+        method = (
+            self._match_texts(("DEFERRED", "IMMEDIATE")) and self._prev.text.upper()
+        )
+        # StarRocks also allows a cron-style `SCHEDULE START (...) EVERY (...)`
+        # trigger alongside ASYNC/MANUAL; the START/EVERY clauses below are
+        # already parsed unconditionally, so recognizing the keyword is
+        # enough to keep the rest of the CREATE MATERIALIZED VIEW parseable.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_MATERIALIZED_VIEW/
+        kind = (
+            self._match_texts(("ASYNC", "MANUAL", "SCHEDULE"))
+            and self._prev.text.upper()
+        )
+        start = self._match_text_seq("START") and self._parse_wrapped(
+            self._parse_string
+        )
+        if self._match_text_seq("EVERY"):
+            self._match_l_paren()
+            self._match_text_seq("INTERVAL")
+            every = self._parse_number()
+            unit = self._parse_var(any_token=True)
+            self._match_r_paren()
+        else:
+            every = None
+            unit = None
+        return self.expression(
+            exp.RefreshTriggerProperty(
+                method=method, kind=kind, starts=start, every=every, unit=unit
+            )
+        )
+
+    def _parse_statement(self) -> exp.Expr | None:
+        # `ADD SQLBLACKLIST|BACKEND BLACKLIST|COMPUTE NODE BLACKLIST` and the
+        # matching `DELETE ...` forms manage cluster-wide denylists. ADD and
+        # DELETE already have dedicated meanings elsewhere in the grammar
+        # (ALTER TABLE ADD ..., the DML DELETE statement), so -- unlike the
+        # keywords in _STARROCKS_COMMAND_KEYWORDS -- they can't be remapped to
+        # TokenType.COMMAND outright; this peeks for the specific StarRocks
+        # phrasing instead and only then treats it as an opaque command.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/cluster-management/sql_blacklist/
+        # https://docs.starrocks.io/docs/administration/management/BE_blacklist/
+        if self._match_texts(("ADD", "DELETE"), advance=False):
+            index = self._index
+            start = self._curr
+            self._advance()
+            is_blacklist_command = (
+                self._match_text_seq("SQLBLACKLIST")
+                or self._match_text_seq("BACKEND", "BLACKLIST")
+                or self._match_text_seq("COMPUTE", "NODE", "BLACKLIST")
+            )
+            self._retreat(index)
+
+            if is_blacklist_command:
+                self._advance()
+                return self._parse_as_command(start)
+
+        # `TRANSLATE TRINO <select_statement>` translates a Trino SELECT into
+        # StarRocks SQL and returns it as a result set -- a read, not a
+        # mutation. Like ADD/DELETE above, this can't be remapped to
+        # TokenType.COMMAND outright: TRANSLATE is also the ordinary
+        # TRANSLATE(string, from, to) scalar function, and mapping the
+        # keyword globally would corrupt every call to it anywhere in a
+        # query, not just at statement start. Peeking for the literal
+        # two-word phrase is safe because a bare `TRANSLATE(...)` call can
+        # never be the first token of a top-level statement on its own --
+        # it only ever appears nested inside an expression.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/TRANSLATE_TRINO/
+        if self._match_text_seq("TRANSLATE", "TRINO", advance=False):
+            return self._parse_as_command(self._curr)
+
+        return super()._parse_statement()
+
+
+class StarRocks(_StarRocks):
+    Parser = StarRocksParser
+
+    class Tokenizer(_StarRocks.Tokenizer):
+        KEYWORDS = {
+            **_StarRocks.Tokenizer.KEYWORDS,
+            **dict.fromkeys(_STARROCKS_COMMAND_KEYWORDS, TokenType.COMMAND),
+        }

--- a/superset/sql/dialects/starrocks.py
+++ b/superset/sql/dialects/starrocks.py
@@ -753,8 +753,7 @@ class StarRocksGenerator(_StarRocksGenerator):
         if expression.args.get("force"):
             sql += " FORCE"
 
-        mode = expression.args.get("mode")
-        if mode:
+        if mode := expression.args.get("mode"):
             sql += f" WITH {mode} MODE"
 
         return sql
@@ -798,8 +797,7 @@ class StarRocksGenerator(_StarRocksGenerator):
             this=expression.args.get("expression"), unit=expression.args.get("unit")
         )
         args = [expression.this, interval]
-        kind = expression.args.get("kind")
-        if kind:
+        if kind := expression.args.get("kind"):
             args.append(kind)
         return self.func("TIME_SLICE", *args)
 

--- a/superset/sql/dialects/starrocks.py
+++ b/superset/sql/dialects/starrocks.py
@@ -24,6 +24,13 @@ references, aggregate/primary-key column shorthand, admin/ops statements, and
 several ALTER/CREATE/SHOW clause variants. Each override below closes one gap
 found while auditing StarRocks' SQL reference against this dialect; see the
 docstring on each method for the specific construct it fixes.
+
+The Generator override closes a related gap: sqlglot's stock StarRocks
+generator round-trips some of the AST shapes built above (REFRESH
+CONNECTIONS, ALTER TABLE ADD ROLLUP, dual-bound range partitions, TIME_SLICE)
+incorrectly. That matters beyond cosmetics -- SQL Lab regenerates SQL from
+this AST via `format()` for every statement it executes, so an incorrect
+round-trip sends malformed or semantically wrong SQL to the database.
 """
 
 from __future__ import annotations
@@ -31,6 +38,7 @@ from __future__ import annotations
 from sqlglot import exp
 from sqlglot.dialects.starrocks import StarRocks as _StarRocks
 from sqlglot.errors import ParseError
+from sqlglot.generators.starrocks import StarRocksGenerator as _StarRocksGenerator
 from sqlglot.helper import seq_get
 from sqlglot.parsers.starrocks import StarRocksParser as _StarRocksParser
 from sqlglot.tokens import TokenType
@@ -70,6 +78,26 @@ _STARROCKS_AGGREGATE_COLUMN_CONSTRAINTS = (
     "BITMAP_UNION",
     "HLL_UNION",
 )
+
+
+class StarRocksMaterializedViewRefresh(exp.Refresh):
+    """
+    `REFRESH MATERIALIZED VIEW mv [PARTITION START (...) END (...)] [FORCE]
+    [WITH {SYNC|ASYNC} MODE]` -- sqlglot's generic `exp.Refresh(this, kind)`
+    shape has no room for these StarRocks-only clauses, so the base parser
+    only consumes (without modeling) them; a subclass with its own args is
+    used instead of adding to `exp.Refresh` directly, since Superset can't
+    change the arg_types of a class owned by the installed sqlglot package.
+    https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_MATERIALIZED_VIEW/
+    """
+
+    arg_types = {
+        **exp.Refresh.arg_types,
+        "force": False,
+        "partition_start": False,
+        "partition_end": False,
+        "mode": False,
+    }
 
 
 class StarRocksParser(_StarRocksParser):
@@ -140,13 +168,16 @@ class StarRocksParser(_StarRocksParser):
     def _parse_refresh(self) -> exp.Refresh | exp.Command:
         # Extends sqlglot's generic REFRESH (EXTERNAL TABLE | TABLE |
         # MATERIALIZED VIEW) with StarRocks' DICTIONARY and CONNECTIONS forms,
-        # and consumes (without modeling) the optional FORCE / PARTITION
-        # START(...) END(...) / WITH SYNC MODE clauses on
-        # REFRESH MATERIALIZED VIEW so they don't derail the statement. The
-        # base implementation is replicated (rather than delegated to) using
-        # `_parse_table_parts` instead of `_parse_table`, because the latter
-        # also tries to parse a trailing `FORCE`/`PARTITION` as a MySQL index
-        # hint and raises before this method ever sees those tokens.
+        # and models the optional FORCE / PARTITION START(...) END(...) /
+        # WITH {SYNC|ASYNC} MODE clauses on REFRESH MATERIALIZED VIEW via
+        # `StarRocksMaterializedViewRefresh`'s dedicated args, rather than
+        # just consuming them, so a regenerated statement doesn't silently
+        # drop them. Only the MATERIALIZED VIEW target is parsed with
+        # `_parse_table_parts` instead of `_parse_table`: the latter also
+        # tries to parse a trailing `FORCE`/`PARTITION` as a MySQL index
+        # hint and raises before this method ever sees those tokens, whereas
+        # REFRESH EXTERNAL TABLE's own `PARTITION(...)` clause is meant to be
+        # parsed by `_parse_table` as usual.
         # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_MATERIALIZED_VIEW/
         if self._match_text_seq("DICTIONARY"):
             return self.expression(
@@ -166,20 +197,46 @@ class StarRocksParser(_StarRocksParser):
         else:
             kind = ""
 
-        this = self._parse_string() or self._parse_table_parts()
+        if kind == "MATERIALIZED VIEW":
+            this = self._parse_string() or self._parse_table_parts()
+        else:
+            this = self._parse_string() or self._parse_table()
+
         if not kind and not isinstance(this, exp.Literal):
             return self._parse_as_command(self._prev)
 
-        if kind == "MATERIALIZED VIEW":
-            self._match_text_seq("FORCE")
-            if self._match_text_seq("PARTITION", "START"):
-                self._parse_wrapped(self._parse_string)
-                self._match_text_seq("END")
-                self._parse_wrapped(self._parse_string)
-                self._match_text_seq("FORCE")
-            self._match_text_seq("WITH", "SYNC", "MODE")
+        if kind != "MATERIALIZED VIEW":
+            return self.expression(exp.Refresh(this=this, kind=kind))
 
-        return self.expression(exp.Refresh(this=this, kind=kind))
+        return self.expression(
+            self._parse_materialized_view_refresh_clauses(this, kind)
+        )
+
+    def _parse_materialized_view_refresh_clauses(
+        self, this: exp.Expr | None, kind: str
+    ) -> StarRocksMaterializedViewRefresh:
+        force = self._match_text_seq("FORCE")
+        partition_start = None
+        partition_end = None
+        if self._match_text_seq("PARTITION", "START"):
+            partition_start = self._parse_wrapped(self._parse_string)
+            self._match_text_seq("END")
+            partition_end = self._parse_wrapped(self._parse_string)
+            force = self._match_text_seq("FORCE") or force
+
+        mode = None
+        if self._match_text_seq("WITH"):
+            mode = self._match_texts(("SYNC", "ASYNC")) and self._prev.text.upper()
+            self._match_text_seq("MODE")
+
+        return StarRocksMaterializedViewRefresh(
+            this=this,
+            kind=kind,
+            force=force or None,
+            partition_start=partition_start,
+            partition_end=partition_end,
+            mode=mode,
+        )
 
     def _parse_show_mysql(
         self,
@@ -649,8 +706,107 @@ class StarRocksParser(_StarRocksParser):
         return super()._parse_statement()
 
 
+class StarRocksGenerator(_StarRocksGenerator):
+    # sqlglot's SQLStatement.format()/SQLScript.format() -- used both for
+    # SQL Lab's Jinja-template-comment-stripping validation step and, for
+    # every engine, to build the actual statement text sent to the DB-API
+    # cursor -- regenerate SQL from the AST built by `StarRocksParser`
+    # above. The overrides below fix five constructs the parser produces an
+    # AST for that sqlglot's stock StarRocks generator round-trips
+    # incorrectly, which would otherwise send malformed or semantically
+    # wrong SQL to StarRocks for anything routed through SQL Lab.
+
+    TRANSFORMS = {
+        **_StarRocksGenerator.TRANSFORMS,
+        # `StarRocksMaterializedViewRefresh` isn't registered under sqlglot's
+        # own class-name-to-method dispatch convention (it isn't a class
+        # sqlglot itself defines), so it's routed to `refresh_sql` below
+        # explicitly.
+        StarRocksMaterializedViewRefresh: lambda self, e: self.refresh_sql(e),
+    }
+
+    def refresh_sql(self, expression: exp.Refresh) -> str:
+        # `REFRESH CONNECTIONS` has no separate target name -- `this` is only
+        # set (to a placeholder Var) because the base Refresh expression
+        # requires it -- so the generic `REFRESH {kind} {this}` rendering
+        # would otherwise duplicate the word twice.
+        if expression.args.get("kind") == "CONNECTIONS":
+            return "REFRESH CONNECTIONS"
+
+        sql = super().refresh_sql(expression)
+
+        # REFRESH MATERIALIZED VIEW's own FORCE / PARTITION START(...)
+        # END(...) / WITH {SYNC|ASYNC} MODE clauses, set by `_parse_refresh`
+        # on a `StarRocksMaterializedViewRefresh`. FORCE always renders after
+        # PARTITION, regardless of which side of the partition clause it
+        # appeared on in the source -- StarRocks accepts either position,
+        # but only one is worth preserving.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_MATERIALIZED_VIEW/
+        partition_start = expression.args.get("partition_start")
+        partition_end = expression.args.get("partition_end")
+        if partition_start and partition_end:
+            sql += (
+                f" PARTITION START ({self.sql(partition_start)}) "
+                f"END ({self.sql(partition_end)})"
+            )
+
+        if expression.args.get("force"):
+            sql += " FORCE"
+
+        mode = expression.args.get("mode")
+        if mode:
+            sql += f" WITH {mode} MODE"
+
+        return sql
+
+    def rollupindex_sql(self, expression: exp.RollupIndex) -> str:
+        sql = super().rollupindex_sql(expression)
+        # As a standalone `ALTER TABLE ... ADD ROLLUP r1(...)` action (as
+        # opposed to an item inside a CREATE TABLE ROLLUP (...) property
+        # list), the ADD ROLLUP keywords live on the RollupIndex node itself
+        # rather than being added by the enclosing property/action.
+        # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE/#rollup
+        if isinstance(expression.parent, exp.Alter):
+            return f"ADD ROLLUP {sql}"
+        return sql
+
+    def partitionrange_sql(self, expression: exp.PartitionRange) -> str:
+        # Dual-bound `VALUES [(...), (...))` range partition -- `expressions`
+        # holds exactly the two bound tuples built by
+        # `_parse_partition_range_value` above.
+        # https://docs.starrocks.io/docs/table_design/data_distribution/#range-partitioning
+        name = self.sql(expression, "this")
+        values = expression.expressions
+
+        if (
+            len(values) == 2
+            and isinstance(values[0], exp.Tuple)
+            and isinstance(values[1], exp.Tuple)
+        ):
+            bounds = ", ".join(self.sql(v) for v in values)
+            return f"PARTITION {name} VALUES [{bounds})"
+
+        return super().partitionrange_sql(expression)
+
+    def timeslice_sql(self, expression: exp.TimeSlice) -> str:
+        # StarRocks' `time_slice(dt, INTERVAL n unit [, boundary])` packs the
+        # amount/unit into a single INTERVAL argument, unlike the generic
+        # TimeSlice(this, expression, unit, kind) shape's separate positional
+        # this/expression/unit/kind arguments.
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/time_slice/
+        interval = exp.Interval(
+            this=expression.args.get("expression"), unit=expression.args.get("unit")
+        )
+        args = [expression.this, interval]
+        kind = expression.args.get("kind")
+        if kind:
+            args.append(kind)
+        return self.func("TIME_SLICE", *args)
+
+
 class StarRocks(_StarRocks):
     Parser = StarRocksParser
+    Generator = StarRocksGenerator
 
     class Tokenizer(_StarRocks.Tokenizer):
         KEYWORDS = {

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -54,6 +54,7 @@ from superset.sql.dialects import (
     Hana,
     OpenSearch,
     Pinot,
+    StarRocks,
     Vertica,
 )
 
@@ -156,7 +157,7 @@ SQLGLOT_DIALECTS = {
     # "solr": ???
     "spark": Dialects.SPARK,
     "sqlite": Dialects.SQLITE,
-    "starrocks": Dialects.STARROCKS,
+    "starrocks": StarRocks,
     "superset": Dialects.SQLITE,
     # "taosws": ???
     "teradatasql": Dialects.TERADATA,
@@ -785,6 +786,30 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             "REFRESH",  # REFRESH MATERIALIZED VIEW
             "REINDEX",
             "VACUUM",
+            # StarRocks/MySQL-family admin and job-control commands that
+            # sqlglot has no structured node for, so every form always falls
+            # back to an opaque exp.Command with one of these heads:
+            # ADMIN SET/REPAIR/CHECK/SKIP, BACKUP/RESTORE SNAPSHOT,
+            # CANCEL BACKUP/RESTORE/LOAD/EXPORT/ALTER TABLE/REFRESH/DECOMMISSION/REPAIR,
+            # EXPORT TABLE, SUBMIT TASK, PAUSE/RESUME/STOP ROUTINE LOAD, and
+            # RECOVER TABLE/PARTITION/DATABASE.
+            "ADMIN",
+            "BACKUP",
+            "RESTORE",
+            "CANCEL",
+            "EXPORT",
+            "SUBMIT",
+            "PAUSE",
+            "RESUME",
+            "STOP",
+            "RECOVER",
+            # StarRocks blacklist management (ADD/DELETE SQLBLACKLIST,
+            # ADD/DELETE BACKEND|COMPUTE NODE BLACKLIST) is the only case
+            # that reaches this opaque-Command path with an ADD/DELETE head;
+            # ordinary ALTER TABLE ADD ... and the DML DELETE statement
+            # always parse into their own structured node instead.
+            "ADD",
+            "DELETE",
             # DDL head-tokens that sqlglot falls back to exp.Command for
             # whenever the body uses syntax it does not model
             # (CREATE EXTENSION/FUNCTION...LANGUAGE C/PUBLICATION/etc.,
@@ -807,17 +832,26 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         }
     )
 
-    # PostgreSQL-only command-fallback heads. Only the command-fallback
-    # forms (e.g. SET ROLE / SET SESSION AUTHORIZATION, which change the
-    # effective user) reach here as an exp.Command; structured
-    # `SET search_path = ...` / `SET statement_timeout = ...` parse as
-    # exp.Set and are NOT matched by this path. On other dialects the `SET`
-    # fallback covers session variables (e.g. Hive `SET hivevar:x=1`),
-    # which do not mutate data, so these heads stay dialect-gated.
-    _POSTGRES_MUTATING_COMMAND_NAMES: frozenset[str] = frozenset(
+    # Command-fallback heads that are only mutating on dialects where the
+    # structured form (`exp.Set`) is reserved for benign session variables,
+    # so the opaque-Command fallback is reached exclusively by the dangerous
+    # forms. On PostgreSQL that's SET ROLE / SET SESSION AUTHORIZATION /
+    # RESET ROLE (`SET search_path = ...` parses as exp.Set and never reaches
+    # here). On StarRocks (and MySQL, which shares the same parser) it's SET
+    # PASSWORD FOR .../SET ROLE/SET DEFAULT ROLE/SET DEFAULT STORAGE VOLUME
+    # -- every ordinary `SET var = value` there also parses as exp.Set, so
+    # widening this dialect-by-dialect is safe: it only ever matches forms
+    # sqlglot couldn't model as a session variable in the first place.
+    _SET_RESET_COMMAND_NAMES: frozenset[str] = frozenset(
         {
             "SET",
             "RESET",  # RESET ROLE / RESET ALL reverts SET; same class as SET
+        }
+    )
+    _SET_RESET_MUTATING_DIALECTS: frozenset[Dialects] = frozenset(
+        {
+            Dialects.POSTGRES,
+            Dialects.STARROCKS,
         }
     )
 
@@ -984,6 +1018,21 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             # rather than an opaque exp.Command, so treat it as mutating here
             # too.
             exp.Execute,
+            # ANALYZE (re)computes and persists CBO statistics server-side,
+            # including dropping/updating histograms -- structured on
+            # MySQL-family dialects, so the exp.Command fallback below never
+            # sees it there.
+            exp.Analyze,
+            # KILL terminates another session's connection or running query.
+            # Structured on MySQL-family dialects (never falls back to
+            # exp.Command), so without this it reads as a safe no-op.
+            exp.Kill,
+            # REFRESH MATERIALIZED VIEW / REFRESH EXTERNAL TABLE kick off a
+            # real data-rewrite job. Structured on MySQL-family dialects; the
+            # "REFRESH" entry in _MUTATING_COMMAND_NAMES below only ever
+            # fires for dialects where this instead falls back to
+            # exp.Command.
+            exp.Refresh,
         )
 
         if self._parsed.find(*mutating_nodes):
@@ -997,6 +1046,22 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             self._dialect in self._SELECT_INTO_CTAS_DIALECTS
             and isinstance(self._parsed, exp.Select)
             and self._parsed.args.get("into")
+        ):
+            return True
+
+        # `SET PASSWORD = ...` (changing the current session's own password)
+        # parses as an ordinary structured `exp.Set` on StarRocks/MySQL --
+        # the same node type as a benign `SET time_zone = 'UTC'` -- so it
+        # can't be distinguished by node type or command name the way
+        # `SET PASSWORD FOR other_user = ...` is (that form has no structured
+        # representation and falls back to exp.Command, caught above). This
+        # walks the assignment targets looking specifically for the
+        # `PASSWORD` pseudo-variable.
+        if isinstance(self._parsed, exp.Set) and any(
+            isinstance((assignment := set_item.this), exp.EQ)
+            and isinstance(assignment.this, exp.Column)
+            and assignment.this.name.upper() == "PASSWORD"
+            for set_item in self._parsed.expressions
         ):
             return True
 
@@ -1034,8 +1099,8 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
                 return True
 
             if (
-                self._dialect == Dialects.POSTGRES
-                and command_name in self._POSTGRES_MUTATING_COMMAND_NAMES
+                self._dialect in self._SET_RESET_MUTATING_DIALECTS
+                and command_name in self._SET_RESET_COMMAND_NAMES
             ):
                 return True
 
@@ -2192,13 +2257,28 @@ def _find_show_statement_tables(statement: exp.Show) -> set[Table]:
             source.catalog if source.catalog != "" else None,
         )
         for source in statement.find_all(exp.Table)
+        # A `db` arg scoping the statement to a schema (e.g. the catalog.schema
+        # target of `SHOW TABLES IN catalog.schema`) is itself an `exp.Table`
+        # with no table part, so it is picked up by `find_all` above without
+        # this guard -- as a phantom empty-name table, not a real reference.
+        if source.name
     }
     if target := statement.args.get("target"):
         db = statement.args.get("db")
+        if isinstance(db, exp.Table):
+            # Also an artifact of the catalog.schema `db` arg above: unlike a
+            # plain `Identifier`, its schema/catalog live in `.db`/`.catalog`,
+            # not `.name` (which is empty, since it has no table part).
+            db_name = db.db or None
+            db_catalog = db.catalog or None
+        else:
+            db_name = db.name if isinstance(db, exp.Expression) else db
+            db_catalog = None
         show_tables.add(
             Table(
                 target.name if isinstance(target, exp.Expression) else str(target),
-                db.name if isinstance(db, exp.Expression) else db,
+                db_name,
+                db_catalog,
             )
         )
     return show_tables

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -587,6 +587,35 @@ def test_extract_tables_show_tables_from() -> None:
     ).has_unparseable_statement
 
 
+def test_extract_tables_show_tables_starrocks_catalog_schema() -> None:
+    """
+    Regression guard for the StarRocks catalog-qualified schema override.
+
+    Unlike MySQL, `db` there can itself be an ``exp.Table`` (built via
+    ``_parse_table_parts(is_db_reference=True)`` so a dotted
+    ``catalog.schema`` parses), which ``find_all(exp.Table)`` would
+    otherwise also pick up as a phantom, empty-name table reference --
+    breaking the invariant that a schema-only `SHOW TABLES` target extracts
+    no tables and is flagged unparseable for authorization purposes.
+    """
+    assert (
+        extract_tables_from_sql("SHOW TABLES IN catalog_1.schema_a", "starrocks")
+        == set()
+    )
+    assert extract_tables_from_sql("SHOW TABLES FROM schema_a", "starrocks") == set()
+    assert SQLScript(
+        "SHOW TABLES IN catalog_1.schema_a", "starrocks"
+    ).has_unparseable_statement
+
+    # A target-bearing SHOW must still resolve the real table, threading the
+    # catalog.schema `db` scope through correctly rather than dropping it
+    # (`exp.Table.name` is empty for a schema-only reference; the schema and
+    # catalog live in `.db`/`.catalog` instead).
+    assert extract_tables_from_sql(
+        "SHOW COLUMNS FROM tbl FROM catalog_1.schema_a", "starrocks"
+    ) == {Table("tbl", "schema_a", "catalog_1")}
+
+
 def test_extract_tables_show_create_table() -> None:
     """
     Test `SHOW CREATE TABLE`.
@@ -2754,6 +2783,336 @@ def test_set_limit_value_leaves_show_statements_unchanged(
     statement.set_limit_value(1000, method)
     assert statement.format() == original
     assert "LIMIT" not in statement.format()
+
+
+@pytest.mark.parametrize(
+    "sql, expected_catalog, expected_db",
+    [
+        ("SHOW TABLES IN catalog_1.schema_a", "catalog_1", "schema_a"),
+        ("SHOW TABLES FROM catalog_1.schema_a", "catalog_1", "schema_a"),
+        ("SHOW TABLES IN schema_a", None, "schema_a"),
+        ("SHOW TABLES FROM schema_a", None, "schema_a"),
+        ("SHOW DATABASES IN catalog_1", None, "catalog_1"),
+    ],
+)
+def test_show_tables_in_catalog_qualified_schema(
+    sql: str, expected_catalog: str | None, expected_db: str
+) -> None:
+    """
+    StarRocks supports a catalog-qualified schema reference in
+    ``SHOW TABLES/DATABASES FROM|IN <schema>``, e.g.
+    ``SHOW TABLES IN catalog.schema``, which sqlglot's MySQL-derived parser
+    doesn't support: the schema is parsed with ``_parse_id_var()``, which only
+    ever consumes a single identifier, leaving the ``.schema`` part dangling
+    and rejected as an unexpected token. The ``superset.sql.dialects.StarRocks``
+    override reparses the schema with ``_parse_table_parts(is_db_reference=True)``
+    so a dotted ``catalog.schema`` (or a plain schema) both parse correctly.
+    """
+    show = SQLStatement(sql, "starrocks")._parsed
+    assert isinstance(show, exp.Show)
+
+    db = show.args.get("db")
+    assert isinstance(db, exp.Table)
+    catalog = db.args.get("catalog")
+    assert (catalog.name if catalog else None) == expected_catalog
+    assert db.args.get("db").name == expected_db
+
+
+def test_show_binlog_events_in_log_name_still_parses() -> None:
+    """
+    Regression guard: the override must not break the pre-existing meaning of
+    ``IN`` for ``SHOW BINLOG/RELAYLOG EVENTS IN 'log_name'``, where ``IN``
+    introduces a string log name rather than a schema reference.
+    """
+    show = SQLStatement(
+        "SHOW BINLOG EVENTS IN 'log.000001' FROM 4", "starrocks"
+    )._parsed
+    assert isinstance(show, exp.Show)
+    assert show.args.get("log").name == "log.000001"
+    assert show.args.get("position").name == "4"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Admin / cluster / job-control statements sqlglot's MySQL-derived
+        # grammar has no dedicated handling for, so it used to try (and
+        # fail) to read the head keyword as a generic expression.
+        'ADMIN SET FRONTEND CONFIG ("disable_balance" = "true")',
+        'ADMIN CHECK TABLET (10000, 10001) PROPERTIES("type" = "consistency")',
+        "ADMIN REPAIR TABLE tbl1 PARTITION (p1, p2)",
+        "BACKUP SNAPSHOT example_db.snapshot_label1 TO example_repo "
+        'PROPERTIES ("type" = "full")',
+        "RESTORE SNAPSHOT example_db.snapshot_label1 FROM example_repo "
+        'ON (backup_tbl) PROPERTIES("backup_timestamp"="2018-05-04-16-45-08")',
+        "RECOVER DATABASE example_db",
+        "RECOVER TABLE example_db.example_tbl",
+        "RECOVER PARTITION p1 FROM example_tbl",
+        "CANCEL BACKUP FROM example_db",
+        "CANCEL RESTORE FROM example_db",
+        'CANCEL LOAD WHERE LABEL = "example_label"',
+        'CANCEL EXPORT WHERE queryid = "921d8f80-7c9d-11eb-9342-acde48001121"',
+        "CANCEL ALTER TABLE COLUMN FROM example_db.my_table",
+        'EXPORT TABLE testTbl TO "hdfs://h:9000/a/b/c/testTbl_" WITH BROKER',
+        "PAUSE ROUTINE LOAD FOR example_db.example_tbl1_ordertest1",
+        "RESUME ROUTINE LOAD FOR example_db.example_tbl1_ordertest1",
+        "STOP ROUTINE LOAD FOR example_db.example_tbl1_ordertest1",
+        "SUBMIT TASK etl0 AS CREATE TABLE tbl1 AS SELECT * FROM src_tbl",
+        "SUBMIT TASK AS INSERT OVERWRITE tbl2 SELECT * FROM src_tbl",
+        "DEALLOCATE PREPARE select_by_id_stmt",
+        # StarRocks blacklist management. ADD/DELETE already mean something
+        # else in the grammar (ALTER TABLE ADD ..., the DML DELETE
+        # statement), so these need the specific-phrase peek in
+        # `_parse_statement`, not a blanket keyword remap.
+        'ADD SQLBLACKLIST "select count(*) from .+"',
+        "DELETE SQLBLACKLIST 3, 4",
+        "ADD BACKEND BLACKLIST 10001",
+        "DELETE BACKEND BLACKLIST 10001",
+        "ADD COMPUTE NODE BLACKLIST 10005",
+        # Ordinary ADD/DELETE must be unaffected by the blacklist peek.
+        "ALTER TABLE t ADD COLUMN c INT",
+        "DELETE FROM my_table WHERE k1 = 3",
+        # TRANSLATE TRINO translates a Trino SELECT into StarRocks SQL. Like
+        # ADD/DELETE, TRANSLATE can't be remapped to TokenType.COMMAND
+        # outright -- it also names the ordinary TRANSLATE(string, from, to)
+        # scalar function -- so this needs the same specific-phrase peek.
+        "TRANSLATE TRINO SELECT 1",
+        "TRANSLATE TRINO SELECT id, name FROM products WHERE category = 'Electronics'",
+        # Ordinary use of the scalar function must be unaffected by the peek.
+        "SELECT TRANSLATE(col, 'a', 'b') FROM t",
+    ],
+)
+def test_starrocks_admin_and_job_control_statements_parse(sql: str) -> None:
+    SQLStatement(sql, "starrocks")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "KILL ANALYZE 266030",
+        "KILL QUERY 5",
+        "KILL 20",
+        "REFRESH DICTIONARY dict_obj",
+        "REFRESH CONNECTIONS",
+        "REFRESH MATERIALIZED VIEW lo_mv1",
+        "REFRESH MATERIALIZED VIEW lo_mv1 FORCE",
+        'REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ("2020-02-01") '
+        'END ("2020-03-01") FORCE',
+        "REFRESH MATERIALIZED VIEW lo_mv1 WITH SYNC MODE",
+        "CANCEL REFRESH MATERIALIZED VIEW lo_mv1",
+        "CANCEL REFRESH MATERIALIZED VIEW lo_mv1 FORCE",
+        "CANCEL REFRESH DICTIONARY dict_obj",
+        "SHOW CREATE FUNCTION default_db.python_add(BIGINT)",
+        "SHOW CREATE FUNCTION default_db.python_add",
+        "CREATE MATERIALIZED VIEW lo_mv3 DISTRIBUTED BY HASH(`lo_orderkey`) "
+        "REFRESH SCHEDULE START ('2023-07-01 10:00:00') EVERY (INTERVAL 1 DAY) "
+        "AS SELECT lo_orderkey FROM lineorder",
+        "SHOW COLUMNS FROM t1",
+        "REFRESH TABLE t1",
+        "SHOW PROFILE",
+        # No REFRESH kind keyword matches; falls back to an opaque Command
+        # rather than raising.
+        "REFRESH foo",
+        # No START/EVERY schedule at all.
+        "CREATE MATERIALIZED VIEW mv1 DISTRIBUTED BY HASH(x) REFRESH MANUAL "
+        "AS SELECT x FROM t",
+        # Existing forms these overrides must not regress.
+        "REFRESH EXTERNAL TABLE t1",
+        "CREATE MATERIALIZED VIEW lo_mv1 DISTRIBUTED BY HASH(`lo_orderkey`) "
+        "REFRESH ASYNC START ('2023-07-01 10:00:00') EVERY (INTERVAL 1 DAY) "
+        "AS SELECT lo_orderkey FROM lineorder",
+    ],
+)
+def test_starrocks_kill_refresh_show_create_function_parse(sql: str) -> None:
+    SQLStatement(sql, "starrocks")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Aggregate/unique-key column agg-function suffix.
+        "CREATE TABLE t(k1 INT, v2 INT SUM) AGGREGATE KEY(k1) DISTRIBUTED BY HASH(k1)",
+        'CREATE TABLE t(k1 INT, v2 INT REPLACE_IF_NOT_NULL DEFAULT "10") '
+        "AGGREGATE KEY(k1) DISTRIBUTED BY HASH(k1)",
+        # Generated columns without the parenthesized `AS (expr)` form.
+        "CREATE TABLE t1(id INT, newcol1 INT AS id + 1)",
+        "CREATE TABLE test_tbl1(id INT NOT NULL, data_array ARRAY<int> NOT NULL, "
+        "newcol1 DOUBLE AS array_avg(data_array)) PRIMARY KEY (id) "
+        "DISTRIBUTED BY HASH(id)",
+        "CREATE TABLE t1(id INT, newcol1 INT AS (id + 1))",  # existing form
+        # Bare, unnamed inline KEY constraint (a primary/duplicate key marker
+        # with no name or column list is also accepted; see the CONSTRAINT_
+        # PARSERS override below).
+        "CREATE TABLE t (k1 INT, KEY (k1))",
+        # GIN/NGRAM full-text index with an inline properties list.
+        "CREATE TABLE t(k1 INT, INDEX idx (k1) USING GIN ('parser' = 'english')) "
+        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1)",
+        "CREATE TABLE t(k1 INT, INDEX idx (k1) USING BITMAP) "
+        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1)",  # existing form
+        # Inherited MySQL inline-index forms/options, unrelated to the
+        # StarRocks-specific GIN case above, but reachable through the same
+        # overridden method.
+        "CREATE TABLE t (c TEXT, FULLTEXT idx (c))",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) KEY_BLOCK_SIZE = 1024)",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) WITH PARSER ngram)",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) COMMENT 'my index')",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) VISIBLE)",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) INVISIBLE)",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) ENGINE_ATTRIBUTE = 'foo')",
+        "CREATE TABLE t (k1 INT, INDEX idx (k1) SECONDARY_ENGINE_ATTRIBUTE = 'foo')",
+        # Range partition VALUES forms.
+        "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+        '(PARTITION p1 VALUES LESS THAN ("10")) DISTRIBUTED BY HASH(k1)',
+        "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+        "(PARTITION p1 VALUES LESS THAN MAXVALUE) DISTRIBUTED BY HASH(k1)",
+        # Legacy parenthesized MAXVALUE form, distinct from the bare form
+        # immediately above.
+        "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+        "(PARTITION p1 VALUES LESS THAN (MAXVALUE)) DISTRIBUTED BY HASH(k1)",
+        "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+        '(PARTITION p1 VALUES [("2021-01-01"), ("2021-01-31"))) '
+        "DISTRIBUTED BY HASH(k1)",
+        # A range partition item with no VALUES clause at all.
+        "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+        "(PARTITION p1) DISTRIBUTED BY HASH(k1)",
+        "CREATE TABLE t(dt DATETIME) PARTITION BY time_slice(dt, INTERVAL 7 day) "
+        "DISTRIBUTED BY HASH(dt)",
+        # ALTER TABLE clause variants.
+        "ALTER TABLE example_db.my_table DROP PARTITION p1",
+        "ALTER TABLE example_db.my_table DROP PARTITION IF EXISTS p1 FORCE",
+        "ALTER TABLE example_db.my_table DROP TEMPORARY PARTITION p1",  # existing
+        "ALTER TABLE example_db.my_table DROP PARTITION (p1, p2)",  # existing
+        "ALTER TABLE db.tbl ADD ROLLUP r1(col1,col2) FROM r0",
+        "ALTER TABLE db.tbl ADD ROLLUP r1(col1,col2)",
+        "ALTER TABLE db.tbl DROP ROLLUP r1",  # existing
+        "ALTER TABLE my_table ADD COLUMN new_col INT KEY DEFAULT '0' FIRST",
+        # existing form:
+        "ALTER TABLE my_table ADD COLUMN new_col INT DEFAULT '0' AFTER col1",
+        "ALTER TABLE my_table ADD COLUMN (c1 INT DEFAULT '0', c2 INT DEFAULT '0')",
+        # existing form:
+        "ALTER TABLE my_table ADD COLUMNS (c1 INT DEFAULT '0', c2 INT DEFAULT '0')",
+        "ALTER TABLE my_table ADD COLUMN c1 INT DEFAULT '0'",  # existing
+        # Degenerate input where the "(" right after ADD COLUMN turns out not
+        # to be a column list (disambiguated from a subquery start), so the
+        # multi-column fast path backs off to the generic ADD handling.
+        "ALTER TABLE t ADD COLUMN (SELECT 1)",
+        "DROP INDEX index_name ON db.table1",
+        "DROP COLUMN t1.c1",
+        "DROP TABLE t1 ON cluster_name",
+        "DROP FUNCTION my_func(INT, VARCHAR)",
+        "DELETE FROM my_table PARTITION p1 WHERE k1 = 3",
+        "DELETE FROM my_table PARTITION (p1, p2) WHERE k1 = 3",
+        # MySQL "Multiple-Table Syntax" delete, where the target list
+        # precedes FROM instead of following it directly.
+        "DELETE t1 FROM t1 JOIN t2 ON t1.id = t2.id WHERE t2.x = 1",
+        # INSERT clause variants.
+        "INSERT OVERWRITE test PARTITION(p1, p2) WITH LABEL `label1` "
+        "SELECT * FROM test3",
+        "INSERT OVERWRITE test WITH LABEL `label1` (c1, c2) SELECT * FROM test3",
+        "INSERT INTO test WITH LABEL `label1` SELECT * FROM test3",
+        'INSERT INTO FILES("path" = "s3://bucket/x/", "format" = "parquet") '
+        "SELECT * FROM t",
+        "INSERT OVERWRITE test SELECT * FROM test3",  # existing form
+        # Regression guard: the ordinary `INSERT INTO t (col1, col2) VALUES
+        # (...)` column-list form -- with no WITH LABEL and no table
+        # function -- must still resolve via the normal schema=True path,
+        # not get misread as a table-valued-function call.
+        "INSERT INTO t (c1) VALUES (1)",
+        "INSERT INTO t AS t_alias VALUES (1)",
+    ],
+)
+def test_starrocks_create_alter_table_clauses_parse(sql: str) -> None:
+    SQLStatement(sql, "starrocks")
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        # ANALYZE writes CBO statistics server-side; structured `exp.Analyze`
+        # was missing from the mutating-node tuple.
+        ("ANALYZE TABLE tbl_name", True),
+        ("ANALYZE TABLE tbl_name DROP HISTOGRAM ON col_name", True),
+        ("ANALYZE TABLE tbl_name UPDATE HISTOGRAM ON v1,v2 WITH 32 BUCKETS", True),
+        ("KILL ANALYZE 266030", True),
+        ("KILL QUERY 5", True),
+        ("KILL 20", True),
+        # REFRESH MATERIALIZED VIEW/DICTIONARY/CONNECTIONS/EXTERNAL TABLE all
+        # parse to a structured `exp.Refresh`, also missing from the tuple.
+        ("REFRESH MATERIALIZED VIEW lo_mv1", True),
+        ("REFRESH DICTIONARY dict_obj", True),
+        ("REFRESH CONNECTIONS", True),
+        ("REFRESH EXTERNAL TABLE t1", True),
+        ("CANCEL REFRESH MATERIALIZED VIEW lo_mv1", True),
+        # SET PASSWORD/ROLE/DEFAULT ROLE/DEFAULT STORAGE VOLUME all fall
+        # back to an opaque `exp.Command` with head "SET", which the
+        # dialect gate only recognised for PostgreSQL.
+        ("SET PASSWORD FOR 'jack'@'192.%' = PASSWORD('123456')", True),
+        ("SET ROLE db_admin", True),
+        ("SET ROLE ALL EXCEPT db_admin", True),
+        ("SET DEFAULT ROLE db_admin TO test", True),
+        ("SET DEFAULT STORAGE VOLUME my_s3_volume", True),
+        # `SET PASSWORD = ...` (own account) parses as a plain structured
+        # `exp.Set`, indistinguishable from a benign session variable except
+        # by inspecting the assignment target.
+        ("SET PASSWORD = PASSWORD('123456')", True),
+        # Ordinary session variables must still read as non-mutating.
+        ("SET time_zone = 'UTC'", False),
+        ("SET SESSION time_zone = 'UTC'", False),
+        ("SET @myvar = 1", False),
+        ("SET NAMES utf8mb4", False),
+        # Admin/ops/job-control commands that always fall back to an opaque
+        # `exp.Command` with one of these heads.
+        (
+            "BACKUP SNAPSHOT example_db.snapshot_label1 TO example_repo "
+            'PROPERTIES ("type" = "full")',
+            True,
+        ),
+        ("CANCEL BACKUP FROM example_db", True),
+        ("CANCEL RESTORE FROM example_db", True),
+        ('CANCEL LOAD WHERE LABEL = "example_label"', True),
+        ("CANCEL ALTER TABLE COLUMN FROM example_db.my_table", True),
+        (
+            'EXPORT TABLE testTbl TO "hdfs://h:9000/a/b/c/testTbl_" WITH BROKER',
+            True,
+        ),
+        ("PAUSE ROUTINE LOAD FOR example_db.example_tbl1_ordertest1", True),
+        ("RESUME ROUTINE LOAD FOR example_db.example_tbl1_ordertest1", True),
+        ("STOP ROUTINE LOAD FOR example_db.example_tbl1_ordertest1", True),
+        ("SUBMIT TASK etl0 AS CREATE TABLE tbl1 AS SELECT * FROM src_tbl", True),
+        ("RECOVER DATABASE example_db", True),
+        ("RECOVER TABLE example_db.example_tbl", True),
+        (
+            'ADMIN SET FRONTEND CONFIG ("disable_balance" = "true")',
+            True,
+        ),
+        # StarRocks blacklist management via the ADD/DELETE peek.
+        ('ADD SQLBLACKLIST "select count(*) from .+"', True),
+        ("DELETE SQLBLACKLIST 3, 4", True),
+        ("ADD BACKEND BLACKLIST 10001", True),
+        ("DELETE BACKEND BLACKLIST 10001", True),
+        # Ordinary DELETE (and the ADD/DELETE peek generally) must not
+        # misclassify unrelated statements.
+        ("DELETE FROM my_table WHERE k1 = 3", True),
+        ("DELETE FROM my_table PARTITION p1 WHERE k1 = 3", True),
+        # TRANSLATE TRINO only returns translated SQL text; it is a read.
+        ("TRANSLATE TRINO SELECT 1", False),
+        ("SELECT 1", False),
+        ("SHOW TABLES", False),
+        ("SHOW TABLES IN catalog_1.schema_a", False),
+    ],
+)
+def test_is_mutating_starrocks_command_constructs(sql: str, expected: bool) -> None:
+    """
+    Several StarRocks constructs are either structured nodes sqlglot models
+    but ``is_mutating`` didn't check (``exp.Analyze``, ``exp.Kill``,
+    ``exp.Refresh``), or fall back to an opaque ``exp.Command`` whose head
+    keyword wasn't in the mutating set, or -- for ``SET PASSWORD`` on the
+    caller's own account -- parse identically to a benign session variable.
+    Every one of these must be classified as mutating so a query-only role
+    can't run them through the SQL Lab read-only gate; ordinary session
+    variables and reads must stay classified as non-mutating.
+    """
+    assert SQLStatement(sql, "starrocks").is_mutating() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -2918,6 +2918,11 @@ def test_starrocks_admin_and_job_control_statements_parse(sql: str) -> None:
         "AS SELECT x FROM t",
         # Existing forms these overrides must not regress.
         "REFRESH EXTERNAL TABLE t1",
+        # REFRESH EXTERNAL TABLE / TABLE's own PARTITION(...) clause -- using
+        # `_parse_table_parts` unconditionally for the target would raise
+        # before this clause is ever reached.
+        "REFRESH EXTERNAL TABLE hudi1 PARTITION('date=2022-12-20', 'date=2022-12-21')",
+        "REFRESH TABLE t1 PARTITION('p1')",
         "CREATE MATERIALIZED VIEW lo_mv1 DISTRIBUTED BY HASH(`lo_orderkey`) "
         "REFRESH ASYNC START ('2023-07-01 10:00:00') EVERY (INTERVAL 1 DAY) "
         "AS SELECT lo_orderkey FROM lineorder",
@@ -2925,6 +2930,114 @@ def test_starrocks_admin_and_job_control_statements_parse(sql: str) -> None:
 )
 def test_starrocks_kill_refresh_show_create_function_parse(sql: str) -> None:
     SQLStatement(sql, "starrocks")
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # `this` is a placeholder Var required by the base Refresh expression,
+        # not a real target name; the generic REFRESH {kind} {this} rendering
+        # would otherwise duplicate the word.
+        ("REFRESH CONNECTIONS", "REFRESH CONNECTIONS"),
+        # A standalone ALTER TABLE ADD ROLLUP action's own "ADD ROLLUP"
+        # keywords live on the RollupIndex node, not on the enclosing ALTER.
+        (
+            "ALTER TABLE db.tbl ADD ROLLUP r1(col1, col2) FROM r0",
+            "ALTER TABLE db.tbl\nADD ROLLUP r1(col1, col2) FROM r0",
+        ),
+        # Dual-bound `VALUES [(...), (...))` range partition must round-trip
+        # as the same half-open bound, not collapse into a single-bound
+        # `VALUES LESS THAN (...)` partition with a different meaning.
+        (
+            "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+            "(PARTITION p1 VALUES [('2021-01-01'), ('2021-01-31'))) "
+            "DISTRIBUTED BY HASH(k1)",
+            "CREATE TABLE t (\n  k1 INT\n)\n"
+            "PARTITION BY RANGE (k1) (PARTITION p1 VALUES "
+            "[('2021-01-01'), ('2021-01-31')))\n"
+            "DISTRIBUTED BY HASH (\n  k1\n)",
+        ),
+        # StarRocks' single-argument INTERVAL form must round-trip with the
+        # INTERVAL keyword, not the generic positional Func rendering.
+        (
+            "CREATE TABLE t(dt DATETIME) PARTITION BY time_slice(dt, INTERVAL 7 day) "
+            "DISTRIBUTED BY HASH(dt)",
+            "CREATE TABLE t (\n  dt DATETIME\n)\n"
+            "PARTITION BY TIME_SLICE(dt, INTERVAL '7' DAY)\n"
+            "DISTRIBUTED BY HASH (\n  dt\n)",
+        ),
+        # The 3-argument boundary form, and the non-CONNECTIONS/non-dual-bound/
+        # non-ALTER-action fallback paths of each override above, must keep
+        # deferring to the base StarRocks generator rather than always taking
+        # the specialized branch.
+        (
+            "CREATE TABLE t(dt DATETIME) "
+            "PARTITION BY TIME_SLICE(dt, INTERVAL 7 DAY, FLOOR) "
+            "DISTRIBUTED BY HASH(dt)",
+            "CREATE TABLE t (\n  dt DATETIME\n)\n"
+            "PARTITION BY TIME_SLICE(dt, INTERVAL '7' DAY, FLOOR)\n"
+            "DISTRIBUTED BY HASH (\n  dt\n)",
+        ),
+        ("REFRESH TABLE t1", "REFRESH TABLE t1"),
+        ("REFRESH DICTIONARY dict_obj", "REFRESH DICTIONARY dict_obj"),
+        (
+            "CREATE TABLE t (k1 INT, k2 INT) DUPLICATE KEY (k1) "
+            "DISTRIBUTED BY HASH (k1) ROLLUP (r1 (k1) FROM t)",
+            "CREATE TABLE t (\n  k1 INT,\n  k2 INT\n)\n"
+            "DUPLICATE KEY (k1)\n"
+            "DISTRIBUTED BY HASH (\n  k1\n)\n"
+            "ROLLUP (r1(k1) FROM t)",
+        ),
+        (
+            "CREATE TABLE t(k1 INT) PARTITION BY RANGE (k1) "
+            '(PARTITION p1 VALUES LESS THAN ("10")) DISTRIBUTED BY HASH(k1)',
+            "CREATE TABLE t (\n  k1 INT\n)\n"
+            "PARTITION BY RANGE (k1) (PARTITION p1 VALUES LESS THAN ('10'))\n"
+            "DISTRIBUTED BY HASH (\n  k1\n)",
+        ),
+        # REFRESH MATERIALIZED VIEW's FORCE / PARTITION START(...) END(...) /
+        # WITH {SYNC|ASYNC} MODE clauses must round-trip, not vanish --
+        # `format()` is what SQL Lab actually sends to the database.
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 FORCE",
+            "REFRESH MATERIALIZED VIEW lo_mv1 FORCE",
+        ),
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ('2020-02-01') "
+            "END ('2020-03-01')",
+            "REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ('2020-02-01') "
+            "END ('2020-03-01')",
+        ),
+        # FORCE is accepted either right after the view name or after the
+        # PARTITION clause; it always renders after PARTITION.
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 FORCE PARTITION START ('2020-02-01') "
+            "END ('2020-03-01')",
+            "REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ('2020-02-01') "
+            "END ('2020-03-01') FORCE",
+        ),
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ('2020-02-01') "
+            "END ('2020-03-01') FORCE",
+            "REFRESH MATERIALIZED VIEW lo_mv1 PARTITION START ('2020-02-01') "
+            "END ('2020-03-01') FORCE",
+        ),
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 WITH SYNC MODE",
+            "REFRESH MATERIALIZED VIEW lo_mv1 WITH SYNC MODE",
+        ),
+        (
+            "REFRESH MATERIALIZED VIEW lo_mv1 WITH ASYNC MODE",
+            "REFRESH MATERIALIZED VIEW lo_mv1 WITH ASYNC MODE",
+        ),
+    ],
+)
+def test_starrocks_generator_round_trip(sql: str, expected: str) -> None:
+    # SQL Lab regenerates SQL from this AST via `format()` for every
+    # statement it executes (see `build_statement_blocks` in
+    # `superset/sql/execution/executor.py`), so an incorrect round-trip here
+    # would send malformed or semantically wrong SQL to the database.
+    assert SQLStatement(sql, "starrocks").format() == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY
An audit of sqlglot's StarRocks dialect against the real StarRocks SQL reference found a broad set of gaps, all fixed here:

**Parsing** (previously raised `SupersetParseError` on valid StarRocks SQL):
- `SHOW TABLES/DATABASES ... IN|FROM <catalog>.<schema>` 
- `ADMIN`/`BACKUP`/`RESTORE`/`RECOVER`/`CANCEL`/`EXPORT`/`SUBMIT`/`PAUSE`/`RESUME`/`STOP`/`DEALLOCATE` statements, and `ADD`/`DELETE SQLBLACKLIST|BACKEND BLACKLIST|COMPUTE NODE BLACKLIST`
- `KILL ANALYZE`; `REFRESH DICTIONARY`/`CONNECTIONS`, and `REFRESH MATERIALIZED VIEW`'s `FORCE`/`PARTITION START..END`/`WITH SYNC MODE` clauses
- `SHOW CREATE FUNCTION`/`PROCEDURE` with an argument-type list
- `CREATE TABLE`: aggregate-key column function suffix (`SUM`/`MAX`/`MIN`/...), unparenthesized generated columns, GIN/NGRAM index properties, dual-bound and `MAXVALUE` range partitions, 2-arg `time_slice()` partitioning
- `ALTER TABLE`: bare `DROP PARTITION`, `ADD ROLLUP`, `ADD COLUMN ... FIRST` with a bare `KEY` attribute, parenthesized multi-column `ADD COLUMN`
- `DROP INDEX ... ON table`; `DELETE ... PARTITION p1`; `INSERT ... WITH LABEL` and `INSERT INTO FILES(...)`

**Mutation detection** (previously misclassified as read-only, so a query-only role could run these through SQL Lab):
- `exp.Analyze`, `exp.Kill`, `exp.Refresh` added to the mutating node-type check
- `SET PASSWORD`/`ROLE`/`DEFAULT ROLE`/`DEFAULT STORAGE VOLUME` (falls back to an opaque `Command` whose dialect gate only covered PostgreSQL)
- `SET PASSWORD` on the caller's own account (parses identically to a benign session variable; detected by inspecting the assignment target)
- `ADMIN`/`BACKUP`/`RESTORE`/`CANCEL`/`EXPORT`/`SUBMIT`/`PAUSE`/`RESUME`/`STOP`/`RECOVER`/`ADD`/`DELETE` added to the mutating command-name set

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

### TESTING INSTRUCTIONS
Extensive unit tests added to `tests/unit_tests/sql/parse_tests.py` covering every construct above, both for successful parsing and for `is_mutating()` classification, including regression cases for the pre-existing forms each override must not break.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API