### PR TITLE
fix(dashboard): accept async_mode in json_metadata schema

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -231,6 +231,10 @@ class DashboardJSONMetadataSchema(Schema):
     remote_id = fields.Integer()
     filter_bar_orientation = fields.Str(allow_none=True)
     native_filter_migration = fields.Dict()
+    async_mode = fields.Str(
+        allow_none=True,
+        validate=OneOf(["default", "force_on", "force_off"]),
+    )
 
     @pre_load
     def remove_show_native_filters(  # pylint: disable=unused-argument

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -2266,6 +2266,7 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
                         "stagger_refresh": True,
                         "stagger_time": 500,
                         "timed_refresh_immune_slices": [1, 2],
+                        "async_mode": "force_off",
                     }
                 )
             },
@@ -2278,6 +2279,7 @@ class TestDashboardApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCa
         assert saved_metadata["stagger_refresh"] is True
         assert saved_metadata["stagger_time"] == 500
         assert saved_metadata["timed_refresh_immune_slices"] == [1, 2]
+        assert saved_metadata["async_mode"] == "force_off"
 
         db.session.delete(model)
         db.session.commit()


### PR DESCRIPTION
### SUMMARY

Addresses the blocking finding in the umbrella review ([#43407 review](https://github.com/apache/superset/pull/43407#pullrequestreview-5117266775)): the per-dashboard async override could not be saved.

The Properties modal writes the override into `json_metadata.async_mode`, but `DashboardJSONMetadataSchema` did not declare the field. `validate_json_metadata` calls `DashboardJSONMetadataSchema().validate(..., partial=False)`, which rejects unknown fields, so the dashboard `PUT` failed with `422 "Unknown field"` and the override never persisted.

This declares `async_mode` as an optional string validated to `default` / `force_on` / `force_off` (the values the frontend `resolveAsyncMode` chain emits; the modal deletes the key for `default`). No backend execution change — chart-data async is driven by a **request-level** `async_mode` flag on `/chart/data`, not this metadata key, which is frontend-consumed.

### TESTING INSTRUCTIONS

Folded the persistence assertion into the existing `test_update_dashboard_persists_metadata_fields_without_dedicated_handling` (integration `dashboards/api_tests.py`): the PUT payload now includes `async_mode: "force_off"` and asserts it round-trips. Schema accept/reject was also verified directly (`force_on`/`force_off`/`default` valid; unknown value rejected).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` (the override only surfaces in the UI when async is available)
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

---

Note on the review's second (non-blocking) point — the possibly-leaked GTF abort listener flaking the oauth2 test's caplog: I could not reproduce or localize it. The tasks tests that start a real abort listener (`test_handlers`, `test_timeout`) already stop it in fixture teardown, and the others (`test_manager`, `test_query_cancel`) mock the listener, so there's no obvious unstopped listener in the current code. Suggest handling as a separate follow-up once we have the failing CI seed to reproduce deterministically, rather than adding a speculative teardown here.