### PR TITLE
fix(row-level-security): allow roles as RLS rule subjects

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -625,14 +625,16 @@ become active dashboard Viewers after migration.
 API clients and automation should send and read `editors`, `viewers`, and `subjects` instead
 of the legacy fields.
 
-Subject pickers support users, groups, and roles, but only users and groups are selectable by
-default. Roles remain supported as Subject types for backwards compatibility with RLS role
+Subject pickers support users, groups, and roles. Dashboard, chart, and alert/report pickers show
+only users and groups by default, while the RLS picker also shows roles to preserve role-based RLS
+workflows. Roles remain supported as Subject types for backwards compatibility with RLS role
 assignments and the previous `DASHBOARD_RBAC` model, but they are not recommended for new
 resource-specific assignments. Prefer groups for membership-based access and keep roles focused
 on capability grants. Existing Role subject assignments remain effective after migration even when
-Roles are hidden from the default dropdown values; configure the relevant `SUBJECTS_RELATED_TYPES_*`
-setting to make Roles selectable when editing subject lists. See the [Security documentation](docs/admin_docs/security/security.mdx#subjects)
-for the full Subject model and picker configuration guidance.
+Roles are hidden from a picker's dropdown values; configure the relevant
+`SUBJECTS_RELATED_TYPES_*` setting to make Roles selectable in non-RLS subject lists. See the
+[Security documentation](docs/admin_docs/security/security.mdx#subjects) for the full Subject model
+and picker configuration guidance.
 
 To make roles selectable everywhere:
 
@@ -646,15 +648,13 @@ SUBJECTS_RELATED_TYPES = [
 ]
 ```
 
-To make roles selectable for RLS while other pickers keep the user and group default, use the
-RLS-specific override:
+The RLS picker includes users, roles, and groups by default. To customize it, use the RLS-specific
+override. For example, to show only roles:
 
 ```python
 from superset.subjects.types import SubjectType
 
 SUBJECTS_RELATED_TYPES_RLS = [
-    SubjectType.USER,
-    SubjectType.GROUP,
     SubjectType.ROLE,
 ]
 ```

--- a/docs/admin_docs/security/security.mdx
+++ b/docs/admin_docs/security/security.mdx
@@ -143,17 +143,19 @@ dashboards, charts, and datasets. Subjects come in three types:
 
 Subjects are used throughout Superset to assign **editors** (who can modify a resource) and
 **viewers** (who can view it). For new resource-specific assignments, Superset defaults to
-**Users** and **Groups** in subject pickers. Groups are the recommended way to grant access to a
-set of people because they represent organizational membership, while roles remain focused on
-capability grants such as "can read dashboards" or "can write charts".
+**Users** and **Groups** in dashboard, chart, and alert/report subject pickers. The Row Level
+Security picker also includes **Roles** by default to preserve role-based RLS workflows. Groups
+are the recommended way to grant access to a set of people because they represent organizational
+membership, while roles remain focused on capability grants such as "can read dashboards" or
+"can write charts".
 
 Role subjects are still supported for backwards compatibility with features that previously used
 roles directly, including Row Level Security role assignments and `DASHBOARD_RBAC`. Existing role
 subject assignments continue to be enforced even when roles are not exposed in the default picker
-configuration. However, when an administrator edits a subject list, roles are not available as new
-dropdown values unless that picker has been configured to expose role subjects. Roles are not
-recommended for new subject assignments, because using roles for both permissions and resource
-membership couples two separate concerns.
+configuration. The RLS picker exposes roles by default; other subject pickers do not expose roles
+as new dropdown values unless configured to do so. Roles are not recommended for new
+resource-specific assignments, because using roles for both permissions and resource membership
+couples two separate concerns.
 
 Administrators can control which subject types are available in pickers with
 `SUBJECTS_RELATED_TYPES`. By default, this setting exposes only users and groups:
@@ -167,8 +169,8 @@ SUBJECTS_RELATED_TYPES = [
 ]
 ```
 
-Set `SUBJECTS_RELATED_TYPES = None` to expose all subject types, including roles. To expose roles
-only for a specific entity, set that entity's override:
+Set `SUBJECTS_RELATED_TYPES = None` to expose all subject types, including roles. The RLS picker
+has the following entity-specific default so role-based RLS rules remain selectable:
 
 ```python
 from superset.subjects.types import SubjectType
@@ -178,15 +180,15 @@ SUBJECTS_RELATED_TYPES = [
     SubjectType.GROUP,
 ]
 
-# Leave dashboard, chart, and alert/report overrides unset so they inherit
-# the users + groups default. Expose roles only in the RLS subject picker for
-# compatibility with existing role-based RLS workflows.
 SUBJECTS_RELATED_TYPES_RLS = [
     SubjectType.USER,
-    SubjectType.GROUP,
     SubjectType.ROLE,
+    SubjectType.GROUP,
 ]
 ```
+
+Dashboard, chart, and alert/report overrides remain `None` by default and inherit the global
+users-and-groups setting. Set an entity-specific override explicitly to customize its picker.
 
 Available per-entity overrides are:
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -3178,7 +3178,13 @@ SUBJECTS_RELATED_TYPES: list[SubjectType] | None = [
 # None = inherit global behavior.
 SUBJECTS_RELATED_TYPES_DASHBOARDS: list[SubjectType] | None = None
 SUBJECTS_RELATED_TYPES_CHARTS: list[SubjectType] | None = None
-SUBJECTS_RELATED_TYPES_RLS: list[SubjectType] | None = None
+# Row level security rules are commonly scoped to a role, so the RLS rule
+# editor's Subjects picker exposes roles in addition to the global default.
+SUBJECTS_RELATED_TYPES_RLS: list[SubjectType] | None = [
+    SubjectType.USER,
+    SubjectType.ROLE,
+    SubjectType.GROUP,
+]
 SUBJECTS_RELATED_TYPES_ALERT_REPORTS: list[SubjectType] | None = None
 
 

--- a/tests/unit_tests/subjects/test_filters.py
+++ b/tests/unit_tests/subjects/test_filters.py
@@ -243,6 +243,31 @@ def test_subject_type_filter_config_default_user_and_group():
     assert SUBJECTS_RELATED_TYPES == [SubjectType.USER, SubjectType.GROUP]
 
 
+def test_subject_type_filter_rls_config_default_includes_role():
+    """The RLS rule editor's Subjects picker must offer roles by default.
+
+    Row level security rules are commonly scoped to a role rather than an
+    individual user, so RLS should not silently inherit the global picker's
+    exclusion of ROLE.
+    """
+    from superset.config import SUBJECTS_RELATED_TYPES, SUBJECTS_RELATED_TYPES_RLS
+
+    assert SUBJECTS_RELATED_TYPES_RLS == [
+        SubjectType.USER,
+        SubjectType.ROLE,
+        SubjectType.GROUP,
+    ]
+
+    query, result = _apply_subject_type_filter(
+        global_types=SUBJECTS_RELATED_TYPES,
+        entity_types=SUBJECTS_RELATED_TYPES_RLS,
+        entity_key="SUBJECTS_RELATED_TYPES_RLS",
+    )
+    query.filter.assert_called_once()
+    _assert_subject_type_filter_values(query, SUBJECTS_RELATED_TYPES_RLS)
+    assert result is query.filter.return_value
+
+
 def test_subject_type_filter_global_only():
     """Global set, entity None -> filters by global types."""
     query, result = _apply_subject_type_filter(


### PR DESCRIPTION
### SUMMARY

Before this change, the RLS **+ Rule** Subjects picker only showed Users because `SUBJECTS_RELATED_TYPES_RLS` had no default and fell back to the global `SUBJECTS_RELATED_TYPES` default, which excludes `ROLE`.

This change gives the RLS-specific setting an explicit default containing User, Role, and Group subjects. Roles are therefore selectable as RLS subjects again, matching the pre-refactor behavior, while the unrelated global `SUBJECTS_RELATED_TYPES` default remains untouched. The Subject configuration documentation is updated to describe the RLS-specific default.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

| Before | After |
| --- | --- |
| ![Before — RLS +Rule Subjects picker, typing 'Admin'](https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/before.png) | ![After — RLS +Rule Subjects picker, typing 'Admin'](https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/after.png) |

Before video: https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/before.mp4

![Before — RLS +Rule Subjects picker, typing 'Admin' recording](https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/before.gif)

After video: https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/after.mp4

![After — RLS +Rule Subjects picker, typing 'Admin' recording](https://gist.githubusercontent.com/sadpandajoe/16eb8ec2d02e8f5f9270828c85541caa/raw/8bd732f2b472a316bfe2b1d1b3aa45c7d500ab18/after.gif)

### TESTING INSTRUCTIONS

Run the updated subject-filter unit test file:

```bash
PYTHONPATH="$PWD/superset-core/src${PYTHONPATH:+:$PYTHONPATH}" pytest -q tests/unit_tests/subjects/test_filters.py
```

Expected result: all tests pass, including `test_subject_type_filter_rls_config_default_includes_role`, which verifies that the RLS picker uses the explicit User/Role/Group default rather than inheriting the global User/Group default.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

