### PR TITLE
fix(security): use self-repository uses syntax in supersetbot workflow

### DIFF
--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
 
       - name: Execute custom Node.js script
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,7 +178,7 @@ repos:
         name: zizmor (GHA security audit)
         entry: zizmor
         language: python
-        additional_dependencies: [zizmor==1.25.2]
+        additional_dependencies: [zizmor==1.30.0]
         files: ^\.github/
         types: [yaml]
         pass_filenames: false


### PR DESCRIPTION
### SUMMARY
Fixes a `zizmor/self-repository` code-scanning finding on `.github/workflows/supersetbot.yml`. The `Setup supersetbot` step referenced the local composite action with the older workspace-relative syntax (`uses: ./.github/actions/setup-supersetbot/`). GitHub Actions now has a dedicated ["self-repository" reference syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) (`uses: $/...`) for this exact case: it resolves against the workflow's own repository at the commit that is running, isn't subject to runtime filesystem state (unlike `./...`, which silently breaks if the caller checks the repo out somewhere other than the default path), and lets GitHub enforce fully-pinned `uses:` policies that the old form can't support.

This also bumps the pinned `zizmor` pre-commit dependency from `1.25.2` to `1.30.0`. The older version can't parse the new `$/...` syntax at all (it hard-fails with "malformed `uses` ref: missing `@<ref>`" instead of just flagging it), and `1.30.0` is the release that added the `self-repository` audit itself, matching the tool version GitHub's code-scanning already runs.

Scope note: this same pattern (`uses: ./...`) appears in most other workflows in the repo and has open code-scanning alerts for each occurrence. This PR only addresses the specific alert requested (#2675); the rest are good candidates for a mechanical follow-up PR.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow file change only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/supersetbot.yml .pre-commit-config.yaml` passes, including the `zizmor` hook (previously it hard-failed to parse the file with the old pinned zizmor version, before the fix that failure was masked by it being a different error path)
- `zizmor .github/workflows/supersetbot.yml` (v1.30.0) reports no findings for this file
- CI running this workflow itself exercises the new `uses:` reference

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2675