### PR TITLE
docs(security): document PERMISSION_INSTRUCTIONS_LINK templating

### DIFF
--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -132,6 +132,31 @@ tables in the **Permissions** dropdown. To select the data sources you want to a
 You can then confirm with users assigned to the **Gamma** role that they see the
 objects (dashboards and slices) associated with the tables you just extended them.
 
+### Actionable Access-Denied Messages
+
+When a viewer opens a chart or dashboard built on a dataset they don't have access to, Superset
+shows a plain-language error naming the dataset (or tables, for SQL Lab) and, when known, the
+chart owners to contact. You can also point users at your own access-request process by setting
+`PERMISSION_INSTRUCTIONS_LINK` in `superset_config.py`:
+
+```python
+PERMISSION_INSTRUCTIONS_LINK = (
+    "https://access.example.com/request?dataset={datasource_name}&user={username}"
+)
+```
+
+The URL may include any of the following placeholders, which are substituted with URL-encoded
+values so the link can deep-link into an internal ticketing or access-request tool with the
+denied resource pre-filled:
+
+- `{datasource_id}` — id of the denied dataset (datasource errors)
+- `{datasource_name}` — name of the denied dataset (datasource errors)
+- `{table_names}` — comma-separated denied table names (table/SQL errors)
+- `{username}` — the requesting user's username
+
+A URL with no placeholders is used as-is, and leaving `PERMISSION_INSTRUCTIONS_LINK` unset (the
+default) omits the "Request access" link, falling back to owner-contact guidance.
+
 ### Subjects
 
 A **subject** is a unified identity that can be granted access to Superset resources such as

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -136,12 +136,12 @@ objects (dashboards and slices) associated with the tables you just extended the
 
 When a viewer opens a chart or dashboard built on a dataset they don't have access to, Superset
 shows a plain-language error naming the dataset (or tables, for SQL Lab) and, when known, the
-chart owners to contact. You can also point users at your own access-request process by setting
+dataset owners to contact. You can also point users at your own access-request process by setting
 `PERMISSION_INSTRUCTIONS_LINK` in `superset_config.py`:
 
 ```python
 PERMISSION_INSTRUCTIONS_LINK = (
-    "https://access.example.com/request?dataset={datasource_name}&user={username}"
+    "https://access.example.com/request?dataset={datasource_name}&table={table_names}&user={username}"
 )
 ```
 
@@ -149,11 +149,13 @@ The URL may include any of the following placeholders, which are substituted wit
 values so the link can deep-link into an internal ticketing or access-request tool with the
 denied resource pre-filled:
 
-- `{datasource_id}` — id of the denied dataset (datasource errors)
-- `{datasource_name}` — name of the denied dataset (datasource errors)
-- `{table_names}` — comma-separated denied table names (table/SQL errors)
+- `{datasource_id}` — id of the denied dataset (chart/dashboard errors only)
+- `{datasource_name}` — name of the denied dataset (chart/dashboard errors only)
+- `{table_names}` — comma-separated denied table names (SQL Lab/table errors only)
 - `{username}` — the requesting user's username
 
+Only the placeholders that apply to the triggering error type are filled in; the rest are replaced
+with an empty string, so a single URL template can cover both chart/dashboard and SQL Lab denials.
 A URL with no placeholders is used as-is, and leaving `PERMISSION_INSTRUCTIONS_LINK` unset (the
 default) omits the "Request access" link, falling back to owner-contact guidance.
 


### PR DESCRIPTION
### SUMMARY
#41843 (merged) added templated `{datasource_id}`, `{datasource_name}`, `{table_names}`, and `{username}` placeholders to `PERMISSION_INSTRUCTIONS_LINK`, so the "Request access" link on data-permission errors can deep-link into an org's access-request tool with the denied resource pre-filled. The security config docs only described roles/permissions in general terms and never mentioned this. Adding a short section to the admin security docs covering the config and its placeholders.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
Read `docs/admin_docs/security/security.mdx` and confirm the new "Actionable Access-Denied Messages" section (under "Managing Data Source Access for Gamma Roles") accurately reflects the behavior in `superset/security/manager.py`'s `_render_permission_instructions_link`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Co-Authored-By: Claude <noreply@anthropic.com>