### PR TITLE
fix(cache): support Flask-Caching 2.5 initialization

### DIFF
--- a/superset/extensions/metastore_cache.py
+++ b/superset/extensions/metastore_cache.py
@@ -44,8 +44,9 @@ class SupersetMetastoreCache(BaseCache):
         namespace: UUID,
         codec: KeyValueCodec,
         default_timeout: int = 300,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(default_timeout)
+        super().__init__(default_timeout, **kwargs)
         self.namespace = namespace
         self.codec = codec
 

--- a/superset/utils/cache.py
+++ b/superset/utils/cache.py
@@ -325,7 +325,7 @@ def etag_cache(  # noqa: C901
         wrapper.uncached = f  # type: ignore
         wrapper.cache_timeout = timeout  # type: ignore
         wrapper.make_cache_key = cache._memoize_make_cache_key(  # type: ignore # pylint: disable=protected-access
-            make_name=None, timeout=timeout, hash_method=configurable_hash_method
+            make_name=None, hash_method=configurable_hash_method
         )
 
         return wrapper

--- a/superset/utils/cache_manager.py
+++ b/superset/utils/cache_manager.py
@@ -147,19 +147,17 @@ class SupersetCache(Cache):
     def _memoize_make_cache_key(
         self,
         make_name: Callable[..., Any] | None = None,
-        timeout: Callable[..., Any] | None = None,
-        forced_update: bool = False,
         hash_method: Callable[..., Any] = configurable_hash_method,
         source_check: bool | None = False,
         args_to_ignore: Any | None = None,
+        **kwargs: Any,
     ) -> Callable[..., Any]:
         return super()._memoize_make_cache_key(
             make_name=make_name,
-            timeout=timeout,
-            forced_update=forced_update,
             hash_method=hash_method,
             source_check=source_check,
             args_to_ignore=args_to_ignore,
+            **kwargs,
         )
 
 

--- a/tests/unit_tests/extensions/test_metastore_cache.py
+++ b/tests/unit_tests/extensions/test_metastore_cache.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from importlib.metadata import version
+from uuid import UUID
+
+import pytest
+from flask import Flask
+from flask_caching import Cache
+from packaging.version import Version
+
+from superset.extensions.metastore_cache import SupersetMetastoreCache
+from superset.key_value.types import JsonKeyValueCodec
+from superset.key_value.utils import get_uuid_namespace
+
+
+def test_metastore_cache_constructor() -> None:
+    """Direct construction remains compatible without extra backend options."""
+    namespace = UUID("ee173d1b-ccf3-40aa-941c-985c15224496")
+    codec = JsonKeyValueCodec()
+
+    cache = SupersetMetastoreCache(namespace, codec)
+
+    assert cache.default_timeout == 300
+    assert cache.namespace == namespace
+    assert cache.codec is codec
+
+
+@pytest.mark.parametrize("ignore_errors", [False, True])
+def test_metastore_cache_init_app(ignore_errors: bool) -> None:
+    """Flask-Caching can initialize the backend with its generated options."""
+    app = Flask(__name__)
+    app.config["HASH_ALGORITHM"] = "sha256"
+    codec = JsonKeyValueCodec()
+    cache = Cache()
+
+    cache.init_app(
+        app,
+        {
+            "CACHE_TYPE": "superset.extensions.metastore_cache.SupersetMetastoreCache",
+            "CACHE_DEFAULT_TIMEOUT": 600,
+            "CACHE_KEY_PREFIX": "filter_state",
+            "CACHE_IGNORE_ERRORS": ignore_errors,
+            "CODEC": codec,
+        },
+    )
+
+    with app.app_context():
+        backend = cache.cache
+        assert isinstance(backend, SupersetMetastoreCache)
+        assert backend.default_timeout == 600
+        assert backend.namespace == get_uuid_namespace("filter_state", app)
+        assert backend.codec is codec
+        if Version(version("flask-caching")) >= Version("2.5.0"):
+            assert backend.ignore_delete_many_errors is ignore_errors
+
+
+@pytest.mark.skipif(
+    Version(version("flask-caching")) < Version("2.5.0"),
+    reason="ignore_delete_many_errors requires Flask-Caching 2.5.0",
+)
+def test_metastore_cache_options_override_ignore_errors() -> None:
+    """Explicit cache options override the general error-handling setting."""
+    app = Flask(__name__)
+    app.config["HASH_ALGORITHM"] = "sha256"
+    cache = Cache()
+
+    cache.init_app(
+        app,
+        {
+            "CACHE_TYPE": "superset.extensions.metastore_cache.SupersetMetastoreCache",
+            "CACHE_IGNORE_ERRORS": False,
+            "CACHE_OPTIONS": {"ignore_delete_many_errors": True},
+            "CODEC": JsonKeyValueCodec(),
+        },
+    )
+
+    with app.app_context():
+        assert cache.cache.ignore_delete_many_errors is True

--- a/tests/unit_tests/utils/cache_test.py
+++ b/tests/unit_tests/utils/cache_test.py
@@ -20,7 +20,47 @@
 from typing import Any
 from unittest.mock import MagicMock
 
+from flask import Flask, Response
+from freezegun import freeze_time
 from pytest_mock import MockerFixture
+
+
+def test_etag_cache_lifecycle() -> None:
+    """ETag views cache responses, handle conditional GETs, and expire."""
+    from superset.utils.cache import etag_cache
+    from superset.utils.cache_manager import SupersetCache
+
+    app = Flask(__name__)
+    app.config.update(HASH_ALGORITHM="sha256", DEBUG=True)
+    cache = SupersetCache(app, config={"CACHE_TYPE": "SimpleCache"})
+    calls = 0
+
+    with app.app_context():
+
+        @app.route("/cached")
+        @etag_cache(cache=cache, max_age=60)
+        def cached_view() -> Response:
+            """Return a distinct response when the cached value expires."""
+            nonlocal calls
+            calls += 1
+            return Response(str(calls))
+
+    with app.test_client() as client, freeze_time("2026-01-01") as clock:
+        first = client.get("/cached")
+        assert first.status_code == 200
+        assert first.data == b"1"
+        assert first.headers.get("ETag")
+        assert client.get("/cached").data == b"1"
+        conditional = client.get(
+            "/cached", headers={"If-None-Match": first.headers["ETag"]}
+        )
+        assert conditional.status_code == 304
+        assert calls == 1
+        clock.tick(61)
+        expired = client.get("/cached")
+        assert expired.status_code == 200
+        assert expired.data == b"2"
+        assert expired.headers["ETag"] != first.headers["ETag"]
 
 
 def test_memoized_func(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/utils/test_cache_manager.py
+++ b/tests/unit_tests/utils/test_cache_manager.py
@@ -18,12 +18,43 @@ import hashlib
 from unittest.mock import MagicMock, patch
 
 import pytest
+from flask import Flask
+from freezegun import freeze_time
 
 from superset.utils.cache_manager import (
     configurable_hash_method,
     ConfigurableHashMethod,
     SupersetCache,
 )
+
+
+def test_superset_cache_memoize_lifecycle() -> None:
+    """Memoization supports cache hits, refresh, invalidation, and expiration."""
+    app = Flask(__name__)
+    app.config.update(HASH_ALGORITHM="sha256", DEBUG=True)
+    cache = SupersetCache(app, config={"CACHE_TYPE": "SimpleCache"})
+    calls = 0
+    force_refresh = False
+
+    @cache.memoize(timeout=60, forced_update=lambda: force_refresh)
+    def compute() -> int:
+        """Return a distinct value each time the function is evaluated."""
+        nonlocal calls
+        calls += 1
+        return calls
+
+    with app.app_context(), freeze_time("2026-01-01") as clock:
+        assert compute() == 1
+        assert compute() == 1
+        force_refresh = True
+        assert compute() == 2
+        force_refresh = False
+        assert compute() == 2
+        cache.delete_memoized(compute)
+        assert compute() == 3
+        assert compute() == 3
+        clock.tick(61)
+        assert compute() == 4
 
 
 def test_configurable_hash_method_uses_sha256():


### PR DESCRIPTION
### SUMMARY

Flask-Caching 2.5 passes `ignore_delete_many_errors` to custom cache backends during initialization. Accept and forward backend keyword arguments in `SupersetMetastoreCache` so initialization succeeds and `CACHE_IGNORE_ERRORS` is honored.

On master, application initialization also fails when `SupersetCache._memoize_make_cache_key` supplies `timeout` and `forced_update`, which Flask-Caching 2.5 removed from this helper. Forward version-specific options only when supplied by the caller, preserving the configured hash method and compatibility with Flask-Caching 2.4.1.

Fixes #43860. Related to #43935; this change also forwards backend options to the base class and addresses the memoization startup failure.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; backend-only change.

### TESTING INSTRUCTIONS

```sh
pytest tests/unit_tests/extensions/test_metastore_cache.py tests/unit_tests/utils/test_cache_manager.py -q
```

Verified on Python 3.12.14 / Windows with the repository's application fixtures enabled:

- Flask-Caching 2.5.0 / cachelib 0.17.0: 17 passed.
- Flask-Caching 2.4.1 / cachelib 0.13.0: 16 passed, 1 version-specific test skipped.
- Before the fixes, isolated tests reproduced both constructor and memoization `TypeError` failures.
- Coverage includes backend initialization, timeout/namespace/codec preservation, error-option propagation and override, cache hits, forced refresh, invalidation, and expiration.
- Ruff checks and formatting passed. Pylint with Superset plugins passed on both production files. Mypy with `--platform linux --check-untyped-defs` passed on all four changed files.

The unmodified pre-commit invocation has Windows limitations: mypy reports three existing `signal.SIGALRM`/`signal.alarm` errors in `superset/utils/core.py`, and the pylint hook requires `bash`. The direct Linux-target mypy and direct pylint checks above passed. The full repository suite and a released 6.1.0 installation were not tested.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43860
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
