### PR TITLE
ci: fail when the published OpenAPI spec is stale

### DIFF
--- a/.github/workflows/check-openapi-spec-drift.yml
+++ b/.github/workflows/check-openapi-spec-drift.yml
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name: Check OpenAPI spec drift
+on:
+  push:
+    branches:
+      - "master"
+      - "[0-9].[0-9]*"
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+
+# No `paths:` filter on purpose, matching enforce-single-migration-head: a
+# required check that never runs for a given PR blocks that PR forever. The
+# job is ~10s, so it fires on every PR rather than guessing which file edits
+# can move the spec.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-openapi-spec-drift:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: ./.github/actions/setup-backend/
+        with:
+          # base.txt pins apispec, which decides the generated output: 6.10.0
+          # renders marshmallow 4's unknown=RAISE as "additionalProperties":
+          # false while the pinned 6.6.1 does not. Regenerating off-pin
+          # produces a spec no CI run can reproduce.
+          requirements-type: base
+      - name: Regenerate the spec
+        env:
+          # No SUPERSET_CONFIG_PATH: the published spec documents the routes a
+          # default deployment registers. A config enabling feature flags adds
+          # paths that would 404 for everyone who has not enabled them.
+          SUPERSET__SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
+          FLASK_APP: "superset.app:create_app()"
+        run: superset update-api-docs
+      - name: Assert the published spec is up to date
+        run: |
+          if ! git diff --quiet -- docs/static/resources/openapi.json; then
+            echo "::error::docs/static/resources/openapi.json is stale."
+            echo "Regenerate it on the pinned requirements, with no config file:"
+            echo "  SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
+            echo "    FLASK_APP='superset.app:create_app()' superset update-api-docs"
+            git diff --stat -- docs/static/resources/openapi.json
+            exit 1
+          fi

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -13719,6 +13719,111 @@
         ],
         "type": "object"
       },
+      "chart_get_list_schema": {
+        "properties": {
+          "columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "filters": {
+            "items": {
+              "properties": {
+                "col": {
+                  "type": "string"
+                },
+                "opr": {
+                  "type": "string"
+                },
+                "value": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "col",
+                "opr",
+                "value"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "keys": {
+            "items": {
+              "enum": [
+                "list_columns",
+                "order_columns",
+                "label_columns",
+                "description_columns",
+                "list_title",
+                "none"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "order_column": {
+            "type": "string"
+          },
+          "order_direction": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "select_columns": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "viz_type_order": {
+            "description": "Visualization type slugs in display-name order. Used only when order_column is viz_type.",
+            "items": {
+              "maxLength": 250,
+              "type": "string"
+            },
+            "maxItems": 256,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
       "database_catalogs_query_schema": {
         "properties": {
           "force": {
@@ -15680,10 +15785,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/get_list_schema"
+                  "$ref": "#/components/schemas/chart_get_list_schema"
                 }
               }
             },
+            "description": "Rison-encoded list query. viz_type_order may contain up to 256 unique visualization type slugs, each at most 250 characters, in the display-name order to use when sorting by viz_type.",
             "in": "query",
             "name": "q"
           }
@@ -15695,57 +15801,15 @@
                 "schema": {
                   "properties": {
                     "count": {
-                      "description": "The total record count on the backend",
-                      "type": "number"
-                    },
-                    "description_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The description for the column name. Will be translated by babel",
-                          "example": "A Nice description for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
+                      "type": "integer"
                     },
                     "ids": {
-                      "description": "A list of item ids, useful when you don't know the column id",
                       "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "label_columns": {
-                      "properties": {
-                        "column_name": {
-                          "description": "The label for the column name. Will be translated by babel",
-                          "example": "A Nice label for the column",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    "list_columns": {
-                      "description": "A list of columns",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "list_title": {
-                      "description": "A title to render. Will be translated by babel",
-                      "example": "List Items",
-                      "type": "string"
-                    },
-                    "order_columns": {
-                      "description": "A list of allowed columns to sort",
-                      "items": {
-                        "type": "string"
+                        "type": "integer"
                       },
                       "type": "array"
                     },
                     "result": {
-                      "description": "The result from the get list query",
                       "items": {
                         "$ref": "#/components/schemas/ChartRestApi.get_list"
                       },
@@ -15756,7 +15820,7 @@
                 }
               }
             },
-            "description": "Items from Model"
+            "description": "Charts"
           },
           "400": {
             "$ref": "#/components/responses/400"

--- a/superset/cli/update.py
+++ b/superset/cli/update.py
@@ -92,13 +92,16 @@ def update_api_docs() -> None:
         if isinstance(base_api, BaseApi) and base_api.version == api_version:
             base_api.add_api_spec(api_spec)
             version_found = True
-    if version_found:
-        click.secho("Generating openapi.json", fg="green")
-        with open(openapi_json, "w") as outfile:
-            json.dump(api_spec.to_dict(), outfile, sort_keys=True, indent=2)
-            outfile.write("\n")
-    else:
-        click.secho("API version not found", err=True)
+    if not version_found:
+        # Exiting zero here would leave the stale file in place and report
+        # success, which reads as "the spec is current" to any caller diffing
+        # the result.
+        raise click.ClickException(f"No {api_version} API found to document")
+
+    click.secho("Generating openapi.json", fg="green")
+    with open(openapi_json, "w") as outfile:
+        json.dump(api_spec.to_dict(), outfile, sort_keys=True, indent=2)
+        outfile.write("\n")
 
 
 @click.command()

--- a/tests/unit_tests/cli/update_test.py
+++ b/tests/unit_tests/cli/update_test.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from click.testing import CliRunner
+from pytest_mock import MockerFixture
+
+from superset.cli.update import update_api_docs
+
+
+def test_update_api_docs_fails_when_no_api_is_documented(
+    mocker: MockerFixture, app_context: None
+) -> None:
+    """A registration regression must not report success.
+
+    Exiting zero here leaves the committed spec in place, so a caller diffing
+    the result reads staleness as "up to date".
+    """
+    mocker.patch("superset.cli.update.current_app.appbuilder.baseviews", [])
+    write = mocker.patch("superset.cli.update.open")
+
+    result = CliRunner().invoke(update_api_docs, [])
+
+    assert result.exit_code != 0
+    assert "No v1 API found to document" in result.output
+    write.assert_not_called()


### PR DESCRIPTION
### SUMMARY

`docs/static/resources/openapi.json` is generated from the running app but committed by hand, so it drifts silently. The last genuine regeneration before #43788 was #33378, sixteen months earlier. This regenerates the spec on every PR and fails on a dirty diff.

Two generation inputs are pinned deliberately, because getting either wrong was a real failure while preparing #43788. The job installs `requirements/base.txt`: apispec 6.10.0 renders marshmallow 4's `unknown=RAISE` as `"additionalProperties": false` where the pinned 6.6.1 does not, so an unpinned guard would fail every PR. And it passes no config file, so generation reflects the routes a default deployment registers — a config with feature flags enabled documents paths that 404 for everyone who hasn't enabled them.

No `paths:` filter, matching `enforce-single-migration-head`: a required check that never runs on a PR blocks it forever. The job is ~10s.

### TESTING INSTRUCTIONS

Passes on unmodified `master` — the committed spec reproduces byte-identically on the pinned requirements. To see it fail, add a field to any marshmallow schema without regenerating:

```bash
SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \
  FLASK_APP='superset.app:create_app()' superset update-api-docs
git diff --stat -- docs/static/resources/openapi.json
```

Adding one schema renumbers apispec's auto-generated suffixes (`User1`, `Subject1`), so diffs are routinely larger than the change.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
