### PR TITLE
fix(ci): use self-repository syntax for supersetbot setup in tag-release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -81,7 +81,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot
 
       - name: Execute custom Node.js script
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,7 +178,7 @@ repos:
         name: zizmor (GHA security audit)
         entry: zizmor
         language: python
-        additional_dependencies: [zizmor==1.25.2]
+        additional_dependencies: [zizmor==1.30.0]
         files: ^\.github/
         types: [yaml]
         pass_filenames: false


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2677 (zizmor/self-repository, note severity).

`tag-release.yml`'s `docker-release` job references the in-repo
`setup-supersetbot` composite action with the legacy workspace-relative
syntax (`uses: ./.github/actions/setup-supersetbot/`). GitHub now supports
a dedicated "self-repository" syntax (`uses: $/...`) for same-repo
actions/reusable workflows, which zizmor recommends because it resolves to
the workflow's own repository at the exact commit that is running, isn't
subject to runtime filesystem state (it can't be swapped out by an earlier
step cloning something into that path), and is treated as a pinned
reference for GitHub's "fully pinned" `uses:` policy enforcement.

Also bumps the `zizmor` version pinned in `.pre-commit-config.yaml` from
1.25.2 to 1.30.0 (the first release that understands `$/...` refs — the
old pin fatal-errors trying to parse the new syntax, e.g. `malformed 'uses'
ref: missing '@<ref>' in $/...`). 1.30.0 is also the version GitHub's
code-scanning zizmor integration already runs, so this keeps local
pre-commit in sync with CI.

Only the one flagged line/instance (line 84) is changed. Two other
`./`-style local action refs remain in this same file as separate open
code-scanning alerts (#2676, #2678), already addressed by sibling PRs
#43961 and #43963, to keep each diff scoped to its own alert.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/tag-release.yml .pre-commit-config.yaml` passes (zizmor hook green).
- Verified locally with `zizmor==1.30.0` (the version GitHub code scanning runs) that the finding at `tag-release.yml:84` no longer appears after the change; the two unrelated findings at lines 69 and 142 (separate alerts, separate PRs) are unaffected.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2677: https://github.com/apache/superset/security/code-scanning/2677

🤖 Generated with [Claude Code](https://claude.com/claude-code)