### PR TITLE
fix(matrixify): apply dimension filters to all query-specific adhoc filter collections

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.test.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.test.ts
@@ -116,6 +116,79 @@ test('should generate grid for dimensions mode', () => {
   );
 });
 
+test('should add dimension filters to every query-specific adhoc filter collection', () => {
+  // Multi-query charts (e.g. Mixed Chart) read each query's filters from a
+  // separate collection. The cell's dimension filter must reach all of them.
+  const formDataWithMultipleQueries: TestFormData = {
+    viz_type: 'mixed_timeseries',
+    datasource: '1__table',
+    matrixify_enable: true,
+    matrixify_mode_rows: 'dimensions',
+    matrixify_mode_columns: 'disabled',
+    matrixify_dimension_rows: {
+      dimension: 'country',
+      values: ['USA'],
+    },
+    adhoc_filters: [
+      {
+        expressionType: 'SIMPLE',
+        subject: 'year',
+        operator: 'TEMPORAL_RANGE',
+        comparator: '2024-01-01 : 2024-12-31',
+        clause: 'WHERE',
+      },
+    ],
+    adhoc_filters_b: [
+      {
+        expressionType: 'SIMPLE',
+        subject: 'region',
+        operator: '==',
+        comparator: 'North America',
+        clause: 'WHERE',
+      },
+    ],
+    adhoc_filters_c: [],
+    // A non-adhoc-filter field that must not be touched by the fan-out.
+    filters_b: [{ col: 'should_not_change', op: '==', val: 'unchanged' }],
+  };
+
+  const grid = generateMatrixifyGrid(formDataWithMultipleQueries);
+
+  expect(grid).not.toBeNull();
+  const cell = grid!.cells[0][0]!;
+
+  // The dimension filter is added to the primary and every query-specific
+  // collection, including one that started empty (`adhoc_filters_c`).
+  ['adhoc_filters', 'adhoc_filters_b', 'adhoc_filters_c'].forEach(key => {
+    expect(cell.formData[key]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: 'country',
+          comparator: 'USA',
+        }),
+      ]),
+    );
+  });
+
+  // Pre-existing filters on each collection are preserved.
+  expect(cell.formData.adhoc_filters).toEqual(
+    expect.arrayContaining([expect.objectContaining({ subject: 'year' })]),
+  );
+  expect(cell.formData.adhoc_filters_b).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        subject: 'region',
+        comparator: 'North America',
+      }),
+    ]),
+  );
+
+  // Fields that merely look similar (`filters_b`) are left untouched.
+  expect(cell.formData.filters_b).toEqual(
+    formDataWithMultipleQueries.filters_b,
+  );
+});
+
 test('should generate grid for mixed mode (metrics rows, dimensions columns)', () => {
   const mixedFormData: TestFormData = {
     viz_type: 'table',

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.ts
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/Matrixify/MatrixifyGridGenerator.ts
@@ -104,6 +104,36 @@ function createDimensionFilter(
   };
 }
 
+function isAdhocFilterArray(value: unknown): value is AdhocFilter[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Append the given filters to the primary `adhoc_filters` collection as well as
+ * every query-specific `adhoc_filters_*` collection present on the formData.
+ * Charts with more than one query (e.g. Mixed Chart) read each query's filters
+ * from a separate collection (`adhoc_filters_b`, `adhoc_filters_c`, ...), so a
+ * cell's dimension filter must be added to all of them to slice every query.
+ */
+function appendMatrixifyFilters(
+  formData: QueryFormData & MatrixifyFormData,
+  additionalFilters: AdhocFilter[],
+): void {
+  const filterFields: Record<string, unknown> = formData;
+  const filterKeys = [
+    'adhoc_filters',
+    ...Object.keys(filterFields).filter(key => /^adhoc_filters_.+$/u.test(key)),
+  ];
+
+  filterKeys.forEach(key => {
+    const existingFilters = filterFields[key];
+    filterFields[key] = [
+      ...(isAdhocFilterArray(existingFilters) ? existingFilters : []),
+      ...additionalFilters,
+    ];
+  });
+}
+
 /**
  * Generate form data for a specific grid cell
  */
@@ -169,12 +199,9 @@ function generateCellFormData(
     }
   }
 
-  // Add filters to existing adhoc_filters
+  // Add filters to the primary and query-specific adhoc filter collections.
   if (additionalFilters.length > 0) {
-    cellFormData.adhoc_filters = [
-      ...(cellFormData.adhoc_filters || []),
-      ...additionalFilters,
-    ];
+    appendMatrixifyFilters(cellFormData, additionalFilters);
   }
 
   // Set metrics based on row/column configuration

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import {
+  BinaryAdhocFilter,
   ComparisonType,
   FreeFormAdhocFilter,
   RollingType,
@@ -195,6 +196,35 @@ test('should compile query object B', () => {
     ],
     orderby: [['count', true]],
   });
+});
+
+test('should compile Matrixify filters for both mixed timeseries queries', () => {
+  // Matrixify injects a per-cell dimension filter into `adhoc_filters` and every
+  // query-specific `adhoc_filters_*` collection. Query A reads `adhoc_filters`
+  // and query B reads `adhoc_filters_b`, so both queries must end up filtered.
+  const matrixifyCountryFilter: BinaryAdhocFilter = {
+    clause: 'WHERE',
+    expressionType: 'SIMPLE',
+    subject: 'country',
+    operator: '==',
+    comparator: 'USA',
+    isExtra: false,
+  };
+  const formData = {
+    ...formDataMixedChart,
+    adhoc_filters: [...formDataMixedChart.adhoc_filters, matrixifyCountryFilter],
+    adhoc_filters_b: [
+      ...formDataMixedChart.adhoc_filters_b,
+      matrixifyCountryFilter,
+    ],
+  };
+
+  const [queryA, queryB] = buildQuery(formData).queries;
+
+  expect(queryA.filters).toEqual([{ col: 'country', op: '==', val: 'USA' }]);
+  expect(queryB.filters).toEqual([{ col: 'country', op: '==', val: 'USA' }]);
+  // The pre-existing free-form filter on query B is preserved in `extras`.
+  expect(queryB.extras?.where).toBe("(name in ('c', 'd'))");
 });
 
 test('should compile AA in query A', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts
@@ -212,7 +212,10 @@ test('should compile Matrixify filters for both mixed timeseries queries', () =>
   };
   const formData = {
     ...formDataMixedChart,
-    adhoc_filters: [...formDataMixedChart.adhoc_filters, matrixifyCountryFilter],
+    adhoc_filters: [
+      ...formDataMixedChart.adhoc_filters,
+      matrixifyCountryFilter,
+    ],
     adhoc_filters_b: [
       ...formDataMixedChart.adhoc_filters_b,
       matrixifyCountryFilter,


### PR DESCRIPTION
### SUMMARY

Matrixify builds a grid of chart cells, injecting a per-cell dimension filter (e.g. `country == 'USA'`) into each cell's `formData`. That filter was appended **only** to `adhoc_filters`.

Charts with more than one query route each query through a separate adhoc-filter collection — Mixed Chart reads query A from `adhoc_filters`, query B from `adhoc_filters_b`, query C from `adhoc_filters_c`. As a result, on multi-query charts the Matrixify slice filter was **silently dropped from every query except the first**, so those cells rendered unfiltered data.

This change introduces `appendMatrixifyFilters`, which fans the injected filters out to `adhoc_filters` **plus every `adhoc_filters_*` collection** present on the `formData`, so all of a chart's queries are sliced by the cell's dimension value.

Design notes:
- Non-array values on a matched key are treated as empty.
- Each key is reassigned to a **new** array rather than mutating the shared base `formData`, so cells don't contaminate each other.
- `matrixify_*` keys are deleted **before** the fan-out, so they can't be matched by the `adhoc_filters_*` pattern.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavior fix, no visual/layout change. Effect: Mixed Chart Matrixify cells now filter query B/C data to the cell's dimension value instead of showing the full, unfiltered series.

### TESTING INSTRUCTIONS

Manual:
1. Create a Mixed Chart (query A + query B).
2. Enable Matrixify with a row dimension (e.g. `country` with 2+ values).
3. Before this change: query B's series ignore the per-cell dimension filter (every cell shows the same B data). After: both query A and query B are filtered to the cell's dimension value.

Automated:
- `superset-ui-core/.../Matrixify/MatrixifyGridGenerator.test.ts` — asserts the dimension filter reaches `adhoc_filters`, `adhoc_filters_b`, and `adhoc_filters_c` (including one that started empty), preserves pre-existing filters, and leaves look-alike keys such as `filters_b` untouched.
- `plugin-chart-echarts/test/MixedTimeseries/buildQuery.test.ts` — asserts both compiled queries carry the Matrixify filter and query B's pre-existing free-form filter is preserved.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #39007
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API