### PR TITLE
docs(reports): document retry-on-failure behavior for reports

### DIFF
--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -472,6 +472,48 @@ ALERT_REPORTS_ENABLE_LINK_REDIRECT = False
 The feature uses `WEBDRIVER_BASEURL_USER_FRIENDLY` (or `WEBDRIVER_BASEURL`)
 to determine which hosts are internal.
 
+## Retry on Failure
+
+Reports (not alerts) can be configured to automatically retry when delivery
+fails — for example a transient SMTP or Slack error — instead of moving
+straight to an `Error` state. This is configured per report in the **Error
+Handling** section of the report modal:
+
+- **Enable Retries** – turn on automatic retries for this report.
+- **Maximum Retry Attempts** – how many times to retry before giving up (1–10, default 3).
+- **Send Failed Reports** – still deliver the report to its recipients even after all retries fail (default off).
+- **Failure Notifications** – choose whether **Owners** and/or **Report Recipients** get an email after each failed attempt.
+
+While a retry is pending, the report's status shows as **Retrying**
+(`RETRYING` in `ReportState`) rather than `Error`. Each retry uses
+exponential backoff — the delay doubles after every attempt, up to a
+configurable cap:
+
+```python
+# Delay before the first retry, in seconds. Each subsequent retry doubles
+# this value, up to ALERT_REPORTS_RETRY_MAX_DELAY_SECONDS.
+ALERT_REPORTS_RETRY_BASE_DELAY_SECONDS = 60
+
+# Maximum delay between retries, in seconds.
+ALERT_REPORTS_RETRY_MAX_DELAY_SECONDS = 3600
+```
+
+If the report's regular schedule fires again while a previous run is still
+retrying, Superset skips the new run and lets the in-flight retries finish,
+unless that retry chain looks abandoned (no activity for longer than
+`ALERT_REPORTS_RETRY_MAX_DELAY_SECONDS`), in which case the new run proceeds
+with a fresh retry budget.
+
+Once all retries are exhausted, the report moves to the `Error` state. With
+Send Failed Reports enabled, the report is still delivered to its normal
+recipients even though the final state is `Error`.
+
+This per-report retry budget is independent of the
+[Slack delivery retry budget](#slack-delivery-timeouts-and-retries) and the
+[webhook retry behavior](#retry-behavior) described above, which retry
+individual delivery requests within a single execution rather than
+re-running the whole report.
+
 ## Troubleshooting
 
 There are many reasons that reports might not be working. Try these steps to check for specific issues.

--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -474,15 +474,24 @@ to determine which hosts are internal.
 
 ## Retry on Failure
 
-Reports (not alerts) can be configured to automatically retry when delivery
-fails — for example a transient SMTP or Slack error — instead of moving
-straight to an `Error` state. This is configured per report in the **Error
-Handling** section of the report modal:
+This feature is gated behind the `ALERT_REPORTS_RETRY` feature flag, which is
+disabled by default:
+
+```python
+FEATURE_FLAGS = {
+    "ALERT_REPORTS_RETRY": True,
+}
+```
+
+With the flag enabled, reports (not alerts) can be configured to
+automatically retry when delivery fails — for example a transient SMTP or
+Slack error — instead of moving straight to an `Error` state. This is
+configured per report in the **Error Handling** section of the report modal:
 
 - **Enable Retries** – turn on automatic retries for this report.
 - **Maximum Retry Attempts** – how many times to retry before giving up (1–10, default 3).
-- **Send Failed Reports** – still deliver the report to its recipients even after all retries fail (default off).
-- **Failure Notifications** – choose whether **Owners** and/or **Report Recipients** get an email after each failed attempt.
+- **Send Failed Reports** – send a final failure notification to the report's recipients once all retries fail (default off).
+- **Failure Notifications** – choose whether **Owners** and/or **Report Recipients** get a notification after a failed retry attempt (not the initial failure). Owners are notified by email; report recipients are notified on their configured channel (email, Slack, etc).
 
 While a retry is pending, the report's status shows as **Retrying**
 (`RETRYING` in `ReportState`) rather than `Error`. Each retry uses
@@ -505,8 +514,9 @@ unless that retry chain looks abandoned (no activity for longer than
 with a fresh retry budget.
 
 Once all retries are exhausted, the report moves to the `Error` state. With
-Send Failed Reports enabled, the report is still delivered to its normal
-recipients even though the final state is `Error`.
+Send Failed Reports enabled, a final failure notification (not the report's
+screenshot/PDF/CSV/XLSX content) is sent to the report's normal recipients
+even though the final state is `Error`.
 
 This per-report retry budget is independent of the
 [Slack delivery retry budget](#slack-delivery-timeouts-and-retries) and the

--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -484,9 +484,11 @@ FEATURE_FLAGS = {
 ```
 
 With the flag enabled, reports (not alerts) can be configured to
-automatically retry when delivery fails — for example a transient SMTP or
-Slack error — instead of moving straight to an `Error` state. This is
-configured per report in the **Error Handling** section of the report modal:
+automatically retry when sending fails — this covers rendering/export
+failures (e.g. a chart screenshot or CSV export erroring out) as well as
+delivery failures such as a transient SMTP or Slack error — instead of
+moving straight to an `Error` state. This is configured per report in the
+**Error Handling** section of the report modal:
 
 - **Enable Retries** – turn on automatic retries for this report.
 - **Maximum Retry Attempts** – how many times to retry before giving up (1–10, default 3).
@@ -506,6 +508,11 @@ ALERT_REPORTS_RETRY_BASE_DELAY_SECONDS = 60
 # Maximum delay between retries, in seconds.
 ALERT_REPORTS_RETRY_MAX_DELAY_SECONDS = 3600
 ```
+
+Both values are read as-is with no validation, so keep them positive and
+make sure the max is greater than or equal to the base delay — otherwise
+retries will fire immediately or the exponential backoff won't behave as
+advertised.
 
 If the report's regular schedule fires again while a previous run is still
 retrying, Superset skips the new run and lets the in-flight retries finish,

--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -488,9 +488,10 @@ automatically retry when sending fails — this covers rendering/export
 failures (e.g. a chart screenshot or CSV export erroring out) as well as
 delivery failures such as a transient SMTP or Slack error — instead of
 moving straight to an `Error` state. Execution timeouts (the Celery soft
-time limit) and the `ALERT_REPORTS_EXECUTION_BUDGET_SECONDS` budget being
-exceeded are not covered — those go straight to `Error` without a retry
-even with this setting enabled. This is configured per report in the
+time limit), the `ALERT_REPORTS_EXECUTION_BUDGET_SECONDS` budget being
+exceeded, and a schedule that stays `WORKING` past its `working_timeout`
+are not covered — those go straight to `Error` without a retry even with
+this setting enabled. This is configured per report in the
 **Error Handling** section of the report modal:
 
 - **Enable Retries** – turn on automatic retries for this report.

--- a/docs/admin_docs/configuration/alerts-reports.mdx
+++ b/docs/admin_docs/configuration/alerts-reports.mdx
@@ -487,13 +487,16 @@ With the flag enabled, reports (not alerts) can be configured to
 automatically retry when sending fails — this covers rendering/export
 failures (e.g. a chart screenshot or CSV export erroring out) as well as
 delivery failures such as a transient SMTP or Slack error — instead of
-moving straight to an `Error` state. This is configured per report in the
+moving straight to an `Error` state. Execution timeouts (the Celery soft
+time limit) and the `ALERT_REPORTS_EXECUTION_BUDGET_SECONDS` budget being
+exceeded are not covered — those go straight to `Error` without a retry
+even with this setting enabled. This is configured per report in the
 **Error Handling** section of the report modal:
 
 - **Enable Retries** – turn on automatic retries for this report.
 - **Maximum Retry Attempts** – how many times to retry before giving up (1–10, default 3).
 - **Send Failed Reports** – send a final failure notification to the report's recipients once all retries fail (default off).
-- **Failure Notifications** – choose whether **Owners** and/or **Report Recipients** get a notification after a failed retry attempt (not the initial failure). Owners are notified by email; report recipients are notified on their configured channel (email, Slack, etc).
+- **Failure Notifications** – choose whether **Owners** and/or **Report Recipients** get a notification after a failed retry attempt (not the initial failure). Report recipients are notified on their configured channel (email, Slack, etc). Owner notifications only go to owners who are individual users — a report owned solely through a role or group won't get an owner notification even with this enabled.
 
 While a retry is pending, the report's status shows as **Retrying**
 (`RETRYING` in `ReportState`) rather than `Error`. Each retry uses


### PR DESCRIPTION
### SUMMARY

#42481 added retry-on-failure support for reports (the Error Handling panel, the RETRYING state, and the exponential backoff config settings), but the alerts-reports docs never got updated for it. This fills that gap: a new "Retry on Failure" section covering the UI fields, the RETRYING state, and `ALERT_REPORTS_RETRY_BASE_DELAY_SECONDS` / `ALERT_REPORTS_RETRY_MAX_DELAY_SECONDS`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A, docs only.

### TESTING INSTRUCTIONS

Read the new "Retry on Failure" section in `docs/admin_docs/configuration/alerts-reports.mdx` (renders under Admin Docs > Configuration > Alerts and Reports) and check it against the behavior in `superset/commands/report/execute.py` and the Error Handling panel in the report modal.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Co-Authored-By: Claude <noreply@anthropic.com>