### PR TITLE
fix(chart): include echart_options in Matrixify render-trigger allowlist

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
@@ -566,6 +566,56 @@ test('should NOT refetch data when other string-based renderTrigger controls cha
   });
 });
 
+test('should NOT refetch data when echart_options (string-based renderTrigger control) changes', async () => {
+  // Matches how the Timeseries/MixedTimeseries control panels reference this
+  // shared control: a bare string, e.g. ['echart_options'].
+  const controlPanelConfig = {
+    controlPanelSections: [
+      {
+        controlSetRows: [['echart_options']],
+      },
+    ],
+  };
+
+  jest.mocked(getChartControlPanelRegistry).mockReturnValue({
+    get: jest.fn().mockReturnValue(controlPanelConfig),
+  } as unknown as ReturnType<typeof getChartControlPanelRegistry>);
+
+  const formDataWithEchartOptions = {
+    ...mockFormData,
+    echart_options: '{}',
+  };
+
+  const { rerender, getByTestId } = render(
+    <StatefulChart
+      formData={formDataWithEchartOptions}
+      chartType="test_chart"
+    />,
+  );
+
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(1);
+  });
+
+  // Edit the ECharts Options field (e.g. from the Customize tab while the
+  // chart is part of a Matrixify grid cell).
+  const updatedFormData = {
+    ...formDataWithEchartOptions,
+    echart_options: '{"title": {"text": "My Chart"}}',
+  };
+
+  rerender(<StatefulChart formData={updatedFormData} chartType="test_chart" />);
+
+  await waitFor(() => {
+    // Should NOT refetch data - echart_options is a renderTrigger control
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(1);
+    // But should re-render with the new formData
+    expect(getByTestId('super-chart')).toHaveTextContent(
+      JSON.stringify(updatedFormData),
+    );
+  });
+});
+
 test('should refetch when string control is NOT in RENDER_TRIGGER_SHARED_CONTROLS', async () => {
   // Control panel with a string control that is NOT in the renderTrigger set
   const controlPanelConfig = {

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.test.tsx
@@ -616,6 +616,54 @@ test('should NOT refetch data when echart_options (string-based renderTrigger co
   });
 });
 
+test('should refetch when a chart overrides a shared renderTrigger control to renderTrigger: false', async () => {
+  // Matches Country Map's controlPanel.controlOverrides, which sets
+  // linear_color_scheme to renderTrigger: false because it drives the
+  // choropleth data query rather than just styling.
+  const controlPanelConfig = {
+    controlPanelSections: [
+      {
+        controlSetRows: [['linear_color_scheme']],
+      },
+    ],
+    controlOverrides: {
+      linear_color_scheme: {
+        renderTrigger: false,
+      },
+    },
+  };
+
+  jest.mocked(getChartControlPanelRegistry).mockReturnValue({
+    get: jest.fn().mockReturnValue(controlPanelConfig),
+  } as unknown as ReturnType<typeof getChartControlPanelRegistry>);
+
+  const formDataWithColorScheme = {
+    ...mockFormData,
+    linear_color_scheme: 'schemeA',
+  };
+
+  const { rerender } = render(
+    <StatefulChart formData={formDataWithColorScheme} chartType="test_chart" />,
+  );
+
+  await waitFor(() => {
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(1);
+  });
+
+  const updatedFormData = {
+    ...formDataWithColorScheme,
+    linear_color_scheme: 'schemeB',
+  };
+
+  rerender(<StatefulChart formData={updatedFormData} chartType="test_chart" />);
+
+  await waitFor(() => {
+    // Should refetch because this chart's controlOverrides mark the control
+    // as data-affecting, overriding the shared-control fallback.
+    expect(mockChartClient.client.post).toHaveBeenCalledTimes(2);
+  });
+});
+
 test('should refetch when string control is NOT in RENDER_TRIGGER_SHARED_CONTROLS', async () => {
   // Control panel with a string control that is NOT in the renderTrigger set
   const controlPanelConfig = {

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -119,6 +119,28 @@ function shouldRefetchData(
       }
     });
 
+    // Individual chart types can override a shared control's renderTrigger
+    // behavior (e.g., Country Map sets `linear_color_scheme` to
+    // renderTrigger: false because it drives the choropleth query, not just
+    // styling). Apply those overrides on top of the shared-control fallback
+    // so such controls still trigger a refetch for that chart type.
+    const { controlOverrides } = controlPanel;
+    if (controlOverrides) {
+      Object.entries(controlOverrides).forEach(([controlName, override]) => {
+        if (
+          override &&
+          typeof override === 'object' &&
+          'renderTrigger' in override
+        ) {
+          if ((override as { renderTrigger?: boolean }).renderTrigger) {
+            renderTriggerControls.add(controlName);
+          } else {
+            renderTriggerControls.delete(controlName);
+          }
+        }
+      });
+    }
+
     // Check which fields changed
     const changedFields = Object.keys(nextFormData).filter(
       key =>

--- a/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/chart/components/StatefulChart.tsx
@@ -50,6 +50,9 @@ type LoadingState = 'uninitialized' | 'loading' | 'loaded' | 'error';
  * This list is needed because string-based control references (e.g., ['zoomable'])
  * cannot be introspected for their renderTrigger property without importing
  * sharedControls, which would create a circular dependency.
+ *
+ * Keep this list in sync with the `renderTrigger: true` entries in
+ * @superset-ui/chart-controls's sharedControls.tsx.
  */
 const RENDER_TRIGGER_SHARED_CONTROLS = new Set([
   'zoomable',
@@ -57,6 +60,11 @@ const RENDER_TRIGGER_SHARED_CONTROLS = new Set([
   'time_shift_color',
   'y_axis_format',
   'currency_format',
+  'color_picker',
+  'linear_color_scheme',
+  'x_axis_time_format',
+  'x_axis_number_format',
+  'echart_options',
 ]);
 
 /**


### PR DESCRIPTION
### SUMMARY
`StatefulChart` (used to render each Matrixify grid cell) keeps its own hardcoded `RENDER_TRIGGER_SHARED_CONTROLS` allowlist of shared controls that only affect rendering, not data fetching. It exists because string-based control references (e.g. `['echart_options']`) can't be introspected for their `renderTrigger` flag without importing `@superset-ui/chart-controls` into `@superset-ui/core`, which would create a circular dependency.

That allowlist only listed 5 of the 10 controls that `sharedControls.tsx` actually marks `renderTrigger: true`, missing `echart_options`, `color_picker`, `linear_color_scheme`, `x_axis_time_format`, and `x_axis_number_format`. Since the Timeseries Line/Bar/SmoothLine/Area and MixedTimeseries control panels reference `echart_options` as a bare string, `shouldRefetchData()` couldn't tell it apart from a data-affecting control, so editing the "ECharts Options" field on a chart embedded in a Matrixify grid forced a full per-cell data requery instead of a plain re-render (matches the "works outside Matrixify, breaks once it's active" repro in #39008).

This adds the missing entries to the allowlist and a comment noting it needs to stay in sync with `sharedControls.tsx`.

### TESTING INSTRUCTIONS
- Added a unit test in `StatefulChart.test.tsx` that reproduces the bug: with a control panel referencing `echart_options` as a string (as Timeseries charts do), changing `echart_options` should not trigger a data refetch, only a re-render. Fails before this change, passes after.
- `npm run test -- StatefulChart.test.tsx` (from `superset-frontend/`)

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes #39008
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API