### PR TITLE
fix(plugin-chart-pivot-table): sticky-position row labels and corner header cells

### DIFF
--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -39,6 +39,20 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       top: 0;
     }
 
+    /* Corner cell(s) sitting above the frozen row-label column: the
+     * placeholder cell spanning the column-attribute rows, and the
+     * row-attribute name cell(s) in the final header row. Needs a
+     * higher z-index than .pvtRowLabel so it stays on top when both
+     * stick at the same scroll position. */
+    table.pvtTable thead tr:first-of-type th[aria-hidden='true'],
+    table.pvtTable thead tr:last-of-type th.pvtAxisLabel {
+      position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
+      top: 0;
+      left: 0;
+      z-index: 2;
+      background-color: ${theme.colorBgBase};
+    }
+
     table tbody tr {
       font-feature-settings: 'tnum' 1;
     }
@@ -120,6 +134,10 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
 
     table.pvtTable tbody tr th.pvtRowLabel {
       vertical-align: baseline;
+      position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
+      left: 0;
+      z-index: 1;
+      background-color: ${theme.colorBgBase};
     }
 
     table.pvtTable tbody tr th.pvtRowLabel.pvtRowLabelLast {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -45,18 +45,25 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       z-index: 2;
     }
 
-    /* Corner cell(s) sitting above the frozen row-label column: the
-     * placeholder cell spanning the column-attribute rows, and the
-     * row-attribute name cell(s) in the row-header row (which only
-     * renders when there are row dimensions). The z-index keeps them
-     * over the column labels scrolling underneath within the thead. */
-    table.pvtTable thead tr:first-of-type th[aria-hidden='true'],
+    /* Corner cells sitting above the frozen row-label column: the
+     * column-attribute name cell spanning the full leading block in each
+     * column-header row, and the row-attribute name cell(s) in the
+     * row-header row. Both only render when there are row dimensions.
+     * The z-index keeps them over the column labels scrolling underneath
+     * within the thead. */
+    table.pvtTable thead th.pvtCornerLabel,
     table.pvtTable thead tr.pvtRowHeaderRow th.pvtAxisLabel {
       position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
       top: 0;
       left: 0;
       z-index: 1;
       background-color: ${theme.colorBgBase};
+    }
+
+    /* Keep the column-attribute name next to the column labels it names
+     * rather than at the far left of the merged corner block. */
+    table.pvtTable thead th.pvtCornerLabel {
+      text-align: right;
     }
 
     table tbody tr {
@@ -82,6 +89,15 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
     table.pvtTable tbody tr.pvtRowTotals th,
     table.pvtTable tbody tr.pvtRowTotals td {
       background-color: ${theme.colorBgBase};
+    }
+
+    /* The totals row's leading label freezes at the left edge like the
+     * body row labels above it. The z-index keeps it over the totals
+     * values scrolling underneath within the row's own stacking context. */
+    table.pvtTable tbody tr.pvtRowTotals th.pvtRowTotalLabel {
+      position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
+      left: 0;
+      z-index: 1;
     }
 
     table.pvtTable thead tr:last-of-type th,

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/Styles.ts
@@ -33,23 +33,29 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       line-height: 1.4;
     }
 
+    /* The sticky thead and totals row each form their own stacking
+     * context, so a z-index on a cell inside them can't outrank the
+     * frozen row labels (z-index 1) in the body. The bands themselves
+     * carry the z-index that keeps them painting over row labels
+     * scrolling underneath. */
     table thead {
       background-color: ${theme.colorBgBase};
       position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
       top: 0;
+      z-index: 2;
     }
 
     /* Corner cell(s) sitting above the frozen row-label column: the
      * placeholder cell spanning the column-attribute rows, and the
-     * row-attribute name cell(s) in the final header row. Needs a
-     * higher z-index than .pvtRowLabel so it stays on top when both
-     * stick at the same scroll position. */
+     * row-attribute name cell(s) in the row-header row (which only
+     * renders when there are row dimensions). The z-index keeps them
+     * over the column labels scrolling underneath within the thead. */
     table.pvtTable thead tr:first-of-type th[aria-hidden='true'],
-    table.pvtTable thead tr:last-of-type th.pvtAxisLabel {
+    table.pvtTable thead tr.pvtRowHeaderRow th.pvtAxisLabel {
       position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
       top: 0;
       left: 0;
-      z-index: 2;
+      z-index: 1;
       background-color: ${theme.colorBgBase};
     }
 
@@ -69,6 +75,7 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
     table.pvtTable tbody tr.pvtRowTotals {
       position: ${isDashboardEditMode ? 'inherit' : 'sticky'};
       bottom: 0;
+      z-index: 2;
       background-color: ${theme.colorBgBase};
     }
 
@@ -138,6 +145,23 @@ export const Styles = styled.div<{ isDashboardEditMode: boolean }>`
       left: 0;
       z-index: 1;
       background-color: ${theme.colorBgBase};
+    }
+
+    /* The frozen-cell background above is more specific than the generic
+     * .hoverable:hover and th.active rules, so restate those states here
+     * to keep hover and cross-filter highlighting visible on row labels.
+     * The hover tint is layered as a background-image over the opaque
+     * base so scrolled-under cells don't bleed through a translucent
+     * fill token. */
+    table.pvtTable tbody tr th.pvtRowLabel.hoverable:hover {
+      background-image: linear-gradient(
+        ${theme.colorFillContentHover},
+        ${theme.colorFillContentHover}
+      );
+    }
+
+    table.pvtTable tbody tr th.pvtRowLabel.active {
+      background-color: ${theme.colorPrimaryBg};
     }
 
     table.pvtTable tbody tr th.pvtRowLabel.pvtRowLabelLast {

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1137,12 +1137,29 @@ export function TableRenderer(props: TableRendererProps) {
         namesMapping,
         allowRenderHtml: settingsAllowRenderHtml,
       } = settings;
+      // When column attributes are present, renderTableRow gives the last
+      // row-label cell in the body an extra colSpan to absorb the corner
+      // placeholder column (see colIncrSpan below). Mirror that here by
+      // folding the trailing placeholder into the last axis-label cell
+      // instead of rendering it separately, so the frozen corner block in
+      // the header spans the same columns as the frozen cell it sits above.
+      const mergeTotalLabel =
+        settingsColAttrs.length !== 0 && settingsRowAttrs.length !== 0;
+      const totalLabelClickHandler = clickHeaderHandler(
+        pivotData,
+        [],
+        rows,
+        0,
+        tableOptions.clickRowHeaderCallback,
+        false,
+        true,
+      );
       return (
         <tr key="rowHdr" className="pvtRowHeaderRow">
           {settingsRowAttrs.map((r, i) => {
+            const isLastRowAttr = i === settingsRowAttrs.length - 1;
             const needLabelToggle =
-              settingsRowSubtotalDisplay.enabled === true &&
-              i !== settingsRowAttrs.length - 1;
+              settingsRowSubtotalDisplay.enabled === true && !isLastRowAttr;
             let arrowClickHandle = null;
             let subArrow = null;
             if (needLabelToggle) {
@@ -1154,7 +1171,16 @@ export function TableRenderer(props: TableRendererProps) {
                 i + 1 < maxRowVisible! ? arrowExpanded : arrowCollapsed;
             }
             return (
-              <th className="pvtAxisLabel" key={`rowAttr-${i}`}>
+              <th
+                className="pvtAxisLabel"
+                key={`rowAttr-${i}`}
+                colSpan={isLastRowAttr && mergeTotalLabel ? 2 : undefined}
+                onClick={
+                  isLastRowAttr && mergeTotalLabel
+                    ? totalLabelClickHandler
+                    : undefined
+                }
+              >
                 {displayHeaderCell(
                   needLabelToggle,
                   subArrow,
@@ -1166,21 +1192,15 @@ export function TableRenderer(props: TableRendererProps) {
               </th>
             );
           })}
-          <th
-            className="pvtTotalLabel"
-            key="padding"
-            onClick={clickHeaderHandler(
-              pivotData,
-              [],
-              rows,
-              0,
-              tableOptions.clickRowHeaderCallback,
-              false,
-              true,
-            )}
-          >
-            {settingsColAttrs.length === 0 ? t('Total') : null}
-          </th>
+          {mergeTotalLabel ? null : (
+            <th
+              className="pvtTotalLabel"
+              key="padding"
+              onClick={totalLabelClickHandler}
+            >
+              {t('Total')}
+            </th>
+          )}
         </tr>
       );
     },

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -1138,7 +1138,7 @@ export function TableRenderer(props: TableRendererProps) {
         allowRenderHtml: settingsAllowRenderHtml,
       } = settings;
       return (
-        <tr key="rowHdr">
+        <tr key="rowHdr" className="pvtRowHeaderRow">
           {settingsRowAttrs.map((r, i) => {
             const needLabelToggle =
               settingsRowSubtotalDisplay.enabled === true &&

--- a/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/src/react-pivottable/TableRenderers.tsx
@@ -888,16 +888,6 @@ export function TableRenderer(props: TableRendererProps) {
         return null;
       }
 
-      const spaceCell =
-        attrIdx === 0 && settingsRowAttrs.length !== 0 ? (
-          <th
-            key="padding"
-            colSpan={settingsRowAttrs.length}
-            rowSpan={settingsColAttrs.length}
-            aria-hidden="true"
-          />
-        ) : null;
-
       const needToggle =
         settingsColSubtotalDisplay.enabled === true &&
         attrIdx !== settingsColAttrs.length - 1;
@@ -911,8 +901,21 @@ export function TableRenderer(props: TableRendererProps) {
         subArrow =
           attrIdx + 1 < maxColVisible! ? arrowExpanded : arrowCollapsed;
       }
+      // With row dimensions, the corner block above the frozen row labels
+      // is rowAttrs.length + 1 columns wide: the row-attribute columns plus
+      // the padding column that renderTableRow folds into the last row
+      // label. Span the column-attribute name across that whole block so a
+      // single sticky cell freezes it, rather than a rowAttrs-wide spacer
+      // that leaves the name's own column scrolling through the corner.
+      const hasRowAttrs = settingsRowAttrs.length !== 0;
       const attrNameCell = (
-        <th key="label" className="pvtAxisLabel">
+        <th
+          key="label"
+          className={
+            hasRowAttrs ? 'pvtAxisLabel pvtCornerLabel' : 'pvtAxisLabel'
+          }
+          colSpan={hasRowAttrs ? settingsRowAttrs.length + 1 : undefined}
+        >
           {displayHeaderCell(
             needToggle,
             subArrow,
@@ -1102,7 +1105,7 @@ export function TableRenderer(props: TableRendererProps) {
           </th>
         ) : null;
 
-      const cells = [spaceCell, attrNameCell, ...attrValueCells, totalCell];
+      const cells = [attrNameCell, ...attrValueCells, totalCell];
       return <tr key={`colAttr-${attrIdx}`}>{cells}</tr>;
     },
     [

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import PivotTableChart from '../../src/PivotTableChart';
+import transformProps from '../../src/plugin/transformProps';
+import testData from '../testData';
+import { ProviderWrapper } from '../testHelpers';
+
+test('sticky-positions the row-label column and its corner header cell(s) so they stay visible while scrolling', () => {
+  const transformedProps = {
+    ...transformProps(testData.withoutColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  const rowLabelCell = container.querySelector('tbody th.pvtRowLabel');
+  expect(rowLabelCell).toBeInTheDocument();
+  const rowLabelStyle = getComputedStyle(rowLabelCell as Element);
+  expect(rowLabelStyle.position).toBe('sticky');
+  expect(rowLabelStyle.left).toBe('0px');
+
+  // The corner cell(s) above the frozen row-label column (the padding
+  // placeholder and/or the row-attribute name cell in the last header
+  // row) must stick on both axes with a higher z-index than the row
+  // label column, so they stay on top at the intersection.
+  const cornerCells = [
+    ...container.querySelectorAll(
+      "thead tr:first-of-type th[aria-hidden='true']",
+    ),
+    ...container.querySelectorAll('thead tr:last-of-type th.pvtAxisLabel'),
+  ];
+  expect(cornerCells.length).toBeGreaterThan(0);
+  cornerCells.forEach(cell => {
+    const style = getComputedStyle(cell);
+    expect(style.position).toBe('sticky');
+    expect(style.top).toBe('0px');
+    expect(style.left).toBe('0px');
+    expect(Number(style.zIndex)).toBeGreaterThan(Number(rowLabelStyle.zIndex));
+  });
+});
+
+test('does not sticky-position the row-label column or corner cell(s) in dashboard edit mode', () => {
+  // TableRenderers detects dashboard edit mode by looking for this class
+  // on the document, rather than via a prop.
+  const editingMarker = document.createElement('div');
+  editingMarker.className = 'dashboard--editing';
+  document.body.appendChild(editingMarker);
+
+  try {
+    const transformedProps = {
+      ...transformProps(testData.withoutColTotals),
+      margin: 32,
+      legacy_order_by: null,
+      order_desc: false,
+    };
+    const { container } = render(
+      ProviderWrapper({
+        children: <PivotTableChart {...transformedProps} />,
+      }),
+    );
+
+    const rowLabelCell = container.querySelector('tbody th.pvtRowLabel');
+    expect(rowLabelCell).toBeInTheDocument();
+    expect(getComputedStyle(rowLabelCell as Element).position).toBe('inherit');
+  } finally {
+    editingMarker.remove();
+  }
+});

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
@@ -84,7 +84,9 @@ test('does not sticky-position the row-label column or corner cell(s) in dashboa
 
     const rowLabelCell = container.querySelector('tbody th.pvtRowLabel');
     expect(rowLabelCell).toBeInTheDocument();
-    expect(getComputedStyle(rowLabelCell as Element).position).toBe('inherit');
+    expect(getComputedStyle(rowLabelCell as Element).position).not.toBe(
+      'sticky',
+    );
   } finally {
     editingMarker.remove();
   }

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
@@ -18,6 +18,7 @@
  */
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
+import { supersetTheme } from '@apache-superset/core/theme';
 import PivotTableChart from '../../src/PivotTableChart';
 import transformProps from '../../src/plugin/transformProps';
 import testData from '../testData';
@@ -43,14 +44,14 @@ test('sticky-positions the row-label column and its corner header cell(s) so the
   expect(rowLabelStyle.left).toBe('0px');
 
   // The corner cell(s) above the frozen row-label column (the padding
-  // placeholder and/or the row-attribute name cell in the last header
-  // row) must stick on both axes with a higher z-index than the row
-  // label column, so they stay on top at the intersection.
+  // placeholder and/or the row-attribute name cell in the row-header
+  // row) must stick on both axes and paint over the column labels that
+  // scroll underneath them.
   const cornerCells = [
     ...container.querySelectorAll(
       "thead tr:first-of-type th[aria-hidden='true']",
     ),
-    ...container.querySelectorAll('thead tr:last-of-type th.pvtAxisLabel'),
+    ...container.querySelectorAll('thead tr.pvtRowHeaderRow th.pvtAxisLabel'),
   ];
   expect(cornerCells.length).toBeGreaterThan(0);
   cornerCells.forEach(cell => {
@@ -58,7 +59,95 @@ test('sticky-positions the row-label column and its corner header cell(s) so the
     expect(style.position).toBe('sticky');
     expect(style.top).toBe('0px');
     expect(style.left).toBe('0px');
-    expect(Number(style.zIndex)).toBeGreaterThan(Number(rowLabelStyle.zIndex));
+    expect(Number(style.zIndex)).toBeGreaterThan(0);
+  });
+
+  // The sticky thead is its own stacking context, so the corner cell's
+  // z-index can't outrank the row labels by itself. The thead as a whole
+  // has to sit above the frozen row-label column.
+  const thead = container.querySelector('thead');
+  expect(thead).toBeInTheDocument();
+  expect(Number(getComputedStyle(thead as Element).zIndex)).toBeGreaterThan(
+    Number(rowLabelStyle.zIndex),
+  );
+});
+
+test('keeps the sticky totals row above the frozen row-label column', () => {
+  const transformedProps = {
+    ...transformProps(testData.withColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  const rowLabelCell = container.querySelector('tbody th.pvtRowLabel');
+  const totalsRow = container.querySelector('tbody tr.pvtRowTotals');
+  expect(rowLabelCell).toBeInTheDocument();
+  expect(totalsRow).toBeInTheDocument();
+  expect(Number(getComputedStyle(totalsRow as Element).zIndex)).toBeGreaterThan(
+    Number(getComputedStyle(rowLabelCell as Element).zIndex),
+  );
+});
+
+test('lets the active (cross-filter) highlight win over the frozen row-label background', () => {
+  const transformedProps = {
+    ...transformProps(testData.withoutColTotals),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  // Computed colors come back normalized (rgb()), so run the theme tokens
+  // through the same normalization before comparing.
+  const normalizeColor = (color: string) => {
+    const probe = document.createElement('div');
+    probe.style.backgroundColor = color;
+    return probe.style.backgroundColor;
+  };
+
+  const rowLabelCell = container.querySelector('tbody th.pvtRowLabel');
+  expect(rowLabelCell).toBeInTheDocument();
+  expect(getComputedStyle(rowLabelCell as Element).backgroundColor).toBe(
+    normalizeColor(supersetTheme.colorBgBase),
+  );
+
+  rowLabelCell?.classList.add('active');
+  expect(getComputedStyle(rowLabelCell as Element).backgroundColor).toBe(
+    normalizeColor(supersetTheme.colorPrimaryBg),
+  );
+});
+
+test('does not freeze any header cell when the pivot has column dimensions but no row dimensions', () => {
+  const transformedProps = {
+    ...transformProps(testData.columnsOnly),
+    margin: 32,
+    legacy_order_by: null,
+    order_desc: false,
+  };
+  const { container } = render(
+    ProviderWrapper({
+      children: <PivotTableChart {...transformedProps} />,
+    }),
+  );
+
+  // Without row dimensions there is no row-header row, so the leading
+  // cell of the last header row is the column attribute name. It must
+  // scroll with its column rather than being treated as a corner cell.
+  expect(container.querySelector('thead tr.pvtRowHeaderRow')).toBeNull();
+  const headerCells = container.querySelectorAll('thead th');
+  expect(headerCells.length).toBeGreaterThan(0);
+  headerCells.forEach(cell => {
+    expect(getComputedStyle(cell).position).not.toBe('sticky');
   });
 });
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
@@ -43,17 +43,24 @@ test('sticky-positions the row-label column and its corner header cell(s) so the
   expect(rowLabelStyle.position).toBe('sticky');
   expect(rowLabelStyle.left).toBe('0px');
 
-  // The corner cell(s) above the frozen row-label column (the padding
-  // placeholder and/or the row-attribute name cell in the row-header
-  // row) must stick on both axes and paint over the column labels that
-  // scroll underneath them.
+  // The corner cells above the frozen row-label column (the column
+  // attribute name cell in each column-header row and the row-attribute
+  // name cell in the row-header row) must stick on both axes and paint
+  // over the column labels that scroll underneath them.
   const cornerCells = [
-    ...container.querySelectorAll(
-      "thead tr:first-of-type th[aria-hidden='true']",
-    ),
+    ...container.querySelectorAll('thead th.pvtCornerLabel'),
     ...container.querySelectorAll('thead tr.pvtRowHeaderRow th.pvtAxisLabel'),
   ];
   expect(cornerCells.length).toBeGreaterThan(0);
+  // The frozen block in each column-header row has to cover the same
+  // columns as the frozen row label below it (its own column plus the
+  // padding column), otherwise the uncovered strip shows column labels
+  // scrolling through the corner.
+  const rowLabelSpan = (rowLabelCell as HTMLTableCellElement).colSpan;
+  expect(rowLabelSpan).toBe(2);
+  container.querySelectorAll('thead th.pvtCornerLabel').forEach(cell => {
+    expect((cell as HTMLTableCellElement).colSpan).toBe(rowLabelSpan);
+  });
   cornerCells.forEach(cell => {
     const style = getComputedStyle(cell);
     expect(style.position).toBe('sticky');
@@ -91,6 +98,18 @@ test('keeps the sticky totals row above the frozen row-label column', () => {
   expect(totalsRow).toBeInTheDocument();
   expect(Number(getComputedStyle(totalsRow as Element).zIndex)).toBeGreaterThan(
     Number(getComputedStyle(rowLabelCell as Element).zIndex),
+  );
+
+  // The totals row's leading label freezes at the left edge alongside the
+  // body row labels, and sits above the totals values in its own row.
+  const totalsLabel = totalsRow?.querySelector('th.pvtRowTotalLabel');
+  expect(totalsLabel).toBeInTheDocument();
+  const totalsLabelStyle = getComputedStyle(totalsLabel as Element);
+  expect(totalsLabelStyle.position).toBe('sticky');
+  expect(totalsLabelStyle.left).toBe('0px');
+  expect(Number(totalsLabelStyle.zIndex)).toBeGreaterThan(0);
+  expect((totalsLabel as HTMLTableCellElement).colSpan).toBe(
+    (rowLabelCell as HTMLTableCellElement).colSpan,
   );
 });
 

--- a/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
+++ b/superset-frontend/plugins/plugin-chart-pivot-table/test/testData.ts
@@ -224,9 +224,31 @@ const groupedRowsWithColTotals = {
   queriesData: groupedRowsQueriesData,
 };
 
+/**
+ * Column dimensions only (no row dimensions): the thead has no row-header
+ * row, so the last header row is a column-attribute row whose leading
+ * cell is the column attribute name, not a corner cell.
+ */
+const columnsOnly = {
+  ...new ChartProps({
+    ...basicChartProps,
+    formData: {
+      ...basicFormData,
+      groupbyRows: [],
+      groupbyColumns: ['city'],
+      colTotals: false,
+      rowTotals: false,
+      rowSubTotals: false,
+      colSubTotals: false,
+    },
+  }),
+  queriesData: basicQueriesData,
+};
+
 export default {
   withColTotals,
   withoutColTotals,
   groupedRowsWithoutColTotals,
   groupedRowsWithColTotals,
+  columnsOnly,
 };


### PR DESCRIPTION
### SUMMARY
Column headers (`<thead>`) and row totals (`.pvtRowTotals`) already stick via CSS, but the row-label column and the corner cell(s) above it did not, so on wide/tall pivot tables they scrolled out of view while the header and totals row stayed put. This adds `position: sticky; left: 0` to `.pvtRowLabel` cells, plus a combined top+left sticky rule (with a higher z-index so it wins over the row-label column at the intersection) for the corner cell(s): the placeholder cell spanning the column-attribute rows, and the row-attribute name cell(s) in the final header row. Both are gated by the existing `isDashboardEditMode` flag, same as the pre-existing sticky rules.

This is scoped to single-level row headers (a fixed `left: 0` offset). Multi-level row headers (more than one row dimension) need a per-column inline `left` style computed in `TableRenderers.tsx`, which is a reasonable fast-follow rather than something that should block this fix, per the discussion on #43352.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CSS-only change to an existing scroll behavior; see testing instructions to verify visually).

### TESTING INSTRUCTIONS
1. Added `plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx`, which renders a pivot table and asserts (via `getComputedStyle`) that `.pvtRowLabel` and the corner header cell(s) are `position: sticky` with the expected offsets and z-index ordering, and that this is suppressed in dashboard edit mode. This test fails against the pre-fix `Styles.ts` and passes with the fix.
2. Manually: create a Pivot Table chart with enough rows/columns to require scrolling in both directions, and confirm the row-label column and the corner cell stay pinned to the left/top while scrolling.

```
npm run test -- plugins/plugin-chart-pivot-table/test/react-pivottable/Styles.test.tsx
```

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #43352
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API