### PR TITLE
fix(sqllab): wrap cost-estimate JSON parse to prevent raw JSONDecodeError leak

### DIFF
--- a/superset/commands/sql_lab/estimate.py
+++ b/superset/commands/sql_lab/estimate.py
@@ -37,7 +37,7 @@ from superset.exceptions import (
 from superset.jinja_context import get_template_processor
 from superset.models.core import Database
 from superset.sql.parse import SQLScript
-from superset.utils import core as utils
+from superset.utils import core as utils, json
 from superset.utils.rls import apply_rls
 
 logger = logging.getLogger(__name__)
@@ -205,6 +205,18 @@ class QueryEstimationCommand(BaseCommand):
                         sqllab_timeout=app.config["SQLLAB_QUERY_COST_ESTIMATE_TIMEOUT"],
                     ),
                     error_type=SupersetErrorType.SQLLAB_TIMEOUT_ERROR,
+                    level=ErrorLevel.ERROR,
+                ),
+                status=500,
+            ) from ex
+        except json.JSONDecodeError as ex:
+            logger.exception(ex)
+            raise SupersetErrorException(
+                SupersetError(
+                    message=__(
+                        "Unable to parse the cost estimate returned by the database."
+                    ),
+                    error_type=SupersetErrorType.GENERIC_BACKEND_ERROR,
                     level=ErrorLevel.ERROR,
                 ),
                 status=500,

--- a/tests/unit_tests/commands/sql_lab/test_estimate.py
+++ b/tests/unit_tests/commands/sql_lab/test_estimate.py
@@ -445,3 +445,45 @@ def test_run_wraps_raw_jinja_undefined_error(
 
     assert exc_info.value.status == 400
     assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_COMMAND_ERROR
+
+
+# ---------------------------------------------------------------------------
+# estimate_query_cost() error handling: a raw simplejson JSONDecodeError from
+# parsing the engine's cost-estimate response must not leak from run()
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.DatabaseDAO")
+def test_run_wraps_raw_jsondecodeerror_from_cost_estimation(
+    mock_dao: MagicMock,
+    mock_security_manager: MagicMock,
+) -> None:
+    """A raw ``simplejson.JSONDecodeError`` raised while parsing the engine's
+    cost-estimate response (e.g. Presto/Trino ``EXPLAIN (TYPE IO, FORMAT JSON)``
+    emitting a bare ``NaN`` token for tables lacking computed statistics) must
+    not leak past ``run()`` -- it should surface as a typed
+    ``SupersetErrorException`` with a 500 ``GENERIC_BACKEND_ERROR``, mirroring
+    the sibling ``TemplateError`` conversion in the same function."""
+    # ``superset.utils.json`` is simplejson-backed, so ``json.JSONDecodeError``
+    # here *is* ``simplejson.errors.JSONDecodeError`` -- the concrete class the
+    # Presto/Trino cost-estimate parse raises, which is distinct from the stdlib
+    # ``json.JSONDecodeError``. Using the util keeps us off the banned direct
+    # ``simplejson`` import while exercising the exact raised type.
+    from superset.utils import json
+
+    mock_database = MagicMock()
+    mock_dao.find_by_id.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    # The raw class actually raised by superset.utils.json (simplejson-backed)
+    # when the driver response contains a literal NaN token.
+    mock_database.db_engine_spec.estimate_query_cost.side_effect = json.JSONDecodeError(
+        "Expecting value", "{}", 0
+    )
+
+    command = QueryEstimationCommand(_make_params())
+    with pytest.raises(SupersetErrorException) as exc_info:
+        command.run()
+
+    assert exc_info.value.status == 500
+    assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_BACKEND_ERROR


### PR DESCRIPTION
### SUMMARY

Running **Estimate cost** in SQL Lab against a Presto/Trino table that lacks computed statistics currently crashes with an opaque `500 GENERIC_BACKEND_ERROR` instead of a clean, typed error.

**Root cause.** `QueryEstimationCommand.run()` (`superset/commands/sql_lab/estimate.py`) calls `db_engine_spec.estimate_query_cost(...)`. For Presto/Trino, `PrestoBaseEngineSpec.estimate_statement_cost` runs `EXPLAIN (TYPE IO, FORMAT JSON) <statement>` and does `json.loads(cursor.fetchone()[0])` using the simplejson-backed `superset.utils.json` (`allow_nan=False`). Trino/Presto represent unknown/uncollected cost statistics as a **literal `NaN` token** in that JSON (e.g. `{"estimate": {"outputRowCount": NaN, ...}}`), which happens for any table without an `ANALYZE`. `allow_nan=False` then makes `json.loads` raise a raw `simplejson.errors.JSONDecodeError`.

That exception is **not caught** anywhere in the call chain:
- `BaseEngineSpec.estimate_query_cost` calls `estimate_statement_cost` with no guard;
- `QueryEstimationCommand.run()` only wraps the call in `try/except SupersetTimeoutException`;
- `SqlLabRestApi.estimate_query_cost` has no `try/except`.

So it falls through to Flask's global `@app.errorhandler(Exception)` and leaks to the user as an unhandled 500.

### FIX

Add a sibling `except json.JSONDecodeError` block to the existing `try/except` around the `estimate_query_cost(...)` call, converting it to a typed `SupersetErrorException`. This is a backend/driver response-parsing failure (missing table statistics on the remote engine), not a user-input error, so it is bucketed as `500 GENERIC_BACKEND_ERROR` (code 1011) rather than `400 GENERIC_COMMAND_ERROR`.

This mirrors the pre-existing sibling conversion in the very same function — the raw `jinja2.TemplateError` handling added by #42757 (`fix(sqllab): wrap process_template() in QueryEstimationCommand to prevent raw UndefinedError leak`) — and continues the SQL Lab exception-cleanup series (#43883 / #43795 / #43772).

The change is strictly additive: successful estimates are unchanged; only the previously-unhandled malformed/`NaN` cost-estimate JSON now returns a clean typed 500.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

_N/A — backend error-handling change._

**Before:** opaque unhandled `500 GENERIC_BACKEND_ERROR` from an escaped `simplejson.JSONDecodeError`.
**After:** typed `SupersetErrorException` → `500 GENERIC_BACKEND_ERROR` with message _"Unable to parse the cost estimate returned by the database."_

### TESTING INSTRUCTIONS

Automated (new regression test in `tests/unit_tests/commands/sql_lab/test_estimate.py`):

```
pytest tests/unit_tests/commands/sql_lab/test_estimate.py
```

`test_run_wraps_raw_jsondecodeerror_from_cost_estimation` mocks `estimate_query_cost` to raise the concrete simplejson `JSONDecodeError` (via `superset.utils.json.JSONDecodeError`, which *is* `simplejson.errors.JSONDecodeError` — distinct from the stdlib class) and asserts `run()` raises `SupersetErrorException` with `.status == 500` and `.error.error_type == GENERIC_BACKEND_ERROR`. Verified failing on pre-fix code and passing after.

Manual: in SQL Lab, point at a Presto/Trino database, select a table with no computed statistics, enter any `SELECT`, and click **Estimate cost**. Previously an opaque 500; now a clean typed backend error.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)