### PR TITLE
fix(gtf): keep per-tab subscribers across executor writes; stable guest subscriber key

### DIFF
--- a/docs/developer_docs/extensions/tasks.md
+++ b/docs/developer_docs/extensions/tasks.md
@@ -183,11 +183,15 @@ A task's state lives in three tiers:
      `task.update_framework_private({...})`.
    - `private.task` — freeform, task-type-specific internal handles (e.g. the
      chart-data query task's engine cancel handle,
-     `cancel_query_id`/`cancel_database_id`, or a
-     [subscription policy](#per-client-subscriptions-subscription-policies)'s
-     per-client bookkeeping). Written by task/execution code via
+     `cancel_query_id`/`cancel_database_id`). Written by task/execution code via
      `task.update_task_private({...})`.
-   Both namespaces merge independently (a write to one never clobbers the other).
+   - `private.subscription` — a
+     [subscription policy](#per-client-subscriptions-subscription-policies)'s
+     per-client bookkeeping (e.g. chart-data's per-tab consumer list). Written
+     only from the policy hooks via `TaskDAO.merge_subscription_state(task, {...})`;
+     the executor never writes it, and its whole-blob property writes carry the
+     row's current value through instead of overwriting it.
+   All namespaces merge independently (a write to one never clobbers another).
 3. **Results (`payload`)** — end-user-facing task output (intermediate/final):
    e.g. a `cache_key` or an engine tracking URL. Set via
    `ctx.update_task(payload=...)` and rendered in the Task List info bubble. In
@@ -195,7 +199,8 @@ A task's state lives in three tiers:
 
 Rule of thumb: user-facing status → top-level `properties`; user-facing output →
 `payload`; framework plumbing → `private.framework`; task-specific internal
-handles → `private.task`.
+handles → `private.task`; subscription-policy bookkeeping →
+`private.subscription`.
 
 
 ### Handlers
@@ -310,8 +315,8 @@ from superset_core.tasks.subscription import TaskSubscriptionPolicy
 class MyConsumerPolicy(TaskSubscriptionPolicy):
     def on_subscribe(self, task, *, principal, client_ref):
         # Record this client (e.g. append f"{principal}:{client_ref}" to a list
-        # in task.update_task_private({...})). Called after the framework has
-        # ensured the principal's subscriber row.
+        # via TaskDAO.merge_subscription_state(task, {...})). Called after the
+        # framework has ensured the principal's subscriber row.
         ...
 
     def on_unsubscribe(self, task, *, principal, client_ref) -> bool:
@@ -329,8 +334,14 @@ def my_task() -> None:
 
 Both hooks run in the web request process, inside the lock that serializes
 concurrent submit/cancel for the task, so an implementation can safely
-read-modify-write task state (typically a list under `private.task`, which the
-framework never inspects) without extra locking. `client_ref` is the caller's
+read-modify-write its bookkeeping without extra locking against other
+submits/cancels. Keep that bookkeeping under `private.subscription` and write it
+with `TaskDAO.merge_subscription_state(task, {...})`: the executor does not hold
+the submit/cancel lock and keeps writing the task's properties while it runs, so
+the helper merges under a row lock and the executor's own writes preserve that
+namespace, where a plain `task.update_task_private({...})` would be overwritten
+by the executor's next write and silently drop a client that joined
+mid-execution. `client_ref` is the caller's
 opaque per-client id (for chart-data, the browser tab id sent as `tab_id` on the
 request); it is **not** an authorization token — the framework authorizes the
 calling principal before the policy runs, and the policy only ever records or

--- a/superset-core/src/superset_core/tasks/models.py
+++ b/superset-core/src/superset_core/tasks/models.py
@@ -140,8 +140,9 @@ class Task(CoreModel):
         Update specific properties fields (merge semantics).
 
         Only updates fields present in the updates dict. The ``private`` subtree
-        is merged recursively (its ``framework`` and ``task`` namespaces merge
-        independently), so a write to one namespace never clobbers the other.
+        is merged recursively (its ``framework``, ``task`` and ``subscription``
+        namespaces merge independently), so a write to one namespace never
+        clobbers the others.
 
         Host implementations will replace this method during initialization.
 
@@ -159,7 +160,8 @@ class Task(CoreModel):
         The freeform, task-type-specific internal namespace (isolated from the
         framework-owned ``private["framework"]`` keys) for handles a task type
         needs to persist but that are not task output — e.g. an engine query
-        cancel handle, or a subscription policy's per-client bookkeeping. Never
+        cancel handle. A subscription policy's per-client bookkeeping belongs in
+        the separate ``private["subscription"]`` namespace instead. Never
         surfaced to user-facing API payloads except in debug mode.
 
         Host implementations will replace this method during initialization.

--- a/superset-core/src/superset_core/tasks/subscription.py
+++ b/superset-core/src/superset_core/tasks/subscription.py
@@ -48,7 +48,7 @@ points:
 
 A task type with no policy behaves exactly as before (principal-grain). The
 policy owns its own bookkeeping — the chart-data policy, for instance, stores
-its per-tab set in the task's ``private["task"]`` namespace (see
+its per-tab set in the task's ``private["subscription"]`` namespace (see
 :class:`superset_core.tasks.types.PrivateProperties`), which the framework never
 inspects. ``client_ref`` is an opaque, client-supplied identifier (e.g. a
 browser-tab id); it is **not** an authorization token — the framework has
@@ -72,7 +72,7 @@ class TaskSubscriptionPolicy(ABC):
     (``@task(..., subscription_policy=MyPolicy())``). Both hooks run in the web
     request process, inside the distributed lock that serializes concurrent
     submit/cancel for the task, so an implementation may safely read-modify-write
-    task state (e.g. a list in ``private["task"]``) without additional locking.
+    task state (e.g. a list in ``private["subscription"]``) without additional locking.
     """
 
     @abstractmethod

--- a/superset-core/src/superset_core/tasks/types.py
+++ b/superset-core/src/superset_core/tasks/types.py
@@ -114,19 +114,25 @@ class PrivateProperties(TypedDict, total=False):
     """Internal task runtime state, stored under ``TaskProperties["private"]``.
 
     Never surfaced to user-facing API payloads except in debug mode; distinct
-    from task output, which belongs in the task's ``payload``. Split into two
+    from task output, which belongs in the task's ``payload``. Split into three
     structurally isolated namespaces so a task type's freeform key can never
-    collide with a framework orchestration key:
+    collide with a framework orchestration key or a subscription policy's
+    bookkeeping:
 
     - ``framework``: named framework-owned keys, common to all tasks (see
       ``FrameworkPrivateProperties``).
     - ``task``: freeform, task-type-specific internal handles, written only by
       task/execution code. E.g. the chart-data query task stores its engine
       cancel handle here (``cancel_query_id`` / ``cancel_database_id``).
+    - ``subscription``: freeform bookkeeping owned by the task type's
+      ``SubscriptionPolicy`` (see ``superset_core.tasks.subscription``), written
+      only through the policy hooks. E.g. the chart-data policy stores its
+      per-client consumer list here. The framework never inspects it.
     """
 
     framework: "FrameworkPrivateProperties"
     task: dict[str, Any]
+    subscription: dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/superset-frontend/src/features/tasks/TaskPayloadPopover.test.tsx
+++ b/superset-frontend/src/features/tasks/TaskPayloadPopover.test.tsx
@@ -39,6 +39,24 @@ test('shows results plus a separate internal section when private is present', a
   expect(screen.getByText(/celery_task_id/)).toBeInTheDocument();
 });
 
+test('shows the internal section for subscription-policy bookkeeping alone', async () => {
+  render(
+    <TaskPayloadPopover
+      payload={{}}
+      taskPrivate={{
+        framework: {},
+        task: {},
+        subscription: { consumers: ['user:1:tabA'] },
+      }}
+    />,
+  );
+
+  fireEvent.mouseEnter(screen.getByRole('img'));
+
+  expect(await screen.findByText('Internal')).toBeInTheDocument();
+  expect(screen.getByText(/consumers/)).toBeInTheDocument();
+});
+
 test('shows only the results payload when private is empty', async () => {
   render(
     <TaskPayloadPopover

--- a/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
+++ b/superset-frontend/src/features/tasks/TaskPayloadPopover.tsx
@@ -80,7 +80,9 @@ export default function TaskPayloadPopover({
 
   const hasPayload = hasContent(payload);
   const hasPrivate =
-    hasContent(taskPrivate?.framework) || hasContent(taskPrivate?.task);
+    hasContent(taskPrivate?.framework) ||
+    hasContent(taskPrivate?.task) ||
+    hasContent(taskPrivate?.subscription);
 
   const content = (
     <PayloadContainer>

--- a/superset-frontend/src/features/tasks/types.ts
+++ b/superset-frontend/src/features/tasks/types.ts
@@ -56,8 +56,8 @@ export enum TaskScope {
 
 /**
  * Internal, debug-only task state, under `properties.private`. Present in API
- * responses only in debug mode. Two isolated namespaces so a task-specific key
- * can never collide with a framework key.
+ * responses only in debug mode. Isolated namespaces so a task-specific key can
+ * never collide with a framework key or a subscription policy's bookkeeping.
  */
 export interface TaskPrivateProperties {
   // Framework-owned orchestration + error debug.
@@ -69,6 +69,8 @@ export interface TaskPrivateProperties {
   };
   // Freeform task-type-specific handles (e.g. cancel_query_id/cancel_database_id).
   task?: Record<string, unknown>;
+  // Subscription-policy bookkeeping (e.g. chart-data's per-tab consumer list).
+  subscription?: Record<string, unknown>;
 }
 
 /**

--- a/superset/daos/tasks.py
+++ b/superset/daos/tasks.py
@@ -18,10 +18,11 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Literal, TypedDict
+from typing import Any, cast, Literal, TypedDict
 from uuid import UUID
 
 import sqlalchemy as sa
+from sqlalchemy.orm import object_session
 from sqlalchemy.sql.elements import ColumnElement
 from superset_core.tasks.types import TaskProperties, TaskScope, TaskStatus
 
@@ -722,6 +723,64 @@ class TaskDAO(BaseDAO[Task]):
         return [required_by_uuid for (required_by_uuid,) in rows]
 
     @classmethod
+    def _with_current_subscription_state(
+        cls, task_uuid: UUID, properties: TaskProperties
+    ) -> TaskProperties:
+        """Return ``properties`` with ``private.subscription`` as it is on the row.
+
+        Reads the row under ``FOR UPDATE`` so the subsequent UPDATE and a
+        concurrent policy write (:meth:`merge_subscription_state`, which takes the
+        same lock) serialize instead of racing; a missing row yields the input
+        unchanged and the caller's UPDATE then matches nothing.
+        """
+        from superset.tasks.utils import preserve_subscription_state
+
+        current_raw = (
+            db.session.query(Task.properties)
+            .filter(Task.uuid == task_uuid)
+            .with_for_update()
+            .scalar()
+        )
+        if current_raw is None:
+            return properties
+        return preserve_subscription_state(properties, parse_properties(current_raw))
+
+    @classmethod
+    def merge_subscription_state(cls, task: Task, updates: dict[str, Any]) -> None:
+        """Merge ``updates`` into the task's ``private.subscription`` namespace.
+
+        The write path for subscription-policy hooks (chart-data's per-tab
+        consumer list). Hooks run under the submit/cancel lock, but the executor
+        does not hold that lock and keeps writing the task's properties while it
+        runs (``is_abortable``, the engine cancel handle, progress), so two things
+        are needed for the two writers not to clobber each other: the entity is
+        refreshed from a row-locked read before merging, so the merge lands on top
+        of whatever the executor has committed since the caller loaded the task
+        rather than on the caller's stale copy; and the executor's whole-blob
+        writes take the same row lock and re-read this namespace
+        (:meth:`_with_current_subscription_state`). Pending changes on the
+        session are flushed first so the refresh cannot discard them. A task not
+        attached to a session (a bare model in a unit test) is merged in memory.
+        """
+        from superset.tasks.utils import SUBSCRIPTION_PRIVATE_NAMESPACE
+
+        if object_session(task) is not None and task.id is not None:
+            db.session.flush()
+            (
+                db.session.query(Task)
+                .filter(Task.id == task.id)
+                .with_for_update()
+                .populate_existing()
+                .one()
+            )
+        task.update_properties(
+            cast(
+                TaskProperties,
+                {"private": {SUBSCRIPTION_PRIVATE_NAMESPACE: updates}},
+            )
+        )
+
+    @classmethod
     def set_properties_and_payload(
         cls,
         task_uuid: UUID,
@@ -742,8 +801,15 @@ class TaskDAO(BaseDAO[Task]):
         It does NOT touch the status column, so it's safe to use concurrently
         with operations that modify status (like abort).
 
+        The one exception to "zero-read" is the ``private.subscription`` subtree:
+        it is owned by the task type's subscription policy and written under the
+        submit/cancel lock, which the executor does not hold, so a complete-blob
+        write re-reads that subtree from the row (under a row lock) and carries it
+        through instead of overwriting it with the executor's pickup-time snapshot.
+
         :param task_uuid: UUID of the task to update
-        :param properties: Complete properties dict to write (replaces existing)
+        :param properties: Complete properties dict to write (replaces existing,
+            except ``private.subscription`` which is preserved from the row)
         :param payload: Complete payload dict to write (replaces existing)
         :returns: True if task was updated, False if not found or nothing to update
         """
@@ -754,7 +820,9 @@ class TaskDAO(BaseDAO[Task]):
         update_values: dict[str, Any] = {}
 
         if properties is not None:
-            # Write complete properties (caller manages merging in their cache)
+            # Write complete properties (caller manages merging in their cache),
+            # keeping the policy-owned subscription subtree as it is on the row.
+            properties = cls._with_current_subscription_state(task_uuid, properties)
             update_values["properties"] = json.dumps(properties)
 
         if payload is not None:
@@ -825,6 +893,11 @@ class TaskDAO(BaseDAO[Task]):
         update_values: dict[str, Any] = {"status": new_status_val}
 
         if properties is not None:
+            # A terminal write carries the executor's full property cache; keep the
+            # policy-owned subscription subtree from the row (see
+            # ``set_properties_and_payload``) so a late-joining client is still
+            # routed the completion it is waiting for.
+            properties = cls._with_current_subscription_state(task_uuid, properties)
             update_values["properties"] = json.dumps(properties)
 
         # Store as naive UTC (see ``naive_utcnow``), matching Task.set_status.

--- a/superset/models/tasks.py
+++ b/superset/models/tasks.py
@@ -180,9 +180,11 @@ class Task(CoreTask, AuditMixinNullable, Model):
 
         Only updates fields present in the updates dict. Top-level keys are
         shallow-merged, but the ``private`` subtree is merged *recursively* — its
-        ``framework`` and ``task`` namespaces (and the keys within each) merge
-        independently, so a write to one namespace never clobbers the other or
-        drops earlier keys.
+        ``framework``, ``task`` and ``subscription`` namespaces (and the keys
+        within each) merge independently, so a write to one namespace never
+        clobbers the others or drops earlier keys. The ``subscription`` namespace
+        is written through ``TaskDAO.merge_subscription_state`` (a row-locked
+        merge) rather than directly, see that method for why.
 
         :param updates: TaskProperties dict with fields to update
 

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import Any, Iterator, TYPE_CHECKING
+from typing import Any, cast, Iterator, TYPE_CHECKING
 from uuid import UUID
 
 from flask import current_app
@@ -43,7 +43,10 @@ from superset.tasks.query_cancel import (
     capture_cancel_query_id,
 )
 from superset.tasks.subscription import get_request_tab_id, TaskSubscriptionPolicy
-from superset.tasks.utils import floored_status_cursor
+from superset.tasks.utils import (
+    floored_status_cursor,
+    SUBSCRIPTION_PRIVATE_NAMESPACE,
+)
 from superset.utils.core import override_user
 
 if TYPE_CHECKING:
@@ -81,12 +84,17 @@ class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
     other tab's still-pending query.
 
     This policy keeps a list of ``"<principal>:<tab_id>"`` entries in the task's
-    ``private["task"]`` namespace (framework-invisible, task-owned, debug-gated).
-    On subscribe it adds the calling tab; on unsubscribe it removes the calling
-    tab and reports whether the principal has any tab left, so the framework
-    aborts the task only once the principal's last tab is gone. Both hooks run
-    under the submit/cancel lock, so the read-modify-write on the list is
-    race-free.
+    ``private["subscription"]`` namespace (policy-owned, debug-gated). On
+    subscribe it adds the calling tab; on unsubscribe it removes the calling tab
+    and reports whether the principal has any tab left, so the framework aborts
+    the task only once the principal's last tab is gone. Both hooks run under the
+    submit/cancel lock, so the read-modify-write on the list is race-free against
+    other submits/cancels; the executor, which does not hold that lock, writes
+    the task's properties while it runs, so the list is written through
+    ``TaskDAO.merge_subscription_state`` (a row-locked merge) and the executor's
+    whole-blob writes preserve this namespace rather than replacing it with their
+    pickup-time snapshot. Otherwise a tab joining mid-execution would be dropped
+    and the other tab's detach would abort work it still awaits.
 
     A request without a ``tab_id`` (a non-interactive or legacy caller) is a
     no-op on subscribe and proceeds (principal-grain) on unsubscribe; in practice
@@ -96,9 +104,17 @@ class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
     @staticmethod
     def _consumers(task: "CoreTask") -> list[str]:
         private = task.properties_dict.get("private") or {}
-        task_private = private.get("task") or {}
-        consumers = task_private.get(CONSUMERS_PRIVATE_KEY) or []
+        subscription = private.get(SUBSCRIPTION_PRIVATE_NAMESPACE) or {}
+        consumers = subscription.get(CONSUMERS_PRIVATE_KEY) or []
         return [entry for entry in consumers if isinstance(entry, str)]
+
+    @staticmethod
+    def _write_consumers(task: "CoreTask", consumers: list[str]) -> None:
+        from superset.daos.tasks import TaskDAO
+
+        TaskDAO.merge_subscription_state(
+            cast("Task", task), {CONSUMERS_PRIVATE_KEY: consumers}
+        )
 
     def on_subscribe(
         self, task: "CoreTask", *, principal: str, client_ref: str | None
@@ -107,7 +123,7 @@ class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
             return
         entry = f"{principal}:{client_ref}"
         if entry not in (consumers := self._consumers(task)):
-            task.update_task_private({CONSUMERS_PRIVATE_KEY: [*consumers, entry]})
+            self._write_consumers(task, [*consumers, entry])
 
     def on_unsubscribe(
         self, task: "CoreTask", *, principal: str, client_ref: str | None
@@ -124,7 +140,7 @@ class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
             entry = f"{principal}:{client_ref}"
             remaining = [c for c in consumers if c != entry]
         if remaining != consumers:
-            task.update_task_private({CONSUMERS_PRIVATE_KEY: remaining})
+            self._write_consumers(task, remaining)
         # Proceed to unsubscribe the principal only once it has no tab left on
         # this task; a surviving tab of the same principal keeps it subscribed.
         return not any(c.startswith(prefix) for c in remaining)

--- a/superset/tasks/guest.py
+++ b/superset/tasks/guest.py
@@ -39,8 +39,9 @@ def get_current_guest_subscriber_key() -> str | None:
     ``None`` when the request is not an embedded guest (an authenticated user
     subscribes by ``user_id`` instead). The key is an HMAC over the guest token's
     stable identifying claims, keyed with the app ``SECRET_KEY`` so it is
-    unguessable to outside callers and reproducible for the same token across the
-    request that schedules a task and the polls that await it.
+    unguessable to outside callers and reproducible across the request that
+    schedules a task and the polls that await it, including polls made with a
+    refreshed token carrying the same scope.
     """
     guest_user = security_manager.get_current_guest_user_if_guest()
     if not guest_user:
@@ -48,15 +49,18 @@ def get_current_guest_subscriber_key() -> str | None:
     token = guest_user.guest_token
     # Bind the key to every authorization-relevant claim so two tokens that differ
     # in their effective access scope derive different keys (and can't see each
-    # other's tasks): ``iat``/``exp`` pin it to a single issuance, ``resources``/
-    # ``datasets``/``rev`` to the granted resources, and ``rls_rules`` to the
-    # row-level scope.
+    # other's tasks): ``resources``/``datasets``/``rev`` to the granted resources
+    # and ``rls_rules`` to the row-level scope. Issuance claims (``iat``/``exp``)
+    # are deliberately left out: the embedded SDK re-issues the token on a fixed
+    # cadence (shortly before ``exp``), and a key that changed with each issuance
+    # would stop matching the subscriber row mid-query, so the polls after a
+    # refresh could no longer see the task and the chart would spin to the stale
+    # timeout. Tokens with identical scope claims carry identical entitlements,
+    # so sharing a key across them grants nothing extra.
     message = json.dumps(
         {
             "user": token.get("user"),
             "resources": token.get("resources"),
-            "iat": token.get("iat"),
-            "exp": token.get("exp"),
             "aud": token.get("aud"),
             "datasets": token.get("datasets"),
             "rev": token.get("rev"),

--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -368,10 +368,11 @@ def merge_private_subtree(
 ) -> dict[str, Any]:
     """Recursively merge the ``private`` properties subtree, per namespace.
 
-    Each namespace (``framework``, ``task``) is a dict merged independently, so a
-    write to one never clobbers the other or drops earlier keys — this is what
-    structurally isolates task-owned freeform keys from framework orchestration
-    keys. Defensive against a malformed persisted value: a non-dict subtree or a
+    Each namespace (``framework``, ``task``, ``subscription``) is a dict merged
+    independently, so a write to one never clobbers the others or drops earlier
+    keys — this is what structurally isolates task-owned freeform keys from
+    framework orchestration keys and from subscription-policy bookkeeping.
+    Defensive against a malformed persisted value: a non-dict subtree or a
     non-dict namespace is treated as empty rather than raising ``TypeError`` on
     unpacking (``private`` is framework-managed, so this only guards corrupted or
     externally-tampered rows).
@@ -386,6 +387,49 @@ def merge_private_subtree(
         else:
             merged[namespace] = ns_updates
     return merged
+
+
+# ``private`` namespace owned by a task type's subscription policy (per-client
+# bookkeeping such as chart-data's per-tab consumer list). Written only from the
+# policy hooks, under the submit/cancel lock; the executor never writes it, and
+# its whole-blob writes carry the row's current value through
+# :func:`preserve_subscription_state`.
+SUBSCRIPTION_PRIVATE_NAMESPACE = "subscription"
+
+
+def preserve_subscription_state(
+    incoming: TaskProperties, current: TaskProperties | None
+) -> TaskProperties:
+    """Return ``incoming`` with ``private.subscription`` taken from ``current``.
+
+    The executor writes the complete property blob from an in-memory cache it
+    snapshotted when it picked the task up, and does not hold the submit/cancel
+    lock. A client that subscribed since the snapshot (a second browser tab
+    joining a SHARED chart-data task) would be silently dropped by such a write,
+    after which the first tab's detach would abort work the second still awaits,
+    and per-tab status fanout would skip it. Whole-blob writers run their value
+    through this helper with the row's current properties (read under the same
+    row lock as the UPDATE) so that subtree always reflects the policy's latest
+    write, whatever the executor's cache holds.
+    """
+    result: dict[str, Any] = dict(incoming)
+    private_value = result.get("private")
+    private: dict[str, Any] = (
+        dict(private_value) if isinstance(private_value, dict) else {}
+    )
+    current_private = current.get("private") if isinstance(current, dict) else None
+    current_subtree = (
+        current_private.get(SUBSCRIPTION_PRIVATE_NAMESPACE)
+        if isinstance(current_private, dict)
+        else None
+    )
+    if isinstance(current_subtree, dict):
+        private[SUBSCRIPTION_PRIVATE_NAMESPACE] = current_subtree
+    else:
+        private.pop(SUBSCRIPTION_PRIVATE_NAMESPACE, None)
+    if private or "private" in result:
+        result["private"] = private
+    return cast(TaskProperties, result)
 
 
 def merge_properties(

--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -21,7 +21,7 @@ import logging
 import traceback
 from datetime import datetime, timezone
 from http.client import HTTPResponse
-from typing import Any, cast, TYPE_CHECKING
+from typing import Any, cast, Final, TYPE_CHECKING
 from urllib import request
 from uuid import UUID, uuid4
 
@@ -394,7 +394,7 @@ def merge_private_subtree(
 # policy hooks, under the submit/cancel lock; the executor never writes it, and
 # its whole-blob writes carry the row's current value through
 # :func:`preserve_subscription_state`.
-SUBSCRIPTION_PRIVATE_NAMESPACE = "subscription"
+SUBSCRIPTION_PRIVATE_NAMESPACE: Final = "subscription"
 
 
 def preserve_subscription_state(
@@ -438,11 +438,12 @@ def merge_properties(
     """Merge ``updates`` into ``current`` with task-properties semantics.
 
     Top-level keys are shallow-merged; the ``private`` subtree merges recursively
-    (see :func:`merge_private_subtree`), so writing one namespace never clobbers the
-    other. This is the pure form of :meth:`superset.models.tasks.Task.update_properties`
-    — use it to build a complete properties dict for a zero-read write (e.g. a
-    terminal FAILURE that must preserve the executor's runtime state while adding
-    error detail) without loading the ORM entity.
+    (see :func:`merge_private_subtree`), so writing one namespace never clobbers
+    the others. This is the pure form of
+    :meth:`superset.models.tasks.Task.update_properties` — use it to build a
+    complete properties dict for a zero-read write (e.g. a terminal FAILURE that
+    must preserve the executor's runtime state while adding error detail) without
+    loading the ORM entity.
     """
     merged: dict[str, Any] = dict(current or {})
     incoming: dict[str, Any] = dict(updates)

--- a/tests/integration_tests/tasks/commands/test_cancel.py
+++ b/tests/integration_tests/tasks/commands/test_cancel.py
@@ -513,7 +513,11 @@ def test_cancel_shared_task_not_subscribed_raises_not_found(
 
 def _consumers(task) -> list[str]:
     """Read the chart-data per-tab consumer list off a task's private state."""
-    return task.properties_dict.get("private", {}).get("task", {}).get("consumers", [])
+    return (
+        task.properties_dict.get("private", {})
+        .get("subscription", {})
+        .get("consumers", [])
+    )
 
 
 def test_cancel_detaches_one_tab_and_keeps_task_alive(app_context, get_user) -> None:
@@ -532,8 +536,8 @@ def test_cancel_detaches_one_tab_and_keeps_task_alive(app_context, get_user) -> 
     )
     task.created_by = admin
     # Two tabs of the same principal are watching (single subscriber row).
-    task.update_task_private(
-        {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
+    TaskDAO.merge_subscription_state(
+        task, {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
     )
     db.session.commit()
 
@@ -645,8 +649,8 @@ def test_force_cancel_aborts_regardless_of_tabs(app_context, get_user) -> None:
         user_id=admin.id,
     )
     task.created_by = admin
-    task.update_task_private(
-        {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
+    TaskDAO.merge_subscription_state(
+        task, {"consumers": [f"user:{admin.id}:tabA", f"user:{admin.id}:tabB"]}
     )
     db.session.commit()
 

--- a/tests/integration_tests/tasks/commands/test_cancel.py
+++ b/tests/integration_tests/tasks/commands/test_cancel.py
@@ -572,7 +572,7 @@ def test_cancel_last_tab_aborts_shared_task(app_context, get_user) -> None:
         user_id=admin.id,
     )
     task.created_by = admin
-    task.update_task_private({"consumers": [f"user:{admin.id}:tabA"]})
+    TaskDAO.merge_subscription_state(task, {"consumers": [f"user:{admin.id}:tabA"]})
     db.session.commit()
 
     try:
@@ -611,8 +611,8 @@ def test_cancel_last_tab_of_one_user_unsubscribes_not_aborts(
             )
             db.session.commit()
         TaskDAO.add_subscriber(task.id, user_id=gamma.id)
-        task.update_task_private(
-            {"consumers": [f"user:{admin.id}:tabA", f"user:{gamma.id}:tabB"]}
+        TaskDAO.merge_subscription_state(
+            task, {"consumers": [f"user:{admin.id}:tabA", f"user:{gamma.id}:tabB"]}
         )
         db.session.commit()
 

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -776,3 +776,161 @@ def test_get_statuses_changed_since_narrows_by_task_type(
     statuses, _ = TaskDAO.get_statuses_changed_since(boundary, task_type="tracked_type")
 
     assert list(statuses) == [str(TASK_UUID)]
+
+
+def test_set_properties_and_payload_preserves_subscription_state(
+    session_with_task: Session,
+) -> None:
+    """An executor whole-blob write keeps the policy-owned subscription subtree.
+
+    Models a browser tab joining a SHARED task after the worker snapshotted the
+    properties at pickup: the executor's next write must not drop the tab.
+    """
+    from superset.daos.tasks import TaskDAO
+
+    task = create_task(
+        session_with_task,
+        task_uuid=TASK_UUID,
+        task_key="preserve-subscription",
+        properties={"is_abortable": False},
+    )
+    executor_snapshot = dict(task.properties_dict)  # worker pickup: no tabs yet
+
+    TaskDAO.merge_subscription_state(task, {"consumers": ["user:1:tabA"]})
+    session_with_task.flush()
+
+    executor_snapshot["is_abortable"] = True
+    executor_snapshot["private"] = {"task": {"cancel_query_id": "q1"}}
+    assert TaskDAO.set_properties_and_payload(
+        TASK_UUID,
+        properties=executor_snapshot,
+    )
+
+    session_with_task.expire_all()
+    fresh = session_with_task.query(Task).filter(Task.uuid == TASK_UUID).one()
+    private = fresh.properties_dict["private"]
+    assert fresh.properties_dict["is_abortable"] is True
+    assert private["task"] == {"cancel_query_id": "q1"}
+    assert private["subscription"] == {"consumers": ["user:1:tabA"]}
+
+
+def test_conditional_status_update_preserves_subscription_state(
+    session_with_task: Session,
+) -> None:
+    """A terminal transition carrying properties keeps the subscription subtree."""
+    from superset.daos.tasks import TaskDAO
+
+    task = create_task(
+        session_with_task,
+        task_uuid=TASK_UUID,
+        task_key="terminal-preserve-subscription",
+        status=TaskStatus.IN_PROGRESS,
+    )
+    TaskDAO.merge_subscription_state(task, {"consumers": ["user:1:tabA"]})
+    session_with_task.flush()
+
+    assert TaskDAO.conditional_status_update(
+        task_uuid=TASK_UUID,
+        new_status=TaskStatus.FAILURE,
+        expected_status=TaskStatus.IN_PROGRESS,
+        properties={"error_message": "boom"},
+        set_ended_at=True,
+    )
+
+    session_with_task.expire_all()
+    fresh = session_with_task.query(Task).filter(Task.uuid == TASK_UUID).one()
+    assert fresh.status == TaskStatus.FAILURE.value
+    assert fresh.properties_dict["error_message"] == "boom"
+    assert fresh.properties_dict["private"]["subscription"] == {
+        "consumers": ["user:1:tabA"]
+    }
+
+
+def test_merge_subscription_state_keeps_executor_written_keys(
+    session_with_task: Session,
+) -> None:
+    """A policy write lands on top of what the executor committed meanwhile.
+
+    The caller's entity is stale (loaded before the executor's write); the merge
+    must refresh first so the executor's keys survive the flush.
+    """
+    from superset.daos.tasks import TaskDAO
+
+    task = create_task(
+        session_with_task,
+        task_uuid=TASK_UUID,
+        task_key="merge-keeps-executor-keys",
+        properties={"is_abortable": False},
+    )
+    # Executor writes while the caller still holds the pre-write entity.
+    assert TaskDAO.set_properties_and_payload(
+        TASK_UUID,
+        properties={
+            "is_abortable": True,
+            "private": {"task": {"cancel_query_id": "q1"}},
+        },
+    )
+    assert task.properties_dict["is_abortable"] is False  # stale copy
+
+    TaskDAO.merge_subscription_state(task, {"consumers": ["user:1:tabA"]})
+    session_with_task.flush()
+
+    session_with_task.expire_all()
+    fresh = session_with_task.query(Task).filter(Task.uuid == TASK_UUID).one()
+    assert fresh.properties_dict["is_abortable"] is True
+    assert fresh.properties_dict["private"]["task"] == {"cancel_query_id": "q1"}
+    assert fresh.properties_dict["private"]["subscription"] == {
+        "consumers": ["user:1:tabA"]
+    }
+
+
+def test_merge_subscription_state_on_detached_task_merges_in_memory() -> None:
+    """A bare model (no session) is merged in memory, keeping other namespaces."""
+    from superset.daos.tasks import TaskDAO
+
+    task = Task()
+    task.update_properties({"private": {"task": {"cancel_query_id": "q1"}}})
+    TaskDAO.merge_subscription_state(task, {"consumers": ["user:1:tabA"]})
+    assert task.properties_dict["private"] == {
+        "task": {"cancel_query_id": "q1"},
+        "subscription": {"consumers": ["user:1:tabA"]},
+    }
+
+
+def test_chart_policy_join_during_execution_survives_executor_write(
+    session_with_task: Session,
+) -> None:
+    """End-to-end shape of the bug: a second tab joins while the worker runs.
+
+    Tab A submits, the worker snapshots the properties, tab B joins, then the
+    worker flags the task abortable. Afterwards both tabs must still be routed
+    and tab A's detach must not abort the task tab B is waiting on.
+    """
+    from superset.daos.tasks import TaskDAO
+    from superset.tasks.async_queries import ChartQueryConsumerPolicy
+
+    policy = ChartQueryConsumerPolicy()
+    task = create_task(
+        session_with_task,
+        task_uuid=TASK_UUID,
+        task_key="join-during-execution",
+        properties={"is_abortable": False},
+    )
+    policy.on_subscribe(task, principal="user:1", client_ref="tabA")
+    session_with_task.flush()
+    executor_snapshot = dict(task.properties_dict)  # worker pickup: sees tab A
+
+    policy.on_subscribe(task, principal="user:1", client_ref="tabB")
+    session_with_task.flush()
+
+    executor_snapshot["is_abortable"] = True  # ctx._set_abortable() write
+    assert TaskDAO.set_properties_and_payload(
+        TASK_UUID,
+        properties=executor_snapshot,
+    )
+
+    session_with_task.expire_all()
+    fresh = session_with_task.query(Task).filter(Task.uuid == TASK_UUID).one()
+    assert fresh.properties_dict["is_abortable"] is True
+    assert policy.routing_channels(fresh) == ["user:1:tabA", "user:1:tabB"]
+    assert policy.on_unsubscribe(fresh, principal="user:1", client_ref="tabA") is False

--- a/tests/unit_tests/daos/test_tasks.py
+++ b/tests/unit_tests/daos/test_tasks.py
@@ -794,7 +794,7 @@ def test_set_properties_and_payload_preserves_subscription_state(
         task_key="preserve-subscription",
         properties={"is_abortable": False},
     )
-    executor_snapshot = dict(task.properties_dict)  # worker pickup: no tabs yet
+    executor_snapshot = task.properties_dict.copy()  # worker pickup: no tabs yet
 
     TaskDAO.merge_subscription_state(task, {"consumers": ["user:1:tabA"]})
     session_with_task.flush()
@@ -918,7 +918,7 @@ def test_chart_policy_join_during_execution_survives_executor_write(
     )
     policy.on_subscribe(task, principal="user:1", client_ref="tabA")
     session_with_task.flush()
-    executor_snapshot = dict(task.properties_dict)  # worker pickup: sees tab A
+    executor_snapshot = task.properties_dict.copy()  # worker pickup: sees tab A
 
     policy.on_subscribe(task, principal="user:1", client_ref="tabB")
     session_with_task.flush()

--- a/tests/unit_tests/tasks/test_async_queries.py
+++ b/tests/unit_tests/tasks/test_async_queries.py
@@ -381,7 +381,11 @@ def _make_task(properties: "TaskProperties | None" = None):
 
 
 def _consumers(task) -> list[str]:
-    return task.properties_dict.get("private", {}).get("task", {}).get("consumers", [])
+    return (
+        task.properties_dict.get("private", {})
+        .get("subscription", {})
+        .get("consumers", [])
+    )
 
 
 def test_chart_query_task_registers_subscription_policy() -> None:

--- a/tests/unit_tests/tasks/test_guest.py
+++ b/tests/unit_tests/tasks/test_guest.py
@@ -91,8 +91,6 @@ def test_scope_affecting_claims_change_the_key(mocker: MockerFixture) -> None:
         ("resources", [{"type": "dashboard", "id": "xyz"}]),
         ("datasets", [3]),
         ("rev", 2),
-        ("exp", 3000),
-        ("iat", 1500),
         ("aud", "other-audience"),
         ("user", {"username": "other"}),
     ):
@@ -100,6 +98,22 @@ def test_scope_affecting_claims_change_the_key(mocker: MockerFixture) -> None:
         assert get_current_guest_subscriber_key() != baseline, (
             f"differing {claim} should derive a different key"
         )
+
+
+def test_refreshed_token_with_same_scope_keeps_the_key(mocker: MockerFixture) -> None:
+    """A re-issued token (new iat/exp, same scope) must keep the subscriber key.
+
+    The embedded SDK refreshes the guest token on a fixed cadence, so a key that
+    changed per issuance would stop matching the subscriber row mid-query and the
+    polls after a refresh could no longer see the task.
+    """
+    from superset.tasks.guest import get_current_guest_subscriber_key
+
+    _patch_guest(mocker, _guest_token(iat=1000, exp=2000))
+    baseline = get_current_guest_subscriber_key()
+
+    _patch_guest(mocker, _guest_token(iat=1995, exp=2995))
+    assert get_current_guest_subscriber_key() == baseline
 
 
 def test_unrelated_claims_do_not_change_the_key(mocker: MockerFixture) -> None:


### PR DESCRIPTION
### SUMMARY

Fixes for the two remaining review findings on #43407.

**Per-tab consumer list lost on executor writes.** `ChartQueryConsumerPolicy` kept its `"<principal>:<tab_id>"` list in `private.task`, but `TaskContext` snapshots the whole properties blob at pickup and every later write (`_set_abortable`, `update_task`, the terminal transition) replaced the column with that snapshot. A tab that joined a SHARED task after the worker picked it up was silently dropped: the other tab's detach then aborted work the joining tab still awaited, and per-tab `task.status` fanout skipped it. For contribution charts the window is the whole totals query.

The list now lives in a policy-owned `private.subscription` namespace. Policy hooks write it through a new `TaskDAO.merge_subscription_state`, which flushes, refreshes the entity from a `FOR UPDATE` read, and merges, so the write lands on top of whatever the executor committed since the caller loaded the task (this also closes the reverse clobber, where a join could wipe `is_abortable` and the engine cancel handle). The executor's whole-blob writers, `set_properties_and_payload` and `conditional_status_update`, take the same row lock, re-read that subtree and carry it through, so the two writers serialize instead of clobbering each other. The Task List debug bubble shows the new namespace next to `framework`/`task`. Docs and the `superset-core` docstrings are updated to point policies at the new namespace and helper.

**Guest subscriber key rotated with every token refresh.** `get_current_guest_subscriber_key` HMAC'd `iat`/`exp` into the key, but the embedded SDK re-issues the guest token on a fixed cadence (about every 5 minutes at the default lifetime), so the polls after a refresh no longer matched the subscriber row and the chart spun to the stale timeout. Issuance claims are dropped from the message; tokens with identical scope claims carry identical entitlements, so sharing a key across them grants nothing extra.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/daos/test_tasks.py tests/unit_tests/tasks/test_guest.py tests/unit_tests/tasks/test_async_queries.py
pytest tests/integration_tests/tasks/commands/test_cancel.py
npm run test -- src/features/tasks/TaskPayloadPopover.test.tsx
```

New unit tests cover: an executor whole-blob write preserving a consumer added after its snapshot, the terminal transition doing the same, a policy merge keeping executor-written keys it was loaded before, the in-memory fallback for a detached model, the end-to-end join-during-execution shape (tab B joins, worker flags abortable, both tabs still routed and tab A's detach does not abort), and a refreshed guest token keeping its key.

Manual: open a dashboard with a contribution chart in tab A, open the same dashboard in tab B while the totals query is still running, close tab A, and confirm tab B's chart completes instead of erroring with an aborted task.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES`
- [x] Changes UI (debug-only info bubble shows the new `private.subscription` namespace)
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuGcoYy6bWGc9vBTqEB6Aj