### PR TITLE
fix: downgrade md5 namespace-fallback deprecation log to info

### DIFF
--- a/superset/key_value/utils.py
+++ b/superset/key_value/utils.py
@@ -91,7 +91,11 @@ def _uuid_namespace_from_md5(seed: str) -> UUID:
     generated before SHA-256 became the default. It is deprecated and should not
     be selected for new deployments; prefer the SHA-256 generator instead.
     """
-    logger.warning(
+    # Hit on every fallback lookup for a not-yet-migrated legacy entry
+    # (HASH_ALGORITHM_FALLBACKS default) -- an indefinite repeat with nothing
+    # new to report each time until the entry is migrated, so info not warning.
+    # Same rationale as query_object.py's deprecated-field logging (#43520).
+    logger.info(
         "The 'md5' HASH_ALGORITHM is deprecated and retained only for "
         "backwards compatibility; prefer 'sha256' for namespace generation."
     )

--- a/tests/unit_tests/key_value/utils_test.py
+++ b/tests/unit_tests/key_value/utils_test.py
@@ -62,16 +62,20 @@ def test_random_key_rejects_weak_entropy(nbytes: int) -> None:
         random_key(nbytes)
 
 
-def test_uuid_namespace_from_md5_warns(caplog) -> None:
-    """The deprecated MD5 namespace path emits a deprecation warning."""
+def test_uuid_namespace_from_md5_logs_deprecation_at_info(caplog) -> None:
+    """The deprecated MD5 namespace path logs at info (fires on every legacy
+    fallback lookup, so warning would be indefinite noise)."""
     import logging
 
     from superset.key_value.utils import _uuid_namespace_from_md5
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         _uuid_namespace_from_md5("seed")
 
-    assert any("deprecated" in record.message.lower() for record in caplog.records)
+    assert any(
+        "deprecated" in record.message.lower() and record.levelno == logging.INFO
+        for record in caplog.records
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Decisions made that were not in the instructions**
None.

## What

Datadog prod logs show recurring warning-level noise: `The 'md5' HASH_ALGORITHM is deprecated and retained only for backwards compatibility; prefer 'sha256' for namespace generation.` from `_uuid_namespace_from_md5` (`superset/key_value/utils.py`).

This fires via `get_uuid_namespace_with_algorithm(seed, "md5")` from two fallback-lookup call sites whenever `HASH_ALGORITHM_FALLBACKS` (default `["md5"]`) resolves a legacy pre-SHA-256 entry:
- `superset/commands/dashboard/permalink/create.py:CreateDashboardPermalinkCommand.run` -- a fallback hit does not migrate the legacy entry, so every future access of that permalink re-hits the md5 fallback and re-logs. Still indefinite.
- `superset/key_value/shared_entries.py:get_shared_value` -- as of #42916 (merged 2026-08-12), a fallback hit now persists a migrated current-algorithm entry, so this path logs at most once per legacy entry, not indefinitely.

Either way, this is expected fallback behavior, not a one-off actionable event -- warning-level logging is the wrong severity for the repeat case.

## Change

Downgrade the single `logger.warning` call in `_uuid_namespace_from_md5` to `logger.info`. No other behavior change -- the md5 hashing/namespace-generation logic itself is untouched. Mirrors the identical downgrade already applied to `QueryObject`'s deprecated-field warnings in #43520 for the same "expected, indefinite repeat" reasoning.

## Test plan

- Updated `tests/unit_tests/key_value/utils_test.py` (renamed `test_uuid_namespace_from_md5_warns` -> `test_uuid_namespace_from_md5_logs_deprecation_at_info`) to assert `record.levelno == logging.INFO` explicitly, not just message content. Verified it fails if reverted to `logger.warning` and passes on this fix.
- `uvx ruff@0.9.7 check` and `format --check` clean on both changed files.
- `pytest tests/unit_tests/key_value/utils_test.py` -- 24 passed.
