### PR TITLE
refactor(sql): share CTAS/limit helpers + add cancel seam to the execution feature

### DIFF
--- a/superset-core/src/superset_core/queries/types.py
+++ b/superset-core/src/superset_core/queries/types.py
@@ -66,8 +66,6 @@ class QueryOptions:
     - Templates: Jinja2 template parameters
     - Caching: Cache timeout and refresh control
     - Dry run: Return transformed SQL without execution
-    - CTAS/CVAS: create the results as a table/view (SQL Lab)
-    - Result handling: nested-column expansion and results-backend persistence
     """
 
     # Basic options
@@ -84,31 +82,6 @@ class QueryOptions:
 
     # Dry run option
     dry_run: bool = False  # Return transformed SQL without executing
-
-    # CREATE TABLE/VIEW AS SELECT. When ``select_as_cta`` is set the last (CTAS)
-    # or sole (CVAS) SELECT is rewritten to materialize into
-    # ``tmp_schema_name.tmp_table_name`` using ``ctas_method`` ("TABLE"/"VIEW").
-    select_as_cta: bool = False
-    ctas_method: str | None = None
-    tmp_table_name: str | None = None
-    tmp_schema_name: str | None = None
-
-    # Result handling. ``expand_data`` expands nested columns (Presto/Trino).
-    # ``store_results`` persists the serialized result to the results backend and
-    # returns its handle on ``QueryResult.results_key`` (the SQL Lab path);
-    # otherwise results are returned inline as DataFrames on each StatementResult.
-    expand_data: bool = False
-    store_results: bool = False
-
-    # Execute against a pre-created Query row (SQL Lab creates its own row with
-    # client_id/sql_editor_id/tab_name/CTAS fields, the UI's source of truth)
-    # instead of the executor creating a minimal audit row.
-    existing_query_id: int | None = None
-
-    # When True the caller owns the execution timeout (e.g. a GTF ``@task``
-    # timeout wrapping the async path), so the executor skips its own in-process
-    # ``utils.timeout`` to avoid a double timeout.
-    caller_owns_timeout: bool = False
 
 
 @dataclass
@@ -144,11 +117,6 @@ class QueryResult:
         total_execution_time_ms: Total execution time across all statements
         is_cached: Whether result came from cache
         error_message: Query-level error (e.g., "Statement 2 of 3: error")
-        results_key: Results-backend handle when executed with
-            ``QueryOptions.store_results`` (the serialized result is written to
-            the results backend rather than returned inline); None otherwise.
-        limiting_factor: Which limit applied to the result (SQL Lab), e.g.
-            "DROPDOWN"/"QUERY"/"NOT_LIMITED"; None when not tracked.
     """
 
     status: QueryStatus
@@ -157,8 +125,6 @@ class QueryResult:
     total_execution_time_ms: float | None = None
     is_cached: bool = False
     error_message: str | None = None
-    results_key: str | None = None
-    limiting_factor: str | None = None
 
 
 @dataclass

--- a/superset-core/src/superset_core/queries/types.py
+++ b/superset-core/src/superset_core/queries/types.py
@@ -66,6 +66,8 @@ class QueryOptions:
     - Templates: Jinja2 template parameters
     - Caching: Cache timeout and refresh control
     - Dry run: Return transformed SQL without execution
+    - CTAS/CVAS: create the results as a table/view (SQL Lab)
+    - Result handling: nested-column expansion and results-backend persistence
     """
 
     # Basic options
@@ -82,6 +84,31 @@ class QueryOptions:
 
     # Dry run option
     dry_run: bool = False  # Return transformed SQL without executing
+
+    # CREATE TABLE/VIEW AS SELECT. When ``select_as_cta`` is set the last (CTAS)
+    # or sole (CVAS) SELECT is rewritten to materialize into
+    # ``tmp_schema_name.tmp_table_name`` using ``ctas_method`` ("TABLE"/"VIEW").
+    select_as_cta: bool = False
+    ctas_method: str | None = None
+    tmp_table_name: str | None = None
+    tmp_schema_name: str | None = None
+
+    # Result handling. ``expand_data`` expands nested columns (Presto/Trino).
+    # ``store_results`` persists the serialized result to the results backend and
+    # returns its handle on ``QueryResult.results_key`` (the SQL Lab path);
+    # otherwise results are returned inline as DataFrames on each StatementResult.
+    expand_data: bool = False
+    store_results: bool = False
+
+    # Execute against a pre-created Query row (SQL Lab creates its own row with
+    # client_id/sql_editor_id/tab_name/CTAS fields, the UI's source of truth)
+    # instead of the executor creating a minimal audit row.
+    existing_query_id: int | None = None
+
+    # When True the caller owns the execution timeout (e.g. a GTF ``@task``
+    # timeout wrapping the async path), so the executor skips its own in-process
+    # ``utils.timeout`` to avoid a double timeout.
+    caller_owns_timeout: bool = False
 
 
 @dataclass
@@ -117,6 +144,11 @@ class QueryResult:
         total_execution_time_ms: Total execution time across all statements
         is_cached: Whether result came from cache
         error_message: Query-level error (e.g., "Statement 2 of 3: error")
+        results_key: Results-backend handle when executed with
+            ``QueryOptions.store_results`` (the serialized result is written to
+            the results backend rather than returned inline); None otherwise.
+        limiting_factor: Which limit applied to the result (SQL Lab), e.g.
+            "DROPDOWN"/"QUERY"/"NOT_LIMITED"; None when not tracked.
     """
 
     status: QueryStatus
@@ -125,6 +157,8 @@ class QueryResult:
     total_execution_time_ms: float | None = None
     is_cached: bool = False
     error_message: str | None = None
+    results_key: str | None = None
+    limiting_factor: str | None = None
 
 
 @dataclass

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -62,7 +62,7 @@ import logging
 import time
 import uuid
 from datetime import datetime
-from typing import Any, NoReturn, TYPE_CHECKING
+from typing import Any, NoReturn, TYPE_CHECKING, TypeVar
 
 from flask import current_app as app, g, has_app_context
 from flask_babel import gettext as __
@@ -78,7 +78,7 @@ from superset.exceptions import (
     SupersetTimeoutException,
 )
 from superset.extensions import cache_manager
-from superset.sql.parse import SQLScript
+from superset.sql.parse import CTASMethod, SQLScript, Table
 from superset.utils import core as utils
 
 if TYPE_CHECKING:
@@ -92,7 +92,9 @@ if TYPE_CHECKING:
 
     from superset.db_engine_specs.base import BaseEngineSpec
     from superset.models.core import Database
+    from superset.models.sql_lab import Query
     from superset.result_set import SupersetResultSet
+    from superset.sql.parse import BaseSQLStatement
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +262,14 @@ def execute_sql_with_cursor(
         if log_query_fn:
             log_query_fn(stmt_sql, query.schema)
 
+        # Hand the live cursor to any active cancellation sink (a GTF task
+        # wrapping this execution) before the blocking execute, so it can capture
+        # an engine cancel id — the same seam ``Database.get_df`` uses for
+        # chart-data. A no-op when no sink is registered (e.g. the MCP sync path).
+        from superset.tasks.query_cancel import notify_cursor
+
+        notify_cursor(cursor)
+
         # Execute - use custom function or default
         if execute_fn:
             execute_fn(cursor, stmt_sql)
@@ -296,6 +306,58 @@ def execute_sql_with_cursor(
         db.session.commit()  # pylint: disable=consider-using-transaction
 
     return results
+
+
+S = TypeVar("S", bound="BaseSQLStatement[Any]")
+
+
+def apply_ctas(query: "Query", parsed_statement: S) -> S:
+    """
+    Apply CTAS/CVAS: rewrite the SELECT to materialize into the query's temp table.
+
+    Shared by the SQL executor and (until retired) the classic SQL Lab path so
+    both build the same ``CREATE TABLE/VIEW AS`` from the ``Query`` row.
+    """
+    if not query.tmp_table_name:
+        start_dttm = datetime.fromtimestamp(query.start_time)
+        prefix = f"tmp_{query.user_id}_table"
+        query.tmp_table_name = start_dttm.strftime(f"{prefix}_%Y_%m_%d_%H_%M_%S")
+
+    catalog = (
+        query.catalog
+        if query.database.db_engine_spec.supports_cross_catalog_queries
+        else None
+    )
+    table = Table(query.tmp_table_name, query.tmp_schema_name, catalog)
+    method = CTASMethod[query.ctas_method.upper()]
+
+    return parsed_statement.as_create_table(table, method)  # type: ignore[return-value]
+
+
+def apply_limit(query: "Query", parsed_statement: "BaseSQLStatement[Any]") -> None:
+    """
+    Apply the query's row limit to a statement, honoring ``SQLLAB_CTAS_NO_LIMIT``.
+
+    Shared by the SQL executor and (until retired) the classic SQL Lab path.
+    """
+    sqllab_ctas_no_limit = app.config["SQLLAB_CTAS_NO_LIMIT"]
+    sql_max_row = app.config["SQL_MAX_ROW"]
+
+    # Do not apply limit to the CTA queries when SQLLAB_CTAS_NO_LIMIT is set to true
+    if parsed_statement.is_mutating() or (
+        query.select_as_cta_used and sqllab_ctas_no_limit
+    ):
+        return
+
+    if sql_max_row and (not query.limit or query.limit > sql_max_row):
+        query.limit = sql_max_row
+
+    if query.limit:
+        parsed_statement.set_limit_value(
+            # fetch an extra row to inform user if there are more rows
+            query.limit + 1,
+            query.database.db_engine_spec.limit_method,
+        )
 
 
 class SQLExecutor:
@@ -388,11 +450,18 @@ class SQLExecutor:
                 final_sql, opts, catalog, schema, status=QueryStatus.RUNNING
             )
 
-            # 6. Execute with timeout
+            # 6. Execute with timeout. The caller (e.g. a GTF task wrapping this
+            # execution with its own @task timeout) may own the timeout, in which
+            # case we skip the in-process signal timeout to avoid a double timeout.
             timeout = opts.timeout_seconds or app.config.get("SQLLAB_TIMEOUT", 30)
             timeout_msg = f"Query exceeded the {timeout} seconds timeout."
+            timeout_ctx: Any = (
+                contextlib.nullcontext()
+                if getattr(opts, "caller_owns_timeout", False)
+                else utils.timeout(seconds=timeout, error_message=timeout_msg)
+            )
 
-            with utils.timeout(seconds=timeout, error_message=timeout_msg):
+            with timeout_ctx:
                 statement_results = self._execute_statements(
                     original_script,
                     transformed_script,
@@ -903,7 +972,13 @@ class SQLExecutor:
         status: QueryStatus,
     ) -> Any:
         """
-        Create Query model for audit/tracking.
+        Create — or reuse — the Query model for audit/tracking.
+
+        When ``opts.existing_query_id`` is set (the SQL Lab path, where the row is
+        already created with client_id/sql_editor_id/tab_name/CTAS fields and is
+        the UI's source of truth), that row is loaded and advanced to ``status``
+        rather than creating a minimal one. Otherwise a fresh audit row is created
+        (the MCP / generic path).
 
         :param sql: SQL to execute
         :param opts: Query options
@@ -913,6 +988,14 @@ class SQLExecutor:
         :returns: Query model instance
         """
         from superset.models.sql_lab import Query as QueryModel
+
+        if getattr(opts, "existing_query_id", None) is not None:
+            query = (
+                db.session.query(QueryModel).filter_by(id=opts.existing_query_id).one()
+            )
+            query.status = status.value
+            db.session.commit()  # pylint: disable=consider-using-transaction
+            return query
 
         user_id = None
         if has_app_context() and hasattr(g, "user") and g.user:

--- a/superset/sql/execution/executor.py
+++ b/superset/sql/execution/executor.py
@@ -450,18 +450,11 @@ class SQLExecutor:
                 final_sql, opts, catalog, schema, status=QueryStatus.RUNNING
             )
 
-            # 6. Execute with timeout. The caller (e.g. a GTF task wrapping this
-            # execution with its own @task timeout) may own the timeout, in which
-            # case we skip the in-process signal timeout to avoid a double timeout.
+            # 6. Execute with timeout
             timeout = opts.timeout_seconds or app.config.get("SQLLAB_TIMEOUT", 30)
             timeout_msg = f"Query exceeded the {timeout} seconds timeout."
-            timeout_ctx: Any = (
-                contextlib.nullcontext()
-                if getattr(opts, "caller_owns_timeout", False)
-                else utils.timeout(seconds=timeout, error_message=timeout_msg)
-            )
 
-            with timeout_ctx:
+            with utils.timeout(seconds=timeout, error_message=timeout_msg):
                 statement_results = self._execute_statements(
                     original_script,
                     transformed_script,
@@ -972,13 +965,7 @@ class SQLExecutor:
         status: QueryStatus,
     ) -> Any:
         """
-        Create — or reuse — the Query model for audit/tracking.
-
-        When ``opts.existing_query_id`` is set (the SQL Lab path, where the row is
-        already created with client_id/sql_editor_id/tab_name/CTAS fields and is
-        the UI's source of truth), that row is loaded and advanced to ``status``
-        rather than creating a minimal one. Otherwise a fresh audit row is created
-        (the MCP / generic path).
+        Create Query model for audit/tracking.
 
         :param sql: SQL to execute
         :param opts: Query options
@@ -988,14 +975,6 @@ class SQLExecutor:
         :returns: Query model instance
         """
         from superset.models.sql_lab import Query as QueryModel
-
-        if getattr(opts, "existing_query_id", None) is not None:
-            query = (
-                db.session.query(QueryModel).filter_by(id=opts.existing_query_id).one()
-            )
-            query.status = status.value
-            db.session.commit()  # pylint: disable=consider-using-transaction
-            return query
 
         user_id = None
         if has_app_context() and hasattr(g, "user") and g.user:

--- a/superset/sql_lab.py
+++ b/superset/sql_lab.py
@@ -21,9 +21,8 @@ import sys
 import traceback
 import uuid
 from contextlib import closing
-from datetime import datetime
 from sys import getsizeof
-from typing import Any, cast, Optional, TYPE_CHECKING, TypeVar, Union
+from typing import Any, cast, Optional, TYPE_CHECKING, Union
 
 import backoff
 import msgpack
@@ -57,8 +56,12 @@ from superset.exceptions import (
 from superset.extensions import celery_app, event_logger
 from superset.models.sql_lab import Query
 from superset.result_set import SupersetResultSet
-from superset.sql.execution.executor import build_statement_blocks
-from superset.sql.parse import BaseSQLStatement, CTASMethod, SQLScript, Table
+from superset.sql.execution.executor import (
+    apply_ctas,
+    apply_limit,
+    build_statement_blocks,
+)
+from superset.sql.parse import CTASMethod, SQLScript, Table
 from superset.sqllab.limiting_factor import LimitingFactor
 from superset.sqllab.utils import write_ipc_buffer
 from superset.utils import json
@@ -212,53 +215,6 @@ def get_sql_results(  # pylint: disable=too-many-arguments
                 stats_logger.incr("error_sqllab_unhandled")
                 query = get_query(query_id=query_id)
                 return handle_query_error(ex, query)
-
-
-S = TypeVar("S", bound=BaseSQLStatement[Any])
-
-
-def apply_ctas(query: Query, parsed_statement: S) -> S:
-    """
-    Apply CTAS/CVAS.
-    """
-    if not query.tmp_table_name:
-        start_dttm = datetime.fromtimestamp(query.start_time)
-        prefix = f"tmp_{query.user_id}_table"
-        query.tmp_table_name = start_dttm.strftime(f"{prefix}_%Y_%m_%d_%H_%M_%S")
-
-    catalog = (
-        query.catalog
-        if query.database.db_engine_spec.supports_cross_catalog_queries
-        else None
-    )
-    table = Table(query.tmp_table_name, query.tmp_schema_name, catalog)
-    method = CTASMethod[query.ctas_method.upper()]
-
-    return parsed_statement.as_create_table(table, method)  # type: ignore[return-value]
-
-
-def apply_limit(query: Query, parsed_statement: BaseSQLStatement[Any]) -> None:
-    """
-    Apply limit to the SQL statement.
-    """
-    sqllab_ctas_no_limit = app.config["SQLLAB_CTAS_NO_LIMIT"]
-    sql_max_row = app.config["SQL_MAX_ROW"]
-
-    # Do not apply limit to the CTA queries when SQLLAB_CTAS_NO_LIMIT is set to true
-    if parsed_statement.is_mutating() or (
-        query.select_as_cta_used and sqllab_ctas_no_limit
-    ):
-        return
-
-    if sql_max_row and (not query.limit or query.limit > sql_max_row):
-        query.limit = sql_max_row
-
-    if query.limit:
-        parsed_statement.set_limit_value(
-            # fetch an extra row to inform user if there are more rows
-            query.limit + 1,
-            query.database.db_engine_spec.limit_method,
-        )
 
 
 def execute_query(  # pylint: disable=too-many-statements, too-many-locals  # noqa: C901


### PR DESCRIPTION
### SUMMARY

Child PR 1 of the [SQL execution on GTF epic](https://github.com/apache/superset/pull/43928) (umbrella `villebro/sqllab-gtf`).

A clean, purely-internal refactor of the shared SQL execution feature — no public API change, no behavior change — laying groundwork for the SQL-Lab-complete executor and the GTF SQL task in the following child PRs:

- **Share `apply_ctas` / `apply_limit`** — moved from `superset/sql_lab.py` into `superset/sql/execution/executor.py` so the unified `SQLExecutor` and the classic SQL Lab path use one implementation (`sql_lab.py` now imports them). Immediate de-duplication; identical logic.
- **Engine-cancel seam** — call `notify_cursor(cursor)` in the shared `execute_sql_with_cursor` loop before the blocking execute, so a GTF task wrapping this feature can capture an engine cancel id — the same seam `Database.get_df` already uses for chart-data. A no-op when no cancellation sink is registered (e.g. the MCP sync path).

This PR deliberately does **not** touch the public `superset-core` `QueryOptions`/`QueryResult` contract. The SQL-Lab-specific execution options (CTAS config, `expand_data`, results-backend persistence, reusing an existing `Query` row, timeout ownership) are internal details of the SQL Lab execution flow — CTAS config already lives on the `Query` row, and the remaining mode flags belong on an internal SQL-Lab-oriented `SQLExecutor` entry — so they are introduced in the next child PR where they are actually exercised, not pushed onto the public API here.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — no user-facing change.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/sql/execution/ tests/unit_tests/sql_lab_test.py` — 148 existing tests pass unchanged. The `apply_ctas`/`apply_limit` move is behavior-preserving, and the cancel seam is a no-op unless a task registers a cancellation sink; the MCP `execute()` path is unaffected.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
