### PR TITLE
feat(sql): add GTF task for async SQL Lab execution

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1800,6 +1800,7 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         "superset.sql_lab",
         "superset.tasks.deletion_retention",
         "superset.tasks.scheduler",
+        "superset.tasks.sql_queries",
         "superset.tasks.thumbnails",
         "superset.tasks.cache",
         "superset.tasks.slack",

--- a/superset/sql/execution/sqllab_executor.py
+++ b/superset/sql/execution/sqllab_executor.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import logging
 import sys
 import uuid
-from typing import Any, cast, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Optional, TYPE_CHECKING, Union
 
 import msgpack
 from celery.exceptions import SoftTimeLimitExceeded
@@ -316,6 +316,7 @@ def execute_sql_lab_query(  # noqa: C901
     expand_data: bool = False,
     start_time: Optional[float] = None,
     log_params: Optional[dict[str, Any]] = None,
+    cancel_hook: Optional[Callable[[int, str], None]] = None,
 ) -> Optional[dict[str, Any]]:
     """Execute a SQL Lab ``Query`` (multi-statement) and return its payload.
 
@@ -328,6 +329,14 @@ def execute_sql_lab_query(  # noqa: C901
     cooperative stop returns a ``STOPPED`` payload; execution errors propagate as
     exceptions for the caller (the ``/execute/`` command or the GTF task) to
     handle — this entry does not build a FAILED error payload itself.
+
+    ``cancel_hook``, when supplied, is called as ``cancel_hook(database_id,
+    cancel_query_id)`` the moment an engine cancel id is captured off the live
+    cursor (for engines that expose one). It lets a GTF task wrapping this entry
+    register its abort handler and persist the handle so the query can be
+    cancelled — live (user/Task-view stop) or out-of-band by the orphan reaper.
+    ``None`` (the classic caller) leaves cancellation to ``QUERY_CANCEL_KEY`` on
+    the ``Query`` row as before.
     """
     if store_results and start_time:
         app.config["STATS_LOGGER"].timing(
@@ -435,6 +444,15 @@ def execute_sql_lab_query(  # noqa: C901
         if cancel_query_id is not None:
             query.set_extra_json_key(QUERY_CANCEL_KEY, cancel_query_id)
             db.session.commit()
+            if cancel_hook is not None:
+                # Hand the captured engine cancel id to a wrapping GTF task so it
+                # can register its abort handler and persist the handle for the
+                # orphan reaper. Best-effort: a hook failure must not break
+                # execution — it only forfeits cancellability.
+                try:
+                    cancel_hook(database.id, cancel_query_id)
+                except Exception:  # noqa: BLE001  pylint: disable=broad-except
+                    logger.warning("SQL Lab cancel hook failed", exc_info=True)
 
         block_count = len(blocks)
         for i, block in enumerate(blocks):

--- a/superset/tasks/sql_queries.py
+++ b/superset/tasks/sql_queries.py
@@ -1,0 +1,150 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=consider-using-transaction
+"""GTF task for asynchronous SQL Lab query execution.
+
+Wraps the internal SQL-Lab execution entry (``execute_sql_lab_query``) in a
+PRIVATE GTF task so an async SQL Lab query runs on a worker with GTF's lifecycle:
+signal-driven cancellation (with warehouse-query kill), ``@task`` timeout, worker
+heartbeat + orphan reaping, and status. Because it is a PRIVATE task an executing
+SQL Lab statement shows up in the Task List (scoped to the running user) and is
+cancellable from there.
+
+The ``Query`` row remains the SQL-Lab-facing source of truth: the task mirrors its
+terminal state onto ``Query.status`` (SUCCESS is set by the executor; FAILED /
+STOPPED / TIMED_OUT are mirrored here) so the existing ``/query/updated_since``
+poll keeps working. Sync SQL Lab does not use this task — it calls
+``execute_sql_lab_query`` directly, in-process.
+
+Cancellation reuses the engine-generic seam built for chart-data
+(``superset.tasks.query_cancel``): the executor hands us the captured engine
+cancel id, which we persist (for the orphan reaper) and use in an abort handler
+that kills the backend session over a fresh connection — never touching the live
+ORM ``Query`` from the abort-listener thread.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, TYPE_CHECKING
+
+from flask import current_app
+from superset_core.tasks.types import TaskScope
+
+from superset import db, security_manager
+from superset.common.db_query_status import QueryStatus
+from superset.tasks.ambient_context import get_context
+from superset.tasks.decorators import task
+from superset.tasks.query_cancel import cancel_chart_query
+from superset.utils.core import override_user
+from superset.utils.dates import now_as_float
+
+if TYPE_CHECKING:
+    from superset.models.sql_lab import Query
+    from superset.tasks.context import TaskContext
+
+# GTF task type for async SQL Lab query execution. One PRIVATE task per Query,
+# keyed by ``Query.client_id`` (per-user idempotency, subsuming the classic
+# ``is_query_handled`` guard). The SQL Lab client filters
+# ``/api/v1/task/status_changes`` to this type.
+SQL_LAB_TASK = "superset.sql_lab"
+
+
+def _make_cancel_hook(ctx: "TaskContext", query: "Query") -> Callable[[int, str], None]:
+    """Build the ``cancel_hook`` the executor calls once it captures a cancel id.
+
+    Persists the handle so the orphan reaper can cancel a dead worker's query,
+    and registers an abort handler that kills the backend session over a *fresh*
+    connection (engine-generic ``cancel_chart_query``) — unblocking the task's
+    blocked cursor. The handler captures plain values + the app, so it never
+    touches the live ORM ``Query`` from the abort-listener thread.
+    """
+    app = current_app._get_current_object()  # noqa: SLF001
+    database = query.database
+
+    def _hook(database_id: int, cancel_query_id: str) -> None:
+        # Persist before registering the handler: the first on_abort flushes the
+        # property cache, persisting the handle in that same write.
+        ctx.set_cancellation(database_id, cancel_query_id)
+
+        def _cancel() -> None:
+            cancel_chart_query(database, cancel_query_id, app)
+
+        ctx.on_abort(_cancel)
+
+    return _hook
+
+
+def _mirror_terminal_status(query: "Query", ctx: "TaskContext") -> None:
+    """Mirror an abort/timeout onto the ``Query`` row (SUCCESS/FAILED handled
+    elsewhere). Runs on the task's main thread, so touching the ORM row is safe."""
+    query.status = (
+        QueryStatus.TIMED_OUT if ctx.timeout_triggered else QueryStatus.STOPPED
+    )
+    if not query.end_time:
+        query.end_time = now_as_float()
+    db.session.commit()
+
+
+@task(name=SQL_LAB_TASK, scope=TaskScope.PRIVATE)
+def run_sql_lab_query(
+    query_id: int,
+    rendered_query: str,
+    *,
+    store_results: bool = True,
+    expand_data: bool = False,
+    username: Optional[str] = None,
+    start_time: Optional[float] = None,
+    log_params: Optional[dict[str, Any]] = None,
+) -> None:
+    """Execute an async SQL Lab query as a GTF task.
+
+    Runs the (already access-validated, Jinja-rendered) query through the internal
+    SQL-Lab executor entry under the requesting user, wiring GTF cancellation and
+    mirroring the terminal state onto the ``Query`` row.
+    """
+    # Imported lazily to keep this module import-light and avoid any import-order
+    # coupling with the SQL Lab module at app startup.
+    from superset.sql.execution.sqllab_executor import execute_sql_lab_query
+    from superset.sql_lab import get_query, handle_query_error
+
+    ctx = get_context()
+    query = get_query(query_id)
+
+    with override_user(security_manager.find_user(username)):
+        try:
+            execute_sql_lab_query(
+                query,
+                rendered_query,
+                return_results=False,
+                store_results=store_results,
+                expand_data=expand_data,
+                start_time=start_time,
+                log_params=log_params,
+                cancel_hook=_make_cancel_hook(ctx, query),
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            if ctx.aborting_in_flight:
+                # Abort/timeout killed the warehouse query and surfaced as an
+                # error; this is a successful cancellation, not a failure. Mirror
+                # the terminal state to the Query and let the framework finalize
+                # the task as ABORTED / TIMED_OUT.
+                _mirror_terminal_status(query, ctx)
+                return
+            # Genuine execution error: mark the Query FAILED (builds the error
+            # payload) and re-raise so the framework finalizes the task FAILURE.
+            handle_query_error(ex, query)
+            raise

--- a/tests/unit_tests/sql/execution/test_sqllab_executor.py
+++ b/tests/unit_tests/sql/execution/test_sqllab_executor.py
@@ -207,3 +207,44 @@ def test_empty_sql_raises_clean_error(mocker: MockerFixture, app) -> None:
             store_results=False,
             expand_data=False,
         )
+
+
+@with_config(_CONFIG)
+def test_cancel_hook_invoked_when_engine_cancel_id_captured(
+    mocker: MockerFixture, app
+) -> None:
+    """The cancel hook is called with (database_id, cancel_id) once captured."""
+    query = _make_query(mocker)
+    mocker.patch(f"{_MODULE}.db.session.refresh", return_value=None)
+    mocker.patch(f"{_MODULE}.results_backend", return_value=True)
+    hook = mocker.MagicMock()
+
+    execute_sql_lab_query(
+        query,
+        "SELECT 42 AS answer",
+        return_results=False,
+        store_results=False,
+        expand_data=False,
+        cancel_hook=hook,
+    )
+    hook.assert_called_once()
+
+
+@with_config(_CONFIG)
+def test_cancel_hook_failure_is_swallowed(mocker: MockerFixture, app) -> None:
+    """A raising cancel hook only forfeits cancellability; execution proceeds."""
+    query = _make_query(mocker)
+    mocker.patch(f"{_MODULE}.db.session.refresh", return_value=None)
+    mocker.patch(f"{_MODULE}.results_backend", return_value=True)
+    hook = mocker.MagicMock(side_effect=RuntimeError("hook boom"))
+
+    # Must not raise despite the hook failing.
+    execute_sql_lab_query(
+        query,
+        "SELECT 42 AS answer",
+        return_results=False,
+        store_results=False,
+        expand_data=False,
+        cancel_hook=hook,
+    )
+    hook.assert_called_once()

--- a/tests/unit_tests/tasks/test_sql_queries.py
+++ b/tests/unit_tests/tasks/test_sql_queries.py
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-argument
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.common.db_query_status import QueryStatus
+from superset.tasks.sql_queries import run_sql_lab_query, SQL_LAB_TASK
+
+_MOD = "superset.tasks.sql_queries"
+_ENTRY = "superset.sql.execution.sqllab_executor.execute_sql_lab_query"
+
+
+def test_sql_lab_task_type_is_superset_sql_lab() -> None:
+    """The GTF task type is ``superset.sql_lab`` (what the SQL Lab client filters)."""
+    assert SQL_LAB_TASK == "superset.sql_lab"
+    assert run_sql_lab_query.name == "superset.sql_lab"
+
+
+def _wire(mocker: MockerFixture, ctx: Any) -> Any:
+    """Patch the task's lazily-imported deps + context; return the mocked Query."""
+    mocker.patch(f"{_MOD}.get_context", return_value=ctx)
+    mocker.patch(f"{_MOD}.override_user")
+    mocker.patch(f"{_MOD}.security_manager")
+    mocker.patch(f"{_MOD}.db")
+    query = mocker.MagicMock()
+    query.end_time = None
+    mocker.patch("superset.sql_lab.get_query", return_value=query)
+    return query
+
+
+def test_run_sql_lab_query_success(mocker: MockerFixture, app) -> None:
+    """Happy path: the entry runs; no error mirroring; correct args wired."""
+    ctx = mocker.MagicMock(aborting_in_flight=False, timeout_triggered=False)
+    _wire(mocker, ctx)
+    entry = mocker.patch(_ENTRY)
+
+    run_sql_lab_query.func(
+        1, "SELECT 1", store_results=True, expand_data=True, username="admin"
+    )
+
+    entry.assert_called_once()
+    _, kwargs = entry.call_args
+    assert kwargs["return_results"] is False
+    assert kwargs["store_results"] is True
+    assert kwargs["expand_data"] is True
+    assert callable(kwargs["cancel_hook"])
+
+
+def test_run_sql_lab_query_error_marks_failed_and_reraises(
+    mocker: MockerFixture, app
+) -> None:
+    """A genuine execution error fails the Query and propagates (→ task FAILURE)."""
+    ctx = mocker.MagicMock(aborting_in_flight=False, timeout_triggered=False)
+    _wire(mocker, ctx)
+    mocker.patch(_ENTRY, side_effect=RuntimeError("boom"))
+    handle_query_error = mocker.patch("superset.sql_lab.handle_query_error")
+
+    with pytest.raises(RuntimeError):
+        run_sql_lab_query.func(1, "SELECT 1", username="admin")
+
+    handle_query_error.assert_called_once()
+
+
+def test_run_sql_lab_query_abort_mirrors_stopped(mocker: MockerFixture, app) -> None:
+    """An abort (killed query surfaces as an error) mirrors STOPPED, no re-raise."""
+    ctx = mocker.MagicMock(aborting_in_flight=True, timeout_triggered=False)
+    query = _wire(mocker, ctx)
+    mocker.patch(_ENTRY, side_effect=RuntimeError("killed"))
+
+    run_sql_lab_query.func(1, "SELECT 1", username="admin")  # must not raise
+
+    assert query.status == QueryStatus.STOPPED
+
+
+def test_run_sql_lab_query_timeout_mirrors_timed_out(
+    mocker: MockerFixture, app
+) -> None:
+    """A timeout mirrors TIMED_OUT rather than STOPPED."""
+    ctx = mocker.MagicMock(aborting_in_flight=True, timeout_triggered=True)
+    query = _wire(mocker, ctx)
+    mocker.patch(_ENTRY, side_effect=RuntimeError("timed out"))
+
+    run_sql_lab_query.func(1, "SELECT 1", username="admin")
+
+    assert query.status == QueryStatus.TIMED_OUT
+
+
+def test_cancel_hook_registers_abort_and_persists_handle(
+    mocker: MockerFixture, app
+) -> None:
+    """The cancel hook persists the engine handle and registers an abort handler."""
+    ctx = mocker.MagicMock(aborting_in_flight=False, timeout_triggered=False)
+    _wire(mocker, ctx)
+    entry = mocker.patch(_ENTRY)
+
+    run_sql_lab_query.func(1, "SELECT 1", username="admin")
+    cancel_hook = entry.call_args.kwargs["cancel_hook"]
+
+    cancel_hook(7, "cancel-id-123")
+    ctx.set_cancellation.assert_called_once_with(7, "cancel-id-123")
+    ctx.on_abort.assert_called_once()

--- a/tests/unit_tests/tasks/test_sql_queries.py
+++ b/tests/unit_tests/tasks/test_sql_queries.py
@@ -106,10 +106,12 @@ def test_run_sql_lab_query_timeout_mirrors_timed_out(
 def test_cancel_hook_registers_abort_and_persists_handle(
     mocker: MockerFixture, app
 ) -> None:
-    """The cancel hook persists the engine handle and registers an abort handler."""
+    """The cancel hook persists the engine handle and registers an abort handler
+    that cancels the warehouse query over a fresh connection."""
     ctx = mocker.MagicMock(aborting_in_flight=False, timeout_triggered=False)
     _wire(mocker, ctx)
     entry = mocker.patch(_ENTRY)
+    cancel_chart_query = mocker.patch(f"{_MOD}.cancel_chart_query")
 
     run_sql_lab_query.func(1, "SELECT 1", username="admin")
     cancel_hook = entry.call_args.kwargs["cancel_hook"]
@@ -117,3 +119,8 @@ def test_cancel_hook_registers_abort_and_persists_handle(
     cancel_hook(7, "cancel-id-123")
     ctx.set_cancellation.assert_called_once_with(7, "cancel-id-123")
     ctx.on_abort.assert_called_once()
+
+    # Invoke the registered abort handler → it kills the query over a fresh conn.
+    abort_handler = ctx.on_abort.call_args.args[0]
+    abort_handler()
+    cancel_chart_query.assert_called_once()


### PR DESCRIPTION
### SUMMARY

Child PR 3 of the [SQL execution on GTF epic](https://github.com/apache/superset/pull/43928) (umbrella `villebro/sqllab-gtf`).

Adds the **GTF task for asynchronous SQL Lab execution** — `run_sql_lab_query` in `superset/tasks/sql_queries.py`, a **PRIVATE** GTF task of type **`superset.sql_lab`**, keyed by `Query.client_id` (per-user idempotency, subsuming the classic `is_query_handled` guard). It wraps the internal `execute_sql_lab_query` entry (added in #43931) so an async SQL Lab query runs on a worker with GTF's full lifecycle: signal-driven cancellation with warehouse-query kill, `@task` timeout, worker heartbeat + orphan reaping, and status.

Because it's a PRIVATE GTF task, an executing SQL Lab statement now appears in the **Task List** (scoped to the running user) and is cancellable from there — one of the epic's acceptance criteria.

Design:

- **The `Query` row stays the SQL-Lab-facing source of truth.** SUCCESS is set by the executor; the task mirrors **FAILED** (via `handle_query_error`) and **STOPPED / TIMED_OUT** (on abort/timeout) onto `Query.status`, so the existing `/query/updated_since` poll keeps working unchanged.
- **Cancellation reuses the engine-generic chart-data seam** (`superset.tasks.query_cancel`): the executor's new `cancel_hook` hands over the captured engine cancel id, which the task persists via `ctx.set_cancellation` (so the orphan reaper can cancel a dead worker's query) and kills over a **fresh** connection in an `on_abort` handler — never touching the live ORM `Query` from the abort-listener thread.
- **Sync SQL Lab does not use this task** — it calls `execute_sql_lab_query` directly, in-process, so only the async path requires GTF. The task is registered in `CeleryConfig.imports`.
- **Not yet wired to `/execute/`** — that's the next PR (#4), which points the endpoint's async path at `run_sql_lab_query.schedule()` and routes `/query/stop` through `CancelTaskCommand`, and decides GTF-enablement for the async path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — new backend code, not yet wired to the endpoint.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/tasks/test_sql_queries.py` — covers the task type, status mirroring for success / error (→ FAILED + re-raise) / abort (→ STOPPED) / timeout (→ TIMED_OUT), and the cancel hook (persists the handle + registers an abort handler). The execution + `sql_lab` suites pass unchanged.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_TASK_FRAMEWORK` (async SQL Lab execution only; sync is unaffected)
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
