### PR TITLE
docs(mcp): add theme management tools to AI/MCP tools reference

### DIFF
--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -305,6 +305,14 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `list_databases`    | List configured database connections             |
 | `get_database_info` | Get details about a specific database connection |
 
+### Themes
+
+| Tool             | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------- |
+| `list_themes`    | Discover themes (antd design-token configurations) with filters           |
+| `get_theme_info` | Get a theme's tokens (`json_data`) by ID or UUID                          |
+| `create_theme`   | Create a reusable theme from antd design tokens (requires write access)   |
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
### SUMMARY
#41497 added three MCP tools for theme management (`list_themes`, `get_theme_info`, `create_theme`), but the "Using AI with Superset" docs page's tool reference never got updated to list them. This adds a `Themes` table to the `Available Tools Reference` section, matching the existing style for other tool categories.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only text change.

### TESTING INSTRUCTIONS
Render `docs/docs/using-superset/using-ai-with-superset.mdx` and confirm the new `Themes` table appears under `Available Tools Reference`, alongside `Databases`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #41497.