### PR TITLE
test(gtf): stop a leaked abort-listener thread in the abort-handler tests

### DIFF
--- a/tests/unit_tests/tasks/test_handlers.py
+++ b/tests/unit_tests/tasks/test_handlers.py
@@ -308,7 +308,7 @@ class TestAbortHandlerRegistration:
 
         with (
             patch.object(TaskContext, "_set_abortable") as mock_set_abortable,
-            patch.object(TaskContext, "start_abort_polling"),
+            patch.object(TaskContext, "_start_abort_listener"),
         ):
             ctx = TaskContext(mock_task)
 
@@ -330,7 +330,7 @@ class TestAbortHandlerRegistration:
 
         with (
             patch.object(TaskContext, "_set_abortable") as mock_set_abortable,
-            patch.object(TaskContext, "start_abort_polling"),
+            patch.object(TaskContext, "_start_abort_listener"),
         ):
             ctx = TaskContext(mock_task)
 


### PR DESCRIPTION
### SUMMARY

Two tests in `TestAbortHandlerRegistration` (`tests/unit_tests/tasks/test_handlers.py`) patch `TaskContext.start_abort_polling`, but `on_abort` calls `_start_abort_listener` directly, so the patch is a no-op. A real abort listener starts against the `@patch`ed `current_app` mock, whose `app_context()` yields a coroutine, so every predicate check raises. The thread is never stopped and retries with a 1s backoff for the rest of the pytest session, logging an ERROR each time. Any later test asserting an empty ERROR caplog (the oauth2 lock test in CI run 33834826666 on #43407) fails depending on timing.

This patches the method `on_abort` actually calls, so no listener thread is created. Reproduced locally (the unit job has no random ordering, so the interleaving is deterministic) and confirmed with a thread probe that no `coord-listen-*` thread survives the suite after the change.

Split out of the review of #43407 so it can land on `gaq-to-gtf` like the other steps.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (test-only)

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/tasks/test_handlers.py tests/unit_tests/utils/oauth2_tests.py
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGcoYy6bWGc9vBTqEB6Aj