### PR TITLE
ci(playwright): make embedded and app-root E2E coverage required

### DIFF
--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -168,7 +168,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-26.04
-    timeout-minutes: 30
+    # Embedded Tests below adds its own gunicorn boot + spec run on top of
+    # Required and Soft-delete; 30m was tight even for the two-step shadow
+    # job this replaced.
+    timeout-minutes: 40
     permissions:
       contents: read
       pull-requests: read
@@ -176,7 +179,10 @@ jobs:
       fail-fast: false
       matrix:
         browser: ["chromium"]
-        app_root: ${{ github.event_name == 'push' && fromJSON('["", "/app/prefix"]') || fromJSON('[""]') }}
+        # Subdirectory deployment (APPLICATION_ROOT) is a required-to-pass
+        # dimension, not an optional one, so it runs on every event —
+        # unlike cypress-matrix above, which only widens on push.
+        app_root: ["", "/app/prefix"]
     env:
       SUPERSET_ENV: development
       SUPERSET_CONFIG: tests.integration_tests.superset_test_config
@@ -266,14 +272,25 @@ jobs:
           # Scoped to this step: each playwright-run boots its own gunicorn
           # with the step's env, so the Required Tests server above keeps
           # master's Flask configuration while this one runs with SOFT_DELETE
-          # on — the same isolation pattern as the Embedded step in
-          # superset-playwright.yml. Without a flag-on server the
-          # recently-archived specs skip themselves everywhere and ship zero
-          # executed E2E coverage; in the Required run above they are
-          # collected and skipped, which is expected.
+          # on — the same isolation pattern as the Embedded Tests step below.
+          # Without a flag-on server the recently-archived specs skip
+          # themselves everywhere and ship zero executed E2E coverage; in the
+          # Required run above they are collected and skipped, which is
+          # expected.
           SUPERSET_FEATURE_SOFT_DELETE: "true"
         with:
           run: playwright-run "${{ matrix.app_root }}" recently-archived/
+      - name: Run Playwright (Embedded Tests)
+        uses: ./.github/actions/cached-dependencies
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          # Scoped to this step for the same reason as Soft-delete above:
+          # embedding is a real, required feature, so its Playwright coverage
+          # now gates merges instead of running only in shadow mode.
+          SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
+          INCLUDE_EMBEDDED: "true"
+        with:
+          run: playwright-run "${{ matrix.app_root }}" embedded
       - name: Set safe app root
         if: failure()
         id: set-safe-app-root

--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -46,8 +46,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # NOTE: Required Playwright tests are in superset-e2e.yml (E2E / playwright-tests)
-  # This workflow contains only experimental tests that run in shadow mode
+  # NOTE: Required Playwright tests are in superset-e2e.yml (E2E / playwright-tests),
+  # including Embedded — it moved out of this workflow because embedding is a
+  # required feature, not an experimental one. This workflow now contains
+  # only experimental and mobile tests, which run in shadow mode.
   playwright-tests-experimental:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.frontend == 'true'
@@ -130,10 +132,6 @@ jobs:
         uses: ./.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
-      - name: Build embedded SDK
-        uses: ./.github/actions/cached-dependencies
-        with:
-          run: build-embedded-sdk
       - name: Install Playwright
         uses: ./.github/actions/cached-dependencies
         with:
@@ -144,27 +142,13 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}" experimental/
-      - name: Run Playwright (Embedded Tests)
-        uses: ./.github/actions/cached-dependencies
-        env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
-          # Scope embedded-only env vars to this step. Setting them at the job
-          # level enabled the EMBEDDED_SUPERSET feature flag inside Flask for
-          # the preceding "Required Tests" and "Experimental Tests" steps too,
-          # which loads extra handlers and destabilizes the werkzeug dev
-          # server under the 2-worker Playwright load. Required Tests should
-          # match master's Flask configuration.
-          SUPERSET_FEATURE_EMBEDDED_SUPERSET: "true"
-          INCLUDE_EMBEDDED: "true"
-        with:
-          run: playwright-run "${{ matrix.app_root }}" embedded
       - name: Run Playwright (Mobile Tests)
         uses: ./.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
-          # Scoped to this step for the same reason as the embedded flags
-          # above: the mobile consumption mode should not alter Flask's
-          # configuration for the required desktop test steps.
+          # Scoped to this step: setting feature flags at the job level would
+          # alter Flask's configuration for the preceding Experimental step
+          # too — the mobile consumption mode should not do that.
           SUPERSET_FEATURE_MOBILE_CONSUMPTION_MODE: "true"
           INCLUDE_MOBILE: "true"
         with:


### PR DESCRIPTION
### SUMMARY
Embedded dashboard tests only ran in the continue-on-error shadow workflow, so failures never blocked merges despite embedding being a real, required feature. This moves the Embedded Tests step into the required E2E / playwright-tests job.

The subdirectory-deployment (APPLICATION_ROOT) matrix variant only ran on push in the required job, so pull requests never actually exercised it before merge. This widens it to run on every event, matching the shadow workflow's matrix.

### TESTING INSTRUCTIONS
- Confirm the `E2E / playwright-tests` required job now runs both the embedded dashboard suite and the APPLICATION_ROOT matrix variant on pull_request events, and that a failure in either blocks merge.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)