### PR TITLE
fix(versioning): match version-history search on the change author name

### DIFF
--- a/superset/versioning/activity/orchestrator.py
+++ b/superset/versioning/activity/orchestrator.py
@@ -180,12 +180,19 @@ def _parse_iso_datetime(value: str) -> datetime | None:
 def _record_matches(record: dict[str, Any], q: str) -> bool:
     """Case-insensitive substring match for the ``q`` search filter,
     over the human-meaningful surfaces of a decorated activity record:
-    ``summary``, ``entity_name``, ``kind``, the joined ``path`` segments,
-    and the JSON form of ``from_value`` / ``to_value`` (JSON, not Python
+    ``summary``, ``entity_name``, ``kind``, the change author's display
+    name (``changed_by`` first/last), the joined ``path`` segments, and
+    the JSON form of ``from_value`` / ``to_value`` (JSON, not Python
     ``str()``: the client searches the serialized text it renders, so
     ``false`` / ``null`` / double-quoted keys must match — and falsy
     values like ``False`` / ``0`` must not collapse to unsearchable
     empty strings).
+
+    The author name comes from the projected ``changed_by`` DTO, which
+    decoration redacts to ``None`` for a tombstoned related entity
+    (whose editor identity must not be disclosed) — so a redacted
+    record contributes no author text and stays unsearchable by author,
+    preserving that security contract.
     """
 
     def _value_text(value: Any) -> str:
@@ -196,11 +203,19 @@ def _record_matches(record: dict[str, Any], q: str) -> bool:
         except (TypeError, ValueError):
             return str(value)
 
+    changed_by = record.get("changed_by") or {}
+    author_name = " ".join(
+        str(part)
+        for part in (changed_by.get("first_name"), changed_by.get("last_name"))
+        if part
+    )
+
     needle = q.lower()
     haystacks = (
         record.get("summary") or "",
         record.get("entity_name") or "",
         record.get("kind") or "",
+        author_name,
         " ".join(str(seg) for seg in (record.get("path") or [])),
         _value_text(record.get("from_value")),
         _value_text(record.get("to_value")),

--- a/tests/unit_tests/versioning/test_activity.py
+++ b/tests/unit_tests/versioning/test_activity.py
@@ -225,6 +225,13 @@ def test_decoration_redacts_record_from_reused_entity_id() -> None:
     assert record["entity_name"] == ""
     assert record["from_value"] is None
     assert record["to_value"] is None
+    # The editor identity of the deleted related entity must be redacted at the
+    # decoration layer (render.py sets ``changed_by = None``), so the seeded
+    # author "Ada Lovelace" is suppressed and cannot be surfaced or searched.
+    # Without this assertion the redaction can regress silently.
+    assert record["changed_by"] is None
+    assert "first_name" not in record
+    assert "last_name" not in record
 
 
 def test_bounded_heap_merges_newer_rows_from_later_id_chunks() -> None:

--- a/tests/unit_tests/versioning/test_activity.py
+++ b/tests/unit_tests/versioning/test_activity.py
@@ -800,6 +800,62 @@ def test_record_matches_falsy_values_and_json_form() -> None:
     assert _record_matches(nested, '"label"')  # JSON double-quoted key
 
 
+def test_record_matches_searches_author_name() -> None:
+    """The q filter also matches the change author's display name from the
+    projected ``changed_by`` DTO (sc-119374: author-scoped search returned
+    "No actions found" because the author was absent from the haystack)."""
+    from superset.versioning.activity.orchestrator import _record_matches
+
+    record = {
+        "summary": "",
+        "entity_name": "Sales",
+        "kind": "field",
+        "path": ["params"],
+        "from_value": None,
+        "to_value": None,
+        "changed_by": {
+            "id": 1,
+            "first_name": "Test Primary",
+            "last_name": "Contributor",
+        },
+    }
+    assert _record_matches(record, "Primary")  # first-name substring
+    assert _record_matches(record, "contributor")  # last name, case-insensitive
+    assert _record_matches(record, "Test Primary Contributor")  # full name
+    assert not _record_matches(record, "Nonexistent Author")
+
+
+def test_record_matches_author_partial_and_missing_name() -> None:
+    """A user with only one name part still matches on it, and a record
+    whose author is redacted/absent (``changed_by`` is None — the
+    tombstoned-related-entity security contract) contributes no author
+    text and is not matchable by author."""
+    from superset.versioning.activity.orchestrator import _record_matches
+
+    first_only = {
+        "summary": "",
+        "entity_name": "",
+        "kind": "field",
+        "path": [],
+        "from_value": None,
+        "to_value": None,
+        "changed_by": {"id": 2, "first_name": "Ada", "last_name": None},
+    }
+    assert _record_matches(first_only, "ada")
+
+    redacted = {**first_only, "changed_by": None}
+    assert not _record_matches(redacted, "ada")
+
+    # A present DTO with both name parts null (a user row with no names) is
+    # distinct from redaction: it yields an empty author name and is likewise
+    # unsearchable by author, without matching on the literal 'None'.
+    nameless = {
+        **first_only,
+        "changed_by": {"id": 3, "first_name": None, "last_name": None},
+    }
+    assert not _record_matches(nameless, "none")
+
+
 def test_build_summary_meta_headline_branches() -> None:
     """The __meta__ headline dispatches on the transaction's action_kind
     (path is pure navigation): restore renders 'restored to version N'


### PR DESCRIPTION
### SUMMARY

The version-history panel's **"Search actions"** box runs a server-side substring filter (`_record_matches` in `superset/versioning/activity/orchestrator.py`). Its search haystack covered `summary`, `entity_name`, `kind`, the joined `path` segments, and the JSON form of `from_value`/`to_value` — but **never the change author**. So typing an author's name returned "No actions found" even when every entry in the timeline was authored by that user, and the result count undercounted. Filtering history by *who* made a change is a primary expected use of the box, and it was silently broken.

The fix adds the change author's display name to the haystack, sourced from the already-projected `changed_by` DTO (`{id, first_name, last_name}`). Two properties are preserved deliberately:

- **Security/redaction**: record decoration sets `changed_by = None` for a tombstoned *related* entity whose editor identity must not be disclosed. Reading the author from `changed_by` means a redacted record contributes no author text and stays unsearchable by author — the redaction contract is kept intact.
- **Partial names**: a user with only a first or last name still matches on the present part.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Backend-only change. Before: `GET /api/v1/chart/<uuid>/activity/?include=all&q=<author name>` → `count 0` on a timeline entirely authored by that user. After: the same query matches that author's entries.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/versioning/test_activity.py -k record_matches` — adds coverage for author substring / full-name / case-insensitive matching, single-part names, and the redacted (`changed_by is None`) case.

Manual: open a chart/dashboard version-history panel whose saves are by one author, type that author's name in "Search actions" — the timeline filters to their entries instead of showing "No actions found".

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
