### PR TITLE
fix(sqllab): correct Run dropdown crash and caret color regression

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/DropdownButton.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/DropdownButton/DropdownButton.test.tsx
@@ -74,3 +74,17 @@ test('passes button type to underlying Dropdown.Button', () => {
   );
   expect(container.querySelector('.ant-btn-primary')).toBeInTheDocument();
 });
+
+test('opens the popupRender content without crashing on click trigger', async () => {
+  const { getAllByRole, findByText } = render(
+    <DropdownButton
+      popupRender={() => <div>Custom Menu</div>}
+      trigger={['click']}
+    >
+      Click
+    </DropdownButton>,
+  );
+  const buttons = getAllByRole('button');
+  fireEvent.click(buttons[buttons.length - 1]);
+  expect(await findByText('Custom Menu')).toBeInTheDocument();
+});

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/RunQueryActionButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/RunQueryActionButton.test.tsx
@@ -19,6 +19,8 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Store } from 'redux';
+import { supersetTheme } from '@apache-superset/core/theme';
+import { Menu } from '@superset-ui/core/components/Menu';
 
 import { render, fireEvent, waitFor } from 'spec/helpers/testing-library';
 import { initialState, defaultQueryEditor } from 'src/SqlLab/fixtures';
@@ -152,4 +154,26 @@ test('dispatch stopQuery on click while running state', async () => {
   expect(stopQuery).toHaveBeenCalledTimes(0);
   fireEvent.click(button);
   await waitFor(() => expect(stopQuery).toHaveBeenCalledTimes(1));
+});
+
+const ctasMenu = <Menu items={[{ key: 'table', label: 'CREATE TABLE AS' }]} />;
+
+test('opening the CTAS/CVAS dropdown menu does not crash and shows the menu', async () => {
+  const { getAllByRole, findByText } = setup(
+    { overlayCreateAsMenu: ctasMenu },
+    mockStore(initialState),
+  );
+  const buttons = getAllByRole('button');
+  const caretButton = buttons[buttons.length - 1];
+  fireEvent.click(caretButton);
+  expect(await findByText('CREATE TABLE AS')).toBeInTheDocument();
+});
+
+test('renders the caret icon with a color that contrasts with the primary button background', () => {
+  const { container } = setup(
+    { overlayCreateAsMenu: ctasMenu },
+    mockStore(initialState),
+  );
+  const caretIcon = container.querySelector('[data-test="down"]');
+  expect(caretIcon).toHaveStyle({ color: supersetTheme.colorTextLightSolid });
 });

--- a/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
+++ b/superset-frontend/src/SqlLab/components/RunQueryActionButton/index.tsx
@@ -149,11 +149,13 @@ const RunQueryActionButton = ({
         cta
         {...(overlayCreateAsMenu
           ? {
-              overlay: overlayCreateAsMenu,
+              popupRender: () => overlayCreateAsMenu,
               icon: (
                 <Icons.DownOutlined
                   iconColor={
-                    isDisabled ? theme.colorTextDisabled : theme.colorIcon
+                    isDisabled
+                      ? theme.colorTextDisabled
+                      : theme.colorTextLightSolid
                   }
                 />
               ),


### PR DESCRIPTION
## Summary
- The SQL Lab Run control's split-button dropdown (shown when CTAS/CVAS is allowed) passed its menu content through antd's `overlay` prop. Antd v6 dropped that deprecated prop entirely, so the menu never reached antd's internal `Dropdown`, and clicking the caret threw `React.Children.only expected to receive a single React element child.`
- Separately, the caret icon used `theme.colorIcon` (a neutral "weak action" token) instead of a color meant to contrast against the primary button background, rendering it in the wrong dark/grey shade.
- Fixes both by passing the menu via the already-supported `popupRender` prop and using `theme.colorTextLightSolid` for the caret icon color.

This addresses a customer-reported issue.

## Before / After

**Before** — dark/grey caret on the primary button, and clicking it crashes with `React.Children.only`:

![before](https://gist.githubusercontent.com/sadpandajoe/cde4c31f44b14bad608c47f060f7c988/raw/1f06a478a738bd0bd9a5ab967970537ac9a5c7da/before.png)


https://github.com/user-attachments/assets/9ac3163f-9e23-4761-8e39-b4c5e7d09274



**After** — caret color matches the button's other icon, and the dropdown menu opens correctly:

![after](https://gist.githubusercontent.com/sadpandajoe/cde4c31f44b14bad608c47f060f7c988/raw/1f06a478a738bd0bd9a5ab967970537ac9a5c7da/after.png)

[evidence_pr-43849_SQLAB-RUN-E2E-002-video-00.00.14.324-00.00.17.240.webm](https://github.com/user-attachments/assets/94d7a301-6f86-4104-8568-421266981813)


## Test plan
- [x] Added a failing-first RTL test reproducing the `React.Children.only` crash on caret click, confirmed it failed for the predicted reason, then fixed it
- [x] Added a failing-first RTL test asserting the caret icon color, confirmed it failed for the predicted reason, then fixed it
- [x] Added a general regression test to `DropdownButton.test.tsx` covering `popupRender` + click trigger
- [x] All 16 relevant Jest tests pass
- [x] Pre-commit (oxfmt/oxlint/stylelint/type-check) passes on changed files