### PR TITLE
test(treemap): pin border-free labels so tiles render without seams

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
@@ -115,4 +115,48 @@ describe('Treemap transformProps', () => {
       }),
     );
   });
+
+  test('should not draw borders around labels', () => {
+    // A label border is drawn by ECharts as a box that spans the full node
+    // height, which shows up as a vertical line right after the label text
+    // (see #37808 and #43862). Every label style must stay border-free,
+    // including emphasis, upper labels, and the filtered-node label.
+    const filteredChartProps = new ChartProps({
+      ...chartProps,
+      filterState: { selectedValues: ['Sylvester,bar1'] },
+    });
+    const { echartOptions } = transformProps(
+      filteredChartProps as EchartsTreemapChartProps,
+    );
+
+    const labelStyles: Record<string, unknown>[] = [];
+    const collectLabelStyles = (node: unknown) => {
+      if (Array.isArray(node)) {
+        node.forEach(collectLabelStyles);
+        return;
+      }
+      if (!node || typeof node !== 'object') {
+        return;
+      }
+      Object.entries(node as Record<string, unknown>).forEach(
+        ([key, value]) => {
+          if (
+            (key === 'label' || key === 'upperLabel') &&
+            value &&
+            typeof value === 'object'
+          ) {
+            labelStyles.push(value as Record<string, unknown>);
+          }
+          collectLabelStyles(value);
+        },
+      );
+    };
+    collectLabelStyles(echartOptions.series);
+
+    expect(labelStyles.length).toBeGreaterThan(0);
+    labelStyles.forEach(style => {
+      expect(style).not.toHaveProperty('borderWidth');
+      expect(style).not.toHaveProperty('borderColor');
+    });
+  });
 });


### PR DESCRIPTION
### SUMMARY

Regression test for the Treemap "vertical line inside every tile" symptom reported in #43862.

The line came from a 1px `borderColor`/`borderWidth` on the label style. ECharts sizes the label's text box to the full node height (via the treemap view's `beforeUpdate` hook), so the box border rendered as a vertical line right after the label text, spanning the whole tile. #37808 removed the border and the symptom is gone on `master` (the reporter's screenshot also shows the inter-node gaps that #40181 removed, so their build predates both fixes; the border was still present in the 6.0.0 release).

Nothing pinned that fix, so this adds a test that walks every `label` / `upperLabel` style in the transformed options (series, emphasis, levels, upper labels, and the filtered-node label) and asserts none of them declares a border. Verified the test fails if the old `borderColor`/`borderWidth` pair is reintroduced on `labelProps`, and passes on `master`.

Rendered the pre-#37808 options with both ECharts 5.6.0 and 6.1.0 to confirm the mechanism; both draw the same line the reporter sees:

<img width="760" alt="treemap label border artifact" src="https://github.com/user-attachments/assets/f4de4d10-a91b-4c39-8867-8664c47c4ef8" />

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, test-only.

### TESTING INSTRUCTIONS

```
cd superset-frontend
npx jest --runInBand plugins/plugin-chart-echarts/test/Treemap/transformProps.test.ts
```

To see it fail, add `borderColor: theme.colorBgBase, borderWidth: 1` back to `labelProps` in `src/Treemap/transformProps.ts`.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #43862 (already fixed on `master` by #37808; this pins it)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XdpWLXhUs7r8d4F2R5D6F
