### PR TITLE
fix(core): render duration values instead of NaN:NaN:NaN

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
+++ b/superset-frontend/packages/superset-ui-core/src/time-format/utils/stringifyTimeInput.ts
@@ -25,11 +25,22 @@ export default function stringifyTimeInput(
     return `${value}`;
   }
 
+  let time: Date;
   if (typeof value === 'string') {
     const trimmed = value.trim();
     const isIntegerString = /^-?\d+$/.test(trimmed);
-    return fn(new Date(isIntegerString ? Number(trimmed) : value));
+    time = new Date(isIntegerString ? Number(trimmed) : value);
+  } else {
+    time = value instanceof Date ? value : new Date(value);
   }
 
-  return fn(value instanceof Date ? value : new Date(value));
+  // An input that does not resolve to a valid date - a duration such as
+  // "00:01:54", for instance - would otherwise be formatted from an Invalid
+  // Date and render as "NaN:NaN:NaN". Fall back to its own representation,
+  // as is already done for null and undefined above.
+  if (Number.isNaN(time.getTime())) {
+    return `${value}`;
+  }
+
+  return fn(time);
 }

--- a/superset-frontend/packages/superset-ui-core/test/time-format/utils/stringifyTimeInput.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/time-format/utils/stringifyTimeInput.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import stringifyTimeInput from '../../../src/time-format/utils/stringifyTimeInput';
+
+const format = (time: Date) => time.toISOString();
+
+test('returns the stringified value for null and undefined', () => {
+  expect(stringifyTimeInput(null, format)).toBe('null');
+  expect(stringifyTimeInput(undefined, format)).toBe('undefined');
+});
+
+test('formats Date and numeric inputs', () => {
+  const date = new Date(Date.UTC(2017, 1, 14, 11, 22, 33));
+  expect(stringifyTimeInput(date, format)).toBe('2017-02-14T11:22:33.000Z');
+  expect(stringifyTimeInput(date.getTime(), format)).toBe(
+    '2017-02-14T11:22:33.000Z',
+  );
+});
+
+test('treats an integer string as a timestamp in milliseconds', () => {
+  expect(stringifyTimeInput('1487071353000', format)).toBe(
+    '2017-02-14T11:22:33.000Z',
+  );
+});
+
+test('formats a parseable timestamp string', () => {
+  expect(stringifyTimeInput('2017-02-14T11:22:33Z', format)).toBe(
+    '2017-02-14T11:22:33.000Z',
+  );
+});
+
+test('returns unparseable strings unchanged instead of formatting an Invalid Date', () => {
+  // Duration values such as these are not timestamps. Formatting them used to
+  // render as "NaN:NaN:NaN" in the Table chart.
+  expect(stringifyTimeInput('00:01:54', format)).toBe('00:01:54');
+  expect(stringifyTimeInput('0 days 00:01:54', format)).toBe('0 days 00:01:54');
+  expect(stringifyTimeInput('not a date', format)).toBe('not a date');
+});
+
+test('returns the representation of a Date that could not be resolved', () => {
+  expect(stringifyTimeInput(new Date('00:01:54'), format)).toBe('Invalid Date');
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/DateWithFormatter.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/DateWithFormatter.ts
@@ -49,6 +49,13 @@ export default class DateWithFormatter extends Date {
       if (this.formatter === String) {
         return String(this.input);
       }
+      // Values that are not parseable timestamps - durations such as
+      // "00:01:54" or "0 days 00:01:54", for instance - produce an Invalid
+      // Date, and formatting one renders as "NaN:NaN:NaN". Fall back to the
+      // original value instead.
+      if (Number.isNaN(this.getTime())) {
+        return String(this.input);
+      }
       return this.formatter ? this.formatter(this) : Date.toString.call(this);
     };
   }

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/DateWithFormatter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/DateWithFormatter.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getTimeFormatter } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/common';
+import DateWithFormatter from '../../src/utils/DateWithFormatter';
+import { formatColumnValue } from '../../src/utils/formatValue';
+import { DataColumnMeta } from '../../src/types';
+
+const formatter = getTimeFormatter('%H:%M:%S');
+
+test('formats a parseable timestamp with the configured formatter', () => {
+  const value = new DateWithFormatter('2017-02-14T11:22:33Z', { formatter });
+  expect(String(value)).toBe('11:22:33');
+});
+
+test('renders the original value when it is not a parseable timestamp', () => {
+  // Duration columns hold values like these. They produce an Invalid Date,
+  // which used to be formatted and rendered as "NaN:NaN:NaN".
+  ['00:01:54', '0 days 00:01:54'].forEach(input => {
+    const value = new DateWithFormatter(input, { formatter });
+    expect(Number.isNaN(value.getTime())).toBe(true);
+    expect(String(value)).toBe(input);
+  });
+});
+
+test('retains the original input when the formatter is String', () => {
+  const value = new DateWithFormatter('00:01:54');
+  expect(String(value)).toBe('00:01:54');
+});
+
+test('renders a duration cell through the column formatter without producing NaN', () => {
+  // The cell text is produced by formatColumnValue, which hands the wrapped
+  // value straight to the formatter rather than going through toString().
+  const column: DataColumnMeta = {
+    key: 'call_period',
+    label: 'call_period',
+    dataType: GenericDataType.Temporal,
+    formatter,
+    isNumeric: false,
+  };
+  const value = new DateWithFormatter('00:01:54', { formatter });
+
+  expect(formatColumnValue(column, value)).toEqual([false, '00:01:54']);
+});

--- a/superset-frontend/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
+++ b/superset-frontend/plugins/plugin-chart-table/src/utils/DateWithFormatter.ts
@@ -49,6 +49,13 @@ export default class DateWithFormatter extends Date {
       if (this.formatter === String) {
         return String(this.input);
       }
+      // Values that are not parseable timestamps - durations such as
+      // "00:01:54" or "0 days 00:01:54", for instance - produce an Invalid
+      // Date, and formatting one renders as "NaN:NaN:NaN". Fall back to the
+      // original value instead.
+      if (Number.isNaN(this.getTime())) {
+        return String(this.input);
+      }
       return this.formatter ? this.formatter(this) : Date.toString.call(this);
     };
   }

--- a/superset-frontend/plugins/plugin-chart-table/test/utils/DateWithFormatter.test.ts
+++ b/superset-frontend/plugins/plugin-chart-table/test/utils/DateWithFormatter.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { getTimeFormatter } from '@superset-ui/core';
+import { GenericDataType } from '@apache-superset/core/common';
+import DateWithFormatter from '../../src/utils/DateWithFormatter';
+import { formatColumnValue } from '../../src/utils/formatValue';
+import { DataColumnMeta } from '../../src/types';
+
+const formatter = getTimeFormatter('%H:%M:%S');
+
+test('formats a parseable timestamp with the configured formatter', () => {
+  const value = new DateWithFormatter('2017-02-14T11:22:33Z', { formatter });
+  expect(String(value)).toBe('11:22:33');
+});
+
+test('renders the original value when it is not a parseable timestamp', () => {
+  // Duration columns hold values like these. They produce an Invalid Date,
+  // which used to be formatted and rendered as "NaN:NaN:NaN".
+  ['00:01:54', '0 days 00:01:54'].forEach(input => {
+    const value = new DateWithFormatter(input, { formatter });
+    expect(Number.isNaN(value.getTime())).toBe(true);
+    expect(String(value)).toBe(input);
+  });
+});
+
+test('retains the original input when the formatter is String', () => {
+  const value = new DateWithFormatter('00:01:54');
+  expect(String(value)).toBe('00:01:54');
+});
+
+test('renders a duration cell through the column formatter without producing NaN', () => {
+  // The cell text is produced by formatColumnValue, which hands the wrapped
+  // value straight to the formatter rather than going through toString().
+  const column: DataColumnMeta = {
+    key: 'call_period',
+    label: 'call_period',
+    dataType: GenericDataType.Temporal,
+    formatter,
+    isNumeric: false,
+  };
+  const value = new DateWithFormatter('00:01:54', { formatter });
+
+  expect(formatColumnValue(column, value)).toEqual([false, '00:01:54']);
+});


### PR DESCRIPTION
### SUMMARY

A column holding duration strings — `00:01:54`, `0 days 00:01:54` — is not a parseable timestamp. It reaches a d3 time formatter as an `Invalid Date` and is rendered as `NaN:NaN:NaN`, discarding the value the database returned.

Two paths lead there:

- the column is typed **temporal**, so `transformProps` wraps the cell in `DateWithFormatter` and `formatValue` hands that object to the formatter;
- the column is typed **string** but has a d3 time format set in the column config, so `transformProps` assigns a time formatter anyway (`isTime || config.d3TimeFormat`).

They converge in `stringifyTimeInput`, which formats whatever `Date` it ends up with, valid or not. The guard therefore lives there rather than in the plugin: fixing only the table plugin would leave the string-column path broken, and every other consumer of a time formatter exposed to the same thing.

`stringifyTimeInput` now falls back to the input's own representation when it does not resolve to a valid date, exactly as it already does for `null` and `undefined`. `DateWithFormatter.toString()` carries the same guard and returns the input it already retains — that is also what makes the fallback terminate for a wrapped value, since coercing the object would otherwise re-enter the formatter. Both table plugins carry the identical class, so both are covered.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Rendered in Storybook, not the full app. `call_period` is typed temporal (path A); `call_period_str` is a string column with `%H:%M:%S` set in the column config (path B). Same data in both columns.

| value from the database | before | after |
| --- | --- | --- |
| `00:01:54` | `NaN:NaN:NaN` | `00:01:54` |
| `0 days 00:01:54` | `NaN:NaN:NaN` | `0 days 00:01:54` |


### TESTING INSTRUCTIONS

From `superset-frontend/`:

```
npx jest packages/superset-ui-core/test/time-format plugins/plugin-chart-table plugins/plugin-chart-ag-grid-table
```

44 suites, 611 tests. The three test files added here fail on `master` and pass with this change.

To check by hand: put a column of duration strings (`00:01:54`) in a Table chart, either typed as temporal in the dataset or typed as string with a time format set under Customize → column config. Before this change the column renders `NaN:NaN:NaN`; after it renders the stored value.

### ADDITIONAL INFORMATION

- [x] Has associated issue:
  - Fixes #34328
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

<img width="1520" height="460" alt="before" src="https://github.com/user-attachments/assets/6a7925b5-5f9f-4d2e-8f9d-ccdbafb4cbe3" />
<img width="1520" height="460" alt="after" src="https://github.com/user-attachments/assets/65db4f6b-2657-4594-9c9b-62e3ab27e133" />

/review

