### PR TITLE
fix(cache): key on resolved bounds when a query has no time_range

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -602,8 +602,15 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         if self.time_offsets:
             cache_dict["time_offsets"] = self.time_offsets
 
-        for k in ["from_dttm", "to_dttm"]:
-            del cache_dict[k]
+        # Resolved bounds are normally excluded so a relative range ("Last 7
+        # days") keeps one key as time passes; ``time_range`` stands in for them.
+        # Without it — a caller that passes the range only as a TEMPORAL_RANGE
+        # filter, which ``_apply_granularity`` then removes — they are all that
+        # distinguishes one range from another.
+        for key in ["from_dttm", "to_dttm"]:
+            bound = cache_dict.pop(key)
+            if bound is not None and not self.time_range:
+                cache_dict[key] = bound
 
         annotation_fields = [
             "annotationType",

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -1484,10 +1484,14 @@ async def test_query_dataset_returns_engine_time_bounds(
 
 @pytest.mark.parametrize("empty", [False, True])
 @pytest.mark.asyncio
-async def test_query_dataset_cached_bounds_across_rollover(
+async def test_query_dataset_reexecutes_across_rollover(
     mcp_server: FastMCP, empty: bool
 ) -> None:
-    """Round-trip cached rows while resolving bounds for each MCP request."""
+    """A relative range that rolls over re-executes, so bounds match the rows.
+
+    Sharing one cache entry across the rollover reported the requesting range
+    while serving the earlier range's rows.
+    """
     from datetime import timedelta
 
     from flask import current_app
@@ -1564,19 +1568,19 @@ async def test_query_dataset_cached_bounds_across_rollover(
                 assert "from_dttm" not in stored
                 assert "to_dttm" not in stored
 
-    get_query_result.assert_called_once()
-    assert keys[0] == keys[1]
+    assert get_query_result.call_count == 2
+    assert keys[0] != keys[1]
     fresh_data = json.loads(fresh.content[0].text)
     cached_data = json.loads(cached.content[0].text)
     assert fresh_data["data"] == cached_data["data"] == rows
     assert fresh_data["cache_status"]["cache_hit"] is False
-    assert cached_data["cache_status"]["cache_hit"] is True
+    assert cached_data["cache_status"]["cache_hit"] is False
     assert fresh_data["from_dttm"] == "2026-06-17T00:00:00"
     assert fresh_data["to_dttm"] == "2026-07-17T00:00:00"
     assert cached_data["from_dttm"] == "2026-06-18T00:00:00"
     assert cached_data["to_dttm"] == "2026-07-18T00:00:00"
     assert cached_data["performance"]["cache_status"] == (
-        "no_data" if empty else "cached"
+        "no_data" if empty else "fresh"
     )
 
 

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -851,3 +851,34 @@ def test_exec_post_processing_rejects_string_helpers(
 
     with pytest.raises(InvalidPostProcessingError):
         query_object.exec_post_processing(df)
+
+
+def test_cache_key_distinguishes_bounds_without_time_range():
+    """
+    Regression for the datasource query endpoint: a caller that passes a range
+    only as a ``TEMPORAL_RANGE`` filter has no ``time_range``, and
+    ``QueryContextFactory._apply_granularity`` removes that filter once
+    ``granularity`` names its column. The resolved bounds are then the only
+    thing telling one range from another, so they have to reach the key --
+    otherwise every range collides and the second request is served the first
+    range's rows.
+    """
+    query_object1 = QueryObject(
+        from_dttm=datetime(1965, 1, 1), to_dttm=datetime(1968, 1, 1)
+    )
+    query_object2 = QueryObject(
+        from_dttm=datetime(1966, 1, 1), to_dttm=datetime(1967, 1, 1)
+    )
+
+    assert query_object1.cache_key() != query_object2.cache_key()
+
+
+def test_cache_key_ignores_bounds_when_time_range_is_set():
+    """
+    ``time_range`` stands in for the bounds, so they stay out of the key: a
+    relative range such as "Last week" keeps one key as its bounds advance.
+    """
+    query_object1 = QueryObject(time_range="Last week", from_dttm=datetime(1965, 1, 1))
+    query_object2 = QueryObject(time_range="Last week", from_dttm=datetime(1970, 1, 1))
+
+    assert query_object1.cache_key() == query_object2.cache_key()


### PR DESCRIPTION
### SUMMARY

Fixes a cache-key collision in `POST /api/v1/datasource/<type>/<id>/query` (#43527) that returns one time range's rows for another.

`build_query_dict` carries the range as a `TEMPORAL_RANGE` filter and sets `granularity`, but no `time_range`. Three behaviours then compose:

1. `QueryObjectFactory` resolves `from_dttm`/`to_dttm` from the filter, so the **SQL is correct**.
2. `QueryContextFactory._apply_granularity` deletes the temporal filter, since `granularity` names its column.
3. `QueryObject.cache_key` keeps `time_range` only when set, and drops `from_dttm`/`to_dttm` unconditionally.

Nothing time-related survives, so every range for a datasource shares one key and a second request is served the first range's rows until the entry expires. The frontend always sends `time_range`, which is why `/chart/data` never showed it — but any non-frontend caller passing the range only as a filter hits the same collision, so the fix is in `cache_key`, not in the endpoint.

Step 3 drops the bounds deliberately: a relative range like `"Last 7 days"` must keep one key as time passes, and `time_range` stands in for the bounds. The fix keeps them **only when there is no `time_range`** to stand in — the case where they are the sole thing distinguishing one range from another.

**Existing cache entries stay valid.** Verified by comparing keys across the change: a query with `time_range` set hashes to `fcb9dccc…` before and after, while the filter-only query moves from `47f821a0…` to `d662c4d3…`. Only the broken callers get new keys.

### Commits

1. `test(datasource)` — the collision as a failing test, plus the two invariants that bracket it.
2. `fix(cache)` — the one-branch change, and the marker removed.

### TESTING INSTRUCTIONS

```bash
pytest tests/unit_tests/common/test_tabular_query_cache_key.py
```

Four tests: the range resolves to correct bounds; `_apply_granularity` drops the filter; distinct ranges get distinct keys; and a `time_range` expression still ignores resolved bounds, so relative ranges stay stable. Locally 647 tests pass across `tests/unit_tests/{common,queries,charts,datasource}`, with the wider suite left to CI.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
