### PR TITLE
fix(security): use GitHub self-repository syntax for local action ref

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Docker Environment
-        uses: ./.github/actions/setup-docker
+        uses: $/.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2676 (zizmor/self-repository, note severity).

`tag-release.yml` referenced the in-repo `setup-docker` composite action with
the legacy workspace-relative syntax (`uses: ./.github/actions/setup-docker`).
GitHub now supports a dedicated "self-repository" syntax (`uses: $/...`) for
same-repo actions/reusable workflows, which zizmor recommends because it
isn't subject to runtime filesystem state (it can't be swapped out by an
earlier step cloning something into that path) and is treated as a pinned
reference for "fully pinned" policy enforcement.

Also bumps the `zizmor` version pinned in `.pre-commit-config.yaml` from
1.25.2 to 1.30.0 (the first release that understands `$/...` refs — the
old pin fatal-errors trying to parse the new syntax, e.g. `malformed 'uses'
ref: missing '@<ref>' in $/...`). 1.30.0 is also the version GitHub's
code-scanning zizmor integration already runs, so this keeps local
pre-commit in sync with CI.

Only the one flagged line/instance is changed; two other `./`-style local
action refs remain in this same file (and many more exist repo-wide) as
separate open code-scanning alerts (#2677, #2678, etc.) not covered by this
PR, to keep the diff scoped to alert #2676.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/tag-release.yml .pre-commit-config.yaml` passes (zizmor hook green).
- Verified with `zizmor==1.30.0` directly that the self-repository finding on line 69 of `tag-release.yml` no longer appears after the change.
- Verified the workflow YAML still parses correctly (`yaml.safe_load`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2676: https://github.com/apache/superset/security/code-scanning/2676

🤖 Generated with [Claude Code](https://claude.com/claude-code)