### PR TITLE
fix(ci): use self-repository syntax for local supersetbot action ref

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -139,7 +139,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
 
       - name: Label the PRs with the right release-related labels
         env:


### PR DESCRIPTION
### SUMMARY
zizmor flags the workspace-relative `./` reference to the in-repo `setup-supersetbot` action in `tag-release.yml` (line 142) as using the older, less secure reference form. GitHub now supports a dedicated "self-repository" syntax (`$/...`) for referencing local actions/reusable workflows, which — unlike the workspace-relative form — is not subject to runtime filesystem state (e.g. an action that was cloned/modified at runtime in a previous step) and allows GitHub to enforce fully-pinned-action policies.

This PR:
- Switches the flagged `uses: ./.github/actions/setup-supersetbot/` reference to `uses: $/.github/actions/setup-supersetbot/`.
- Bumps the pre-commit `zizmor` pin from 1.25.2 to 1.29.0 — the minimum version whose workflow parser understands the `$/` syntax. Older pinned versions treat it as a malformed ref and fail with a fatal parse error, which would otherwise break `pre-commit run` on this file. (1.29.0 is used rather than 1.30.0, which adds the new `self-repository` audit rule itself, to avoid newly flagging the repo's many other pre-existing `./` references in this same PR; that broader migration is better done separately.)

Resolves code-scanning alert [#2678](https://github.com/apache/superset/security/code-scanning/2678).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow config only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/tag-release.yml .pre-commit-config.yaml` passes.
- Verified locally with `zizmor` 1.30.0 (the version GitHub's code scanning currently uses) that the flagged finding at `tag-release.yml:142` no longer appears after this change.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API