### PR TITLE
fix(examples): correct chart metadata

### DIFF
--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -172,17 +172,18 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
     ]
     metric = "sum__num"
 
-    defaults = {
+    shared_defaults = {
         "compare_lag": "10",
         "compare_suffix": "o10Y",
         "limit": "25",
-        "granularity": "ds",
         "groupby": [],
         "row_limit": current_app.config["ROW_LIMIT"],
         "time_range": "100 years ago : now",
         "viz_type": "table",
         "markup_type": "markdown",
     }
+    defaults = {**shared_defaults, "granularity": "ds"}
+    echarts_defaults = {**shared_defaults, "x_axis": "ds"}
 
     default_query_context = {
         "result_format": "json",
@@ -234,10 +235,9 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Trends",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 viz_type="echarts_timeseries_line",
                 groupby=["name"],
-                granularity="ds",
                 rich_tooltip=True,
                 show_legend=True,
                 metrics=metrics,
@@ -249,7 +249,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Genders by State",
             viz_type="echarts_timeseries_bar",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 adhoc_filters=[
                     {
                         "clause": "WHERE",
@@ -348,7 +348,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 Girl Name Share",
             viz_type="echarts_area",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 adhoc_filters=[gen_filter("gender", "girl")],
                 comparison_type="values",
                 groupby=["name"],
@@ -356,7 +356,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 stacked_style="expand",
                 time_grain_sqla="P1D",
                 viz_type="echarts_area",
-                x_axis_forma="smart_date",
+                x_axis_time_format="smart_date",
                 metrics=metrics,
             ),
             editors=[],
@@ -366,7 +366,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 Boy Name Share",
             viz_type="echarts_area",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 adhoc_filters=[gen_filter("gender", "boy")],
                 comparison_type="values",
                 groupby=["name"],
@@ -374,7 +374,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                 stacked_style="expand",
                 time_grain_sqla="P1D",
                 viz_type="echarts_area",
-                x_axis_forma="smart_date",
+                x_axis_time_format="smart_date",
                 metrics=metrics,
             ),
             editors=[],
@@ -408,7 +408,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Average and Sum Trends",
             viz_type="mixed_timeseries",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 viz_type="mixed_timeseries",
                 metrics=[
                     {
@@ -420,7 +420,6 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                     }
                 ],
                 metrics_b=["sum__num"],
-                granularity="ds",
                 yAxisIndex=0,
                 yAxisIndexB=1,
             ),
@@ -431,7 +430,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Num Births Trend",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                defaults, viz_type="echarts_timeseries_line", metrics=metrics
+                echarts_defaults, viz_type="echarts_timeseries_line", metrics=metrics
             ),
             editors=[],
         ),
@@ -483,7 +482,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 California Names Timeseries",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 metrics=[
                     {
                         "expressionType": "SIMPLE",
@@ -496,7 +495,6 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
                     }
                 ],
                 viz_type="echarts_timeseries_line",
-                granularity="ds",
                 groupby=["name"],
                 series_limit_metric={
                     "expressionType": "SIMPLE",

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -182,7 +182,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
         "viz_type": "table",
         "markup_type": "markdown",
     }
-    legacy_granularity_defaults = {**shared_defaults, "granularity": "ds"}
+    non_echarts_defaults = {**shared_defaults, "granularity": "ds"}
     echarts_x_axis_defaults = {**shared_defaults, "x_axis": "ds"}
 
     default_query_context = {
@@ -212,7 +212,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Participants",
             viz_type="big_number",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="big_number",
                 granularity="ds",
                 compare_lag="5",
@@ -226,7 +226,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Genders",
             viz_type="pie",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="pie",
                 groupby=["gender"],
                 metric=metric,
@@ -289,7 +289,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Girls",
             viz_type="table",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "girl")],
                 row_limit=50,
@@ -303,7 +303,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Girl Name Cloud",
             viz_type="word_cloud",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="word_cloud",
                 size_from="10",
                 series="name",
@@ -320,7 +320,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Boys",
             viz_type="table",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "boy")],
                 row_limit=50,
@@ -334,7 +334,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Boy Name Cloud",
             viz_type="word_cloud",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="word_cloud",
                 size_from="10",
                 series="name",
@@ -387,7 +387,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Pivot Table v2",
             viz_type="pivot_table_v2",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="pivot_table_v2",
                 groupbyRows=["name"],
                 groupbyColumns=["state"],
@@ -444,7 +444,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Daily Totals",
             viz_type="table",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 groupby=["ds"],
                 time_range="1983 : 2023",
                 viz_type="table",
@@ -467,7 +467,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Number of California Births",
             viz_type="big_number_total",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 metric={
                     "expressionType": "SIMPLE",
                     "column": {
@@ -521,7 +521,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Names Sorted by Num in California",
             viz_type="table",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 metrics=metrics,
                 groupby=["name"],
                 row_limit=50,
@@ -542,7 +542,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Number of Girls",
             viz_type="big_number_total",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 metric=metric,
                 viz_type="big_number_total",
                 granularity="ds",
@@ -556,7 +556,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Pivot Table",
             viz_type="pivot_table_v2",
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="pivot_table_v2",
                 groupbyRows=["name"],
                 groupbyColumns=["state"],

--- a/superset/examples/birth_names.py
+++ b/superset/examples/birth_names.py
@@ -182,8 +182,8 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
         "viz_type": "table",
         "markup_type": "markdown",
     }
-    defaults = {**shared_defaults, "granularity": "ds"}
-    echarts_defaults = {**shared_defaults, "x_axis": "ds"}
+    legacy_granularity_defaults = {**shared_defaults, "granularity": "ds"}
+    echarts_x_axis_defaults = {**shared_defaults, "x_axis": "ds"}
 
     default_query_context = {
         "result_format": "json",
@@ -212,7 +212,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Participants",
             viz_type="big_number",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="big_number",
                 granularity="ds",
                 compare_lag="5",
@@ -226,7 +226,10 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Genders",
             viz_type="pie",
             params=get_slice_json(
-                defaults, viz_type="pie", groupby=["gender"], metric=metric
+                legacy_granularity_defaults,
+                viz_type="pie",
+                groupby=["gender"],
+                metric=metric,
             ),
             editors=[],
         ),
@@ -235,7 +238,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Trends",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 viz_type="echarts_timeseries_line",
                 groupby=["name"],
                 rich_tooltip=True,
@@ -249,7 +252,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Genders by State",
             viz_type="echarts_timeseries_bar",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 adhoc_filters=[
                     {
                         "clause": "WHERE",
@@ -286,7 +289,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Girls",
             viz_type="table",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "girl")],
                 row_limit=50,
@@ -300,7 +303,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Girl Name Cloud",
             viz_type="word_cloud",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="word_cloud",
                 size_from="10",
                 series="name",
@@ -317,7 +320,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Boys",
             viz_type="table",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 groupby=["name"],
                 adhoc_filters=[gen_filter("gender", "boy")],
                 row_limit=50,
@@ -331,7 +334,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Boy Name Cloud",
             viz_type="word_cloud",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="word_cloud",
                 size_from="10",
                 series="name",
@@ -348,7 +351,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 Girl Name Share",
             viz_type="echarts_area",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 adhoc_filters=[gen_filter("gender", "girl")],
                 comparison_type="values",
                 groupby=["name"],
@@ -366,7 +369,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 Boy Name Share",
             viz_type="echarts_area",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 adhoc_filters=[gen_filter("gender", "boy")],
                 comparison_type="values",
                 groupby=["name"],
@@ -384,7 +387,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Pivot Table v2",
             viz_type="pivot_table_v2",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="pivot_table_v2",
                 groupbyRows=["name"],
                 groupbyColumns=["state"],
@@ -408,7 +411,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Average and Sum Trends",
             viz_type="mixed_timeseries",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 viz_type="mixed_timeseries",
                 metrics=[
                     {
@@ -430,7 +433,9 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Num Births Trend",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                echarts_defaults, viz_type="echarts_timeseries_line", metrics=metrics
+                echarts_x_axis_defaults,
+                viz_type="echarts_timeseries_line",
+                metrics=metrics,
             ),
             editors=[],
         ),
@@ -439,7 +444,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Daily Totals",
             viz_type="table",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 groupby=["ds"],
                 time_range="1983 : 2023",
                 viz_type="table",
@@ -462,7 +467,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Number of California Births",
             viz_type="big_number_total",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 metric={
                     "expressionType": "SIMPLE",
                     "column": {
@@ -482,7 +487,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Top 10 California Names Timeseries",
             viz_type="echarts_timeseries_line",
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 metrics=[
                     {
                         "expressionType": "SIMPLE",
@@ -516,7 +521,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Names Sorted by Num in California",
             viz_type="table",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 metrics=metrics,
                 groupby=["name"],
                 row_limit=50,
@@ -537,7 +542,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Number of Girls",
             viz_type="big_number_total",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 metric=metric,
                 viz_type="big_number_total",
                 granularity="ds",
@@ -551,7 +556,7 @@ def create_slices(tbl: SqlaTable) -> tuple[list[Slice], list[Slice]]:
             slice_name="Pivot Table",
             viz_type="pivot_table_v2",
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="pivot_table_v2",
                 groupbyRows=["name"],
                 groupbyColumns=["state"],

--- a/superset/examples/featured_charts/datasets/project_management.yaml
+++ b/superset/examples/featured_charts/datasets/project_management.yaml
@@ -16,7 +16,7 @@
 # under the License.
 always_filter_main_dttm: false
 cache_timeout: null
-catalog: examples
+catalog: null
 columns:
 - advanced_data_type: null
   column_name: start_time

--- a/superset/examples/sales_dashboard/charts/Quarterly_Sales_By_Product_Line.yaml
+++ b/superset/examples/sales_dashboard/charts/Quarterly_Sales_By_Product_Line.yaml
@@ -27,7 +27,7 @@ params:
   color_scheme: supersetColors
   comparison_type: null
   datasource: 23__table
-  granularity_sqla: order_date
+  x_axis: order_date
   groupby:
   - product_line
   label_colors:

--- a/superset/examples/sales_dashboard/charts/Revenue_by_Deal_Size.yaml
+++ b/superset/examples/sales_dashboard/charts/Revenue_by_Deal_Size.yaml
@@ -28,7 +28,7 @@ params:
   comparison_type: values
   contribution: false
   datasource: 23__table
-  granularity_sqla: order_date
+  x_axis: order_date
   groupby:
   - deal_size
   label_colors: {}

--- a/superset/examples/slack_dashboard/charts/Messages_per_Channel.yaml
+++ b/superset/examples/slack_dashboard/charts/Messages_per_Channel.yaml
@@ -35,7 +35,7 @@ params:
   color_scheme: supersetColors
   comparison_type: values
   datasource: 56__table
-  granularity_sqla: ts
+  x_axis: ts
   groupby:
   - name
   label_colors:

--- a/superset/examples/usa_births_names/charts/Genders_by_State.yaml
+++ b/superset/examples/usa_births_names/charts/Genders_by_State.yaml
@@ -30,7 +30,7 @@ params:
     subject: state
   compare_lag: '10'
   compare_suffix: o10Y
-  granularity: ds
+  x_axis: ds
   groupby:
   - state
   limit: '25'

--- a/superset/examples/usa_births_names/charts/Top_10_Boy_Name_Share.yaml
+++ b/superset/examples/usa_births_names/charts/Top_10_Boy_Name_Share.yaml
@@ -29,7 +29,7 @@ params:
   compare_lag: '10'
   compare_suffix: o10Y
   comparison_type: values
-  granularity: ds
+  x_axis: ds
   groupby:
   - name
   limit: 10
@@ -47,7 +47,7 @@ params:
   time_grain_sqla: P1D
   time_range: '100 years ago : now'
   viz_type: echarts_area
-  x_axis_forma: smart_date
+  x_axis_time_format: smart_date
 query_context: null
 slice_name: Top 10 Boy Name Share
 uuid: 26a9bde8-eb06-4de3-91f0-5e04d448403a

--- a/superset/examples/usa_births_names/charts/Top_10_Girl_Name_Share.yaml
+++ b/superset/examples/usa_births_names/charts/Top_10_Girl_Name_Share.yaml
@@ -29,7 +29,7 @@ params:
   compare_lag: '10'
   compare_suffix: o10Y
   comparison_type: values
-  granularity: ds
+  x_axis: ds
   groupby:
   - name
   limit: 10
@@ -47,7 +47,7 @@ params:
   time_grain_sqla: P1D
   time_range: '100 years ago : now'
   viz_type: echarts_area
-  x_axis_forma: smart_date
+  x_axis_time_format: smart_date
 query_context: null
 slice_name: Top 10 Girl Name Share
 uuid: 44c4c16f-216d-44c8-b033-6876b8c51fd2

--- a/superset/examples/usa_births_names/charts/Trends.yaml
+++ b/superset/examples/usa_births_names/charts/Trends.yaml
@@ -22,7 +22,7 @@ description: null
 params:
   compare_lag: '10'
   compare_suffix: o10Y
-  granularity: ds
+  x_axis: ds
   groupby:
   - name
   limit: '25'

--- a/superset/examples/video_game_sales/charts/Top_10_Games_Proportion_of_Sales_in_Markets.yaml
+++ b/superset/examples/video_game_sales/charts/Top_10_Games_Proportion_of_Sales_in_Markets.yaml
@@ -37,7 +37,7 @@ params:
   columns: []
   contribution: true
   datasource: 21__table
-  granularity_sqla: year
+  x_axis: year
   groupby:
   - name
   label_colors: {}

--- a/superset/examples/video_game_sales/charts/Total_Sales_per_Market_Grouped_by_Genre.yaml
+++ b/superset/examples/video_game_sales/charts/Total_Sales_per_Market_Grouped_by_Genre.yaml
@@ -28,7 +28,7 @@ params:
   columns: []
   contribution: false
   datasource: 21__table
-  granularity_sqla: year
+  x_axis: year
   groupby:
   - genre
   label_colors:

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -164,7 +164,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
         "entity": "country_code",
         "show_bubbles": True,
     }
-    legacy_granularity_defaults = {**shared_defaults, "granularity": "year"}
+    non_echarts_defaults = {**shared_defaults, "granularity": "year"}
     echarts_x_axis_defaults = {**shared_defaults, "x_axis": "year"}
 
     return [
@@ -174,7 +174,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 since="2000",
                 viz_type="big_number",
                 compare_lag="10",
@@ -188,7 +188,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="table",
                 metrics=["sum__SP_POP_TOTL"],
                 groupby=["country_name"],
@@ -214,7 +214,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="world_map",
                 metric="sum__SP_RUR_TOTL_ZS",
                 num_period_compare="10",
@@ -227,7 +227,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="bubble_v2",
                 since="2011-01-01",
                 until="2011-01-02",
@@ -271,7 +271,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 viz_type="sunburst_v2",
                 columns=["region", "country_name"],
                 since="2011-01-01",
@@ -300,7 +300,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 since="1960-01-01",
                 until="now",
                 whisker_options="Min/max (no outliers)",
@@ -316,7 +316,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 since="1960-01-01",
                 until="now",
                 viz_type="treemap_v2",
@@ -330,7 +330,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                legacy_granularity_defaults,
+                non_echarts_defaults,
                 since="2011-01-01",
                 until="2012-01-01",
                 viz_type="para",

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -164,8 +164,8 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
         "entity": "country_code",
         "show_bubbles": True,
     }
-    defaults = {**shared_defaults, "granularity": "year"}
-    echarts_defaults = {**shared_defaults, "x_axis": "year"}
+    legacy_granularity_defaults = {**shared_defaults, "granularity": "year"}
+    echarts_x_axis_defaults = {**shared_defaults, "x_axis": "year"}
 
     return [
         Slice(
@@ -174,7 +174,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 since="2000",
                 viz_type="big_number",
                 compare_lag="10",
@@ -188,7 +188,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="table",
                 metrics=["sum__SP_POP_TOTL"],
                 groupby=["country_name"],
@@ -200,7 +200,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 viz_type="echarts_timeseries_line",
                 since="1960-01-01",
                 metrics=["sum__SP_POP_TOTL"],
@@ -214,7 +214,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="world_map",
                 metric="sum__SP_RUR_TOTL_ZS",
                 num_period_compare="10",
@@ -227,7 +227,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="bubble_v2",
                 since="2011-01-01",
                 until="2011-01-02",
@@ -271,7 +271,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 viz_type="sunburst_v2",
                 columns=["region", "country_name"],
                 since="2011-01-01",
@@ -286,7 +286,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                echarts_defaults,
+                echarts_x_axis_defaults,
                 since="1960-01-01",
                 until="now",
                 viz_type="echarts_area",
@@ -300,7 +300,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 since="1960-01-01",
                 until="now",
                 whisker_options="Min/max (no outliers)",
@@ -316,7 +316,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 since="1960-01-01",
                 until="now",
                 viz_type="treemap_v2",
@@ -330,7 +330,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                legacy_granularity_defaults,
                 since="2011-01-01",
                 until="2012-01-01",
                 viz_type="para",

--- a/superset/examples/world_bank.py
+++ b/superset/examples/world_bank.py
@@ -150,11 +150,10 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
         "hasCustomLabel": True,
         "label": "Rural Population",
     }
-    defaults = {
+    shared_defaults = {
         "compare_lag": "10",
         "compare_suffix": "o10Y",
         "limit": "25",
-        "granularity": "year",
         "groupby": [],
         "row_limit": current_app.config["ROW_LIMIT"],
         "since": "2014-01-01",
@@ -165,6 +164,8 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
         "entity": "country_code",
         "show_bubbles": True,
     }
+    defaults = {**shared_defaults, "granularity": "year"}
+    echarts_defaults = {**shared_defaults, "x_axis": "year"}
 
     return [
         Slice(
@@ -199,7 +200,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 viz_type="echarts_timeseries_line",
                 since="1960-01-01",
                 metrics=["sum__SP_POP_TOTL"],
@@ -285,7 +286,7 @@ def create_slices(tbl: BaseDatasource) -> list[Slice]:
             datasource_type=DatasourceType.TABLE,
             datasource_id=tbl.id,
             params=get_slice_json(
-                defaults,
+                echarts_defaults,
                 since="1960-01-01",
                 until="now",
                 viz_type="echarts_area",

--- a/superset/examples/world_health/charts/Growth_Rate.yaml
+++ b/superset/examples/world_health/charts/Growth_Rate.yaml
@@ -24,7 +24,7 @@ params:
   compare_suffix: o10Y
   country_fieldtype: cca3
   entity: country_code
-  granularity: year
+  x_axis: year
   groupby:
   - country_name
   limit: '25'

--- a/superset/examples/world_health/charts/World_s_Pop_Growth.yaml
+++ b/superset/examples/world_health/charts/World_s_Pop_Growth.yaml
@@ -24,7 +24,7 @@ params:
   compare_suffix: o10Y
   country_fieldtype: cca3
   entity: country_code
-  granularity: year
+  x_axis: year
   groupby:
   - region
   limit: '25'

--- a/tests/unit_tests/examples/utils_test.py
+++ b/tests/unit_tests/examples/utils_test.py
@@ -23,17 +23,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-ECHARTS_TIMESERIES_VIZ_TYPES = {
-    "echarts_area",
-    "echarts_timeseries",
-    "echarts_timeseries_bar",
-    "echarts_timeseries_line",
-    "echarts_timeseries_scatter",
-    "echarts_timeseries_smooth",
-    "echarts_timeseries_step",
-    "mixed_timeseries",
-}
-
 
 def _create_example_tree(base_dir: Path) -> Path:
     """Create a minimal example directory tree under base_dir/superset/examples/.
@@ -216,23 +205,6 @@ def test_load_examples_from_configs_defaults(
         force_data=False,
     )
     mock_command.run.assert_called_once()
-
-
-def test_echarts_timeseries_yaml_examples_use_x_axis_metadata() -> None:
-    """ECharts time-series examples must set the temporal column on x_axis."""
-    examples_root = Path(__file__).resolve().parents[3] / "superset" / "examples"
-    stale_charts: list[str] = []
-
-    for chart_path in sorted(examples_root.glob("**/charts/*.yaml")):
-        with chart_path.open() as chart_file:
-            chart = yaml.safe_load(chart_file)
-
-        params = chart.get("params") or {}
-        viz_type = chart.get("viz_type") or params.get("viz_type")
-        if viz_type in ECHARTS_TIMESERIES_VIZ_TYPES and "granularity" in params:
-            stale_charts.append(str(chart_path.relative_to(examples_root)))
-
-    assert stale_charts == []
 
 
 def test_load_configs_from_directory_rejects_unsafe_yaml_metadata():

--- a/tests/unit_tests/examples/utils_test.py
+++ b/tests/unit_tests/examples/utils_test.py
@@ -23,6 +23,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+ECHARTS_TIMESERIES_VIZ_TYPES = {
+    "echarts_area",
+    "echarts_timeseries",
+    "echarts_timeseries_bar",
+    "echarts_timeseries_line",
+    "echarts_timeseries_scatter",
+    "echarts_timeseries_smooth",
+    "echarts_timeseries_step",
+    "mixed_timeseries",
+}
+
 
 def _create_example_tree(base_dir: Path) -> Path:
     """Create a minimal example directory tree under base_dir/superset/examples/.
@@ -205,6 +216,23 @@ def test_load_examples_from_configs_defaults(
         force_data=False,
     )
     mock_command.run.assert_called_once()
+
+
+def test_echarts_timeseries_yaml_examples_use_x_axis_metadata() -> None:
+    """ECharts time-series examples must set the temporal column on x_axis."""
+    examples_root = Path(__file__).resolve().parents[3] / "superset" / "examples"
+    stale_charts: list[str] = []
+
+    for chart_path in sorted(examples_root.glob("**/charts/*.yaml")):
+        with chart_path.open() as chart_file:
+            chart = yaml.safe_load(chart_file)
+
+        params = chart.get("params") or {}
+        viz_type = chart.get("viz_type") or params.get("viz_type")
+        if viz_type in ECHARTS_TIMESERIES_VIZ_TYPES and "granularity" in params:
+            stale_charts.append(str(chart_path.relative_to(examples_root)))
+
+    assert stale_charts == []
 
 
 def test_load_configs_from_directory_rejects_unsafe_yaml_metadata():


### PR DESCRIPTION
### SUMMARY
Corrects stale bundled example metadata for ECharts time-series charts that were storing the temporal column in legacy `granularity` / `granularity_sqla` metadata instead of `x_axis`.

This updates the affected USA birth names, World Bank, Sales Dashboard, Slack Dashboard, and Video Game Sales chart YAML files. It also updates the Python example definitions that generate the same metadata, with separate `non_echarts_defaults` and `echarts_x_axis_defaults` so the intended metadata shape is clear at each call site.

This also fixes the stale `x_axis_forma` typo to `x_axis_time_format` for the Top 10 name share examples.

I also fixed the Featured Charts Gantt dataset metadata by clearing its `catalog`; it was the only bundled example dataset with `catalog: examples`, which makes PostgreSQL try to query a catalog/database named `examples`.

I checked the migration path before keeping this as an examples-only fix. Persisted charts that go through the legacy viz migration are already covered by `superset/migrations/shared/migrate_viz/base.py`, which maps `granularity_sqla` to `x_axis` for migrated charts with an x-axis control. A later migration, `2023-07-18_15-30_863adcf72773_delete_obsolete_druid_nosql_slice_parameters.py`, also removes obsolete `granularity` keys from saved slice params and query contexts. If we find production ECharts metadata with this exact stale shape, we can add a runtime shim separately.

### BEFORE

See **Trends** and **Top 10 Girls Names** charts rendering incorrectly:

<img width="1194" height="719" alt="image" src="https://github.com/user-attachments/assets/fed12799-a1c8-484d-8b8d-3d0252dc0b55" />

The **Gantt** chart dataset reference is incorrect, causing a query error:

<img width="402" height="418" alt="image" src="https://github.com/user-attachments/assets/beef7441-4181-47e5-90aa-de8bbbe92b99" />

### AFTER

**Trends** and **Top 10 Girls Names** charts now render correctly:

<img width="1200" height="720" alt="image" src="https://github.com/user-attachments/assets/5e7e925c-1413-45cf-a471-aa5bd9dbb812" />

Gantt also renders correctly:

<img width="400" height="414" alt="image" src="https://github.com/user-attachments/assets/5876eb9b-10a0-4e52-8cc5-cadc7c90e3b2" />

### TESTING INSTRUCTIONS
- `pytest tests/unit_tests/examples/utils_test.py -q`
- `venv/bin/python -m compileall -q superset/examples/birth_names.py superset/examples/world_bank.py tests/unit_tests/examples/utils_test.py`
- `pre-commit run`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
