### PR TITLE
ci: show the spec diff when the staleness check fails

### DIFF
--- a/.github/workflows/check-openapi-spec-drift.yml
+++ b/.github/workflows/check-openapi-spec-drift.yml
@@ -63,37 +63,47 @@ jobs:
         env:
           SPEC: docs/static/resources/openapi.json
         run: |
-          if ! git diff --quiet -- "$SPEC"; then
-            echo "::error::$SPEC is stale."
-            echo "Regenerate it on the pinned requirements, with no config file:"
-            echo "  SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
-            echo "    FLASK_APP='superset.app:create_app()' superset update-api-docs"
-            git diff --stat -- "$SPEC"
-            # Step summaries cap at 1 MiB and a full regeneration runs to tens of
-            # thousands of lines, so the rendered copy is truncated and the log
-            # keeps the whole thing.
-            {
-              echo '### OpenAPI spec is stale'
-              echo
-              git diff --stat -- "$SPEC"
-              echo
-              echo 'Regenerate with:'
-              echo
-              echo '```bash'
-              echo "SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
-              echo "  FLASK_APP='superset.app:create_app()' superset update-api-docs"
-              echo '```'
-              echo
-              echo '```diff'
-              git diff -- "$SPEC" | head -300
-              echo '```'
-              if [ "$(git diff -- "$SPEC" | wc -l)" -gt 300 ]; then
-                echo
-                echo '_Truncated at 300 lines; see the job log for the full diff._'
-              fi
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "::group::Full diff"
-            git diff -- "$SPEC"
-            echo "::endgroup::"
-            exit 1
+          if git diff --quiet -- "$SPEC"; then
+            exit 0
           fi
+
+          # Staged to a file rather than piped: under pipefail, `head` closing
+          # the pipe SIGPIPE-kills `git diff`, which aborts this step before it
+          # writes the rest of the summary.
+          diff_file="$RUNNER_TEMP/openapi.diff"
+          git diff -- "$SPEC" > "$diff_file"
+
+          echo "::error::$SPEC is stale."
+          echo "Regenerate it on the pinned requirements, with no config file:"
+          echo "  SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
+          echo "    FLASK_APP='superset.app:create_app()' superset update-api-docs"
+          git diff --stat -- "$SPEC"
+
+          # Step summaries cap at 1 MiB and a full regeneration runs to tens of
+          # thousands of lines, so the rendered copy is truncated and the log
+          # keeps the whole thing.
+          {
+            echo '### OpenAPI spec is stale'
+            echo
+            git diff --stat -- "$SPEC"
+            echo
+            echo 'Regenerate with:'
+            echo
+            echo '```bash'
+            echo "SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
+            echo "  FLASK_APP='superset.app:create_app()' superset update-api-docs"
+            echo '```'
+            echo
+            echo '```diff'
+            head -300 "$diff_file"
+            echo '```'
+            if [ "$(wc -l < "$diff_file")" -gt 300 ]; then
+              echo
+              echo '_Truncated at 300 lines; see the job log for the full diff._'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::group::Full diff"
+          cat "$diff_file"
+          echo "::endgroup::"
+          exit 1

--- a/.github/workflows/check-openapi-spec-drift.yml
+++ b/.github/workflows/check-openapi-spec-drift.yml
@@ -60,12 +60,40 @@ jobs:
           FLASK_APP: "superset.app:create_app()"
         run: superset update-api-docs
       - name: Assert the published spec is up to date
+        env:
+          SPEC: docs/static/resources/openapi.json
         run: |
-          if ! git diff --quiet -- docs/static/resources/openapi.json; then
-            echo "::error::docs/static/resources/openapi.json is stale."
+          if ! git diff --quiet -- "$SPEC"; then
+            echo "::error::$SPEC is stale."
             echo "Regenerate it on the pinned requirements, with no config file:"
             echo "  SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
             echo "    FLASK_APP='superset.app:create_app()' superset update-api-docs"
-            git diff --stat -- docs/static/resources/openapi.json
+            git diff --stat -- "$SPEC"
+            # Step summaries cap at 1 MiB and a full regeneration runs to tens of
+            # thousands of lines, so the rendered copy is truncated and the log
+            # keeps the whole thing.
+            {
+              echo '### OpenAPI spec is stale'
+              echo
+              git diff --stat -- "$SPEC"
+              echo
+              echo 'Regenerate with:'
+              echo
+              echo '```bash'
+              echo "SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
+              echo "  FLASK_APP='superset.app:create_app()' superset update-api-docs"
+              echo '```'
+              echo
+              echo '```diff'
+              git diff -- "$SPEC" | head -300
+              echo '```'
+              if [ "$(git diff -- "$SPEC" | wc -l)" -gt 300 ]; then
+                echo
+                echo '_Truncated at 300 lines; see the job log for the full diff._'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::group::Full diff"
+            git diff -- "$SPEC"
+            echo "::endgroup::"
             exit 1
           fi

--- a/.github/workflows/check-openapi-spec-drift.yml
+++ b/.github/workflows/check-openapi-spec-drift.yml
@@ -23,10 +23,8 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
 
-# No `paths:` filter on purpose, matching enforce-single-migration-head: a
-# required check that never runs for a given PR blocks that PR forever. The
-# job is ~10s, so it fires on every PR rather than guessing which file edits
-# can move the spec.
+# Deliberately unfiltered by `paths`: a required check that does not run on a
+# PR blocks it from merging forever.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -46,16 +44,12 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         with:
-          # base.txt pins apispec, which decides the generated output: 6.10.0
-          # renders marshmallow 4's unknown=RAISE as "additionalProperties":
-          # false while the pinned 6.6.1 does not. Regenerating off-pin
-          # produces a spec no CI run can reproduce.
+          # The generated output depends on the pinned apispec version.
           requirements-type: base
       - name: Regenerate the spec
         env:
-          # No SUPERSET_CONFIG_PATH: the published spec documents the routes a
-          # default deployment registers. A config enabling feature flags adds
-          # paths that would 404 for everyone who has not enabled them.
+          # No config file: the spec documents what a default deployment
+          # registers, so feature flags must stay off.
           SUPERSET__SQLALCHEMY_DATABASE_URI: "sqlite:///:memory:"
           FLASK_APP: "superset.app:create_app()"
         run: superset update-api-docs
@@ -67,21 +61,18 @@ jobs:
             exit 0
           fi
 
-          # Staged to a file rather than piped: under pipefail, `head` closing
-          # the pipe SIGPIPE-kills `git diff`, which aborts this step before it
-          # writes the rest of the summary.
+          # Staged to a file, not piped: `head` closing the pipe would
+          # SIGPIPE-kill `git diff` under pipefail and abort this step.
           diff_file="$RUNNER_TEMP/openapi.diff"
           git diff -- "$SPEC" > "$diff_file"
 
-          echo "::error::$SPEC is stale."
-          echo "Regenerate it on the pinned requirements, with no config file:"
-          echo "  SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
-          echo "    FLASK_APP='superset.app:create_app()' superset update-api-docs"
+          regen="SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' FLASK_APP='superset.app:create_app()' superset update-api-docs"
+
+          echo "::error::$SPEC is stale. Regenerate it on the pinned requirements:"
+          echo "$regen"
           git diff --stat -- "$SPEC"
 
-          # Step summaries cap at 1 MiB and a full regeneration runs to tens of
-          # thousands of lines, so the rendered copy is truncated and the log
-          # keeps the whole thing.
+          # Summaries cap at 1 MiB, well under a full regeneration.
           {
             echo '### OpenAPI spec is stale'
             echo
@@ -90,8 +81,7 @@ jobs:
             echo 'Regenerate with:'
             echo
             echo '```bash'
-            echo "SUPERSET__SQLALCHEMY_DATABASE_URI='sqlite:///:memory:' \\"
-            echo "  FLASK_APP='superset.app:create_app()' superset update-api-docs"
+            echo "$regen"
             echo '```'
             echo
             echo '```diff'


### PR DESCRIPTION
### SUMMARY

Follow-up to #43841. The failure reported only a line count, so an author seeing red had to regenerate locally to find out what actually changed — which is what happened when `report_format` drifted in #43910.

The diff now renders as markdown on the job summary page, with the `--stat` headline above it and the regeneration command inline. The full diff stays in a collapsed log group. The summary copy is truncated at 300 lines, since step summaries cap at 1 MiB and a full regeneration runs to tens of thousands of lines — #43788 was 25,334.

### TESTING INSTRUCTIONS

Verified by extracting the step body from the workflow and running it under GitHub's shell (`bash -e -o pipefail`) against a seeded spec:

| Case | Result |
|---|---|
| Clean tree | exit 0, empty summary |
| One added property | exit 1, whole diff rendered, no truncation note |
| 44,011-line / 880 KB diff | exit 1, summary 315 lines / 6.5 KB, truncation note and full-diff group present |

The large case matters because it is the size of a full regeneration, and it is where output handling breaks if the diff is streamed through `head` rather than staged to a file.

```bash
# seed a failing case
python -c "import json;p='docs/static/resources/openapi.json';s=json.load(open(p));\
s['components']['schemas']['ReportScheduleRestApi.get_list']['properties']['probe']={'type':'string'};\
json.dump(s,open(p,'w'),sort_keys=True,indent=2)"
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
