### PR TITLE
fix(playwright): match Dashboard v2 palette tab selector

### DIFF
--- a/superset-frontend/playwright/pages/DashboardV2Page.ts
+++ b/superset-frontend/playwright/pages/DashboardV2Page.ts
@@ -115,20 +115,20 @@ export class DashboardV2Page {
   }
 
   /**
-   * Switches back to the "Widgets" palette tab. Placing (or selecting) a
-   * block switches the editor panel to Properties, so a test that places
-   * one block via `placeBlockByClick` and then wants to drag a second one
-   * from the palette needs this in between.
+   * Switches back to the "Building Blocks" palette tab. Placing (or
+   * selecting) a block switches the editor panel to Properties, so a test
+   * that places one block via `placeBlockByClick` and then wants to drag a
+   * second one from the palette needs this in between.
    *
-   * A plain `text=Widgets` locator is unsafe here: on a branch (or any
-   * other page state) where the word "Widgets" happens to appear
-   * elsewhere too — e.g. a dev-mode badge showing the current git branch
-   * name — it resolves to more than one element and Playwright refuses to
-   * click ambiguously. Scoping to the `tab` role narrows that, but not
+   * A plain `text=Building Blocks` locator is unsafe here: on a branch (or
+   * any other page state) where that text happens to appear elsewhere too
+   * — e.g. a dev-mode badge showing the current git branch name — it
+   * resolves to more than one element and Playwright refuses to click
+   * ambiguously. Scoping to the `tab` role narrows that, but not
    * completely: an author can place a `tabs` widget on the canvas itself
-   * and name one of its own panes "Widgets", which is `role="tab"` too —
-   * an unscoped `getByRole('tab', ...)` would then match that canvas tab
-   * *and* the real palette tab, and Playwright would again refuse to
+   * and name one of its own panes "Building Blocks", which is `role="tab"`
+   * too — an unscoped `getByRole('tab', ...)` would then match that canvas
+   * tab *and* the real palette tab, and Playwright would again refuse to
    * click ambiguously. Scoping to `[data-test="editor-panel"]` — the
    * rail the palette's own tab bar lives in, never the canvas — rules
    * that out regardless of what an author names a widget on the canvas.
@@ -136,7 +136,7 @@ export class DashboardV2Page {
   async showPalette(): Promise<void> {
     await this.page
       .locator(DashboardV2Page.SELECTORS.EDITOR_PANEL)
-      .getByRole('tab', { name: 'Widgets', exact: true })
+      .getByRole('tab', { name: 'Building Blocks', exact: true })
       .click();
   }
 


### PR DESCRIPTION
### SUMMARY

A prior playwright fix commit (#43487) updated the selector on the assumption that the tab had been renamed to "Widgets", but a later @EnxDev's commit ([#43588](https://github.com/apache/superset/pull/43588/changes#diff-297f1f61a41f190d99bdacc63c73180be01c6a560f5d0f28d9ed2c98f29384b7R322)) had actually renamed it the other way, back to "Building Blocks".

This updates the selector (and its accompanying comment) in
`DashboardV2Page.ts` to look for "Building Blocks", matching the label
that's actually rendered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Run the experimental Dashboard v2 Playwright

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
