### PR TITLE
fix(gtf): thread per-dashboard async_mode override into self-contained charts

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -40,6 +40,7 @@ import { Logger, LOG_ACTIONS_RENDER_CHART } from 'src/logger/LogUtils';
 import { URL_PARAMS } from 'src/constants';
 import { getUrlParam } from 'src/utils/urlUtils';
 import { isCurrentUserBot } from 'src/utils/isBot';
+import type { AsyncModeOverride } from 'src/utils/asyncMode';
 import { ChartSource } from 'src/types/ChartSource';
 import { ResourceStatus } from 'src/hooks/apiResources/apiResources';
 import { Dispatch } from 'redux';
@@ -92,6 +93,8 @@ export interface ChartProps {
   /** Whether to suppress the loading spinner (during auto-refresh) */
   suppressLoadingSpinner?: boolean;
   filterState?: FilterState;
+  /** Per-dashboard `async_mode` override, threaded to self-contained charts. */
+  asyncModeOverride?: AsyncModeOverride;
 }
 
 export type Actions = {
@@ -211,6 +214,7 @@ function Chart({
     onChartStateChange,
     suppressLoadingSpinner,
     filterState,
+    asyncModeOverride,
   } = restProps;
 
   const renderStartTimeRef = useRef<number>(Logger.getTimestamp());
@@ -383,6 +387,7 @@ function Chart({
             filterState={filterState}
             suppressLoadingSpinner={suppressLoadingSpinner}
             source={dashboardId ? ChartSource.Dashboard : ChartSource.Explore}
+            asyncModeOverride={asyncModeOverride}
           />
         ) : (
           <Loading size={dashboardId ? 's' : 'm'} muted={!!dashboardId} />
@@ -393,6 +398,7 @@ function Chart({
       actions,
       addFilter,
       annotationData,
+      asyncModeOverride,
       chartAlert,
       chartId,
       chartIsStale,

--- a/superset-frontend/src/components/Chart/ChartContainer.tsx
+++ b/superset-frontend/src/components/Chart/ChartContainer.tsx
@@ -19,10 +19,21 @@
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch, AnyAction } from 'redux';
 
+import { selectAsyncModeOverride } from 'src/utils/asyncMode';
+import type { StateWithAsyncModeOverride } from 'src/utils/asyncMode';
 import * as actions from './chartAction';
 import { logEvent } from '../../logger/actions';
 import Chart from './Chart';
 import { updateDataMask } from '../../dataMask/actions';
+
+// Read the per-dashboard `async_mode` override here (the connected boundary) so
+// the presentational Chart/ChartRenderer stay store-agnostic. Undefined outside a
+// dashboard (e.g. Explore), which resolves to the deployment default. This lets
+// self-contained charts (StatefulChart / the Matrixify path) honor the override
+// the Redux chart path already applies.
+function mapStateToProps(state: StateWithAsyncModeOverride) {
+  return { asyncModeOverride: selectAsyncModeOverride(state) };
+}
 
 function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
   return {
@@ -37,4 +48,4 @@ function mapDispatchToProps(dispatch: Dispatch<AnyAction>) {
   };
 }
 
-export default connect(null, mapDispatchToProps)(Chart);
+export default connect(mapStateToProps, mapDispatchToProps)(Chart);

--- a/superset-frontend/src/components/Chart/ChartRenderer.test.tsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.test.tsx
@@ -22,6 +22,7 @@ import {
   getChartMetadataRegistry,
   VizType,
   JsonObject,
+  FeatureFlag,
   FeatureFlagMap,
 } from '@superset-ui/core';
 import ChartRenderer, {
@@ -47,6 +48,11 @@ jest.mock('@superset-ui/core', () => ({
       data-test="mock-super-chart"
       data-is-refreshing={isRefreshing ? 'true' : 'false'}
       data-enable-no-results={props.enableNoResults ? 'true' : 'false'}
+      data-async-mode={String(
+        (props.hooks as { resolveAsyncMode?: () => boolean } | undefined)?.[
+          'resolveAsyncMode'
+        ]?.(),
+      )}
     >
       {JSON.stringify(postTransformProps(props).formData)}
     </div>
@@ -435,6 +441,34 @@ test('does not mark chart as refreshing when spinner suppression is disabled', (
     'data-is-refreshing',
     'false',
   );
+});
+
+test('threads the per-dashboard async_mode override into resolveAsyncMode for self-contained charts', () => {
+  // Self-contained charts (e.g. StatefulChart / the Matrixify path) resolve
+  // async mode through the injected `resolveAsyncMode` hook; it must receive the
+  // dashboard override so `force_on`/`force_off` win over the deployment default,
+  // matching the Redux chart path. GAQ must be on for the override to matter.
+  const previousFlags = window.featureFlags;
+  window.featureFlags = {
+    ...previousFlags,
+    [FeatureFlag.GlobalAsyncQueries]: true,
+  } as FeatureFlagMap;
+  try {
+    const { getByTestId, rerender } = render(
+      <ChartRenderer {...requiredProps} asyncModeOverride="force_off" />,
+    );
+    expect(getByTestId('mock-super-chart')).toHaveAttribute(
+      'data-async-mode',
+      'false',
+    );
+    rerender(<ChartRenderer {...requiredProps} asyncModeOverride="force_on" />);
+    expect(getByTestId('mock-super-chart')).toHaveAttribute(
+      'data-async-mode',
+      'true',
+    );
+  } finally {
+    window.featureFlags = previousFlags;
+  }
 });
 
 test('does not render chart during loading when last data has errors', () => {

--- a/superset-frontend/src/components/Chart/ChartRenderer.tsx
+++ b/superset-frontend/src/components/Chart/ChartRenderer.tsx
@@ -58,7 +58,7 @@ import ChartContextMenu, {
   ChartContextMenuRef,
 } from './ChartContextMenu/ChartContextMenu';
 import { handleChartDataResponse } from './chartAction';
-import { resolveAsyncMode } from 'src/utils/asyncMode';
+import { AsyncModeOverride, resolveAsyncMode } from 'src/utils/asyncMode';
 import { getTabId } from 'src/hooks/useTabId';
 
 // Types for filter values
@@ -143,6 +143,7 @@ export interface ChartRendererProps {
   cacheBusterProp?: string;
   onChartStateChange?: (chartState: AgGridChartState) => void;
   suppressLoadingSpinner?: boolean;
+  asyncModeOverride?: AsyncModeOverride;
 }
 
 // Async resolution is injected for self-contained chart components in
@@ -217,6 +218,7 @@ function ChartRendererComponent({
     source,
     emitCrossFilters,
     onChartStateChange,
+    asyncModeOverride,
   } = restProps;
 
   const theme = useTheme();
@@ -401,9 +403,11 @@ function ChartRendererComponent({
       // StatefulChart) resolve async (202) chart-data responses without
       // depending on app-level async-event middleware.
       handleAsyncChartData: handleChartDataResponse,
-      // Shares the async opt-in policy (feature flag + deployment default) with
-      // those self-contained producers so they don't always run synchronously.
-      resolveAsyncMode: () => resolveAsyncMode(),
+      // Shares the async opt-in policy (feature flag + deployment default, plus
+      // the per-dashboard `async_mode` override) with those self-contained
+      // producers so they don't always run synchronously and honor the
+      // dashboard override like the Redux chart path.
+      resolveAsyncMode: () => resolveAsyncMode(asyncModeOverride),
       // Lets those producers send this tab's id on an async request so the
       // backend ref-counts the tab (per-tab cancel/detach), matching the Redux
       // chart path (see chartAction.ts).
@@ -421,6 +425,7 @@ function ChartRendererComponent({
       onFilterMenuOpen,
       setDataMaskCallback,
       showContextMenu,
+      asyncModeOverride,
     ],
   );
 

--- a/superset-frontend/src/utils/asyncMode.ts
+++ b/superset-frontend/src/utils/asyncMode.ts
@@ -28,7 +28,7 @@ import getBootstrapData from 'src/utils/getBootstrapData';
 export type AsyncModeOverride = 'default' | 'force_on' | 'force_off';
 
 /** State shape the override is read from; matches any store holding dashboard info. */
-type StateWithAsyncModeOverride = {
+export type StateWithAsyncModeOverride = {
   dashboardInfo?: { metadata?: { async_mode?: AsyncModeOverride } };
 };
 

--- a/superset/tasks/utils.py
+++ b/superset/tasks/utils.py
@@ -208,6 +208,16 @@ def floored_status_cursor() -> datetime:
     status cursor (the 202 handshake and each poll response) share this helper so
     the precision contract lives in one place.
 
+    Known limitation: this cursor is stamped on the web tier's clock, while a
+    task's ``changed_on`` on a terminal transition is stamped by whichever worker
+    committed it. If a worker's clock trails the web tier by more than the floored
+    second, that completion can sit just under the ``>=`` bound and be skipped by
+    every poll, so a poll-mode client resolves the chart only at its stale timeout
+    (the websocket transport is unaffected — it delivers completion directly). Keep
+    the web and worker tiers clock-synced (e.g. NTP). The robust fix is a
+    DB-stamped status timestamp — as the orphan reaper already uses the DB clock
+    rather than the app clock — which is tracked as a follow-up.
+
     :returns: Current naive-local time with sub-second precision dropped
     """
     return datetime.now().replace(microsecond=0)


### PR DESCRIPTION
### SUMMARY

Follow-up from the [#43407 review](https://github.com/apache/superset/pull/43407#pullrequestreview-5119075015) (non-blocking).

**Per-dashboard `async_mode` override ignored by self-contained charts.** The dashboard `async_mode` override reached the Redux chart path, DrillBy, and native filters (all read `selectAsyncModeOverride`/`useAsyncModeOverride`), but `ChartRenderer` wired the injected `resolveAsyncMode` hook with **no argument** (`resolveAsyncMode: () => resolveAsyncMode()`), so self-contained charts in `@superset-ui/core` (`StatefulChart` — the Matrixify sub-chart path) never saw a dashboard's `force_on`/`force_off` and always fell through to the deployment default.

The override is now read at the connected boundary (`ChartContainer` `mapStateToProps` via `selectAsyncModeOverride`) and threaded through `Chart` → `ChartRenderer` into `resolveAsyncMode(asyncModeOverride)`. `ChartRenderer`/`Chart` stay store-agnostic (no `useSelector` added — `ChartRenderer.test.tsx` renders without a Provider), and `selectAsyncModeOverride` returns `undefined` outside a dashboard (Explore/embedded) which resolves to the default, so behavior there is unchanged. A regression test asserts `force_off`/`force_on` reach the hook.

**Docs note — poll-cursor clock assumption.** Also documents a known limitation in the `floored_status_cursor` docstring: the `status_changes` poll cursor is stamped on the web tier's clock, while a task's `changed_on` on a terminal transition is stamped by whichever worker committed it. If a worker's clock trails the web tier by more than the floored second, that completion sits under the `changed_on >= cursor` bound and a **poll-mode** client resolves the chart only at its stale timeout (the websocket transport is unaffected — it delivers completion directly). Operators should keep the web and worker tiers clock-synced (NTP); the robust fix is a DB-stamped status timestamp (as the orphan reaper already uses the DB clock), tracked as a follow-up in #43407.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

```
npm run test -- src/components/Chart/ChartRenderer.test.tsx
```

Manual: on a deployment with `GLOBAL_ASYNC_QUERIES` enabled, set a dashboard's async override to `force_off` (Properties → Advanced) and confirm a Matrixify chart on it requests synchronous (`200`) chart data instead of async; set it to `force_on` and confirm it goes async.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
