### PR TITLE
fix(versioning): bound dashboard related history by the chart attach window

### DIFF
--- a/superset/versioning/activity/queries.py
+++ b/superset/versioning/activity/queries.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from heapq import heappush, heapreplace
+from itertools import groupby
 from typing import Any
 from uuid import UUID
 
@@ -118,14 +119,66 @@ def first_tracked_tx(
 # ---- Phase A: relationship-traversal queries ------------------------------
 
 
+# ``operation_type`` values on a Continuum association shadow row
+# (sqlalchemy_continuum.operation.Operation): INSERT attaches, DELETE detaches.
+# UPDATE never occurs for a pure M2M association (there is nothing to update on
+# a (dashboard, slice) pair); if it ever appeared it is ignored — neither
+# opening nor closing a window — so an open attachment simply continues.
+# These mirror the library enum's numeric values; ``test_m2m_op_constants_match_
+# continuum`` pins them so a Continuum renumber fails loudly rather than silently.
+_M2M_OP_INSERT = 0
+_M2M_OP_DELETE = 2
+
+
+def _attachment_windows(
+    rows: list[tuple[int, int, int]],
+) -> list[tuple[int, Window]]:
+    """Pair INSERT / DELETE association-version rows into ``[attach, detach)``
+    windows, one per attachment episode.
+
+    Each row is ``(slice_id, transaction_id, operation_type)``. Continuum
+    **never closes** an association shadow row's ``end_transaction_id`` — its
+    unit-of-work only *inserts* association versions
+    (``create_association_versions``); the validity backfill that sets
+    ``end_transaction_id`` runs for parent objects, not for M2M links. So the
+    detach boundary lives on the DELETE row's ``transaction_id``, not on the
+    attach row's ``end_transaction_id`` (which stays NULL for the association's
+    whole life). An INSERT opens a window; the next DELETE closes it at its
+    transaction id; an attachment with no following DELETE stays open (the
+    chart is still on the dashboard). A DELETE at the same transaction as its
+    open (add-and-remove in one save) yields no window — the chart was never
+    on a committed dashboard state.
+    """
+    result: list[tuple[int, Window]] = []
+    # operation_type is part of the sort key so that, within one transaction,
+    # INSERT (0) sorts before DELETE (2): an add-and-remove in a single save is
+    # then seen open-before-close and collapses to no window (the DELETE finds
+    # ``tx == open_tx``, not ``>``). Do not drop it from the key.
+    rows_sorted = sorted(rows, key=lambda r: (r[0], r[1], r[2]))
+    for slice_id, group in groupby(rows_sorted, key=lambda r: r[0]):
+        open_tx: int | None = None
+        for _slice_id, tx, operation_type in group:
+            if operation_type == _M2M_OP_DELETE:
+                if open_tx is not None and tx > open_tx:
+                    result.append((slice_id, Window(open_tx, tx)))
+                open_tx = None
+            elif operation_type == _M2M_OP_INSERT and open_tx is None:
+                open_tx = tx
+        if open_tx is not None:
+            result.append((slice_id, Window(open_tx, None)))
+    return result
+
+
 def charts_attached_to_dashboard(dashboard_id: int) -> list[tuple[int, Window]]:
     """Return ``(slice_id, window)`` for every chart that has ever been on
-    *dashboard_id*, with each association's validity window in
+    *dashboard_id*, with each attachment episode's validity window in
     transaction-id space.
 
-    Reads from ``dashboard_slices_version`` (Continuum's auto-generated
-    M2M shadow). Rows with ``operation_type = 2`` (DELETE) are excluded
-    so we don't synthesize a phantom window from a detachment row.
+    Reads from ``dashboard_slices_version`` (Continuum's auto-generated M2M
+    shadow) and pairs its INSERT/DELETE rows via :func:`_attachment_windows`,
+    so a chart removed from the dashboard is bounded at the detach transaction
+    rather than open-ended — otherwise the chart's edits made *after* removal
+    would surface in the dashboard's related history.
     """
     # pylint: disable=import-outside-toplevel
     from sqlalchemy_continuum import version_class
@@ -143,33 +196,15 @@ def charts_attached_to_dashboard(dashboard_id: int) -> list[tuple[int, Window]]:
             sa.select(
                 m2m_tbl.c.slice_id,
                 m2m_tbl.c.transaction_id,
-                m2m_tbl.c.end_transaction_id,
+                m2m_tbl.c.operation_type,
             ).where(
                 m2m_tbl.c.dashboard_id == dashboard_id,
-                m2m_tbl.c.operation_type != 2,
                 m2m_tbl.c.slice_id.is_not(None),
             )
         )
         .all()
     )
-    result: list[tuple[int, Window]] = []
-    for row in rows:
-        try:
-            window = Window(row[1], row[2])
-        except ValueError:
-            # A degenerate shadow row (end_tx <= start_tx) must not 500 the
-            # endpoint; skip it and leave a breadcrumb for investigation.
-            logger.warning(
-                "activity: skipping degenerate dashboard_slices_version row "
-                "(dashboard_id=%s, slice_id=%s, tx=%s, end_tx=%s)",
-                dashboard_id,
-                row[0],
-                row[1],
-                row[2],
-            )
-            continue
-        result.append((row[0], window))
-    return result
+    return _attachment_windows([(row[0], row[1], row[2]) for row in rows])
 
 
 def datasets_used_by_chart(slice_id: int) -> list[tuple[int, Window]]:

--- a/tests/unit_tests/versioning/test_activity.py
+++ b/tests/unit_tests/versioning/test_activity.py
@@ -54,6 +54,9 @@ from superset.versioning.activity.orchestrator import (
     _MAX_PAGE_SIZE,
 )
 from superset.versioning.activity.queries import (
+    _attachment_windows,
+    _M2M_OP_DELETE,
+    _M2M_OP_INSERT,
     _merge_result_into_heap,
     _record_sort_key,
     BoundedRecordHeap,
@@ -825,3 +828,64 @@ def test_build_summary_meta_headline_branches() -> None:
         "entity_name": "",
     }
     assert _build_summary("Dashboard", unknown) == "Dashboard updated"
+
+
+# ---- _attachment_windows -------------------------------------------------
+
+
+def test_attachment_windows_closes_at_detach() -> None:
+    """sc-119770: a chart removed from a dashboard is bounded at the detach
+    transaction, not left open-ended. Continuum never closes an association
+    shadow row's end_transaction_id, so the detach boundary is the DELETE
+    row's transaction id — an INSERT at t1 paired with a DELETE at t3 yields
+    the half-open window [t1, t3), so an edit at t2 (while attached) is
+    inside it and an edit at t4 (after removal) is not."""
+    windows = _attachment_windows([(7, 1, 0), (7, 3, 2)])  # INSERT@1, DELETE@3
+
+    assert windows == [(7, Window(1, 3))]
+    window = windows[0][1]
+    assert window.contains(2)  # edit while attached
+    assert not window.contains(3)  # detach tx itself (half-open)
+    assert not window.contains(4)  # edit after removal — excluded
+
+
+def test_attachment_windows_still_attached_is_open_ended() -> None:
+    """A chart with an INSERT and no following DELETE is still on the
+    dashboard, so its window is open-ended (end_tx = None) and every later
+    edit remains in scope."""
+    assert _attachment_windows([(7, 5, 0)]) == [(7, Window(5, None))]
+
+
+def test_attachment_windows_reattach_cycles_and_ordering() -> None:
+    """Multiple attach/detach episodes yield one window each, and the pairing
+    is independent of the row order the query returns them in (the rows are
+    sorted by (slice_id, transaction_id) internally)."""
+    rows = [(7, 7, 2), (7, 1, 0), (7, 5, 0), (7, 3, 2)]  # deliberately shuffled
+    assert _attachment_windows(rows) == [(7, Window(1, 3)), (7, Window(5, 7))]
+
+
+def test_attachment_windows_add_and_remove_same_transaction() -> None:
+    """Attaching and detaching in a single save (INSERT and DELETE at the
+    same transaction) leaves the chart on no committed dashboard state, so it
+    contributes no window (and no degenerate zero-width interval)."""
+    assert _attachment_windows([(7, 2, 0), (7, 2, 2)]) == []
+
+
+def test_attachment_windows_separates_slices() -> None:
+    """Each slice gets its own independent windows."""
+    rows = [(7, 1, 0), (7, 3, 2), (9, 2, 0)]
+    assert _attachment_windows(rows) == [
+        (7, Window(1, 3)),
+        (9, Window(2, None)),
+    ]
+
+
+def test_m2m_op_constants_match_continuum() -> None:
+    """The association-shadow operation-type constants used by
+    _attachment_windows are the numeric values of Continuum's Operation enum.
+    Pin them so a library renumber fails here loudly rather than silently
+    mis-pairing attach/detach rows."""
+    from sqlalchemy_continuum import Operation
+
+    assert _M2M_OP_INSERT == Operation.INSERT
+    assert _M2M_OP_DELETE == Operation.DELETE


### PR DESCRIPTION
### SUMMARY

A dashboard's version-history related items should include a member chart's edits **only while that chart was attached** to the dashboard. In practice, a chart edit made **after** the chart was removed from the dashboard still surfaced as a `Chart updated` related entry — under both "All changes" and "Related items only".

**Root cause** (`superset/versioning/activity/queries.py::charts_attached_to_dashboard`): each attachment window was derived from the `dashboard_slices_version` shadow's `transaction_id` / `end_transaction_id`, with `operation_type = 2` (DELETE) rows excluded as "phantom detachment rows". But sqlalchemy-continuum **never closes an association shadow row's `end_transaction_id`** — its unit-of-work only *inserts* association versions (`create_association_versions`); the validity backfill that sets `end_transaction_id` runs for parent objects, not for M2M links. So the attach (INSERT) row's `end_transaction_id` stays `NULL` for the association's entire life, every derived window was open-ended `[attach_tx, None)`, and the DELETE row that actually carries the detach transaction was exactly the row being discarded. Result: any edit of a chart that was *ever* on the dashboard fell inside the (open) window.

**Fix**: pair the INSERT/DELETE rows. A new pure `_attachment_windows` helper walks the shadow rows per slice in transaction order — opening a window at each INSERT and closing it at the next DELETE's `transaction_id` (open-ended while the chart is still attached; no window at all when a chart is added and removed in the same save, which never reached a committed dashboard state). `charts_attached_to_dashboard` now fetches `operation_type` and delegates the windowing. Downstream scope-resolution, intersection, and union are unchanged.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Backend-only. Before: with chart X attached at t1, edited at t2, removed at t3, edited again at t4, the dashboard's related history showed the t4 edit. After: the window is `[t1, t3)`, so the t2 edit (while attached) is included and the t4 edit (after removal) is excluded.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/versioning/test_activity.py -k attachment_windows` — covers the after-removal exclusion (the ticket's oracle: an INSERT@t1 / DELETE@t3 pair excludes an edit at t4), a still-attached open window, reattach cycles, row-order independence, add-and-remove-in-one-save, and per-slice separation.

Manual: put a chart on a dashboard, edit it (save), remove it from the dashboard (save), edit it again (save); open the dashboard's version history — only the edit made while the chart was on the dashboard appears as a related `Chart updated`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
