### PR TITLE
fix(security): guard is_guest_user against NoAuthorizationError on unauthenticated error paths

### DIFF
--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -64,6 +64,7 @@ from flask_appbuilder.security.views import (
 )
 from flask_babel import lazy_gettext as _
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
+from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask_login import AnonymousUserMixin, LoginManager
 from jwt.api_jwt import _jwt_global_obj
 from sqlalchemy import and_, func as sa_func, inspect, or_
@@ -5487,9 +5488,22 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             return False
 
         if not user:
-            if not get_current_user():
+            # Resolving the current user forces evaluation of flask_login's
+            # ``current_user`` proxy, which on a request that carries no JWT and
+            # no guest token invokes the app's request loader and lets
+            # ``verify_jwt_in_request`` raise ``NoAuthorizationError``. That is
+            # fine for a real view (a global handler turns it into a 401), but
+            # ``is_guest_user`` is also called from paths that run before auth
+            # (e.g. error sanitization while handling an unrelated HTTPException),
+            # where the raise escapes as an unhandled exception. A request with
+            # no JWT/guest token definitionally cannot be an embedded guest
+            # viewer, so returning ``False`` is the semantically correct answer.
+            try:
+                if not get_current_user():
+                    return False
+                user = g.user
+            except NoAuthorizationError:
                 return False
-            user = g.user
 
         return hasattr(user, "is_guest_user") and user.is_guest_user
 

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -53,6 +53,33 @@ def test_security_manager(app_context: None) -> None:
     assert sm
 
 
+def test_is_guest_user_no_jwt_returns_false_without_raising(
+    app_context: None, mocker: MockerFixture
+) -> None:
+    """
+    ``is_guest_user`` must not propagate ``NoAuthorizationError``.
+
+    Resolving the current user on a request with no JWT and no guest token
+    invokes the app's request loader, which lets ``verify_jwt_in_request``
+    raise ``NoAuthorizationError``. When ``is_guest_user`` runs before auth
+    (e.g. error sanitization while handling an unrelated HTTPException) that
+    raise would escape as an unhandled exception. Such a request cannot be an
+    embedded guest viewer, so the method must return ``False`` instead.
+    """
+    from flask_jwt_extended.exceptions import NoAuthorizationError
+
+    mocker.patch(
+        "superset.is_feature_enabled",
+        side_effect=lambda feature: feature == "EMBEDDED_SUPERSET",
+    )
+    mocker.patch(
+        "superset.security.manager.get_current_user",
+        side_effect=NoAuthorizationError("Missing JWT in cookies or headers"),
+    )
+
+    assert SupersetSecurityManager.is_guest_user() is False
+
+
 def _register_views_with_mock_appbuilder(
     mocker: MockerFixture, auth_type: int
 ) -> MagicMock:


### PR DESCRIPTION
### SUMMARY

Fixes [SUPERSET-PYTHON-15J6](https://preset-inc.sentry.io/issues/7684373355/) — `NoAuthorizationError: Missing JWT in cookies or headers`, **28,783 events** since firstSeen 2026-08-21, still firing daily.

**The Sentry-captured exception is not the original problem — it is a _secondary_ exception raised while Flask is already handling an unrelated, benign exception** (in the sampled events, a 405 `MethodNotAllowed` from a request hitting the wrong HTTP method on a route, before any view/auth code runs). The same crash can happen for any early-in-request-lifecycle `HTTPException`.

#### Root-cause chain

1. Flask raises `MethodNotAllowed` (405) during routing, before any view/auth code runs.
2. The global `@app.errorhandler(HTTPException) def show_http_exception` (`superset/views/error_handling.py`) catches it and calls `json_error_response(...)`.
3. `json_error_response` calls `sanitize_superset_errors()` (`superset/utils/error_sanitization.py`).
4. That calls `is_sanitization_required()` → `security_manager.is_guest_user()`.
5. `is_guest_user()` with no `user` argument calls `get_current_user()` (`superset/tasks/utils.py`), whose `g.user` access forces resolution of flask_login's `current_user` `LocalProxy`.
6. Resolving the proxy invokes the app's registered request loader. For a request with **no guest token, no JWT, and not a public-workspace / MCP-OAuth path**, the loader calls `verify_jwt_in_request()` and lets it raise (by design — a global flask-jwt-extended handler is meant to turn that into a 401 for a real unauthenticated _view_ request).
7. But here the raise happens **inside `show_http_exception`, the error handler for the original 405**. This second exception is not caught by anything and propagates out unhandled — captured by Sentry, and turning a benign 405 into an actual crash/500 for any embedded-enabled deployment, for any unauthenticated request that trips an `HTTPException` path before auth ever runs.

#### The fix

Wrap the current-user resolution inside `SupersetSecurityManager.is_guest_user()` in `try/except NoAuthorizationError: return False`.

A request that carries no JWT and no guest token **definitionally cannot be an embedded guest viewer**, so returning `False` is the semantically correct answer, not merely crash avoidance. `is_guest_user` is the shared choke point behind many call sites across the codebase; only the error-sanitization path is normally reachable before auth runs, and this fix protects all of them without changing behavior for any already-authenticated caller.

`NoAuthorizationError` is imported from `flask_jwt_extended.exceptions` (the top-level package does not re-export it). The fix lives entirely in `superset/security/manager.py`; `error_sanitization.py`, `error_handling.py`, and the private request-loader are intentionally untouched — their behavior is correct for real view requests.

### TESTING INSTRUCTIONS

Added `tests/unit_tests/security/manager_test.py::test_is_guest_user_no_jwt_returns_false_without_raising`: with `EMBEDDED_SUPERSET` enabled and the current-user resolution raising `NoAuthorizationError`, `is_guest_user()` must return `False` rather than propagate.

Verified the test **fails before** the fix (raises `NoAuthorizationError`) and **passes after**:

```
$ pytest tests/unit_tests/security/manager_test.py tests/unit_tests/utils/test_error_sanitization.py -q
136 passed

$ ruff check superset/security/manager.py tests/unit_tests/security/manager_test.py
All checks passed!
$ ruff format --check superset/security/manager.py tests/unit_tests/security/manager_test.py
2 files already formatted
```

`pre-commit` (mypy, ruff, ruff-format, pylint) clean on the changed files.

### Tradeoffs

**None as a failure-mode change.** This makes `is_guest_user()` never raise where it previously could sometimes crash the request, which is strictly more correct:

- For an unauthenticated request with no JWT/guest token, `False` is the semantically correct return value (such a request cannot be an embedded guest), so no legitimate guest is misclassified.
- For any already-authenticated caller (real guest token or logged-in user), the proxy resolves without raising, so `NoAuthorizationError` is never hit and behavior is byte-for-byte unchanged.
- No security-boundary change: it never grants guest treatment where it wasn't already granted — it only stops a benign error path from escalating into an unhandled 500. Nothing here is undisclosed.

### ADDITIONAL INFORMATION

- Sentry: [SUPERSET-PYTHON-15J6](https://preset-inc.sentry.io/issues/7684373355/) (28,783 events, auto-resolves on merge via `Fixes SUPERSET-PYTHON-15J6`)
- Shortcut: [SC-119741](https://app.shortcut.com/preset/story/119741)
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
