### PR TITLE
feat(mcp): allow skipping MCP host-tool registration in non-MCP processes

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -539,6 +539,12 @@ CURRENCIES = ["USD", "EUR", "GBP", "INR", "MXN", "JPY", "CNY"]
 #   - stable: Production-ready, tested and supported
 #   - deprecated: Will be removed in a future major release
 
+# Whether this process registers the MCP host tools at startup. Only processes
+# that serve MCP (the web app and the standalone MCP service) need them;
+# deployments can set this to False for processes that never serve MCP (e.g.
+# Celery workers) to avoid the memory cost of importing the MCP stack.
+CORE_MCP_HOST_TOOLS_ENABLED = True
+
 DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # =================================================================
     # IN DEVELOPMENT

--- a/superset/config.py
+++ b/superset/config.py
@@ -539,10 +539,15 @@ CURRENCIES = ["USD", "EUR", "GBP", "INR", "MXN", "JPY", "CNY"]
 #   - stable: Production-ready, tested and supported
 #   - deprecated: Will be removed in a future major release
 
-# Whether this process registers the MCP host tools at startup. Only processes
-# that serve MCP (the web app and the standalone MCP service) need them;
-# deployments can set this to False for processes that never serve MCP (e.g.
-# Celery workers) to avoid the memory cost of importing the MCP stack.
+# Whether this process registers the MCP *host tools* at startup. Registering
+# them imports the MCP service app, which has a real per-process memory cost, and
+# only processes that serve MCP (the web app and the standalone MCP service) need
+# them. Deployments can set this to False for processes that never serve MCP (e.g.
+# Celery workers) to avoid that cost.
+#
+# This gates only host-tool registration. The MCP decorators (@tool/@prompt) are
+# always registered regardless of this flag, so extensions that apply them at
+# import time keep working in every process.
 CORE_MCP_HOST_TOOLS_ENABLED = True
 
 DEFAULT_FEATURE_FLAGS: dict[str, bool] = {

--- a/superset/core/mcp/core_mcp_injection.py
+++ b/superset/core/mcp/core_mcp_injection.py
@@ -272,12 +272,17 @@ def create_prompt_decorator(
     return parameterized_decorator
 
 
-def initialize_core_mcp_dependencies() -> None:
+def initialize_core_mcp_decorators() -> None:
     """
-    Initialize MCP dependency injection by replacing abstract functions
-    in superset_core.api.mcp with concrete implementations.
+    Replace the abstract MCP decorators in ``superset_core.mcp.decorators`` with
+    concrete host implementations.
 
-    Also imports MCP service app to register all host tools BEFORE extension loading.
+    This must run in *every* process that may import extensions -- not only those
+    that serve MCP. Extensions can apply ``@tool``/``@prompt`` at import time, and
+    the abstract decorators raise ``NotImplementedError`` until they are replaced
+    here, so skipping this step would break such extensions at import. It is
+    comparatively cheap: it does not import the MCP service app or register any
+    host tools (see ``initialize_core_mcp_host_tools`` for that).
     """
     import superset_core.mcp.decorators
 
@@ -296,6 +301,18 @@ def initialize_core_mcp_dependencies() -> None:
 
     logger.info("MCP dependency injection initialized successfully")
 
+
+def initialize_core_mcp_host_tools() -> None:
+    """
+    Import the MCP service app so that all host tools are registered BEFORE
+    extension loading.
+
+    This carries a real per-process memory cost -- it imports the MCP service app
+    and every host tool module -- and is only needed in processes that actually
+    serve MCP (the web app and the standalone MCP service). Deployments gate it
+    off (``CORE_MCP_HOST_TOOLS_ENABLED = False``) for processes that never serve
+    MCP, e.g. Celery workers.
+    """
     try:
         # Import MCP service app to register host tools BEFORE extension loading
         # This prevents host tools from being registered during extension context
@@ -304,3 +321,19 @@ def initialize_core_mcp_dependencies() -> None:
         logger.info("MCP service app imported - host tools registered")
     except Exception as e:
         logger.error("Failed to register MCP host tools: %s", e)
+
+
+def initialize_core_mcp_dependencies() -> None:
+    """
+    Initialize MCP dependency injection by replacing abstract functions
+    in superset_core.api.mcp with concrete implementations, then registering the
+    host tools.
+
+    Kept for backwards compatibility and callers that want the full MCP setup in a
+    single call. Processes that must avoid the host-tool import cost should instead
+    call ``initialize_core_mcp_decorators`` unconditionally and gate
+    ``initialize_core_mcp_host_tools`` on ``CORE_MCP_HOST_TOOLS_ENABLED`` (see
+    ``SupersetAppInitializer.init_core_dependencies``).
+    """
+    initialize_core_mcp_decorators()
+    initialize_core_mcp_host_tools()

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -558,7 +558,12 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         )
 
         initialize_core_api_dependencies()
-        initialize_core_mcp_dependencies()
+        # MCP host tools only need to be registered in processes that serve MCP
+        # (the web app and the standalone MCP service). Deployments can disable
+        # this in processes that never serve MCP -- e.g. Celery workers -- to
+        # avoid importing the MCP stack where it is unused.
+        if self.config.get("CORE_MCP_HOST_TOOLS_ENABLED", True):
+            initialize_core_mcp_dependencies()
 
     def init_all_dependencies_and_extensions(self) -> None:
         """

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -554,16 +554,24 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             initialize_core_api_dependencies,
         )
         from superset.core.mcp.core_mcp_injection import (
-            initialize_core_mcp_dependencies,
+            initialize_core_mcp_decorators,
+            initialize_core_mcp_host_tools,
         )
 
         initialize_core_api_dependencies()
-        # MCP host tools only need to be registered in processes that serve MCP
-        # (the web app and the standalone MCP service). Deployments can disable
-        # this in processes that never serve MCP -- e.g. Celery workers -- to
-        # avoid importing the MCP stack where it is unused.
+
+        # The MCP decorators (@tool/@prompt) must be registered in every process:
+        # extensions can apply them at import time, and the abstract versions raise
+        # NotImplementedError until they are swapped for the concrete ones. This is
+        # cheap and does not import the MCP service app.
+        initialize_core_mcp_decorators()
+
+        # Registering the MCP host tools imports the MCP service app, which has a
+        # real per-process memory cost. Only processes that serve MCP (the web app
+        # and the standalone MCP service) need it, so deployments can disable it for
+        # processes that never serve MCP -- e.g. Celery workers -- to avoid the cost.
         if self.config.get("CORE_MCP_HOST_TOOLS_ENABLED", True):
-            initialize_core_mcp_dependencies()
+            initialize_core_mcp_host_tools()
 
     def init_all_dependencies_and_extensions(self) -> None:
         """

--- a/tests/unit_tests/initialization_test.py
+++ b/tests/unit_tests/initialization_test.py
@@ -133,6 +133,72 @@ class TestSupersetAppInitializer:
         # Assert that sync_config_to_db was called on the app
         mock_app.sync_config_to_db.assert_called_once()
 
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_host_tools")
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_decorators")
+    @patch("superset.core.api.core_api_injection.initialize_core_api_dependencies")
+    def test_init_core_dependencies_registers_host_tools_by_default(
+        self,
+        mock_init_api,
+        mock_init_decorators,
+        mock_init_host_tools,
+    ):
+        """Default config (flag absent): decorators and host tools both register."""
+        mock_app = MagicMock()
+        mock_app.config = {}
+        app_initializer = SupersetAppInitializer(mock_app)
+
+        app_initializer.init_core_dependencies()
+
+        mock_init_api.assert_called_once()
+        # Decorators are always registered so extensions using @tool/@prompt at
+        # import time keep working in every process.
+        mock_init_decorators.assert_called_once()
+        # Host tools default to on.
+        mock_init_host_tools.assert_called_once()
+
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_host_tools")
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_decorators")
+    @patch("superset.core.api.core_api_injection.initialize_core_api_dependencies")
+    def test_init_core_dependencies_registers_host_tools_when_enabled(
+        self,
+        mock_init_api,
+        mock_init_decorators,
+        mock_init_host_tools,
+    ):
+        """Flag True: decorators and host tools both register (unchanged behavior)."""
+        mock_app = MagicMock()
+        mock_app.config = {"CORE_MCP_HOST_TOOLS_ENABLED": True}
+        app_initializer = SupersetAppInitializer(mock_app)
+
+        app_initializer.init_core_dependencies()
+
+        mock_init_api.assert_called_once()
+        mock_init_decorators.assert_called_once()
+        mock_init_host_tools.assert_called_once()
+
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_host_tools")
+    @patch("superset.core.mcp.core_mcp_injection.initialize_core_mcp_decorators")
+    @patch("superset.core.api.core_api_injection.initialize_core_api_dependencies")
+    def test_init_core_dependencies_skips_host_tools_when_disabled(
+        self,
+        mock_init_api,
+        mock_init_decorators,
+        mock_init_host_tools,
+    ):
+        """Flag False: host-tool registration is skipped, but core init and the
+        decorator swap still run (so @tool/@prompt extensions don't break)."""
+        mock_app = MagicMock()
+        mock_app.config = {"CORE_MCP_HOST_TOOLS_ENABLED": False}
+        app_initializer = SupersetAppInitializer(mock_app)
+
+        app_initializer.init_core_dependencies()
+
+        # Core API deps and the decorator swap still run.
+        mock_init_api.assert_called_once()
+        mock_init_decorators.assert_called_once()
+        # The heavy MCP service app import is skipped.
+        mock_init_host_tools.assert_not_called()
+
     def test_database_uri_lazy_property(self):
         """Test database_uri property uses lazy initialization with smart caching."""
         # Setup


### PR DESCRIPTION
### SUMMARY

`init_core_dependencies()` calls the MCP host-tool setup in **every** process that
builds the Flask app — including Celery workers, which never serve MCP. Registering the MCP host
tools imports the MCP service app (`from superset.mcp_service import app`), which pulls in every
host-tool module and carries a real per-process memory cost. On high-concurrency prefork worker
pools this import can push workers over their memory limit and OOM them at boot.

This adds a `CORE_MCP_HOST_TOOLS_ENABLED` config flag (default `True`, so **no behavior change**)
and gates the host-tool registration on it. Deployments can set it to `False` for processes that
never serve MCP (e.g. Celery workers) to avoid importing the MCP service app where it is unused.

**MCP decorators are always registered, independent of this flag.** Registering the host tools was
originally bundled with swapping the abstract `@tool`/`@prompt` decorators
(`superset_core.mcp.decorators`) for their concrete implementations. Those abstract decorators
raise `NotImplementedError`, so gating the whole thing would break any extension that applies
`@tool`/`@prompt` at import time in a flag-off worker. The decorator swap is therefore split out
and runs unconditionally; only the host-tool import is gated.

### CHANGES

- `superset/config.py`: new `CORE_MCP_HOST_TOOLS_ENABLED = True` flag; docstring notes it gates
  host-tool registration only (decorators always register).
- `superset/core/mcp/core_mcp_injection.py`: split `initialize_core_mcp_dependencies()` into
  `initialize_core_mcp_decorators()` (decorator swap, always run) and
  `initialize_core_mcp_host_tools()` (imports `superset.mcp_service.app`, gated).
  `initialize_core_mcp_dependencies()` is kept as a thin wrapper calling both.
- `superset/initialization/__init__.py`: `init_core_dependencies()` always calls
  `initialize_core_mcp_decorators()` and gates `initialize_core_mcp_host_tools()` on the flag.
- `tests/unit_tests/initialization_test.py`: regression tests for the flag on / off / default paths.

### Decisions made that were not in the original instructions

This PR gates a startup/behavior path (what happens when the flag is off), so calling out the
choices made while resolving review feedback:

- **Decorator swap is ungated (behavior change on the flag-off path).** Rather than only documenting
  the constraint, `initialize_core_mcp_decorators()` runs even when `CORE_MCP_HOST_TOOLS_ENABLED=False`,
  so `@tool`/`@prompt` extensions keep working in every process. This means a flag-off worker still
  imports the decorator support (`fastmcp` + `mcp`); measured to add ~0 MB beyond what the decorator
  swap requires anyway, and far below the gated `superset.mcp_service.app` import. This is the
  intended, observable trade-off: correctness for extensions over shaving the (small, shared) decorator
  import.
- **Host-tool import failures stay observable.** `initialize_core_mcp_host_tools()` keeps the existing
  `try/except` that logs failures via `logger.error(...)` — the gated/degraded path is not silently
  swallowed.
- **The `core_mcp_injection` module import stays before the flag check** (it can't move — the always-on
  decorator swap lives there), which is fine: its marginal cost is ~0 MB once decorators run.

### TESTING INSTRUCTIONS

- Default (flag `True`): the web app and standalone MCP service register decorators and host tools
  exactly as before.
- Set `CORE_MCP_HOST_TOOLS_ENABLED = False` in a worker's config: the worker registers the MCP
  decorators (so `@tool`/`@prompt` extensions still import cleanly) but skips importing the MCP
  service app / host-tool stack; web / MCP processes are unaffected.
- `pytest tests/unit_tests/initialization_test.py -k init_core_dependencies`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API