### PR TITLE
fix(sqllab): wrap raw DBAPI errors in query cost estimation

### DIFF
--- a/superset/commands/sql_lab/estimate.py
+++ b/superset/commands/sql_lab/estimate.py
@@ -28,6 +28,7 @@ from superset.commands.base import BaseCommand
 from superset.daos.database import DatabaseDAO
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
+    OAuth2RedirectError,
     SupersetDisallowedSQLFunctionException,
     SupersetDisallowedSQLTableException,
     SupersetDMLNotAllowedException,
@@ -222,6 +223,9 @@ class QueryEstimationCommand(BaseCommand):
                 ),
                 status=500,
             ) from ex
+        except OAuth2RedirectError:
+            # user needs to authenticate with OAuth2 in order to run query
+            raise
         except Exception as ex:
             logger.exception("Query cost estimation failed unexpectedly")
             raise SupersetGenericDBErrorException(

--- a/superset/commands/sql_lab/estimate.py
+++ b/superset/commands/sql_lab/estimate.py
@@ -32,6 +32,7 @@ from superset.exceptions import (
     SupersetDisallowedSQLTableException,
     SupersetDMLNotAllowedException,
     SupersetErrorException,
+    SupersetGenericDBErrorException,
     SupersetTimeoutException,
 )
 from superset.jinja_context import get_template_processor
@@ -220,6 +221,11 @@ class QueryEstimationCommand(BaseCommand):
                     level=ErrorLevel.ERROR,
                 ),
                 status=500,
+            ) from ex
+        except Exception as ex:
+            logger.exception("Query cost estimation failed unexpectedly")
+            raise SupersetGenericDBErrorException(
+                utils.error_msg_from_exception(ex)
             ) from ex
 
         spec = self._database.db_engine_spec

--- a/tests/unit_tests/commands/sql_lab/test_estimate.py
+++ b/tests/unit_tests/commands/sql_lab/test_estimate.py
@@ -27,6 +27,7 @@ from superset.commands.sql_lab.estimate import (
 )
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
 from superset.exceptions import (
+    OAuth2RedirectError,
     SupersetErrorException,
     SupersetGenericDBErrorException,
     SupersetSecurityException,
@@ -533,3 +534,46 @@ def test_run_wraps_raw_dbapi_error_from_cost_estimation(
 
     assert exc_info.value.status == 400
     assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
+
+
+# ---------------------------------------------------------------------------
+# OAuth2RedirectError must pass through run() untouched, not be swallowed
+# by the broad DBAPI-error catch-all above
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.estimate.app")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.DatabaseDAO")
+def test_run_reraises_oauth2_redirect_error_from_cost_estimation(
+    mock_dao: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_app: MagicMock,
+) -> None:
+    """``OAuth2RedirectError`` raised by ``estimate_query_cost`` (via
+    ``get_raw_connection`` -> ``check_for_oauth2``) must propagate unchanged
+    so the frontend can drive the interactive re-auth flow — it must not be
+    re-wrapped into ``SupersetGenericDBErrorException`` by the broad
+    except-Exception clause, mirroring the sibling guard in
+    ``sql_lab.py``'s ``execute_sql_statements()``."""
+    mock_database = MagicMock()
+    mock_dao.find_by_id.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    mock_app.config = {
+        "SQLLAB_QUERY_COST_ESTIMATE_TIMEOUT": 10,
+        "QUERY_COST_FORMATTERS_BY_ENGINE": {},
+        "DISALLOWED_SQL_FUNCTIONS": {},
+        "DISALLOWED_SQL_TABLES": {},
+    }
+    mock_database.db_engine_spec.estimate_query_cost.side_effect = OAuth2RedirectError(
+        url="https://example.org/oauth2/authorize",
+        tab_id="tab-1",
+        redirect_uri="https://example.org/oauth2/callback",
+    )
+
+    sql = "SELECT 1"
+    command = QueryEstimationCommand(_make_params(sql=sql))
+    with pytest.raises(OAuth2RedirectError) as exc_info:
+        command.run()
+
+    assert exc_info.value.status == 403

--- a/tests/unit_tests/commands/sql_lab/test_estimate.py
+++ b/tests/unit_tests/commands/sql_lab/test_estimate.py
@@ -26,7 +26,11 @@ from superset.commands.sql_lab.estimate import (
     QueryEstimationCommand,
 )
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
-from superset.exceptions import SupersetErrorException, SupersetSecurityException
+from superset.exceptions import (
+    SupersetErrorException,
+    SupersetGenericDBErrorException,
+    SupersetSecurityException,
+)
 
 
 def _make_params(**kwargs: object) -> EstimateQueryCostType:
@@ -487,3 +491,45 @@ def test_run_wraps_raw_jsondecodeerror_from_cost_estimation(
 
     assert exc_info.value.status == 500
     assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_BACKEND_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Raw DBAPI errors from estimate_query_cost must not leak from run()
+# ---------------------------------------------------------------------------
+
+
+@patch("superset.commands.sql_lab.estimate.app")
+@patch("superset.commands.sql_lab.estimate.security_manager", new_callable=MagicMock)
+@patch("superset.commands.sql_lab.estimate.DatabaseDAO")
+def test_run_wraps_raw_dbapi_error_from_cost_estimation(
+    mock_dao: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_app: MagicMock,
+) -> None:
+    """A raw DBAPI exception (e.g. ``psycopg2.errors.SyntaxError``) raised by
+    ``estimate_query_cost`` when EXPLAIN parses invalid SQL must not leak past
+    ``run()`` — it should surface as ``SupersetGenericDBErrorException`` with
+    ``status == 400`` and ``GENERIC_DB_ENGINE_ERROR``, mirroring the sibling
+    pattern in ``SynchronousSqlJsonExecutor.execute()``."""
+    import psycopg2.errors
+
+    mock_database = MagicMock()
+    mock_dao.find_by_id.return_value = mock_database
+    mock_security_manager.raise_for_access.return_value = None
+    mock_app.config = {
+        "SQLLAB_QUERY_COST_ESTIMATE_TIMEOUT": 10,
+        "QUERY_COST_FORMATTERS_BY_ENGINE": {},
+        "DISALLOWED_SQL_FUNCTIONS": {},
+        "DISALLOWED_SQL_TABLES": {},
+    }
+    mock_database.db_engine_spec.estimate_query_cost.side_effect = (
+        psycopg2.errors.UndefinedTable('relation "nonexistent_table" does not exist')
+    )
+
+    sql = "SELECT 1 FROM nonexistent_table"
+    command = QueryEstimationCommand(_make_params(sql=sql))
+    with pytest.raises(SupersetGenericDBErrorException) as exc_info:
+        command.run()
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.error.error_type == SupersetErrorType.GENERIC_DB_ENGINE_ERROR


### PR DESCRIPTION
### SUMMARY

`QueryEstimationCommand.run()` only caught `SupersetTimeoutException` around the `estimate_query_cost()` call. Any raw DBAPI exception (e.g. `psycopg2.errors.UndefinedTable` from `EXPLAIN` on invalid SQL against Postgres) propagated uncaught through the call stack until Flask's global exception handler turned it into an opaque, unclassified 500-class response.

The sibling execution path (`SynchronousSqlJsonExecutor.execute()` in `superset/sqllab/sql_json_executer.py`) already converts raw DBAPI errors to `SupersetGenericDBErrorException` (status=400, `GENERIC_DB_ENGINE_ERROR`). This PR applies the same pattern to the cost-estimation path.

**What changed:** Added an `except Exception` clause after the existing `except SupersetTimeoutException` handler in `QueryEstimationCommand.run()`. The new clause logs the exception and re-raises it as `SupersetGenericDBErrorException`, giving the frontend a typed, actionable 400 error instead of an opaque 500.

This is part of the ongoing raw-exception-cleanup effort (see #42366, #42401, #43725, #43772, #43795, #43888).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (backend-only error handling change).

**Before:** Clicking "Estimate cost" on invalid SQL against a Postgres connection returns an opaque 500 response with a raw `psycopg2` traceback.

**After:** The same action returns a structured 400 response with `error_type: GENERIC_DB_ENGINE_ERROR` and the database's error message.

### TESTING INSTRUCTIONS

1. Connect to a Postgres database in SQL Lab
2. Enter invalid SQL (e.g. `SELECT 1 FROM nonexistent_table`)
3. Click "Estimate cost"
4. **Before this PR:** Opaque 500 error
5. **After this PR:** Clean 400 error with the database's error message (e.g. `relation "nonexistent_table" does not exist`)

Automated: `pytest tests/unit_tests/commands/sql_lab/test_estimate.py::test_run_wraps_raw_dbapi_error_from_cost_estimation` — verified fail-before/pass-after.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

**Merge-order note:** PR #43888 (JSONDecodeError catch in the same try block) is still open. Both PRs touch the same `try/except` block in `estimate.py`. They are independent — this PR's `except Exception` clause goes after any narrower catches. If #43888 merges first, this PR's rebase will place `except Exception` after the new `except json.JSONDecodeError` clause, which is the correct order. If this PR merges first, #43888's rebase is similarly clean.

**No tradeoffs beyond the intended one:** previously-opaque 500s on bad SQL during cost estimation now correctly 400 with a typed error.