### PR TITLE
fix(explore): open version-history forks in a usable tab, not a blank one

### DIFF
--- a/superset-frontend/src/utils/navigationUtils.test.ts
+++ b/superset-frontend/src/utils/navigationUtils.test.ts
@@ -778,3 +778,158 @@ describe('navigateTo duplicate-assign suppression', () => {
     });
   });
 });
+
+describe('openBlankTab / navigateOpenedTab / closeOpenedTab', () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Default to the blocked-popup return so a test that forgets to set one
+    // does not fall through to jsdom's unimplemented window.open.
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  const makeTab = () =>
+    ({
+      closed: false,
+      close: jest.fn(),
+      location: { replace: jest.fn() },
+    }) as unknown as Window;
+
+  test('openBlankTab opens the placeholder without noopener so the handle is usable', async () => {
+    // Regression: opening a version as new stranded a blank about:blank tab
+    // because window.open(..., 'noopener') returns null, so openBlankTab handed
+    // the caller no window handle to navigate.
+    const tab = makeTab();
+    openSpy.mockReturnValue(tab);
+    const { openBlankTab } = await import('src/utils/navigationUtils');
+
+    const result = openBlankTab();
+
+    expect(result).toBe(tab);
+    // Assert the exact call, not merely the absence of the `noopener` token:
+    // `noreferrer` also forces window.open to return null, so a features arg of
+    // any kind would reship the stranded-tab bug. Only a two-arg call keeps the
+    // handle.
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');
+  });
+
+  test('openBlankTab returns null when the browser blocks the popup', async () => {
+    openSpy.mockReturnValue(null);
+    const { openBlankTab } = await import('src/utils/navigationUtils');
+
+    // The null is the contract callers rely on to detect a blocked popup.
+    expect(openBlankTab()).toBeNull();
+  });
+
+  test('navigateOpenedTab points a live claimed tab at the resolved URL', async () => {
+    await withApplicationRoot('', async () => {
+      const tab = makeTab();
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      navigateOpenedTab(tab, '/dashboard/9/');
+
+      expect(tab.location.replace as jest.Mock).toHaveBeenCalledWith(
+        '/dashboard/9/',
+      );
+      // The live-handle branch must NOT fall through to a second window.open,
+      // which by the time it runs has lost user activation and is popup-blocked.
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  test('navigateOpenedTab prefixes the app root before replacing', async () => {
+    await withApplicationRoot('/superset/', async () => {
+      const tab = makeTab();
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      navigateOpenedTab(tab, '/dashboard/9/');
+
+      expect(tab.location.replace as jest.Mock).toHaveBeenCalledWith(
+        '/superset/dashboard/9/',
+      );
+    });
+  });
+
+  test('navigateOpenedTab falls back to a fresh window.open when the tab is null', async () => {
+    await withApplicationRoot('', async () => {
+      openSpy.mockReturnValue(null);
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      navigateOpenedTab(null, '/explore/?slice_id=1');
+
+      expect(openSpy).toHaveBeenCalledWith(
+        '/explore/?slice_id=1',
+        '_blank',
+        'noopener noreferrer',
+      );
+    });
+  });
+
+  test('navigateOpenedTab falls back when the claimed tab was already closed', async () => {
+    await withApplicationRoot('', async () => {
+      const tab = { ...makeTab(), closed: true } as unknown as Window;
+      openSpy.mockReturnValue(null);
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      navigateOpenedTab(tab, '/explore/?slice_id=1');
+
+      expect(tab.location.replace as jest.Mock).not.toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalledWith(
+        '/explore/?slice_id=1',
+        '_blank',
+        'noopener noreferrer',
+      );
+    });
+  });
+
+  test('navigateOpenedTab does not expose the opener-connected tab to an external URL', async () => {
+    await withApplicationRoot('', async () => {
+      const tab = makeTab();
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      // A safe-but-absolute URL is permitted by assertSafeNavigationUrl, but
+      // must not be navigated on the noopener-less claimed tab: it is closed
+      // and reopened through the noopener fallback instead.
+      navigateOpenedTab(tab, 'https://example.com/');
+
+      expect(tab.location.replace as jest.Mock).not.toHaveBeenCalled();
+      expect(tab.close as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://example.com/',
+        '_blank',
+        'noopener noreferrer',
+      );
+    });
+  });
+
+  test('navigateOpenedTab validates the URL before touching a claimed tab', async () => {
+    await withApplicationRoot('', async () => {
+      const tab = makeTab();
+      const { navigateOpenedTab } = await import('src/utils/navigationUtils');
+
+      expect(() => navigateOpenedTab(tab, '//evil.com')).toThrow();
+      expect(tab.location.replace as jest.Mock).not.toHaveBeenCalled();
+      expect(tab.close as jest.Mock).not.toHaveBeenCalled();
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  test('closeOpenedTab closes a live tab and no-ops on null or already-closed', async () => {
+    const { closeOpenedTab } = await import('src/utils/navigationUtils');
+    const tab = makeTab();
+
+    closeOpenedTab(tab);
+    expect(tab.close as jest.Mock).toHaveBeenCalledTimes(1);
+
+    const closed = { ...makeTab(), closed: true } as unknown as Window;
+    closeOpenedTab(closed);
+    expect(closed.close as jest.Mock).not.toHaveBeenCalled();
+
+    expect(() => closeOpenedTab(null)).not.toThrow();
+  });
+});

--- a/superset-frontend/src/utils/navigationUtils.ts
+++ b/superset-frontend/src/utils/navigationUtils.ts
@@ -466,9 +466,18 @@ export function openInNewTab(path: string): void {
  * refusal is silent -- `window.open` just returns null -- so a caller that
  * awaits first appears to do nothing at all. Call this synchronously in the
  * handler and hand the result to `navigateOpenedTab` when the URL is known.
+ *
+ * The placeholder is opened WITHOUT `noopener`: per the HTML standard,
+ * `window.open(..., 'noopener')` always returns null, which would discard the
+ * very handle this function exists to return and leave the caller with a
+ * stranded `about:blank` tab it can never navigate. The destination is always
+ * a same-origin app route (`ensureAppRoot` in `navigateOpenedTab`), so the
+ * opener relationship carries no cross-origin tabnabbing risk. The one-shot
+ * `window.open(url, ...)` fallback in `navigateOpenedTab` keeps `noopener`,
+ * since it passes the real URL and never needs the handle.
  */
 export function openBlankTab(): Window | null {
-  return window.open('', '_blank', NEW_TAB_FEATURES);
+  return window.open('', '_blank');
 }
 
 /**
@@ -477,12 +486,30 @@ export function openBlankTab(): Window | null {
  *
  * The URL is validated before either branch, so an unsafe path cannot reach
  * a pre-opened tab any more than it could reach `openInNewTab`.
+ *
+ * The external-URL branch (a safe absolute URL on a claimed tab) is defensive:
+ * no current caller passes one, and by the time it would run the click's
+ * activation has lapsed, so the reopen is popup-blocked and the placeholder
+ * closes with nothing opening. It exists only to keep an absolute URL off the
+ * opener-connected tab; a caller needing an external target after an await
+ * should not claim a tab up front.
  */
 export function navigateOpenedTab(tab: Window | null, path: string): void {
   const url = assertSafeNavigationUrl(ensureAppRoot(path));
-  if (tab && !tab.closed) {
+  // Only a same-origin app route may reuse the opener-connected placeholder
+  // from `openBlankTab` (which drops `noopener` to keep its handle).
+  // `ensureAppRoot` leaves an absolute URL untouched, so anything not starting
+  // with a single `/` is external: it must not ride the opener chain. Route it
+  // through the `noopener` fallback instead — closing the claimed tab first so
+  // no `about:blank` is stranded — which makes the same-origin guarantee
+  // structural rather than a caller convention.
+  const isSameOriginRoute = url.startsWith('/') && !url.startsWith('//');
+  if (isSameOriginRoute && tab && !tab.closed) {
     tab.location.replace(url);
     return;
+  }
+  if (tab && !tab.closed) {
+    tab.close();
   }
   window.open(url, '_blank', NEW_TAB_FEATURES);
 }


### PR DESCRIPTION
### SUMMARY

The version-history panel's **"Open as new chart / Open as new dashboard"** (and the related-entity open) opened a **blank `about:blank` tab** instead of the forked object — reproduced for both current and older versions, on charts and dashboards.

Root cause is in `superset-frontend/src/utils/navigationUtils.ts`. These flows follow a *claim-then-navigate* pattern: because the fork takes several sequential requests (snapshot → resolve → copy), they call `openBlankTab()` **synchronously in the click handler** — while the click's transient user activation is still live — and then point that tab at the destination once the new object's id is known, via `navigateOpenedTab()`. This avoids the popup blocker refusing a `window.open` issued after the awaits.

But `openBlankTab()` opened its placeholder with `window.open('', '_blank', 'noopener noreferrer')`, and **per the HTML standard `window.open(..., 'noopener')` always returns `null`** — that is the entire purpose of `noopener`: sever the opener link, so the caller gets no window handle. So the handle the function exists to return was discarded on every call:

1. `openBlankTab()` opens a blank tab but returns `null` → `tab = null`.
2. The fork runs (snapshot fetch, uuid resolve, `POST /copy/` or `POST /chart/`) — all succeed; the server creates the new object.
3. `navigateOpenedTab(null, url)` sees a null handle and falls through to a **second** `window.open(url, ...)`, which by now has lost user activation and is silently refused by the popup blocker.
4. The blank tab from step 1 is stranded on `about:blank`.

The fix opens the placeholder **without** `noopener` so the returned handle is usable, and `navigateOpenedTab` can call `tab.location.replace(url)` on the live tab. The destination is always a **same-origin app route** (built through `ensureAppRoot` and validated by `assertSafeNavigationUrl`), so the opener relationship carries no cross-origin tabnabbing risk. The one-shot `window.open(url, ...)` fallback in `navigateOpenedTab` keeps `noopener`, since it passes the real URL directly and never needs the handle.

Scope: this fixes every claim-then-navigate path — chart open-as-new, dashboard open-as-new, and `openRelatedEntity` (all share `openBlankTab` / `navigateOpenedTab`). In-place **Preview** was never affected because it renders in the panel and opens no tab.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** selecting "Open as new chart/dashboard" from the version-history kebab opens a new tab that stays on `about:blank` — even though the fork succeeded on the server (the copy request returns `200` with the new id). Verified live: `POST /api/v1/dashboard/<id>/copy/` → `200 {"result":{"id":N}}`, and navigating directly to `/dashboard/N/` renders the fork correctly — only the automatic tab navigation was broken.

**After:** the claimed tab receives a real window handle and is navigated to the new object's route (`/explore/?slice_id=N` or `/dashboard/N/`), so the forked chart/dashboard opens populated, as intended.

### TESTING INSTRUCTIONS

Requires the versioning UI (`SOFT_DELETE` / version-history feature) enabled and an object with at least one saved version.

1. Open a chart in Explore (or a dashboard) → 3-dot menu → **View version history**.
2. On a version's kebab → **Open as new chart** / **Open as new dashboard**.
3. **Before this fix:** a new tab opens and stays blank. **After:** the new tab opens the forked chart/dashboard, populated from that version.
4. Repeat for the current version and an older version.

Automated: `cd superset-frontend && npx jest src/utils/navigationUtils.test.ts` — adds coverage for `openBlankTab` (returns a usable handle, no `noopener`), `navigateOpenedTab` (live-handle `replace` with app-root prefix, URL validation before touching the tab, null/closed → `window.open` fallback), and `closeOpenedTab`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
