### PR TITLE
docs(gtf): document GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL cache floor

### DIFF
--- a/docs/admin_docs/configuration/cache.mdx
+++ b/docs/admin_docs/configuration/cache.mdx
@@ -97,6 +97,37 @@ This setting only applies to requests detected as native filter option queries. 
 over the per-chart/dataset/database timeouts, but not over an explicit per-request
 `custom_cache_timeout` override (e.g. "Force refresh").
 
+## Async Query Result Cache TTL
+
+When [Global Async Queries](/admin-docs/configuration/configuring-superset#feature-flags) is
+enabled, a chart-data request that runs asynchronously does not return the result inline. Instead the
+query executes on a background task that **writes the result to the data cache**, and the browser
+then re-issues the same request to read that result back out of the cache once the task succeeds.
+
+This read-back is what makes the result-cache TTL matter for correctness, not just performance: if
+the effective TTL is shorter than the full async round trip (task execution + the client's poll
+interval + the re-fetch), the entry can be **evicted before the client reads it**, leaving the chart
+stuck re-running instead of loading. To prevent this, async requests floor their result-cache TTL to
+`GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL` (seconds, default `300` — five minutes):
+
+```python
+GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL = 300  # seconds
+```
+
+How the floor interacts with the timeouts above:
+
+- It applies **only to async execution**. Synchronous `/chart/data` requests keep their normal
+  chart/dataset/database/`DATA_CACHE_CONFIG` timeout even when Global Async Queries is enabled.
+- A **longer** effective TTL from that chain is kept as-is — the floor only raises TTLs that are
+  shorter than it.
+- A TTL of `0` ("cache forever") is left untouched.
+
+Tuning guidance: raise this value if your workload's async round trip can exceed five minutes (very
+long-running queries or slow warehouses), otherwise those charts may intermittently fail to load. Be
+aware of the trade-off — because the floor can raise an async result's TTL above a shorter cache
+retention policy, it keeps async results in the cache longer and modestly increases cache
+(Redis/Valkey) usage. Do not lower it below your worst-case async round trip.
+
 ## Limiting Cached Result Size
 
 Very large chart or SQL query results can flood the cache backend (Redis/Memcached), evicting many


### PR DESCRIPTION
### SUMMARY

Addresses review feedback on #43407 ([discussion](https://github.com/apache/superset/pull/43407#discussion_r3930062725)): enabling Global Async Queries floors async chart-result cache TTLs (default 5 min), which can override a shorter operator retention policy and increase Redis usage, but the operator docs didn't mention or explain how to tune it.

Adds an **"Async Query Result Cache TTL"** section to `docs/admin_docs/configuration/cache.mdx` covering:

- **Why the floor exists (motivation):** an async `/chart/data` request runs on a background task that writes the result to the data cache, and the browser then re-issues the request to read it back. If the effective TTL is shorter than the async round trip (task execution + poll interval + re-fetch), the entry can be evicted before the client reads it, leaving the chart stuck re-running.
- **How it interacts with the existing timeout chain:** async-only (sync requests unaffected even with GAQ on), raises only TTLs shorter than the floor, and leaves `0` ("cache forever") untouched.
- **How to tune `GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL`** and the retention / Redis-usage trade-off (don't lower it below your worst-case async round trip).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Docs-only. Preview: the new section renders under Configuration → Caching, after "Chart Cache Timeout".

### TESTING INSTRUCTIONS

Docs-only change; no code paths affected. Verify the section renders in the docs preview and the `#feature-flags` anchor resolves.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API