### PR TITLE
fix(versioning): keep the dashboard version-history panel inside the viewport

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -165,19 +165,48 @@ const StyledContent = styled.div<{
 }>`
   grid-column: 2;
   grid-row: 2;
-  /* @z-index-above-dashboard-header (100) + 1 = 101 */
-  ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 101;`}
+  /* @z-index-above-dashboard-header (100) + 2 = 102: a maximized chart
+     must also cover the version-history overlay (101) so the two stack the
+     same way on both sides of the overlay breakpoint. */
+  ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 102;`}
 `;
 
 // Sticks alongside the page scroll so the panel stays fully visible.
+// Below the XXL breakpoint the dashboard grid's min-content width plus the
+// panel exceed the viewport (the content column cannot shrink), which would
+// push the panel past the page's right edge and clip its own controls
+// (sc-119737). Mirror the Explore panel host in spirit — Explore anchors
+// absolutely inside its relatively-positioned container, but the dashboard
+// page owns the scroll, so this pins to the viewport instead. While open at
+// these widths the overlay covers the page's right edge (including the top
+// navbar while scrolled to the top) — accepted: it is a closable surface.
 const VersionHistoryColumn = styled.div`
-  grid-column: 3;
-  grid-row: 1 / span 2;
-  position: sticky;
-  top: 0;
-  align-self: start;
-  height: 100vh;
-  z-index: 99;
+  ${({ theme }) => css`
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    position: sticky;
+    top: 0;
+    align-self: start;
+    height: 100vh;
+    z-index: 99;
+    @media (max-width: ${theme.screenXLMax}px) {
+      /* @z-index-above-dashboard-header (100) + 1 = 101 */
+      position: fixed;
+      right: 0;
+      bottom: 0;
+      height: auto;
+      z-index: 101;
+      box-shadow: ${theme.boxShadow};
+      /* Load-bearing contract with DashboardVersionHistory's closed state:
+         it must render nothing in place (its restore modal portals out of
+         the column), so the column stays :empty and this zero-width fixed
+         box paints no stray shadow at the viewport edge. Pinned by the
+         closed-state test in DashboardVersionHistory.test.tsx. */
+      &:empty {
+        box-shadow: none;
+      }
+    }
+  `}
 `;
 
 const DashboardContentWrapper = styled.div`

--- a/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
+++ b/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import type { AnyAction, Store } from 'redux';
-import { act, render } from 'spec/helpers/testing-library';
+import { act, render, screen } from 'spec/helpers/testing-library';
 import type { VersionHistoryState } from './types';
 import { useVersionActivity } from './useVersionActivity';
 import DashboardVersionHistory from './DashboardVersionHistory';
@@ -25,9 +25,12 @@ import DashboardVersionHistory from './DashboardVersionHistory';
 const mockPanelProps = jest.fn();
 jest.mock('./VersionHistoryPanel', () => ({
   __esModule: true,
+  // Renders a marker so open and closed states are distinguishable in the
+  // DOM: a null-rendering mock would let the closed-state contract test
+  // below pass vacuously, regardless of isPanelOpen.
   default: (props: unknown) => {
     mockPanelProps(props);
-    return null;
+    return <div data-test="mock-version-history-panel" />;
   },
 }));
 jest.mock('./useDashboardVersionPreview', () => ({
@@ -37,7 +40,15 @@ jest.mock('./useVersionActions', () => ({
   useVersionActions: () => ({
     requestRestore: jest.fn(),
     openAsNew: jest.fn(),
-    restoreModal: null,
+    // The real restore modal portals out of the column (Modal renders into
+    // document.body). Model that faithfully so the closed-state test can
+    // assert the column stays DOM-empty even while a modal is alive.
+    restoreModal: jest
+      .requireActual('react-dom')
+      .createPortal(
+        <div data-test="mock-restore-modal" />,
+        globalThis.document.body,
+      ),
   }),
 }));
 jest.mock('./useVersionActivity', () => ({
@@ -258,7 +269,10 @@ test('renders nothing in place while the panel is closed', () => {
   // The DashboardBuilder overlay relies on this contract: the closed
   // column must stay DOM-empty (the restore modal portals out of it), or
   // the :empty shadow guard stops matching and a stray shadow line appears
-  // at the viewport edge below the overlay breakpoint (sc-119737).
+  // at the viewport edge below the overlay breakpoint (sc-119737). The
+  // panel mock renders a marker and the restore-modal mock portals a
+  // marker into document.body, so this test fails if the closed state
+  // ever renders the panel — or any wrapper element — in place.
   const store = makeTestStore({
     versionHistory: versionHistoryState({ isPanelOpen: false }),
     dashboardInfo: {
@@ -270,4 +284,23 @@ test('renders nothing in place while the panel is closed', () => {
   });
   const { container } = renderAdapter(store);
   expect(container).toBeEmptyDOMElement();
+  // The modal is alive OUTSIDE the column — the guard is specifically
+  // about in-place emptiness, not about nothing rendering at all.
+  expect(screen.getByTestId('mock-restore-modal')).toBeInTheDocument();
+  expect(
+    screen.queryByTestId('mock-version-history-panel'),
+  ).not.toBeInTheDocument();
+});
+
+test('renders the panel in place while open — the closed-state discriminator', () => {
+  // Companion control for the contract test above: with the panel open the
+  // very same container is non-empty. Together the pair proves the
+  // closed-state assertion turns on isPanelOpen rather than on mocks that
+  // render nothing in either state.
+  const store = makeStore();
+  const { container } = renderAdapter(store);
+  expect(container).not.toBeEmptyDOMElement();
+  expect(
+    screen.getByTestId('mock-version-history-panel'),
+  ).toBeInTheDocument();
 });

--- a/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
+++ b/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
@@ -253,3 +253,21 @@ test('withholds restore on an externally managed dashboard', () => {
     expect.objectContaining({ canRestore: false }),
   );
 });
+
+test('renders nothing in place while the panel is closed', () => {
+  // The DashboardBuilder overlay relies on this contract: the closed
+  // column must stay DOM-empty (the restore modal portals out of it), or
+  // the :empty shadow guard stops matching and a stray shadow line appears
+  // at the viewport edge below the overlay breakpoint (sc-119737).
+  const store = makeTestStore({
+    versionHistory: versionHistoryState({ isPanelOpen: false }),
+    dashboardInfo: {
+      uuid: 'dash-uuid',
+      last_modified_time: 100,
+      dash_edit_perm: true,
+    },
+    dashboardState: { hasUnsavedChanges: false, lastModifiedTime: 500 },
+  });
+  const { container } = renderAdapter(store);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
+++ b/superset-frontend/src/features/versionHistory/DashboardVersionHistory.test.tsx
@@ -300,7 +300,5 @@ test('renders the panel in place while open — the closed-state discriminator',
   const store = makeStore();
   const { container } = renderAdapter(store);
   expect(container).not.toBeEmptyDOMElement();
-  expect(
-    screen.getByTestId('mock-version-history-panel'),
-  ).toBeInTheDocument();
+  expect(screen.getByTestId('mock-version-history-panel')).toBeInTheDocument();
 });


### PR DESCRIPTION
### SUMMARY
QA (SC-118366) found that on dashboards the open version-history panel — a 320px inline drawer in the third column of the builder grid — has its right edge pinned at ~1446px regardless of viewport width: the grid's content column cannot shrink below its min-content width, so below ~1446px the panel is pushed past the page width, clipping its own version rows, kebab menus, and close ✕ behind horizontal scroll (measured: +6px overflow at 1440, +166px at 1280).

Fix mirrors the responsive pattern the Explore version-history host already uses (`ExploreVersionHistory`'s `PanelHost`): below the `screenXXL` antd breakpoint, `VersionHistoryColumn` becomes a **fixed overlay pinned to the viewport's right edge** (removed from grid flow, so nothing overflows at any narrower width), above the dashboard header (`z-index 101`), with the theme shadow; an `:empty` guard keeps a closed (portal-only) column from painting a stray shadow sliver. At wide viewports the side-by-side layout is unchanged.

The breakpoint is the token-based `screenXXL` (1600) rather than the measured 1446: the inline-fit threshold moves with the filter-bar state and grid min-content, so the token gives margin instead of a magic number; between 1446-1599 the panel overlays where it previously fit inline — a deliberate trade for never overflowing.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before (QA evidence on the ticket): at 1280px the panel's right edge exceeds the viewport by 166px, controls off-screen. After: at any width below 1600 the panel overlays anchored to the right edge; close ✕ and version rows stay reachable.

### TESTING INSTRUCTIONS
1. Open a dashboard → ⋮ menu → "View version history" at viewport widths 1280 / 1366 / 1440: the panel hugs the viewport's right edge, no horizontal page scroll, close ✕ and kebab menus reachable.
2. At ≥1600px: unchanged side-by-side layout (panel in the grid column).
3. With the panel closed at <1600px: no shadow artifact at the right edge.
4. `npm run test -- src/dashboard/components/DashboardBuilder` — builder suites pass.

### ADDITIONAL INFORMATION
- [x] Has associated issue: SC-119737 (Preset Shortcut, QA of SC-118366)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW
