### PR TITLE
docs(mcp): document delete_chart and delete_dashboard tools

### DIFF
--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -269,26 +269,28 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 
 ### Charts
 
-| Tool                    | Description                                                                                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `list_charts`           | List charts with filtering and search                                                                                              |
-| `get_chart_info`        | Get chart metadata and configuration                                                                                               |
-| `get_chart_data`        | Retrieve chart data (JSON, CSV, or Excel)                                                                                          |
-| `get_chart_preview`     | Generate a chart preview (URL, ASCII, table, or Vega-Lite)                                                                         |
-| `get_chart_type_schema` | Get the configuration schema for a chart type                                                                                      |
-| `generate_chart`        | Create a new chart from a specification (defaults to preview mode — review before saving)                                          |
-| `update_chart`          | Modify an existing chart's configuration (pass `generate_preview=False` to persist immediately instead of returning a preview URL) |
-| `update_chart_preview`  | Update a cached chart preview without saving                                                                                       |
-| `generate_explore_link` | Generate an Explore URL for interactive visualization                                                                              |
+| Tool                    | Description                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_charts`           | List charts with filtering and search                                                                                                             |
+| `get_chart_info`        | Get chart metadata and configuration                                                                                                              |
+| `get_chart_data`        | Retrieve chart data (JSON, CSV, or Excel)                                                                                                         |
+| `get_chart_preview`     | Generate a chart preview (URL, ASCII, table, or Vega-Lite)                                                                                        |
+| `get_chart_type_schema` | Get the configuration schema for a chart type                                                                                                     |
+| `generate_chart`        | Create a new chart from a specification (defaults to preview mode — review before saving)                                                        |
+| `update_chart`          | Modify an existing chart's configuration (pass `generate_preview=False` to persist immediately instead of returning a preview URL)               |
+| `update_chart_preview`  | Update a cached chart preview without saving                                                                                                      |
+| `generate_explore_link` | Generate an Explore URL for interactive visualization                                                                                             |
+| `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't owner/Admin)   |
 
 ### Dashboards
 
-| Tool                              | Description                                  |
-| --------------------------------- | -------------------------------------------- |
-| `list_dashboards`                 | List dashboards with filtering and search    |
-| `get_dashboard_info`              | Get dashboard metadata and layout            |
-| `generate_dashboard`              | Create a new dashboard with specified charts |
-| `add_chart_to_existing_dashboard` | Add a chart to an existing dashboard         |
+| Tool                              | Description                                                                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `list_dashboards`                 | List dashboards with filtering and search                                                                                                                                            |
+| `get_dashboard_info`              | Get dashboard metadata and layout                                                                                                                                                    |
+| `generate_dashboard`              | Create a new dashboard with specified charts                                                                                                                                         |
+| `add_chart_to_existing_dashboard` | Add a chart to an existing dashboard                                                                                                                                                 |
+| `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't owner/Admin) |
 
 ### SQL
 

--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -280,7 +280,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `update_chart`          | Modify an existing chart's configuration (pass `generate_preview=False` to persist immediately instead of returning a preview URL)               |
 | `update_chart_preview`  | Update a cached chart preview without saving                                                                                                      |
 | `generate_explore_link` | Generate an Explore URL for interactive visualization                                                                                             |
-| `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't owner/Admin)   |
+| `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't an editor of the chart — owners, Admins, and explicitly granted editors qualify)   |
 
 ### Dashboards
 
@@ -290,7 +290,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `get_dashboard_info`              | Get dashboard metadata and layout                                                                                                                                                    |
 | `generate_dashboard`              | Create a new dashboard with specified charts                                                                                                                                         |
 | `add_chart_to_existing_dashboard` | Add a chart to an existing dashboard                                                                                                                                                 |
-| `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't owner/Admin) |
+| `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't an editor of the dashboard — owners, Admins, and explicitly granted editors qualify) |
 
 ### SQL
 

--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -280,7 +280,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `update_chart`          | Modify an existing chart's configuration (pass `generate_preview=False` to persist immediately instead of returning a preview URL)               |
 | `update_chart_preview`  | Update a cached chart preview without saving                                                                                                      |
 | `generate_explore_link` | Generate an Explore URL for interactive visualization                                                                                             |
-| `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't an editor of the chart — owners, Admins, and explicitly granted editors qualify)   |
+| `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; fails if alerts/reports are still attached, checked before editorship; otherwise returns `permission_denied` if the caller isn't an editor of the chart — owners, Admins, and explicitly granted editors qualify)   |
 
 ### Dashboards
 
@@ -290,7 +290,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `get_dashboard_info`              | Get dashboard metadata and layout                                                                                                                                                    |
 | `generate_dashboard`              | Create a new dashboard with specified charts                                                                                                                                         |
 | `add_chart_to_existing_dashboard` | Add a chart to an existing dashboard                                                                                                                                                 |
-| `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; returns `permission_denied` if the caller isn't an editor of the dashboard — owners, Admins, and explicitly granted editors qualify) |
+| `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; fails if alerts/reports are still attached, checked before editorship; otherwise returns `permission_denied` if the caller isn't an editor of the dashboard — owners, Admins, and explicitly granted editors qualify) |
 
 ### SQL
 


### PR DESCRIPTION
### SUMMARY
#41472 added `delete_chart` and `delete_dashboard` MCP tools, but the "Available Tools Reference" section of `docs/docs/using-superset/using-ai-with-superset.mdx` only listed the create/read/update tools for charts and dashboards. This adds a row for each new tool, noting the `soft_deleted`/`permission_denied` response semantics (soft-delete to trash when `SOFT_DELETE` is on, permission_denied when the caller isn't an owner or Admin).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A - doc table update only.

### TESTING INSTRUCTIONS
Render `docs/docs/using-superset/using-ai-with-superset.mdx` (or just read the diff) and confirm the Charts and Dashboards tool tables include `delete_chart` / `delete_dashboard` alongside the existing tools.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs for #41472.