### PR TITLE
feat(gtf): make the realtime pub/sub channel prefix configurable

### DIFF
--- a/docker/entrypoints/run-websocket.sh
+++ b/docker/entrypoints/run-websocket.sh
@@ -27,6 +27,8 @@
 # StatsD, etc.). The values that MUST match the Flask app's config are:
 #   JWT_SECRET      == WEBSOCKET_JWT_SECRET
 #   JWT_COOKIE_NAME == WEBSOCKET_JWT_COOKIE_NAME (default superset-ws-token)
+#   REALTIME_CHANNEL_PREFIX == Flask REALTIME_CHANNEL_PREFIX (default empty; set a
+#     per-deployment value on both sides to isolate a shared Redis/Valkey)
 # Optional rotation setting:
 #   PREVIOUS_JWT_SECRET == old WEBSOCKET_JWT_SECRET accepted for verification
 # and the Redis connection (REDIS_HOST/REDIS_PORT/...) must point at the same

--- a/superset-websocket/README.md
+++ b/superset-websocket/README.md
@@ -39,12 +39,14 @@ same browser-visible host.
 
 ### The `realtime` Pub/Sub channel and the message envelope
 
-Realtime events are published to a single Redis **Pub/Sub** channel, `realtime`,
-by the Superset Flask app (`superset/tasks/manager.py`). Pub/Sub is intentionally
-best-effort (fire-and-forget, at-most-once — no replay): it accelerates each
-feature's authoritative REST/poll path rather than guaranteeing delivery, so a
-message missed during a disconnect is reconciled by a frontend catch-up / REST
-refetch.
+Realtime events are published to a single Redis **Pub/Sub** channel,
+`<REALTIME_CHANNEL_PREFIX>realtime` (just `realtime` with the default empty
+prefix), by the Superset Flask app (`superset/tasks/manager.py`). Pub/Sub is
+intentionally best-effort (fire-and-forget, at-most-once — no replay): it
+accelerates each feature's authoritative REST/poll path rather than guaranteeing
+delivery, so a message missed during a disconnect is reconciled by a frontend
+catch-up / REST refetch. See [Superset Configuration](#superset-configuration)
+for the prefix and its Redis ACL implications.
 
 Each Redis message is a self-describing envelope that separates **what** a message
 is from **who** receives it:
@@ -233,7 +235,7 @@ Note also that `localhost` and `127.0.0.1` are not considered the same host. For
 example, if you're pointing your browser to `localhost:<port>` for Superset,
 then the WebSocket url will need to be configured as `localhost:<port>`.
 
-The following auth values must be coordinated between the Flask app config and
+The following values must be coordinated between the Flask app config and
 this server's `config.json` (or its environment-variable overrides):
 
 | Purpose                     | Flask app config            | WebSocket server config                     |
@@ -241,13 +243,20 @@ this server's `config.json` (or its environment-variable overrides):
 | Current signing/verify key  | `WEBSOCKET_JWT_SECRET`      | `jwtSecret` / `JWT_SECRET`                  |
 | Previous verify-only key    | not needed                  | `previousJwtSecret` / `PREVIOUS_JWT_SECRET` |
 | Cookie name                 | `WEBSOCKET_JWT_COOKIE_NAME` | `jwtCookieName` / `JWT_COOKIE_NAME`         |
+| Realtime channel prefix     | `REALTIME_CHANNEL_PREFIX`   | `realtimeChannelPrefix` / `REALTIME_CHANNEL_PREFIX` |
 
 The Redis connection (`redis` / `REDIS_*`) must point at the same Redis instance
 Superset publishes to (`DISTRIBUTED_COORDINATION_CONFIG`). The channel the server
-**subscribes** to (`realtime`) is a fixed wire-protocol contract with the backend
-producer and is not configurable; the server forwards each envelope to browsers as
-`{topic, payload}`. A Redis ACL for this server must therefore allow subscribing to
-`realtime`.
+**subscribes** to is `<REALTIME_CHANNEL_PREFIX>realtime` — the prefix is empty by
+default (channel `realtime`), and the resulting name is a wire-protocol contract
+with the backend producer, so the prefix **must be set identically** on both
+sides (`REALTIME_CHANNEL_PREFIX` in Superset and `REALTIME_CHANNEL_PREFIX` /
+`realtimeChannelPrefix` here). The server forwards each envelope to browsers as
+`{topic, payload}`. A Redis ACL for this server must therefore allow subscribing
+to the **resulting** channel — `realtime` by default, or e.g. `tenant-a:realtime`
+when `REALTIME_CHANNEL_PREFIX=tenant-a:`. Set a per-deployment prefix to keep
+deployments that share one Redis/Valkey from cross-delivering realtime nudges
+(Redis pub/sub is not scoped by DB number).
 
 ## StatsD monitoring
 

--- a/superset-websocket/spec/config.test.ts
+++ b/superset-websocket/spec/config.test.ts
@@ -36,6 +36,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   expect(config.statsd.host).toEqual('127.0.0.1');
   expect(config.statsd.port).toEqual(8125);
   expect(config.statsd.globalTags).toEqual([]);
+  expect(config.realtimeChannelPrefix).toEqual('');
 
   process.env.JWT_SECRET = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   process.env.PREVIOUS_JWT_SECRET = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
@@ -47,6 +48,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   process.env.STATSD_HOST = '15.15.15.15';
   process.env.STATSD_PORT = '8000';
   process.env.STATSD_GLOBAL_TAGS = 'tag-1,tag-2';
+  process.env.REALTIME_CHANNEL_PREFIX = 'tenant-a:';
 
   config = buildConfig();
 
@@ -60,6 +62,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   expect(config.statsd.host).toEqual('15.15.15.15');
   expect(config.statsd.port).toEqual(8000);
   expect(config.statsd.globalTags).toEqual(['tag-1', 'tag-2']);
+  expect(config.realtimeChannelPrefix).toEqual('tenant-a:');
 
   delete process.env.JWT_SECRET;
   delete process.env.PREVIOUS_JWT_SECRET;
@@ -71,6 +74,7 @@ test('buildConfig() builds configuration and applies env var overrides', () => {
   delete process.env.STATSD_HOST;
   delete process.env.STATSD_PORT;
   delete process.env.STATSD_GLOBAL_TAGS;
+  delete process.env.REALTIME_CHANNEL_PREFIX;
 });
 
 test('buildConfig() performs deep merge between configs', () => {

--- a/superset-websocket/spec/index.test.ts
+++ b/superset-websocket/spec/index.test.ts
@@ -298,6 +298,24 @@ describe('server', () => {
       expect(messageHandlers()).toHaveLength(1);
     });
 
+    test('subscribes to the prefixed channel when REALTIME_CHANNEL_PREFIX is set', async () => {
+      mockSubscribe.mockResolvedValue(1);
+      process.env.REALTIME_CHANNEL_PREFIX = 'tenant-a:';
+      vi.resetModules();
+      try {
+        // Re-import so the module re-reads config: REALTIME_CHANNEL is derived
+        // from opts at load time, so the prefix must flow env -> config -> the
+        // subscribed channel name.
+        const freshServer = await import('../src/index');
+        await freshServer.subscribeToChannels();
+
+        expect(mockSubscribe).toHaveBeenCalledWith('tenant-a:realtime');
+      } finally {
+        delete process.env.REALTIME_CHANNEL_PREFIX;
+        vi.resetModules();
+      }
+    });
+
     test('retries a rejected subscription without stacking a second router', async () => {
       vi.useFakeTimers();
       try {

--- a/superset-websocket/src/config.ts
+++ b/superset-websocket/src/config.ts
@@ -46,6 +46,7 @@ type ConfigType = {
   jwtSecret: string;
   previousJwtSecret: string;
   jwtCookieName: string;
+  realtimeChannelPrefix: string;
   allowedOrigins: string[];
   socketResponseTimeoutMs: number;
   pingSocketsIntervalMs: number;
@@ -65,6 +66,7 @@ function defaultConfig(): ConfigType {
     jwtSecret: '',
     previousJwtSecret: '',
     jwtCookieName: 'superset-ws-token',
+    realtimeChannelPrefix: '',
     allowedOrigins: [],
     socketResponseTimeoutMs: 60 * 1000,
     pingSocketsIntervalMs: 20 * 1000,
@@ -144,6 +146,7 @@ function applyEnvOverrides(config: ConfigType): ConfigType {
     JWT_SECRET: val => (config.jwtSecret = val),
     PREVIOUS_JWT_SECRET: val => (config.previousJwtSecret = val),
     JWT_COOKIE_NAME: val => (config.jwtCookieName = val),
+    REALTIME_CHANNEL_PREFIX: val => (config.realtimeChannelPrefix = val),
     ALLOWED_ORIGINS: val => (config.allowedOrigins = toStringArray(val)),
     SOCKET_RESPONSE_TIMEOUT_MS: val =>
       (config.socketResponseTimeoutMs = toNonNegativeNumber(

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -193,11 +193,13 @@ export const wss = new WebSocketServer({
 const SOCKET_ACTIVE_STATES: number[] = [WebSocket.OPEN, WebSocket.CONNECTING];
 
 // The single Pub/Sub channel the server tails. This is a wire-protocol contract
-// with the Superset producer (superset/tasks/manager.py: REALTIME_CHANNEL), NOT a
-// deployment knob - an independent override on this side with no matching producer
-// config would silently subscribe to a channel nothing publishes to, so it is a
-// fixed constant that must stay in lockstep with the producer.
-const REALTIME_CHANNEL = 'realtime';
+// with the Superset producer (superset/tasks/manager.py). The name is
+// `${prefix}realtime`, where the prefix comes from REALTIME_CHANNEL_PREFIX (empty
+// by default). Redis Pub/Sub is not scoped by DB number, so deployments sharing
+// one Redis/Valkey set a per-deployment prefix to isolate their channels — it MUST
+// be set identically here and on the producer (Flask REALTIME_CHANNEL_PREFIX),
+// since a mismatch would subscribe to a channel nothing publishes to.
+const REALTIME_CHANNEL = `${opts.realtimeChannelPrefix}realtime`;
 
 // Envelope scopes (delivery breadth), mirrored from the producer. A message is
 // broadcast to every authenticated socket when its scope is `authenticated_global`,

--- a/superset-websocket/src/index.ts
+++ b/superset-websocket/src/index.ts
@@ -539,7 +539,8 @@ export const routeRedisMessage = (
 };
 
 /**
- * Subscribes the Redis connection to the single `realtime` channel that carries
+ * Subscribes the Redis connection to the single realtime channel
+ * (`REALTIME_CHANNEL`, i.e. `<REALTIME_CHANNEL_PREFIX>realtime`) that carries
  * every browser-bound message (broadcast and targeted, distinguished by each
  * envelope's scope).
  *

--- a/superset-websocket/utils/loadtest.js
+++ b/superset-websocket/utils/loadtest.js
@@ -23,11 +23,15 @@ const redis = new Redis(config.redis);
 
 const numClients = 256;
 
-// The single Pub/Sub channel the server tails; a fixed wire-protocol contract
-// with the Superset producer, mirrored from superset-websocket/src/index.ts.
-// Every browser-bound message rides this channel as a self-describing
+// The single Pub/Sub channel the server tails, mirrored from
+// superset-websocket/src/index.ts: `<REALTIME_CHANNEL_PREFIX>realtime`. Resolve
+// the prefix the same way the server does (env override, else config.json, else
+// empty) so a loadtest points at a prefixed server's channel. Every
+// browser-bound message rides this channel as a self-describing
 // `{topic, scope, routes, payload}` envelope.
-const realtimeChannel = 'realtime';
+const realtimeChannelPrefix =
+  process.env.REALTIME_CHANNEL_PREFIX || config.realtimeChannelPrefix || '';
+const realtimeChannel = `${realtimeChannelPrefix}realtime`;
 
 let entityId = 0;
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -3015,6 +3015,15 @@ WEBSOCKET_JWT_COOKIE_SAMESITE: None | (Literal["None", "Lax", "Strict"]) = None
 WEBSOCKET_JWT_COOKIE_DOMAIN = None
 WEBSOCKET_JWT_EXPIRATION_SECONDS = int(timedelta(minutes=15).total_seconds())
 
+# Prefix for the realtime pub/sub channel (default ""). Redis pub/sub is not
+# scoped by DB number, so deployments sharing one Redis/Valkey would cross-deliver
+# realtime envelopes (opaque entity-change + task-status nudges) — cross-tenant id
+# leakage and spurious refetches. Set a per-deployment value (e.g. "<keyPrefix>:")
+# here AND on the websocket server (REALTIME_CHANNEL_PREFIX env) to isolate them.
+# May be a string or a zero-argument callable resolved at publish time, mirroring
+# Superset's other cache-key helpers. Empty is a no-op for single-instance setups.
+REALTIME_CHANNEL_PREFIX: Callable[[], str] | str = ""
+
 # Embedded config options
 GUEST_ROLE_NAME = "Public"
 GUEST_TOKEN_JWT_SECRET = CHANGE_ME_GUEST_TOKEN_JWT_SECRET

--- a/superset/config.py
+++ b/superset/config.py
@@ -3020,7 +3020,7 @@ WEBSOCKET_JWT_EXPIRATION_SECONDS = int(timedelta(minutes=15).total_seconds())
 # realtime envelopes (opaque entity-change + task-status nudges) — cross-tenant id
 # leakage and spurious refetches. Set a per-deployment value (e.g. "<keyPrefix>:")
 # here AND on the websocket server (REALTIME_CHANNEL_PREFIX env) to isolate them.
-# May be a string or a zero-argument callable resolved at publish time, mirroring
+# May be a string or a zero-argument callable, resolved once at startup, mirroring
 # Superset's other cache-key helpers. Empty is a no-op for single-instance setups.
 REALTIME_CHANNEL_PREFIX: Callable[[], str] | str = ""
 

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -75,6 +75,7 @@ class TaskManager:
     # Class-level state (initialized once via init_app)
     _channel_prefix: str = "gtf:abort:"
     _completion_channel_prefix: str = "gtf:complete:"
+    _realtime_channel_prefix: Callable[[], str] | str = ""
     _initialized: bool = False
 
     @classmethod
@@ -93,6 +94,7 @@ class TaskManager:
         cls._completion_channel_prefix = app.config.get(
             "TASKS_COMPLETION_CHANNEL_PREFIX", "gtf:complete:"
         )
+        cls._realtime_channel_prefix = app.config.get("REALTIME_CHANNEL_PREFIX", "")
 
         cls._initialized = True
 
@@ -112,12 +114,15 @@ class TaskManager:
     # This separates the semantic topic (what a message is) from the route (who
     # receives it): a new surface adds a topic without inventing channel names or
     # overloading payload shapes. The channel name and envelope shape are a
-    # wire-protocol contract with the Node server. Pub/Sub is best-effort, so no
-    # message here may carry a signal a receiver must not miss — each feature's
-    # authorized REST poll/fetch is the correctness backstop. Moving a surface to
-    # websocket-only (retiring its poll) requires guaranteed, replayable delivery
-    # first (e.g. Redis Streams with a per-consumer cursor).
-    REALTIME_CHANNEL = "realtime"
+    # wire-protocol contract with the Node server. The name is
+    # ``<REALTIME_CHANNEL_PREFIX>realtime``: Redis Pub/Sub is not scoped by DB
+    # number, so deployments sharing one Redis/Valkey set a per-deployment prefix
+    # (identically on both sides) to keep their channels isolated. Pub/Sub is
+    # best-effort, so no message here may carry a signal a receiver must not miss —
+    # each feature's authorized REST poll/fetch is the correctness backstop. Moving
+    # a surface to websocket-only (retiring its poll) requires guaranteed,
+    # replayable delivery first (e.g. Redis Streams with a per-consumer cursor).
+    _REALTIME_CHANNEL_BASE = "realtime"
 
     # Envelope topics.
     TOPIC_TASK_STATUS = "task.status"
@@ -127,6 +132,19 @@ class TaskManager:
     SCOPE_AUTHENTICATED_GLOBAL = "authenticated_global"
     SCOPE_PRINCIPAL = "principal"
     SCOPE_TAB = "tab"
+
+    @classmethod
+    def get_realtime_channel(cls) -> str:
+        """Resolve the realtime pub/sub channel name (prefix + base).
+
+        The prefix may be a string or a zero-argument callable (resolved here at
+        call time), so a deployment sharing a Redis/Valkey with others can
+        namespace the channel to avoid cross-tenant delivery.
+        """
+        prefix = cls._realtime_channel_prefix
+        if callable(prefix):
+            prefix = prefix()
+        return f"{prefix}{cls._REALTIME_CHANNEL_BASE}"
 
     @classmethod
     def _publish_realtime(
@@ -151,7 +169,7 @@ class TaskManager:
         envelope: dict[str, Any] = {"topic": topic, "scope": scope, "payload": payload}
         if routes is not None:
             envelope["routes"] = routes
-        CoordinationService.publish(cls.REALTIME_CHANNEL, json.dumps(envelope))
+        CoordinationService.publish(cls.get_realtime_channel(), json.dumps(envelope))
         return True
 
     @staticmethod

--- a/superset/tasks/manager.py
+++ b/superset/tasks/manager.py
@@ -75,7 +75,7 @@ class TaskManager:
     # Class-level state (initialized once via init_app)
     _channel_prefix: str = "gtf:abort:"
     _completion_channel_prefix: str = "gtf:complete:"
-    _realtime_channel_prefix: Callable[[], str] | str = ""
+    _realtime_channel_prefix: str = ""
     _initialized: bool = False
 
     @classmethod
@@ -94,7 +94,14 @@ class TaskManager:
         cls._completion_channel_prefix = app.config.get(
             "TASKS_COMPLETION_CHANNEL_PREFIX", "gtf:complete:"
         )
-        cls._realtime_channel_prefix = app.config.get("REALTIME_CHANNEL_PREFIX", "")
+        # The realtime prefix may be configured as a string or a zero-argument
+        # callable; resolve it once here so the channel is fixed for the process
+        # lifetime (the consumer subscribes to a single channel and cannot follow
+        # a value that changes between publishes).
+        realtime_prefix = app.config.get("REALTIME_CHANNEL_PREFIX", "")
+        cls._realtime_channel_prefix = (
+            realtime_prefix() if callable(realtime_prefix) else realtime_prefix
+        )
 
         cls._initialized = True
 
@@ -135,16 +142,14 @@ class TaskManager:
 
     @classmethod
     def get_realtime_channel(cls) -> str:
-        """Resolve the realtime pub/sub channel name (prefix + base).
+        """Return the realtime pub/sub channel name (prefix + base).
 
-        The prefix may be a string or a zero-argument callable (resolved here at
-        call time), so a deployment sharing a Redis/Valkey with others can
-        namespace the channel to avoid cross-tenant delivery.
+        The prefix is resolved once from config in ``init_app`` (string, or a
+        zero-argument callable evaluated there), so the channel is stable for the
+        process lifetime and stays in lockstep with the consumer's single
+        subscription.
         """
-        prefix = cls._realtime_channel_prefix
-        if callable(prefix):
-            prefix = prefix()
-        return f"{prefix}{cls._REALTIME_CHANNEL_BASE}"
+        return f"{cls._realtime_channel_prefix}{cls._REALTIME_CHANNEL_BASE}"
 
     @classmethod
     def _publish_realtime(

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -66,6 +66,17 @@ class TestTaskManagerInitApp:
         assert TaskManager._completion_channel_prefix == "custom:complete:"
         assert TaskManager._realtime_channel_prefix == "custom:"
 
+    def test_init_app_resolves_callable_realtime_prefix(self):
+        """A callable REALTIME_CHANNEL_PREFIX is resolved once to a string."""
+        app = MagicMock()
+        app.config.get.side_effect = lambda key, default=None: {
+            "REALTIME_CHANNEL_PREFIX": lambda: "tenant-b:",
+        }.get(key, default)
+
+        TaskManager.init_app(app)
+
+        assert TaskManager._realtime_channel_prefix == "tenant-b:"
+
     def test_init_app_skips_if_already_initialized(self):
         """Test init_app is idempotent"""
         TaskManager._initialized = True
@@ -108,10 +119,6 @@ class TestTaskManagerChannels:
     def test_get_realtime_channel_custom_prefix(self):
         TaskManager._realtime_channel_prefix = "tenant-a:"
         assert TaskManager.get_realtime_channel() == "tenant-a:realtime"
-
-    def test_get_realtime_channel_callable_prefix(self):
-        TaskManager._realtime_channel_prefix = lambda: "tenant-b:"
-        assert TaskManager.get_realtime_channel() == "tenant-b:realtime"
 
 
 class TestTaskManagerPublish:

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -38,6 +38,7 @@ def _reset_prefixes() -> None:
     TaskManager._initialized = False
     TaskManager._channel_prefix = "gtf:abort:"
     TaskManager._completion_channel_prefix = "gtf:complete:"
+    TaskManager._realtime_channel_prefix = ""
 
 
 class TestTaskManagerInitApp:
@@ -55,6 +56,7 @@ class TestTaskManagerInitApp:
         app.config.get.side_effect = lambda key, default=None: {
             "TASKS_ABORT_CHANNEL_PREFIX": "custom:abort:",
             "TASKS_COMPLETION_CHANNEL_PREFIX": "custom:complete:",
+            "REALTIME_CHANNEL_PREFIX": "custom:",
         }.get(key, default)
 
         TaskManager.init_app(app)
@@ -62,6 +64,7 @@ class TestTaskManagerInitApp:
         assert TaskManager._initialized is True
         assert TaskManager._channel_prefix == "custom:abort:"
         assert TaskManager._completion_channel_prefix == "custom:complete:"
+        assert TaskManager._realtime_channel_prefix == "custom:"
 
     def test_init_app_skips_if_already_initialized(self):
         """Test init_app is idempotent"""
@@ -98,6 +101,17 @@ class TestTaskManagerChannels:
             TaskManager.get_completion_channel("test-uuid")
             == "custom:complete:test-uuid"
         )
+
+    def test_get_realtime_channel(self):
+        assert TaskManager.get_realtime_channel() == "realtime"
+
+    def test_get_realtime_channel_custom_prefix(self):
+        TaskManager._realtime_channel_prefix = "tenant-a:"
+        assert TaskManager.get_realtime_channel() == "tenant-a:realtime"
+
+    def test_get_realtime_channel_callable_prefix(self):
+        TaskManager._realtime_channel_prefix = lambda: "tenant-b:"
+        assert TaskManager.get_realtime_channel() == "tenant-b:realtime"
 
 
 class TestTaskManagerPublish:

--- a/tests/unit_tests/tasks/test_manager.py
+++ b/tests/unit_tests/tasks/test_manager.py
@@ -216,6 +216,30 @@ class TestTaskManagerEntityChange:
             "payload": {"entity_type": "task", "id": 42},
         }
 
+    @patch(GET_ID, return_value=42)
+    @patch(PUBLISH)
+    @patch(IS_DEFINED, return_value=True)
+    def test_publishes_on_configured_prefixed_channel(
+        self, mock_defined, mock_publish, mock_get_id
+    ):
+        """A configured REALTIME_CHANNEL_PREFIX reaches the published channel.
+
+        Drives init_app and the public publisher end to end, so it guards the
+        _publish_realtime wiring (not just the get_realtime_channel helper): were
+        the publish to revert to the literal ``realtime``, the producer would
+        diverge from a websocket server subscribed to ``tenant-a:realtime``.
+        """
+        app = MagicMock()
+        app.config.get.side_effect = lambda key, default=None: {
+            "REALTIME_CHANNEL_PREFIX": "tenant-a:",
+        }.get(key, default)
+        TaskManager.init_app(app)
+
+        assert TaskManager.publish_entity_change(uuid.uuid4()) is True
+
+        channel = mock_publish.call_args.args[0]
+        assert channel == "tenant-a:realtime"
+
     @patch(GET_ID, return_value=None)
     @patch(PUBLISH)
     @patch(IS_DEFINED, return_value=True)


### PR DESCRIPTION
### SUMMARY

Redis Pub/Sub is **not** scoped by DB number, so multiple Superset deployments sharing one Redis/Valkey cross-deliver realtime envelopes (opaque entity-change + task-status nudges) — cross-tenant id leakage and spurious refetches. All other coordination state is already namespaceable (cache key prefix, `TASKS_ABORT_CHANNEL_PREFIX` / `TASKS_COMPLETION_CHANNEL_PREFIX`); only this Pub/Sub channel was hardcoded to `"realtime"` on both the producer (`superset/tasks/manager.py`) and the consumer (`superset-websocket/src/index.ts`).

This PR adds `REALTIME_CHANNEL_PREFIX` (default `""`, a no-op for single-instance deployments) so an operator can namespace the channel per deployment:

- **Superset (producer):** the channel is now `"<prefix>realtime"`, resolved via a new `TaskManager.get_realtime_channel()` classmethod. The prefix may be a **string or a zero-argument callable resolved at publish time**, mirroring Superset's existing cache-key pattern (`KeyLike` in `superset/coordination/base.py`, and `SLACK_API_TOKEN` / `GUEST_TOKEN_JWT_AUDIENCE`).
- **websocket server (consumer):** reads `REALTIME_CHANNEL_PREFIX` from the environment (via `config.ts`) and subscribes to `"<prefix>realtime"`.

An operator sets `REALTIME_CHANNEL_PREFIX` identically on both sides (e.g. `"<keyPrefix>:"`) to make a shared Redis/Valkey safe. This isolates the shared **Redis instance**; the topology remains one websocket server per deployment (the server subscribes to a single channel, and routing keys / JWT secret are per-deployment).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — configuration/backend change.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/tasks/test_manager.py`
- `cd superset-websocket && npm test -- spec/config.test.ts spec/index.test.ts && npm run lint`
- Manual: set `REALTIME_CHANNEL_PREFIX = "tenantA:"` in `superset_config.py` and `REALTIME_CHANNEL_PREFIX=tenantA:` on the websocket container; confirm the producer publishes to `tenantA:realtime` and the server subscribes to the same, while a second deployment with a different prefix sees no cross-delivery.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API