### PR TITLE
fix(async): restore downstream extension seams on GTF

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -34,9 +34,9 @@ transport below) and re-issuing the original `/chart/data` request against the
 now-warm per-query cache, and the realtime WebSocket server is a generic,
 feature-agnostic task push transport rather than a GAQ-specific event tail.
 
-Breaking removals (no deprecation window):
+Breaking protocol removals (Python import adapters are described below):
 
-- The `/api/v1/async_event/` REST API, `AsyncQueryManager`, and the
+- The `/api/v1/async_event/` REST API and the
   `qc-<hash>` query-context descriptor replay endpoint
   (`GET /api/v1/chart/data/<cache_key>`) are removed. Any client that consumed a
   `result_url` from a `202` response must move to the re-request model (the
@@ -47,9 +47,35 @@ Breaking removals (no deprecation window):
   `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT`,
   `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT_FIREHOSE`,
   `GLOBAL_ASYNC_QUERIES_REGISTER_REQUEST_HANDLERS`,
-  `GLOBAL_ASYNC_QUERIES_JWT_*`, and
-  `GLOBAL_ASYNC_QUERY_MANAGER_CLASS`. The coordinator (locks, GTF, and now GAQ)
+  `GLOBAL_ASYNC_QUERIES_JWT_*`. The coordinator (locks, GTF, and now GAQ)
   uses `DISTRIBUTED_COORDINATION_CONFIG` exclusively.
+
+Downstream extension migration:
+
+- `ASYNC_QUERY_MANAGER_CLASS` selects an app-local
+  `superset.tasks.query_manager.QueryManager` subclass (class or dotted path).
+  Chart submission and `/api/v1/task/status_changes` use this manager; the
+  default implementation delegates to GTF. Frontend forks can supply a polling
+  reader to `asyncEvent.init(config, pollingTransport)` without replacing the
+  GTF waiter, cancellation, or cache re-request logic.
+- `superset.extensions.async_query_manager_factory`, `async_query_manager`,
+  `superset.async_events.async_query_manager.AsyncQueryManager`,
+  `AsyncQueryTokenException`, and `CreateAsyncChartDataJobCommand` are deprecated
+  import adapters. `GLOBAL_ASYNC_QUERY_MANAGER_CLASS` is a deprecated fallback
+  for the new setting. Use emits `DeprecationWarning`; these adapters and the
+  config alias will be retained throughout the first major release containing
+  this change, with removal no earlier than the following major release.
+- This is **import compatibility, not legacy job-protocol compatibility**.
+  Submission returns GTF `task_ids`/`cursor`, not `job_id`/`result_url`.
+  `init_job`, `update_job`, `read_events`, the old cookie/Redis settings, and
+  legacy Explore Celery tasks are not restored. Existing subclasses must migrate
+  those overrides; importing successfully does not make them runtime-compatible.
+- Verified Manager-JWT `jti` channel IDs can still be returned by an overridden
+  `parse_channel_id_from_request` for custom transports. They do not replace GTF
+  subscriber authorization or its principal-prefixed websocket routing keys.
+
+See [Async-query extension migration](docs/developer_docs/extensions/async-queries.md)
+for the supported contract and the complete configuration disposition.
 
 Enabling async chart data in the new flow:
 

--- a/docs/developer_docs/extensions/async-queries.md
+++ b/docs/developer_docs/extensions/async-queries.md
@@ -1,0 +1,154 @@
+---
+title: Async-query extension migration
+sidebar_position: 11
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Async-query extension migration
+
+Global Async Queries uses Global Task Framework (GTF) execution: one task per
+QueryObject, shared-task deduplication, task UUIDs and a status cursor, followed
+by a synchronous re-request against the warmed query cache. The extension seam
+below does not reinstate the retired Redis job/event protocol.
+
+## Backend manager
+
+Set `ASYNC_QUERY_MANAGER_CLASS` in `superset_config.py` to a `QueryManager`
+subclass or its dotted import path. Instances belong to a Flask app, not a
+process-global singleton. `init_app(app)` runs once, inside that app's context;
+do not store request-specific state on the manager. Configure web and worker
+apps consistently. Obtain the active instance with
+`superset.extensions.query_manager.get_query_manager()`.
+
+```python
+from flask import Request
+from superset.tasks.query_manager import QueryManager
+
+class DeploymentQueryManager(QueryManager):
+    def parse_channel_id_from_request(self, req: Request) -> str:
+        # Use the deployment's authenticated, signature-verified JWT claims.
+        # Never decode an unverified bearer token to obtain this identity.
+        return verified_manager_claims()["jti"]
+
+ASYNC_QUERY_MANAGER_CLASS = DeploymentQueryManager
+```
+
+`verified_manager_claims` above represents your authentication integration, not
+an API provided by Superset. The built-in channel resolver uses the current
+user/guest principal and does not require the removed async-token cookie.
+
+Supported methods:
+
+- `submit(query_context, user_id)`: called after the chart route's access checks
+  and cache probe. Delegate to `super().submit(...)` to retain query serialization,
+  effective identity/RLS, contribution DAGs, cancellation and deduplication.
+  Return the GTF `task_ids`/`cursor`/optional `tab_id` handshake unchanged. Custom
+  callers must authorize the QueryContext before submitting it.
+- `status_changes(cursor, task_type=None)`: called by the protected Task REST
+  endpoint. The default delegates to `TaskDAO.get_statuses_changed_since`, with
+  subscriber/guest visibility filters. A custom reader must preserve those
+  checks, the optional task-type filter, and the datetime cursor contract. This
+  endpoint also serves non-chart task consumers; do not limit all reads to charts.
+- `parse_channel_id_from_request(req)`: an overridable identity helper for custom
+  transports and the legacy command adapter. Native GTF submission/polling does
+  **not** use the returned channel to authorize tasks. A custom submission or
+  polling override can call this helper in the authenticated request context.
+
+A Manager JWT's opaque `jti` can remain the custom transport's channel ID, but it
+cannot directly become the built-in websocket's routing key: GTF validates
+routes against task subscribers (`user:<id>` or `guest:<hmac>`, optionally with a
+per-client suffix). Use a custom authenticated transport with an authorized
+mapping to GTF tasks, or migrate to GTF principal/per-tab subscriptions. A `jti`
+alone must never grant access to another principal's task. No JWT secret or
+cookie settings are automatically copied to the new websocket trust domain.
+
+## Custom client polling
+
+Frontend forks can initialize the async middleware with a typed reader:
+
+```typescript
+import { init, AsyncQueryPollingTransport } from 'src/middleware/asyncEvent';
+
+const poll: AsyncQueryPollingTransport = async ({ cursor, task_type }) => {
+  // deploymentClient authenticates using your deployment's transport.
+  return deploymentClient.readTaskStatuses({ cursor, task_type });
+};
+init(appConfig, poll);
+```
+
+The reader receives the server cursor and task type and returns
+`{ statuses: { [taskUuid]: { status, progress } }, cursor }`. Its endpoint must
+read authoritative, authorized GTF state, not translate Redis stream IDs into
+timestamps. It is used for both interval polling and websocket reconciliation;
+backoff, waiter aggregation, failures and cache re-requests stay in Superset.
+Set `WEBSOCKET_ENABLE=False` to use polling alone. Calling `init` without a
+reader restores the default Task REST API transport. Install the override after
+the application's normal initialization and before submitting chart requests.
+
+## Deprecated imports and migration window
+
+The Python import adapters and manager config alias emit `DeprecationWarning`
+and remain available throughout the first major release containing this change;
+removal is no earlier than the following major release. Enable Python's default
+warning filter during downstream migration (`PYTHONWARNINGS=default`).
+
+| Removed surface | Disposition |
+| --- | --- |
+| `superset.async_events` | Deprecated import namespace only; no API or Redis engine |
+| `superset.extensions.async_query_manager_factory` | Lazy factory alias; `init_app(app)` (or current app) initializes the GTF-backed manager once |
+| `superset.extensions.async_query_manager` | Lazy app-local proxy; replace with `get_query_manager()` |
+| `AsyncQueryManager` | Subclassable `QueryManager` adapter; `submit_chart_data_job` validates access and delegates to GTF |
+| `AsyncQueryTokenException` | Alias for `AsyncQueryTokenError`; existing exception catches retain identity |
+| `create_async_job_command.CreateAsyncChartDataJobCommand` | `validate` resolves the custom channel; `run` validates QueryContext access and returns the GTF handshake |
+| `init_job`, `update_job`, `read_events`, legacy cancellation and `result_url` replay | Not emulated; use GTF task lifecycle, status reads, task cancellation and chart-data re-request |
+
+Legacy Explore task implementations belong to the downstream fork. Only the imports listed above are covered; imports of removed private task
+helpers and legacy lifecycle calls still require migration to GTF. Old overrides of `submit_chart_data_job`/`read_events` are not
+invoked by the native GTF chart/status routes; port them to `submit` and
+`status_changes`. This layer is not a promise that an unchanged legacy subclass
+can execute requests.
+
+## Configuration disposition
+
+| Key | Replacement or disposition |
+| --- | --- |
+| `GLOBAL_ASYNC_QUERY_MANAGER_CLASS` | Deprecated fallback for `ASYNC_QUERY_MANAGER_CLASS`; the new key takes precedence |
+| `GLOBAL_ASYNC_QUERIES` feature flag | Retained; auto-enables GTF |
+| `GLOBAL_ASYNC_QUERIES_POLLING_DELAY` | Retained, same base polling cadence |
+| `GLOBAL_ASYNC_QUERIES_CACHE_BACKEND` | Removed; use `DISTRIBUTED_COORDINATION_CONFIG` for coordination and `DATA_CACHE_CONFIG` for results |
+| `GLOBAL_ASYNC_QUERIES_TRANSPORT` | Removed; `WEBSOCKET_ENABLE=False` uses polling, or supply a client polling reader |
+| `GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL` | Removed; use `WEBSOCKET_URL` with the new websocket server |
+| `GLOBAL_ASYNC_QUERIES_JWT_SECRET` | Removed; explicitly configure `WEBSOCKET_JWT_SECRET` only if using websocket transport |
+| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME` | Removed; `WEBSOCKET_JWT_COOKIE_NAME` (new token claims, not old-token compatibility) |
+| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_SECURE` | Removed; `WEBSOCKET_JWT_COOKIE_SECURE` |
+| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_SAMESITE` | Removed; `WEBSOCKET_JWT_COOKIE_SAMESITE` |
+| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_DOMAIN` | Removed; `WEBSOCKET_JWT_COOKIE_DOMAIN` |
+| `GLOBAL_ASYNC_QUERIES_JWT_EXPIRATION_SECONDS` | Removed; `WEBSOCKET_JWT_EXPIRATION_SECONDS` for websocket token lifetime, not task timeout |
+| `GLOBAL_ASYNC_QUERIES_REGISTER_REQUEST_HANDLERS` | Removed; websocket cookie handling follows `WEBSOCKET_ENABLE`; custom manager owns its transport handlers |
+| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_PREFIX` | Removed; no browser-facing GAQ Redis streams; coordination uses its own namespace |
+| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT` | Removed; no GAQ per-channel event log |
+| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT_FIREHOSE` | Removed; no GAQ firehose; use GTF task observability/retention |
+
+The GTF-era settings `GLOBAL_ASYNC_QUERIES_DEFAULT`,
+`GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL`, `GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT`,
+`GLOBAL_ASYNC_QUERIES_POLLING_MAX_DELAY` and
+`GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT` are unchanged. Retired settings
+other than the manager alias are not interpreted or silently translated.

--- a/superset-frontend/src/middleware/asyncEvent.test.ts
+++ b/superset-frontend/src/middleware/asyncEvent.test.ts
@@ -835,3 +835,42 @@ test('WS mode: the last-chance catch-up before give-up recovers a missed complet
   expect(refetch).toHaveBeenCalledTimes(1);
   jest.useRealTimers();
 });
+
+test.each([false, true])(
+  'uses a custom status transport for polling and websocket catch-up (ws=%s)',
+  async websocket => {
+    const transport = jest.fn().mockResolvedValue({
+      statuses: { 'task-1': { status: 'success', progress: null } },
+      cursor: '2026-01-01T00:00:01',
+    });
+    asyncEvent.init(
+      {
+        ...config,
+        WEBSOCKET_ENABLE: websocket,
+        WEBSOCKET_URL: 'ws://localhost:8080/',
+      },
+      transport,
+    );
+    const refetch = jest.fn().mockResolvedValue([{ rows: 1 }]);
+    await asyncEvent.waitForAsyncData(
+      { task_ids: ['task-1'], cursor: '2026-01-01T00:00:00' },
+      refetch,
+    );
+    expect(transport).toHaveBeenCalledWith({
+      cursor: '2026-01-01T00:00:00',
+      task_type: 'superset.query_object_v1',
+    });
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(fetchMock.callHistory.calls(STATUS_CHANGES_ENDPOINT)).toHaveLength(
+      0,
+    );
+
+    // Reinitializing without a custom transport restores the built-in reader.
+    queueStatuses({ 'task-2': { status: 'success' } });
+    asyncEvent.init(config);
+    await asyncEvent.waitForAsyncData({ task_ids: ['task-2'] }, refetch);
+    expect(
+      fetchMock.callHistory.calls(STATUS_CHANGES_ENDPOINT).length,
+    ).toBeGreaterThan(0);
+  },
+);

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -64,7 +64,7 @@ const TERMINAL_STATUSES = new Set([
 ]);
 
 type TaskStatusChange = { status: string; progress: number | null };
-type StatusChangesResponse = {
+export type StatusChangesResponse = {
   statuses: Record<string, TaskStatusChange>;
   cursor: string | null;
 };
@@ -172,13 +172,24 @@ const stopIfStale = (generation: number): boolean => {
 // that reaches this browser is always its own.
 const TASK_STATUS_TOPIC = 'task.status';
 
-const fetchStatusChanges = makeApi<
-  { cursor?: string | null; task_type: string },
+export type StatusChangesRequest = {
+  cursor?: string | null;
+  task_type: string;
+};
+
+export type AsyncQueryPollingTransport = (
+  request: StatusChangesRequest,
+) => Promise<StatusChangesResponse>;
+
+const defaultFetchStatusChanges = makeApi<
+  StatusChangesRequest,
   StatusChangesResponse
 >({
   method: 'GET',
   endpoint: STATUS_CHANGES_URL,
 });
+
+let fetchStatusChanges: AsyncQueryPollingTransport = defaultFetchStatusChanges;
 
 const cancelTask = (taskId: string, tabId: string) => {
   // Best-effort task abort/unsubscribe. This prevents pending work from starting
@@ -587,7 +598,11 @@ export const waitForAsyncData = async <T = unknown[]>(
   return refetch(taskIds);
 };
 
-export const init = (appConfig?: AppConfig) => {
+export const init = (
+  appConfig?: AppConfig,
+  pollingTransport: AsyncQueryPollingTransport = defaultFetchStatusChanges,
+) => {
+  fetchStatusChanges = pollingTransport;
   pollingGeneration += 1;
   if (pollingTimeoutId) clearTimeout(pollingTimeoutId);
 

--- a/superset/async_events/__init__.py
+++ b/superset/async_events/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Deprecated GAQ import namespace; execution is provided by GTF."""

--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Deprecated import adapters, not the retired Redis-stream job protocol."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from superset.tasks.query_manager import AsyncQueryTokenError, QueryManager
+
+warnings.warn(
+    "superset.async_events.async_query_manager is deprecated; use "
+    "superset.tasks.query_manager. Execution and polling use the GTF protocol.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+AsyncQueryTokenException = AsyncQueryTokenError
+
+
+class AsyncQueryManager(QueryManager):
+    """Import-compatible base class delegating chart submission to GTF.
+
+    Legacy init_job/update_job/read_events and Redis result_url replay are not
+    emulated. Migrate these to GTF task lifecycle and status_changes instead.
+    """
+
+    def submit_chart_data_job(
+        self,
+        channel_id: str,
+        form_data: dict[str, Any],
+        user_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Validate a legacy submission and return GTF task_ids/cursor, not job_id."""
+        from superset.commands.chart.data.get_data_command import ChartDataCommand
+        from superset.common.query_context_factory import QueryContextFactory
+
+        warnings.warn(
+            "submit_chart_data_job is deprecated; use QueryManager.submit. "
+            "The return value is a GTF task_ids/cursor handshake.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        query_context = QueryContextFactory().create(**form_data)
+        ChartDataCommand(query_context).validate()
+        return self.submit(query_context, user_id)

--- a/superset/charts/data/api.py
+++ b/superset/charts/data/api.py
@@ -54,8 +54,8 @@ from superset.constants import CACHE_DISABLED_TIMEOUT
 from superset.daos.exceptions import DatasourceNotFound
 from superset.exceptions import QueryObjectValidationError, SupersetSecurityException
 from superset.extensions import cache_manager, event_logger
+from superset.extensions.query_manager import get_query_manager
 from superset.models.sql_lab import Query
-from superset.tasks.async_queries import submit_chart_data_query_tasks
 from superset.tasks.guest import get_current_guest_subscriber_key
 from superset.utils import json
 from superset.utils.core import (
@@ -429,7 +429,7 @@ class ChartDataRestApi(ChartRestApi):
         # chart query. The client polls /api/v1/task/status_changes, aggregates the
         # tasks' statuses, and on success re-issues this same request — now served
         # synchronously from the per-query DATA cache the tasks populated.
-        job = submit_chart_data_query_tasks(command.query_context, get_user_id())
+        job = get_query_manager().submit(command.query_context, get_user_id())
         return self.response(202, **job)
 
     def _send_chart_response(  # noqa: C901

--- a/superset/commands/chart/data/create_async_job_command.py
+++ b/superset/commands/chart/data/create_async_job_command.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Deprecated chart submission adapter for downstream imports."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from flask import Request
+
+from superset.commands.chart.data.get_data_command import ChartDataCommand
+from superset.common.query_context_factory import QueryContextFactory
+from superset.extensions.query_manager import get_query_manager
+
+warnings.warn(
+    "CreateAsyncChartDataJobCommand is deprecated; use QueryManager.submit "
+    "with an authorized QueryContext. Results use the GTF task_ids/cursor protocol.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class CreateAsyncChartDataJobCommand:
+    """Preserve validate/run imports while submitting through GTF."""
+
+    _async_channel_id: str | None = None
+
+    def validate(self, request: Request) -> None:
+        """Resolve the downstream transport identity from an authenticated request."""
+        self._async_channel_id = get_query_manager().parse_channel_id_from_request(
+            request
+        )
+
+    def run(self, form_data: dict[str, Any], user_id: int | None) -> dict[str, Any]:
+        """Authorize chart access before submitting and returning a GTF handshake."""
+        if not self._async_channel_id:
+            raise RuntimeError("Call validate() before run()")
+        query_context = QueryContextFactory().create(**form_data)
+        ChartDataCommand(query_context).validate()
+        return get_query_manager().submit(query_context, user_id)

--- a/superset/config.py
+++ b/superset/config.py
@@ -2926,6 +2926,12 @@ SQLA_TABLE_MUTATOR = lambda table: table  # noqa: E731
 # queries run on the Global Task Framework (one task per QueryObject) over
 # DISTRIBUTED_COORDINATION_CONFIG; the client polls /api/v1/task/status_changes at
 # this interval (milliseconds) and re-issues its request once the tasks succeed.
+# Operator-supplied QueryManager subclass (class or dotted import path).
+# None selects the built-in GTF implementation.
+ASYNC_QUERY_MANAGER_CLASS: type | str | None = None
+# Deprecated alias, honored only when ASYNC_QUERY_MANAGER_CLASS is unset.
+GLOBAL_ASYNC_QUERY_MANAGER_CLASS: type | str | None = None
+
 GLOBAL_ASYNC_QUERIES_POLLING_DELAY = int(
     timedelta(milliseconds=500).total_seconds() * 1000
 )

--- a/superset/extensions/__init__.py
+++ b/superset/extensions/__init__.py
@@ -199,3 +199,25 @@ security_manager: SupersetSecurityManager = LocalProxy(lambda: appbuilder.sm)
 ssh_manager_factory = SSHManagerFactory()
 stats_logger_manager = BaseStatsLoggerManager()
 talisman = Talisman()
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve deprecated GAQ extension imports without initializing an app."""
+    if name in {"async_query_manager_factory", "async_query_manager"}:
+        import warnings
+
+        from superset.extensions.query_manager import (
+            get_query_manager,
+            query_manager_factory,
+        )
+
+        warnings.warn(
+            f"superset.extensions.{name} is deprecated; use "
+            "superset.extensions.query_manager.get_query_manager instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if name == "async_query_manager_factory":
+            return query_manager_factory
+        return LocalProxy(get_query_manager)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/superset/extensions/query_manager.py
+++ b/superset/extensions/query_manager.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Flask lifecycle for the GTF async-query extension seam."""
+
+from __future__ import annotations
+
+import warnings
+from typing import cast
+
+from flask import current_app, Flask
+from werkzeug.utils import import_string
+
+from superset.tasks.query_manager import QueryManager
+
+_EXTENSION_KEY = "superset.query_manager"
+
+
+class QueryManagerFactory:
+    """Keep managers app-local, including in multi-app worker processes."""
+
+    def init_app(self, app: Flask | None = None) -> None:
+        """Initialize once; legacy callers may use the current app context."""
+        if app is None:
+            app = current_app._get_current_object()  # noqa: SLF001
+        if _EXTENSION_KEY in app.extensions:
+            return
+        manager_class = app.config.get("ASYNC_QUERY_MANAGER_CLASS")
+        legacy_class = app.config.get("GLOBAL_ASYNC_QUERY_MANAGER_CLASS")
+        if legacy_class:
+            warnings.warn(
+                "GLOBAL_ASYNC_QUERY_MANAGER_CLASS is deprecated; use "
+                "ASYNC_QUERY_MANAGER_CLASS and the GTF QueryManager contract.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        manager_class = manager_class or legacy_class or QueryManager
+        if isinstance(manager_class, str):
+            manager_class = import_string(manager_class)
+        if not isinstance(manager_class, type) or not issubclass(
+            manager_class, QueryManager
+        ):
+            raise TypeError("ASYNC_QUERY_MANAGER_CLASS must subclass QueryManager")
+        manager = manager_class()
+        with app.app_context():
+            manager.init_app(app)
+        app.extensions[_EXTENSION_KEY] = manager
+
+    @property
+    def instance(self) -> QueryManager:
+        """Return the current app's manager, initializing on first use if needed."""
+        self.init_app()
+        return cast(QueryManager, current_app.extensions[_EXTENSION_KEY])
+
+
+query_manager_factory = QueryManagerFactory()
+
+
+def get_query_manager() -> QueryManager:
+    """Return the manager for the active Flask app."""
+    return query_manager_factory.instance

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -1040,6 +1040,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         self.configure_ssh_manager()
         self.configure_stats_manager()
         self.configure_task_manager()
+        self.configure_async_queries()
         self.configure_websocket()
 
         # Hook that provides administrators a handle on the Flask APP
@@ -1621,6 +1622,12 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             from superset.tasks.manager import TaskManager
 
             TaskManager.init_app(self.superset_app)
+
+    def configure_async_queries(self) -> None:
+        """Initialize the app-local GTF query manager, including downstream hooks."""
+        from superset.extensions.query_manager import query_manager_factory
+
+        query_manager_factory.init_app(self.superset_app)
 
     def configure_websocket(self) -> None:
         """Mint the websocket channel-token cookie when the transport is enabled."""

--- a/superset/tasks/api.py
+++ b/superset/tasks/api.py
@@ -272,8 +272,9 @@ class TaskRestApi(BaseSupersetModelRestApi):
     @safe
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}"
-        ".status_changes",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.status_changes"
+        ),
         log_to_statsd=False,
     )
     def status_changes(self) -> Response:
@@ -318,7 +319,7 @@ class TaskRestApi(BaseSupersetModelRestApi):
             401:
               $ref: '#/components/responses/401'
         """
-        from superset.daos.tasks import TaskDAO
+        from superset.extensions.query_manager import get_query_manager
 
         cursor: datetime | None = None
         if cursor_arg := request.args.get("cursor"):
@@ -327,7 +328,7 @@ class TaskRestApi(BaseSupersetModelRestApi):
             except ValueError:
                 return self.response_400(message="Invalid cursor")
 
-        statuses, next_cursor = TaskDAO.get_statuses_changed_since(
+        statuses, next_cursor = get_query_manager().status_changes(
             cursor, task_type=request.args.get("task_type")
         )
         return self.response(

--- a/superset/tasks/query_manager.py
+++ b/superset/tasks/query_manager.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""App-scoped extension points for chart queries executed by GTF."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, TYPE_CHECKING
+
+from flask import Flask, Request
+
+if TYPE_CHECKING:
+    from superset.common.query_context import QueryContext
+
+
+class AsyncQueryTokenError(Exception):
+    """The request has no usable async-query transport identity."""
+
+
+class QueryManager:
+    """Customize submission and polling without replacing GTF execution.
+
+    Implementations are operator-supplied, instantiated once per Flask app, and
+    must not store request identities on the instance. Status readers must retain
+    GTF's subscriber/guest authorization; channel IDs are not authorization.
+    """
+
+    def init_app(self, app: Flask) -> None:
+        """Initialize app-local resources (no legacy Redis streams or cookies)."""
+
+    def submit(
+        self, query_context: QueryContext, user_id: int | None
+    ) -> dict[str, Any]:
+        """Submit an already-authorized query context using the GTF handshake."""
+        from superset.tasks.async_queries import submit_chart_data_query_tasks
+
+        return submit_chart_data_query_tasks(query_context, user_id)
+
+    def status_changes(
+        self, cursor: datetime | None, task_type: str | None = None
+    ) -> tuple[dict[str, dict[str, Any]], datetime]:
+        """Read authoritative task status scoped to the current principal."""
+        from superset.daos.tasks import TaskDAO
+
+        return TaskDAO.get_statuses_changed_since(cursor, task_type=task_type)
+
+    def parse_channel_id_from_request(self, req: Request) -> str:
+        """Resolve a transport identity, independently of task authorization.
+
+        Forks may override this to return a verified Manager-JWT jti. An opaque
+        channel is usable by a custom transport, not by GTF websocket routing.
+        """
+        from superset.tasks.guest import get_current_guest_subscriber_key
+        from superset.tasks.subscription import principal_channel
+        from superset.utils.core import get_user_id
+
+        channel = principal_channel(get_user_id(), get_current_guest_subscriber_key())
+        if channel is None:
+            raise AsyncQueryTokenError("No async-query principal on request")
+        return channel

--- a/tests/unit_tests/charts/test_chart_data_api.py
+++ b/tests/unit_tests/charts/test_chart_data_api.py
@@ -824,7 +824,7 @@ def test_run_async_does_not_project_timing_onto_a_job_response(
         with (
             app.test_request_context("/api/v1/chart/data", method="POST"),
             patch(
-                "superset.charts.data.api.submit_chart_data_query_tasks",
+                "superset.tasks.async_queries.submit_chart_data_query_tasks",
                 return_value={
                     "task_ids": ["task-1", "task-2"],
                     "cursor": "2020-01-01T00:00:00",

--- a/tests/unit_tests/tasks/test_query_manager.py
+++ b/tests/unit_tests/tasks/test_query_manager.py
@@ -1,0 +1,248 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Regression coverage for the GTF downstream seam and import adapters."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Flask, Request
+
+from superset.extensions.query_manager import (
+    get_query_manager,
+    query_manager_factory,
+    QueryManagerFactory,
+)
+from superset.tasks.query_manager import AsyncQueryTokenError, QueryManager
+
+
+class CustomManager(QueryManager):
+    """An operator-owned manager with a verified token transport identity."""
+
+    def init_app(self, app: Flask) -> None:
+        """Record initialization on this app only."""
+        app.config["QUERY_MANAGER_INIT_COUNT"] = (
+            app.config.get("QUERY_MANAGER_INIT_COUNT", 0) + 1
+        )
+
+    def parse_channel_id_from_request(self, req: Request) -> str:
+        """Stand in for a downstream verified-JWT jti reader."""
+        return "verified-manager-jti"
+
+
+def test_factory_app_isolation_and_idempotency() -> None:
+    """Repeated downstream initialization must not replace managers or leak apps."""
+    apps = [Flask("one"), Flask("two")]
+    managers = []
+    for app in apps:
+        app.config["ASYNC_QUERY_MANAGER_CLASS"] = CustomManager
+        query_manager_factory.init_app(app)
+        with app.app_context():
+            query_manager_factory.init_app()
+            managers.append(get_query_manager())
+            assert isinstance(managers[-1], CustomManager)
+            assert app.config["QUERY_MANAGER_INIT_COUNT"] == 1
+    assert managers[0] is not managers[1]
+
+
+def test_legacy_class_config_and_new_config_precedence() -> None:
+    """Warn for the alias while giving the new config precedence."""
+    for config in (
+        {"GLOBAL_ASYNC_QUERY_MANAGER_CLASS": CustomManager},
+        {
+            "GLOBAL_ASYNC_QUERY_MANAGER_CLASS": "unused.invalid.Class",
+            "ASYNC_QUERY_MANAGER_CLASS": CustomManager,
+        },
+    ):
+        app = Flask(__name__)
+        app.config.update(config)
+        with pytest.warns(DeprecationWarning, match="GLOBAL_ASYNC_QUERY_MANAGER_CLASS"):
+            QueryManagerFactory().init_app(app)
+        with app.app_context():
+            assert isinstance(get_query_manager(), CustomManager)
+
+
+def test_factory_import_path_and_invalid_class() -> None:
+    """Load dotted paths and reject objects that do not implement the contract."""
+    app = Flask(__name__)
+    app.config["ASYNC_QUERY_MANAGER_CLASS"] = (
+        "superset.tasks.query_manager.QueryManager"
+    )
+    QueryManagerFactory().init_app(app)
+    with app.app_context():
+        assert type(get_query_manager()) is QueryManager
+    app = Flask("invalid")
+    app.config["ASYNC_QUERY_MANAGER_CLASS"] = object
+    with pytest.raises(TypeError, match="subclass QueryManager"):
+        QueryManagerFactory().init_app(app)
+
+
+def test_default_submission_and_polling_delegate_to_gtf() -> None:
+    """Keep the task handshake and authorized DAO cursor semantics unchanged."""
+    manager = QueryManager()
+    context = Mock()
+    handshake = {"task_ids": ["task-uuid"], "cursor": "2026-01-01T00:00:00"}
+    with patch(
+        "superset.tasks.async_queries.submit_chart_data_query_tasks",
+        return_value=handshake,
+    ) as submit:
+        assert manager.submit(context, 7) == handshake
+        submit.assert_called_once_with(context, 7)
+    cursor = datetime(2026, 1, 1)
+    statuses = ({"task-uuid": {"status": "success", "progress": None}}, cursor)
+    with patch(
+        "superset.daos.tasks.TaskDAO.get_statuses_changed_since", return_value=statuses
+    ) as poll:
+        assert manager.status_changes(cursor, "superset.query_object_v1") == statuses
+        poll.assert_called_once_with(cursor, task_type="superset.query_object_v1")
+
+
+def test_channel_hook_keeps_custom_jti_without_changing_authorization() -> None:
+    """A fork can retain its verified JWT channel without a Superset cookie."""
+    app = Flask(__name__)
+    app.config["ASYNC_QUERY_MANAGER_CLASS"] = CustomManager
+    with app.test_request_context():
+        from flask import request
+
+        assert get_query_manager().parse_channel_id_from_request(request) == (
+            "verified-manager-jti"
+        )
+
+
+def test_default_channel_rejects_anonymous() -> None:
+    """An unidentified request cannot gain a transport identity."""
+    with (
+        patch("superset.utils.core.get_user_id", return_value=None),
+        patch(
+            "superset.tasks.guest.get_current_guest_subscriber_key", return_value=None
+        ),
+        pytest.raises(AsyncQueryTokenError),
+    ):
+        QueryManager().parse_channel_id_from_request(Mock(spec=Request))
+
+
+def test_deprecated_extensions_import_without_app_context() -> None:
+    """Imports remain lazy; no GTF/Redis resources are started by the shims."""
+    import superset.extensions as extensions
+
+    with pytest.warns(DeprecationWarning, match="async_query_manager_factory"):
+        assert extensions.async_query_manager_factory is query_manager_factory
+    with pytest.warns(DeprecationWarning, match="async_query_manager"):
+        proxy = extensions.async_query_manager
+    app = Flask(__name__)
+    with app.app_context():
+        assert proxy._get_current_object() is get_query_manager()
+    with pytest.raises(AttributeError):
+        _ = extensions.not_an_extension
+
+
+def test_deprecated_manager_import_and_submission() -> None:
+    """The adapter validates access before scheduling; it returns GTF metadata."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        module = importlib.import_module("superset.async_events.async_query_manager")
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        importlib.reload(module)
+    assert module.AsyncQueryTokenException is AsyncQueryTokenError
+    manager = module.AsyncQueryManager()
+    with (
+        patch("superset.common.query_context_factory.QueryContextFactory") as factory,
+        patch(
+            "superset.commands.chart.data.get_data_command.ChartDataCommand"
+        ) as command,
+        patch.object(manager, "submit", return_value={"task_ids": ["uuid"]}) as submit,
+    ):
+        with pytest.warns(DeprecationWarning, match="submit_chart_data_job"):
+            result = manager.submit_chart_data_job("jti", {}, 7)
+        assert result == {"task_ids": ["uuid"]}
+        command.return_value.validate.assert_called_once_with()
+        submit.assert_called_once_with(factory.return_value.create.return_value, 7)
+
+
+def test_deprecated_command_validates_and_uses_custom_manager() -> None:
+    """The removed command remains importable, but never restores legacy jobs."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        module = importlib.import_module(
+            "superset.commands.chart.data.create_async_job_command"
+        )
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        importlib.reload(module)
+    command = module.CreateAsyncChartDataJobCommand()
+    with pytest.raises(RuntimeError, match="validate"):
+        command.run({}, 7)
+    with (
+        patch.object(module, "get_query_manager") as get_manager,
+        patch.object(module, "QueryContextFactory") as factory,
+        patch.object(module, "ChartDataCommand") as chart_command,
+    ):
+        get_manager.return_value.parse_channel_id_from_request.return_value = "jti"
+        command.validate(Mock(spec=Request))
+        command.run({}, 7)
+        chart_command.return_value.validate.assert_called_once_with()
+        get_manager.return_value.submit.assert_called_once_with(
+            factory.return_value.create.return_value, 7
+        )
+        chart_command.return_value.validate.side_effect = AsyncQueryTokenError()
+        get_manager.return_value.submit.reset_mock()
+        with pytest.raises(AsyncQueryTokenError):
+            command.run({}, 7)
+        get_manager.return_value.submit.assert_not_called()
+
+
+def test_task_status_route_dispatches_to_custom_manager() -> None:
+    """The protected route uses the configured reader and serializes its cursor."""
+    from inspect import unwrap
+
+    from superset.tasks.api import TaskRestApi
+
+    api = Mock(spec=TaskRestApi)
+    cursor = datetime(2026, 1, 1)
+    with (
+        Flask(__name__).test_request_context(
+            "/?cursor=2026-01-01T00:00:00&task_type=superset.query_object_v1"
+        ),
+        patch("superset.extensions.query_manager.get_query_manager") as manager,
+    ):
+        manager.return_value.status_changes.return_value = ({}, cursor)
+        unwrap(TaskRestApi.status_changes)(api)
+        manager.return_value.status_changes.assert_called_once_with(
+            cursor, task_type="superset.query_object_v1"
+        )
+        api.response.assert_called_once_with(
+            200, statuses={}, cursor="2026-01-01T00:00:00"
+        )
+
+
+def test_task_status_route_rejects_invalid_cursor_before_dispatch() -> None:
+    """Custom readers retain the REST endpoint's cursor validation."""
+    from inspect import unwrap
+
+    from superset.tasks.api import TaskRestApi
+
+    api = Mock(spec=TaskRestApi)
+    with (
+        Flask(__name__).test_request_context("/?cursor=not-a-cursor"),
+        patch("superset.extensions.query_manager.get_query_manager") as manager,
+    ):
+        unwrap(TaskRestApi.status_changes)(api)
+        manager.assert_not_called()
+        api.response_400.assert_called_once_with(message="Invalid cursor")


### PR DESCRIPTION
### SUMMARY

Follow-up to #43407. Restore a narrow, documented downstream extension seam without reverting GAQ's migration to GTF.

**Design decision:** use an app-local `QueryManager` selected by `ASYNC_QUERY_MANAGER_CLASS`, plus a typed frontend polling reader. The default manager delegates to the existing per-QueryObject GTF submitter and authorized Task DAO. The chart route and protected status endpoint dispatch through it. There is no second scheduler, Redis event engine, task table, or result cache. This keeps deduplication, effective user/guest identity, contribution DAGs, cancellation, and the task-UUID/cache-re-request contract with GTF.

- The manager supports app-scoped initialization, submission, status reads and downstream request-channel parsing; initialization is idempotent and does not share an instance across Flask apps.
- `asyncEvent.init(config, pollingTransport)` lets a frontend fork use a custom authenticated polling endpoint/client while retaining the shared waiter, backoff, cancellation and websocket catch-up logic. Omitting it preserves existing behavior.
- Deprecated Python imports resolve lazily instead of failing at import. The legacy chart submission adapters authorize QueryContext access before delegating to GTF. They return **GTF task_ids/cursor**, not legacy job_id/result_url.
- Deprecation window: retain the Python adapters and manager config alias throughout the first major release containing this change; removal no earlier than the following major release. Imports/config use emit `DeprecationWarning`. `UPDATING.md` and the extension guide document the boundary.

**Not a drop-in restoration of the old protocol or an unchanged-downstream deployment fix.** Recreating `init_job`/`update_job`/Redis stream replay would undo the architectural simplification in #43407. Those lifecycle overrides must move to GTF; the old methods are deliberately not silently implemented as no-ops.

#### Manager-JWT channels and transport finding

A downstream override of `parse_channel_id_from_request` can continue returning a signature-verified Manager JWT's `jti`, with no old async-token cookie required. Custom manager/transport code can use it as its transport identity. **GTF does not natively express an arbitrary opaque `jti` as a built-in websocket routing principal.** Its producer validates routes against task subscribers (`user:<id>` / `guest:<hmac>`, optionally per-client). This PR does not weaken that validation or treat channel possession as task authorization. A custom transport must map the authenticated identity to authorized GTF state, or the downstream must adopt principal/per-tab routing. The default GTF routes do not use the custom channel helper as an authorization source.

#### Per-symbol disposition

| Removed surface | Disposition |
| --- | --- |
| `superset.async_events` | Deprecated import namespace only; no API or Redis engine |
| `superset.extensions.async_query_manager_factory` | Lazy factory alias; `init_app(app)` (or current app) initializes the GTF-backed manager once |
| `superset.extensions.async_query_manager` | Lazy app-local proxy; replace with `get_query_manager()` |
| `AsyncQueryManager` | Subclassable `QueryManager` adapter; `submit_chart_data_job` validates access and delegates to GTF |
| `AsyncQueryTokenException` | Alias for `AsyncQueryTokenError`; existing exception catches retain identity |
| `create_async_job_command.CreateAsyncChartDataJobCommand` | `validate` resolves the custom channel; `run` validates QueryContext access and returns the GTF handshake |
| `init_job`, `update_job`, `read_events`, legacy cancellation and `result_url` replay | Not emulated; use GTF task lifecycle, status reads, task cancellation and chart-data re-request |


#### Per-config disposition

| Key | Replacement or disposition |
| --- | --- |
| `GLOBAL_ASYNC_QUERY_MANAGER_CLASS` | Deprecated fallback for `ASYNC_QUERY_MANAGER_CLASS`; the new key takes precedence |
| `GLOBAL_ASYNC_QUERIES` feature flag | Retained; auto-enables GTF |
| `GLOBAL_ASYNC_QUERIES_POLLING_DELAY` | Retained, same base polling cadence |
| `GLOBAL_ASYNC_QUERIES_CACHE_BACKEND` | Removed; use `DISTRIBUTED_COORDINATION_CONFIG` for coordination and `DATA_CACHE_CONFIG` for results |
| `GLOBAL_ASYNC_QUERIES_TRANSPORT` | Removed; `WEBSOCKET_ENABLE=False` uses polling, or supply a client polling reader |
| `GLOBAL_ASYNC_QUERIES_WEBSOCKET_URL` | Removed; use `WEBSOCKET_URL` with the new websocket server |
| `GLOBAL_ASYNC_QUERIES_JWT_SECRET` | Removed; explicitly configure `WEBSOCKET_JWT_SECRET` only if using websocket transport |
| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_NAME` | Removed; `WEBSOCKET_JWT_COOKIE_NAME` (new token claims, not old-token compatibility) |
| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_SECURE` | Removed; `WEBSOCKET_JWT_COOKIE_SECURE` |
| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_SAMESITE` | Removed; `WEBSOCKET_JWT_COOKIE_SAMESITE` |
| `GLOBAL_ASYNC_QUERIES_JWT_COOKIE_DOMAIN` | Removed; `WEBSOCKET_JWT_COOKIE_DOMAIN` |
| `GLOBAL_ASYNC_QUERIES_JWT_EXPIRATION_SECONDS` | Removed; `WEBSOCKET_JWT_EXPIRATION_SECONDS` for websocket token lifetime, not task timeout |
| `GLOBAL_ASYNC_QUERIES_REGISTER_REQUEST_HANDLERS` | Removed; websocket cookie handling follows `WEBSOCKET_ENABLE`; custom manager owns its transport handlers |
| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_PREFIX` | Removed; no browser-facing GAQ Redis streams; coordination uses its own namespace |
| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT` | Removed; no GAQ per-channel event log |
| `GLOBAL_ASYNC_QUERIES_REDIS_STREAM_LIMIT_FIREHOSE` | Removed; no GAQ firehose; use GTF task observability/retention |

The GTF-era settings `GLOBAL_ASYNC_QUERIES_DEFAULT`,
`GLOBAL_ASYNC_QUERIES_MIN_CACHE_TTL`, `GLOBAL_ASYNC_QUERIES_QUERY_TIMEOUT`,
`GLOBAL_ASYNC_QUERIES_POLLING_MAX_DELAY` and
`GLOBAL_ASYNC_QUERIES_POLLING_STALE_TIMEOUT` are unchanged. Retired settings
other than the manager alias are not interpreted or silently translated.

#### Remaining downstream work

Port legacy manager hooks to `submit`/`status_changes`, consume the GTF multi-task handshake and re-request chart data, supply the custom polling reader, and migrate retired deployment settings. Lifecycle metrics tied to Redis `xadd`/one legacy job must be adapted to GTF task lifecycle rather than assumed to run through these shims.

A downstream legacy Explore worker also imports removed **private** helpers from `superset.tasks.async_queries`: `_handle_soft_time_limit`, `_load_user_from_job_metadata`, `query_timeout`, and `set_form_data`. Those imports are not covered by this public-seam adapter and can still fail during downstream manager initialization. That worker needs a separate downstream migration; this PR must not be presented as sufficient to make the unchanged shell boot. No downstream source, gitlinks, dependency pins, Helm templates or CI configuration were modified.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (extension API/import compatibility; no visual change).

Before: downstream imports of the removed GAQ manager/factory fail, and chart submission/status reads have no manager hook.
After: the listed imports emit deprecation warnings; configured managers and polling readers are invoked while GTF remains the execution/state source.

### TESTING INSTRUCTIONS

Automated validation:

```bash
PYTHONPATH=superset-core/src SUPERSET_SECRET_KEY=test pytest \
  tests/unit_tests/tasks/test_query_manager.py \
  tests/unit_tests/charts/test_chart_data_api.py \
  tests/unit_tests/tasks/test_async_queries.py \
  tests/unit_tests/tasks/test_subscription.py \
  tests/unit_tests/tasks/test_filters.py \
  tests/unit_tests/tasks/test_guest.py -q
# 96 passed

cd superset-frontend
npm ci --ignore-scripts --legacy-peer-deps
npm run test -- --maxWorkers=2 src/middleware/asyncEvent.test.ts
# 34 passed, including custom polling and websocket reconciliation
npx tsc --build packages/superset-ui-core
cd ..
PYTHONPATH=superset-core/src pre-commit run
```

The documented changed-files pre-commit subset is used rather than modifying unrelated master-baseline files. Also ran pylint directly against all changed backend files (10.00/10), because the staged-file hook's pylint wrapper computes its file list from committed history.

Manual verification on a configured deployment:
1. Enable `GLOBAL_ASYNC_QUERIES`; keep websocket disabled for the polling case.
2. Configure a `QueryManager` subclass that records/delegates `submit` and `status_changes`; load an uncached chart and verify 202 task UUIDs followed by the warm-cache response.
3. Initialize the frontend with a custom authenticated reader returning the same GTF status schema. Verify completion and repeat with websocket enabled to exercise catch-up.
4. Enable Python deprecation warnings and import each legacy symbol. Verify the old class-config fallback warns, the new config takes precedence, and repeated initialization keeps one instance per app.
5. Check the same flow with an authorized guest and a user without access; custom transport code must preserve the documented authorization contract.

Local HTTP health check was unavailable (no running Superset service), so live Celery/browser deployment validation was not performed. Unit tests and middleware tests above are the executed checks; this does not claim full shell runtime validation.

### ADDITIONAL INFORMATION

- [x] Has associated issue: follow-up to #43407
- [x] Required feature flags: `GLOBAL_ASYNC_QUERIES` for asynchronous chart execution (auto-enables GTF)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

AI-assisted implementation and tests; signed-off commit. Deprecation policy and supported extension contract are proposed for upstream review.
