### PR TITLE
fix(dashboard): store native filter scope as root plus exclusions

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.test.ts
@@ -18,7 +18,7 @@
  */
 import { Layout, LayoutItem, Charts } from 'src/dashboard/types';
 import { VizType } from '@superset-ui/core';
-import { buildTree, getTreeCheckedItems } from './utils';
+import { buildTree, findFilterScope, getTreeCheckedItems } from './utils';
 import type { TreeItem } from './types';
 
 // The types defined for Layout and sub elements is not compatible with the data we get back fro a real dashboard layout
@@ -18199,5 +18199,91 @@ describe('Ensure buildTree does not throw runtime errors when encountering an in
         () => 'Fake title',
       );
     }).not.toThrow();
+  });
+});
+
+// eslint-disable-next-line no-restricted-globals -- TODO: Migrate from describe blocks
+describe('findFilterScope', () => {
+  // Chart 1 sits directly in the grid, charts 2 and 3 each live in their own tab
+  const layout = {
+    ROOT_ID: { id: 'ROOT_ID', type: 'ROOT', children: ['GRID_ID'], parents: [] },
+    GRID_ID: {
+      id: 'GRID_ID',
+      type: 'GRID',
+      children: ['CHART-1', 'TABS-1'],
+      parents: ['ROOT_ID'],
+    },
+    'CHART-1': {
+      id: 'CHART-1',
+      type: 'CHART',
+      children: [],
+      parents: ['ROOT_ID', 'GRID_ID'],
+      meta: { chartId: 1 },
+    },
+    'TABS-1': {
+      id: 'TABS-1',
+      type: 'TABS',
+      children: ['TAB-1', 'TAB-2'],
+      parents: ['ROOT_ID', 'GRID_ID'],
+    },
+    'TAB-1': {
+      id: 'TAB-1',
+      type: 'TAB',
+      children: ['CHART-2'],
+      parents: ['ROOT_ID', 'GRID_ID', 'TABS-1'],
+    },
+    'TAB-2': {
+      id: 'TAB-2',
+      type: 'TAB',
+      children: ['CHART-3'],
+      parents: ['ROOT_ID', 'GRID_ID', 'TABS-1'],
+    },
+    'CHART-2': {
+      id: 'CHART-2',
+      type: 'CHART',
+      children: [],
+      parents: ['ROOT_ID', 'GRID_ID', 'TABS-1', 'TAB-1'],
+      meta: { chartId: 2 },
+    },
+    'CHART-3': {
+      id: 'CHART-3',
+      type: 'CHART',
+      children: [],
+      parents: ['ROOT_ID', 'GRID_ID', 'TABS-1', 'TAB-2'],
+      meta: { chartId: 3 },
+    },
+  } as unknown as Layout;
+
+  test('returns an empty scope when nothing is checked', () => {
+    expect(findFilterScope([], layout)).toEqual({ rootPath: [], excluded: [] });
+  });
+
+  test('scopes every chart when all of them are checked', () => {
+    expect(
+      findFilterScope(['CHART-1', 'CHART-2', 'CHART-3'], layout),
+    ).toEqual({ rootPath: ['ROOT_ID'], excluded: [] });
+  });
+
+  test('keeps the root anchor when the only chart outside a tab is unchecked', () => {
+    // Unchecking chart 1 used to move the anchor down to ['TAB-1', 'TAB-2'] and
+    // report no exclusions at all, dropping any chart outside those two tabs
+    // out of scope without recording it
+    expect(findFilterScope(['CHART-2', 'CHART-3'], layout)).toEqual({
+      rootPath: ['ROOT_ID'],
+      excluded: [1],
+    });
+  });
+
+  test('records charts of a tab that has no checked chart', () => {
+    expect(findFilterScope(['CHART-1', 'CHART-2'], layout)).toEqual({
+      rootPath: ['ROOT_ID'],
+      excluded: [3],
+    });
+  });
+
+  test('round-trips through getTreeCheckedItems', () => {
+    const checked = ['CHART-2', 'CHART-3'];
+    const scope = findFilterScope(checked, layout);
+    expect(getTreeCheckedItems(scope, layout).sort()).toEqual(checked.sort());
   });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts
@@ -257,7 +257,8 @@ export const getTreeCheckedItems = (
   return [...new Set(checkedItems)];
 };
 
-// Looking for first common parent for selected charts/tabs/tab
+// Builds the scope of the selected charts/tabs as the dashboard root plus
+// the charts to exclude
 export const findFilterScope = (
   checkedKeys: string[],
   layout: Layout,
@@ -293,34 +294,30 @@ export const findFilterScope = (
     }
   });
 
-  // Get arrays of parents for selected charts
-  const checkedItemParents = chartKeys
-    .filter(item => layout[item]?.type === CHART_TYPE)
-    .map(key => {
-      const parents = [DASHBOARD_ROOT_ID, ...(layout[key]?.parents || [])];
-      return parents.filter(parent => isShowTypeInTree(layout[parent]));
-    });
-  // Sort arrays of parents to get first shortest array of parents,
-  // that means on it's level of parents located common parent, from this place parents start be different
-  checkedItemParents.sort((p1, p2) => p1.length - p2.length);
-  const rootPath = checkedItemParents.map(
-    parents => parents[checkedItemParents[0].length - 1],
+  // Anchor the scope at the dashboard root and let `excluded` carry the whole
+  // selection. Deriving `rootPath` from the closest common ancestor is lossy on
+  // dashboards with tabs: its depth was decided by the shallowest checked
+  // chart, so unchecking a single chart could move the anchor from ROOT down to
+  // the tab level. Every tab holding no checked chart then fell out of
+  // `rootPath`, and its charts never reached `excluded` either (that loop only
+  // visited charts whose parent is in `rootPath`), so they left the scope
+  // unreported and the filter bar showed the filter as out of scope on tabs the
+  // user never edited.
+  const checkedChartIds = new Set(
+    chartKeys
+      .filter(item => layout[item]?.type === CHART_TYPE)
+      .map(item => layout[item]?.meta?.chartId as number),
   );
 
-  const excluded: number[] = [];
-  const isExcluded = (parent: string, item: string) =>
-    rootPath.includes(parent) && !chartKeys.includes(item);
-  // looking for charts to be excluded: iterate over all charts
-  // and looking for charts that have one of their parents in `rootPath` and not in selected items
-  Object.entries(layout).forEach(([key, value]) => {
-    const parents = value.parents || [];
-    if (
-      value.type === CHART_TYPE &&
-      [DASHBOARD_ROOT_ID, ...parents]?.find(parent => isExcluded(parent, key))
-    ) {
-      excluded.push(value.meta.chartId as number);
-    }
-  });
+  const rootPath = [DASHBOARD_ROOT_ID];
+  const excluded = Object.values(layout)
+    .filter(
+      item =>
+        item.type === CHART_TYPE &&
+        item.meta?.chartId != null &&
+        !checkedChartIds.has(item.meta.chartId as number),
+    )
+    .map(item => item.meta.chartId as number);
 
   return {
     rootPath: [...new Set(rootPath)],


### PR DESCRIPTION
### SUMMARY

`findFilterScope` (`superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FilterScope/utils.ts`) encodes a native filter's scope as the closest common ancestor of the checked charts instead of `ROOT + excluded`:

```js
const checkedItemParents = chartKeys
  .filter(item => layout[item]?.type === CHART_TYPE)
  .map(key => {
    const parents = [DASHBOARD_ROOT_ID, ...(layout[key]?.parents || [])];
    return parents.filter(parent => isShowTypeInTree(layout[parent]));
  });
checkedItemParents.sort((p1, p2) => p1.length - p2.length);
const rootPath = checkedItemParents.map(
  parents => parents[checkedItemParents[0].length - 1],
);

const excluded = [];
const isExcluded = (parent, item) =>
  rootPath.includes(parent) && !chartKeys.includes(item);
```

The depth of `rootPath` is decided by the **shallowest checked chart**. On a dashboard with tabs, as soon as every checked chart lives inside a tab, `rootPath` stops being `["ROOT_ID"]` and becomes a list of tab ids, and `excluded` stays empty — the charts outside those tabs are out of scope implicitly, because the exclusion loop only visits charts whose parent is in `rootPath`.

`getChartIdsInFilterScope` derives the same `chartsInScope` from either representation right after the save (I replayed both implementations over the same layouts to confirm), so the cost lands on the stored value:

1. **The saved intent is lost.** The scope reads `{"rootPath": ["TAB-1", "TAB-2"], "excluded": []}` — "nothing is excluded" — while a chart *is* excluded. A chart added or moved outside those tabs afterwards silently falls out of scope, with nothing in the metadata explaining why.
2. **Tab ids are layout-local.** Copying a dashboard, or exporting and re-importing it, regenerates them. `rootPath` then resolves to nothing, `parents ∩ rootPath` is empty for every chart, `chartsInScope` empties out, `findTabsWithChartsInScope` derives an empty `tabsInScope`, and `useIsFilterInScope` (`components/nativeFilters/state.ts`) reports the filter under "Filters out of scope" on *every* tab.
3. **The modal round trip is unstable.** `getTreeCheckedItems` walks the tree from `rootPath`, so a scope anchored at tab ids cannot show charts living elsewhere as checked.

This PR anchors `rootPath` at `DASHBOARD_ROOT_ID` and lets `excluded` carry the whole selection (every chart in the layout minus the checked ones). `chartsInScope` is unchanged for every scope the previous code represented, and the stored value no longer depends on tab ids.

`getTreeCheckedItems` is untouched, so scopes already persisted with tab-level `rootPath` values keep resolving as they do today.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — no visual change. The difference is in the persisted `native_filter_configuration`:

Dashboard with chart A directly in the grid (no tab), plus tabs `TAB-1` (chart B) and `TAB-2` (chart C). Filter scoped to everything, then chart A unchecked:

| | `scope` |
| --- | --- |
| before | `{"rootPath": ["TAB-1", "TAB-2"], "excluded": []}` |
| after | `{"rootPath": ["ROOT_ID"], "excluded": [1]}` |

### TESTING INSTRUCTIONS

No test covered `findFilterScope`. This PR adds unit tests in `FilterScope/utils.test.ts` for the empty selection, the all-checked case, unchecking the only chart outside a tab, a tab holding no checked chart, and the `getTreeCheckedItems` round trip.

Manually: create a dashboard with one chart outside any tab and two tabs each holding a chart, add a native filter, open its scope, uncheck the chart outside the tabs, save, and inspect `native_filter_configuration` in **Edit properties → Advanced**. The scope stays anchored at `ROOT_ID` and names the excluded chart. Then copy the dashboard and confirm the filter is still in scope on both tabs.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
