### PR TITLE
chore(api): regenerate the spec for ReportScheduleRestApi.report_format

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -8888,6 +8888,11 @@
             },
             "type": "array"
           },
+          "report_format": {
+            "maxLength": 50,
+            "nullable": true,
+            "type": "string"
+          },
           "retry_max_attempts": {
             "type": "integer"
           },


### PR DESCRIPTION
### SUMMARY

Unblocks the API staleness check on `master`. #43365 added `report_format` to `ReportScheduleRestApi`'s list columns without regenerating `openapi.json`, so `ReportScheduleRestApi.get_list` is missing the field.

The check was already on `master` when #43365 merged, but that PR's last CI run predated it and GitHub does not re-run workflows at merge time, so the check never reported there. Any PR whose latest run predates #43841 can still land stale this way; enabling "require branches to be up to date before merging" for the check would close it, otherwise it self-heals as open PRs rebase.

### TESTING INSTRUCTIONS

```bash
SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \
  FLASK_APP='superset.app:create_app()' superset update-api-docs
git diff --stat -- docs/static/resources/openapi.json   # clean with this PR
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
