### PR TITLE
fix(datasets): warn about affected charts and dashboards on bulk delete

### DIFF
--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -14109,6 +14109,17 @@
         },
         "type": "object"
       },
+      "get_related_objects_ids_schema": {
+        "example": [
+          1,
+          2,
+          3
+        ],
+        "items": {
+          "type": "integer"
+        },
+        "type": "array"
+      },
       "get_related_schema": {
         "properties": {
           "filter": {
@@ -23648,6 +23659,60 @@
           }
         ],
         "summary": "Get related fields data",
+        "tags": [
+          "Datasets"
+        ]
+      }
+    },
+    "/api/v1/dataset/related_objects/": {
+      "get": {
+        "description": "Aggregates the charts built on any of the requested datasets and the dashboards those charts appear on. Each chart and dashboard is listed once even if it depends on several of the datasets.",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/get_related_objects_ids_schema"
+                }
+              }
+            },
+            "in": "query",
+            "name": "q"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetRelatedObjectsResponse"
+                }
+              }
+            },
+            "description": "Query result"
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        },
+        "security": [
+          {
+            "jwt": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Get charts and dashboards associated to multiple datasets",
         "tags": [
           "Datasets"
         ]

--- a/docs/static/resources/openapi.json
+++ b/docs/static/resources/openapi.json
@@ -6070,6 +6070,10 @@
             "description": "Chart count",
             "type": "integer"
           },
+          "restricted_count": {
+            "description": "Charts the current user cannot access",
+            "type": "integer"
+          },
           "result": {
             "description": "A list of dashboards",
             "items": {
@@ -6101,6 +6105,10 @@
         "properties": {
           "count": {
             "description": "Dashboard count",
+            "type": "integer"
+          },
+          "restricted_count": {
+            "description": "Dashboards the current user cannot access",
             "type": "integer"
           },
           "result": {
@@ -23666,7 +23674,7 @@
     },
     "/api/v1/dataset/related_objects/": {
       "get": {
-        "description": "Aggregates the charts built on any of the requested datasets and the dashboards those charts appear on. Each chart and dashboard is listed once even if it depends on several of the datasets.",
+        "description": "Aggregates the charts built on any of the requested datasets and the dashboards those charts appear on. Each chart and dashboard is listed once even if it depends on several of the datasets. Requested datasets the user cannot see are ignored; the response is 404 only when none of them are visible.",
         "parameters": [
           {
             "content": {

--- a/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/ConfirmStatusChange.test.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/ConfirmStatusChange.test.tsx
@@ -175,3 +175,26 @@ test('closes modal when onHide is called', () => {
   // Modal should be hidden (not visible)
   expect(modal).not.toBeVisible();
 });
+
+test('keeps the confirm button disabled while disablePrimaryButton is set', () => {
+  const { getByTestId, getByRole, rerender } = render(
+    <ConfirmStatusChange {...mockedProps} disablePrimaryButton>
+      {confirm => <Button data-test="trigger" onClick={confirm} />}
+    </ConfirmStatusChange>,
+  );
+
+  fireEvent.click(getByTestId('trigger'));
+  fireEvent.change(getByTestId('delete-modal-input'), {
+    target: { value: 'DELETE' },
+  });
+
+  expect(getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+  rerender(
+    <ConfirmStatusChange {...mockedProps} disablePrimaryButton={false}>
+      {confirm => <Button data-test="trigger" onClick={confirm} />}
+    </ConfirmStatusChange>,
+  );
+
+  expect(getByRole('button', { name: 'Delete' })).toBeEnabled();
+});

--- a/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/index.tsx
@@ -27,6 +27,7 @@ export function ConfirmStatusChange({
   onConfirm,
   children,
   recoverable,
+  disablePrimaryButton,
 }: ConfirmStatusChangeProps) {
   const [open, setOpen] = useState(false);
   const [currentCallbackArgs, setCurrentCallbackArgs] = useState<any[]>([]);
@@ -69,6 +70,7 @@ export function ConfirmStatusChange({
         name="please confirm"
         title={title}
         recoverable={recoverable}
+        disablePrimaryButton={disablePrimaryButton}
       />
     </>
   );

--- a/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/components/ConfirmStatusChange/types.ts
@@ -30,4 +30,10 @@ export interface ConfirmStatusChangeProps {
    * drops the "type DELETE to confirm" step and uses a primary confirm button.
    */
   recoverable?: boolean;
+  /**
+   * Forwarded to the underlying DeleteModal: keeps the confirm button disabled
+   * regardless of the typed-text gate, e.g. while the caller is still loading
+   * information the user needs before confirming.
+   */
+  disablePrimaryButton?: boolean;
 }

--- a/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
@@ -378,6 +378,39 @@ test('bulk delete confirm says when nothing depends on the selection', async () 
   expect(within(modal).queryByText('Affected Charts')).not.toBeInTheDocument();
 }, 45000);
 
+test('bulk delete confirm never claims a semantic view has no dependents', async () => {
+  // Semantic views have no dependents lookup, so a mixed selection must say
+  // their charts are unchecked instead of reporting the dataset-only result
+  // as the whole picture.
+  const dataset = mockDatasets[0];
+  const semanticView = {
+    ...mockDatasets[1],
+    id: 99,
+    table_name: 'orders_semantic',
+    kind: 'semantic_view',
+  };
+  fetchMock.get(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+    emptyRelatedObjects,
+  );
+
+  const modal = await openBulkDeleteConfirm([dataset, semanticView]);
+
+  expect(
+    await within(modal).findByText(
+      /charts built on the selected semantic view/i,
+    ),
+  ).toBeInTheDocument();
+  expect(modal).not.toHaveTextContent(/no charts or dashboards depend on/i);
+
+  // Only the regular dataset goes to the dataset lookup.
+  const [lookup] = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+  );
+  const query = new URL(lookup.url, 'http://localhost').searchParams.get('q');
+  expect(rison.decode(query!)).toEqual([dataset.id]);
+}, 45000);
+
 test('bulk delete confirm says when the dependents lookup failed', async () => {
   // A failed lookup must read as "unknown", never as "nothing depends on
   // these". The delete itself stays possible: the warning is an aid, not a

--- a/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
@@ -329,9 +329,7 @@ test('bulk delete confirm names the charts and dashboards that will break', asyn
   expect(within(modal).getByText('Chart A')).toBeInTheDocument();
   expect(within(modal).getByText('Chart B')).toBeInTheDocument();
   expect(within(modal).getByText('Executive Dashboard')).toBeInTheDocument();
-  expect(modal).toHaveTextContent(
-    /linked to 2 charts that appear on 1 dashboards/i,
-  );
+  expect(modal).toHaveTextContent(/linked to 2 charts on 1 dashboard\./i);
 
   // The whole selection goes out in one lookup.
   const [lookup] = fetchMock.callHistory.calls(
@@ -356,9 +354,7 @@ test('bulk delete confirm counts dependents the user cannot see', async () => {
   const modal = await openBulkDeleteConfirm([mockDatasets[0], mockDatasets[1]]);
 
   expect(await within(modal).findByText('Chart A')).toBeInTheDocument();
-  expect(modal).toHaveTextContent(
-    /linked to 2 charts that appear on 1 dashboards/i,
-  );
+  expect(modal).toHaveTextContent(/linked to 2 charts on 1 dashboard\./i);
   expect(modal).toHaveTextContent(/1 additional restricted chart/i);
   expect(modal).toHaveTextContent(/1 additional restricted dashboard/i);
   expect(modal).not.toHaveTextContent(/no charts or dashboards depend on/i);

--- a/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
@@ -341,6 +341,29 @@ test('bulk delete confirm names the charts and dashboards that will break', asyn
   expect(rison.decode(query!)).toEqual(selected.map(({ id }) => id));
 }, 45000);
 
+test('bulk delete confirm counts dependents the user cannot see', async () => {
+  // An editor who is not on a dependent chart's viewer list still breaks it
+  // by deleting the dataset, so the total must not collapse to zero.
+  fetchMock.get(API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS, {
+    charts: {
+      count: 2,
+      restricted_count: 1,
+      result: [{ id: 101, slice_name: 'Chart A' }],
+    },
+    dashboards: { count: 1, restricted_count: 1, result: [] },
+  });
+
+  const modal = await openBulkDeleteConfirm([mockDatasets[0], mockDatasets[1]]);
+
+  expect(await within(modal).findByText('Chart A')).toBeInTheDocument();
+  expect(modal).toHaveTextContent(
+    /linked to 2 charts that appear on 1 dashboards/i,
+  );
+  expect(modal).toHaveTextContent(/1 additional restricted chart/i);
+  expect(modal).toHaveTextContent(/1 additional restricted dashboard/i);
+  expect(modal).not.toHaveTextContent(/no charts or dashboards depend on/i);
+}, 45000);
+
 test('bulk delete confirm says when nothing depends on the selection', async () => {
   fetchMock.get(
     API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,

--- a/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.integration.test.tsx
@@ -260,6 +260,151 @@ test('bulk action orchestration: selection → action → cleanup cycle works co
   // selection state → action handler → list refresh → state cleanup
 }, 45000);
 
+const emptyRelatedObjects = {
+  charts: { count: 0, result: [] },
+  dashboards: { count: 0, result: [] },
+};
+
+/**
+ * Renders the list, bulk-selects the given datasets, opens the bulk Delete
+ * confirm and resolves with the dialog.
+ */
+async function openBulkDeleteConfirm(selected: typeof mockDatasets) {
+  mockDatasetListEndpoints({ result: selected, count: selected.length });
+  fetchMock.delete(API_ENDPOINTS.DATASET_BULK_DELETE, {
+    message: `${selected.length} datasets deleted successfully`,
+  });
+
+  renderDatasetList(mockAdminUser);
+  await waitFor(() => {
+    expect(screen.getByTestId('listview-table')).toBeInTheDocument();
+  });
+
+  await userEvent.click(screen.getByRole('button', { name: /bulk select/i }));
+  const bulkSelectControls = await screen.findByTestId('bulk-select-controls');
+  const table = screen.getByTestId('listview-table');
+  await within(table).findAllByRole('checkbox');
+
+  for (const { table_name: name } of selected) {
+    // eslint-disable-next-line no-await-in-loop
+    const cell = await within(table).findByText(name);
+    // eslint-disable-next-line no-await-in-loop
+    await userEvent.click(within(cell.closest('tr')!).getByRole('checkbox'));
+  }
+  await waitFor(() => {
+    expect(screen.getByTestId('bulk-select-copy')).toHaveTextContent(
+      new RegExp(`${selected.length} Selected`, 'i'),
+    );
+  });
+
+  await userEvent.click(
+    await within(bulkSelectControls).findByRole('button', { name: 'Delete' }),
+  );
+  return screen.findByRole('dialog');
+}
+
+test('bulk delete confirm names the charts and dashboards that will break', async () => {
+  // Single-row delete names the affected charts and counts dashboards; the
+  // bulk confirm must surface the same warning for the whole selection.
+  const selected = [mockDatasets[0], mockDatasets[1]];
+  fetchMock.get(API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS, {
+    charts: {
+      count: 2,
+      result: [
+        { id: 101, slice_name: 'Chart A' },
+        { id: 102, slice_name: 'Chart B' },
+      ],
+    },
+    dashboards: {
+      count: 1,
+      result: [{ id: 201, title: 'Executive Dashboard' }],
+    },
+  });
+
+  const modal = await openBulkDeleteConfirm(selected);
+
+  // findByText waits out the async lookup.
+  expect(await within(modal).findByText('Affected Charts')).toBeInTheDocument();
+  expect(within(modal).getByText('Affected Dashboards')).toBeInTheDocument();
+  expect(within(modal).getByText('Chart A')).toBeInTheDocument();
+  expect(within(modal).getByText('Chart B')).toBeInTheDocument();
+  expect(within(modal).getByText('Executive Dashboard')).toBeInTheDocument();
+  expect(modal).toHaveTextContent(
+    /linked to 2 charts that appear on 1 dashboards/i,
+  );
+
+  // The whole selection goes out in one lookup.
+  const [lookup] = fetchMock.callHistory.calls(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+  );
+  const query = new URL(lookup.url, 'http://localhost').searchParams.get('q');
+  expect(rison.decode(query!)).toEqual(selected.map(({ id }) => id));
+}, 45000);
+
+test('bulk delete confirm says when nothing depends on the selection', async () => {
+  fetchMock.get(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+    emptyRelatedObjects,
+  );
+
+  const modal = await openBulkDeleteConfirm([mockDatasets[0], mockDatasets[1]]);
+
+  expect(
+    await within(modal).findByText(/no charts or dashboards depend on/i),
+  ).toBeInTheDocument();
+  expect(within(modal).queryByText('Affected Charts')).not.toBeInTheDocument();
+}, 45000);
+
+test('bulk delete confirm says when the dependents lookup failed', async () => {
+  // A failed lookup must read as "unknown", never as "nothing depends on
+  // these". The delete itself stays possible: the warning is an aid, not a
+  // gate.
+  fetchMock.get(API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS, 500);
+
+  const modal = await openBulkDeleteConfirm([mockDatasets[0], mockDatasets[1]]);
+
+  expect(
+    await within(modal).findByText(
+      /could not check which charts and dashboards/i,
+    ),
+  ).toBeInTheDocument();
+  expect(modal).not.toHaveTextContent(/linked to/i);
+  await userEvent.type(
+    within(modal).getByTestId('delete-modal-input'),
+    'DELETE',
+  );
+  expect(within(modal).getByRole('button', { name: 'Delete' })).toBeEnabled();
+}, 45000);
+
+test('bulk delete confirm cannot be submitted before the dependents lookup resolves', async () => {
+  // Typing DELETE while the lookup is still pending must not enable the
+  // button, or a fast user confirms before seeing the blast radius.
+  let resolveLookup: (response: typeof emptyRelatedObjects) => void = () => {};
+  fetchMock.get(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+    () =>
+      new Promise<typeof emptyRelatedObjects>(resolve => {
+        resolveLookup = resolve;
+      }),
+  );
+
+  const modal = await openBulkDeleteConfirm([mockDatasets[0], mockDatasets[1]]);
+
+  expect(
+    within(modal).getByText(/checking for affected charts and dashboards/i),
+  ).toBeInTheDocument();
+  await userEvent.type(
+    within(modal).getByTestId('delete-modal-input'),
+    'DELETE',
+  );
+  expect(within(modal).getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+  resolveLookup(emptyRelatedObjects);
+
+  await within(modal).findByText(/no charts or dashboards depend on/i);
+  expect(within(modal).getByRole('button', { name: 'Delete' })).toBeEnabled();
+}, 45000);
+
 /**
  * Renders the list with one regular dataset plus the given semantic-view row,
  * bulk-selects both, opens the bulk Archive confirm, and asserts the modal

--- a/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.listview.test.tsx
@@ -1836,6 +1836,10 @@ test('bulk delete error shows toast without refreshing list', async () => {
     status: 500,
     body: { message: 'Bulk delete failed' },
   });
+  fetchMock.get(API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS, {
+    charts: { count: 0, result: [] },
+    dashboards: { count: 0, result: [] },
+  });
 
   mockDatasetListEndpoints({
     result: [mockDatasets[0]],
@@ -1891,6 +1895,8 @@ test('bulk delete error shows toast without refreshing list', async () => {
   const confirmButton = within(modal)
     .getAllByRole('button', { name: /^delete$/i })
     .pop();
+  // The button stays disabled until the dependents lookup resolves.
+  await waitFor(() => expect(confirmButton).toBeEnabled());
   await userEvent.click(confirmButton!);
 
   // Wait for error toast

--- a/superset-frontend/src/pages/DatasetList/DatasetList.testHelpers.tsx
+++ b/superset-frontend/src/pages/DatasetList/DatasetList.testHelpers.tsx
@@ -360,6 +360,7 @@ export const API_ENDPOINTS = {
   DATASOURCE_COMBINED: 'glob:*/api/v1/datasource/?*',
   DATASET_GET: 'glob:*/api/v1/dataset/[0-9]*',
   DATASET_RELATED_OBJECTS: 'glob:*/api/v1/dataset/*/related_objects*',
+  DATASET_BULK_RELATED_OBJECTS: 'glob:*/api/v1/dataset/related_objects/?q=*',
   DATASET_DELETE: 'glob:*/api/v1/dataset/[0-9]*',
   DATASET_BULK_DELETE: 'glob:*/api/v1/dataset/?q=*', // Matches DELETE /api/v1/dataset/?q=...
   DATASET_DUPLICATE: 'glob:*/api/v1/dataset/duplicate*',
@@ -479,10 +480,21 @@ export const setupDuplicateMocks = () => {
 };
 
 export const setupBulkDeleteMocks = () => {
-  fetchMock.removeRoutes({ names: [API_ENDPOINTS.DATASET_BULK_DELETE] });
+  fetchMock.removeRoutes({
+    names: [
+      API_ENDPOINTS.DATASET_BULK_DELETE,
+      API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+    ],
+  });
   fetchMock.delete(API_ENDPOINTS.DATASET_BULK_DELETE, {
     message: '3 datasets deleted successfully',
   });
+  // The bulk confirm looks up the dependents of the selection; default to none.
+  fetchMock.get(
+    API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS,
+    { charts: { count: 0, result: [] }, dashboards: { count: 0, result: [] } },
+    { name: API_ENDPOINTS.DATASET_BULK_RELATED_OBJECTS },
+  );
 };
 
 // Setup error mocks for negative flow testing

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -732,8 +732,9 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
   }, []);
 
   const fetchBulkRelatedObjects = useCallback((selected: Dataset[]) => {
-    // Semantic views delete through their own endpoint and have no
-    // related_objects lookup, so only regular datasets are checked.
+    // Semantic views share the id space with datasets but have no
+    // related_objects lookup, so only regular datasets are checked; the modal
+    // says so rather than claiming nothing depends on them.
     const ids = selected.filter(d => !isSemanticView(d)).map(({ id }) => id);
     bulkRelatedLookupId.current += 1;
     const lookupId = bulkRelatedLookupId.current;
@@ -1672,13 +1673,25 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                   />
                 </>
               ) : (
-                <p>
-                  {t(
-                    'No charts or dashboards depend on the selected %s.',
-                    datasetsLabelLower(),
-                  )}
-                </p>
+                pendingBulkSemanticCount === 0 && (
+                  <p>
+                    {t(
+                      'No charts or dashboards depend on the selected %s.',
+                      datasetsLabelLower(),
+                    )}
+                  </p>
+                )
               ))}
+            {pendingBulkSemanticCount > 0 && (
+              <p>
+                {tn(
+                  'Charts built on the selected semantic view are not checked and will break if it is deleted.',
+                  'Charts built on the %s selected semantic views are not checked and will break if they are deleted.',
+                  pendingBulkSemanticCount,
+                  pendingBulkSemanticCount,
+                )}
+              </p>
+            )}
           </>
         }
         onConfirm={handleBulkDatasetDelete}

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -199,6 +199,94 @@ type RelatedObjects = {
   result: Array<Record<string, unknown>>;
 };
 
+type DatasetRelatedObjects = {
+  charts: RelatedObjects;
+  dashboards: RelatedObjects;
+};
+
+type BulkRelatedLookup =
+  | { status: 'idle' | 'loading' | 'failed' }
+  | { status: 'done'; related: DatasetRelatedObjects };
+
+/**
+ * The "Affected Dashboards" / "Affected Charts" lists rendered inside a dataset
+ * delete confirmation, capped at 10 each with an overflow footer. Shared by the
+ * single-row delete modal and the bulk-delete confirm.
+ */
+const AffectedObjectsList: FunctionComponent<DatasetRelatedObjects> = ({
+  charts,
+  dashboards,
+}) => (
+  <>
+    {dashboards.count >= 1 && (
+      <>
+        <h4>{t('Affected Dashboards')}</h4>
+        <List
+          split={false}
+          size="small"
+          dataSource={dashboards.result.slice(0, 10)}
+          renderItem={(result: {
+            id: Key | null | undefined;
+            title: string;
+          }) => (
+            <List.Item key={result.id} compact>
+              <List.Item.Meta
+                avatar={<span>•</span>}
+                title={
+                  <Typography.Link
+                    href={ensureAppRoot(`/dashboard/${result.id}`)}
+                    target="_atRiskItem"
+                  >
+                    {result.title}
+                  </Typography.Link>
+                }
+              />
+            </List.Item>
+          )}
+          footer={
+            dashboards.result.length > 10 && (
+              <div>{t('... and %s others', dashboards.result.length - 10)}</div>
+            )
+          }
+        />
+      </>
+    )}
+    {charts.count >= 1 && (
+      <>
+        <h4>{t('Affected Charts')}</h4>
+        <List
+          split={false}
+          size="small"
+          dataSource={charts.result.slice(0, 10)}
+          renderItem={(result: {
+            id: Key | null | undefined;
+            slice_name: string;
+          }) => (
+            <List.Item key={result.id} compact>
+              <List.Item.Meta
+                avatar={<span>•</span>}
+                title={
+                  <Typography.Link
+                    href={ensureAppRoot(`/explore/?slice_id=${result.id}`)}
+                    target="_atRiskItem"
+                  >
+                    {result.slice_name}
+                  </Typography.Link>
+                }
+              />
+            </List.Item>
+          )}
+          footer={
+            charts.result.length > 10 && (
+              <div>{t('... and %s others', charts.result.length - 10)}</div>
+            )
+          }
+        />
+      </>
+    )}
+  </>
+);
+
 const DatasetList: FunctionComponent<DatasetListProps> = ({
   addDangerToast,
   addSuccessToast,
@@ -222,6 +310,14 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
   // change with the selection. Captured when the bulk action fires, before
   // the modal opens.
   const [pendingBulkSemanticCount, setPendingBulkSemanticCount] = useState(0);
+  // Dependents of the current bulk selection, so the bulk confirm can warn
+  // about the blast radius the same way the single-row delete modal does.
+  const [bulkRelatedLookup, setBulkRelatedLookup] = useState<BulkRelatedLookup>(
+    { status: 'idle' },
+  );
+  // Bumped on every lookup so a slow response for a previous selection is
+  // dropped instead of overwriting the current one.
+  const bulkRelatedLookupId = useRef(0);
   const [datasets, setDatasets] = useState<Dataset[]>([]);
   const [datasetCount, setDatasetCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -611,6 +707,35 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
 
   const openDatasetDuplicateModal = useCallback((dataset: VirtualDataset) => {
     setDatasetCurrentlyDuplicating(dataset);
+  }, []);
+
+  const fetchBulkRelatedObjects = useCallback((selected: Dataset[]) => {
+    // Semantic views delete through their own endpoint and have no
+    // related_objects lookup, so only regular datasets are checked.
+    const ids = selected.filter(d => !isSemanticView(d)).map(({ id }) => id);
+    bulkRelatedLookupId.current += 1;
+    const lookupId = bulkRelatedLookupId.current;
+    if (ids.length === 0) {
+      setBulkRelatedLookup({ status: 'idle' });
+      return;
+    }
+    setBulkRelatedLookup({ status: 'loading' });
+    SupersetClient.get({
+      endpoint: `/api/v1/dataset/related_objects/?q=${rison.encode(ids)}`,
+    })
+      .then(({ json }) => {
+        if (lookupId === bulkRelatedLookupId.current) {
+          setBulkRelatedLookup({
+            status: 'done',
+            related: { charts: json.charts, dashboards: json.dashboards },
+          });
+        }
+      })
+      .catch(() => {
+        if (lookupId === bulkRelatedLookupId.current) {
+          setBulkRelatedLookup({ status: 'failed' });
+        }
+      });
   }, []);
 
   const handleBulkDatasetExport = useCallback(
@@ -1273,6 +1398,8 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
   };
 
   const handleBulkDatasetDelete = (datasetsToDelete: Dataset[]) => {
+    bulkRelatedLookupId.current += 1;
+    setBulkRelatedLookup({ status: 'idle' });
     // Misrouting here sends a semantic-view id to the dataset delete
     // endpoint, which looks rows up by bare numeric id against `tables`
     // only (see the export handler's comment) — hence the shared predicate.
@@ -1389,92 +1516,10 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                   datasetCurrentlyDeleting.dashboards.count,
                 )}
               </p>
-              {datasetCurrentlyDeleting.dashboards.count >= 1 && (
-                <>
-                  <h4>{t('Affected Dashboards')}</h4>
-                  <List
-                    split={false}
-                    size="small"
-                    dataSource={datasetCurrentlyDeleting.dashboards.result.slice(
-                      0,
-                      10,
-                    )}
-                    renderItem={(result: {
-                      id: Key | null | undefined;
-                      title: string;
-                    }) => (
-                      <List.Item key={result.id} compact>
-                        <List.Item.Meta
-                          avatar={<span>•</span>}
-                          title={
-                            <Typography.Link
-                              href={ensureAppRoot(`/dashboard/${result.id}`)}
-                              target="_atRiskItem"
-                            >
-                              {result.title}
-                            </Typography.Link>
-                          }
-                        />
-                      </List.Item>
-                    )}
-                    footer={
-                      datasetCurrentlyDeleting.dashboards.result.length >
-                        10 && (
-                        <div>
-                          {t(
-                            '... and %s others',
-                            datasetCurrentlyDeleting.dashboards.result.length -
-                              10,
-                          )}
-                        </div>
-                      )
-                    }
-                  />
-                </>
-              )}
-              {datasetCurrentlyDeleting.charts.count >= 1 && (
-                <>
-                  <h4>{t('Affected Charts')}</h4>
-                  <List
-                    split={false}
-                    size="small"
-                    dataSource={datasetCurrentlyDeleting.charts.result.slice(
-                      0,
-                      10,
-                    )}
-                    renderItem={(result: {
-                      id: Key | null | undefined;
-                      slice_name: string;
-                    }) => (
-                      <List.Item key={result.id} compact>
-                        <List.Item.Meta
-                          avatar={<span>•</span>}
-                          title={
-                            <Typography.Link
-                              href={ensureAppRoot(
-                                `/explore/?slice_id=${result.id}`,
-                              )}
-                              target="_atRiskItem"
-                            >
-                              {result.slice_name}
-                            </Typography.Link>
-                          }
-                        />
-                      </List.Item>
-                    )}
-                    footer={
-                      datasetCurrentlyDeleting.charts.result.length > 10 && (
-                        <div>
-                          {t(
-                            '... and %s others',
-                            datasetCurrentlyDeleting.charts.result.length - 10,
-                          )}
-                        </div>
-                      )
-                    }
-                  />
-                </>
-              )}
+              <AffectedObjectsList
+                charts={datasetCurrentlyDeleting.charts}
+                dashboards={datasetCurrentlyDeleting.dashboards}
+              />
               {DatasetDeleteRelatedExtension && (
                 <DatasetDeleteRelatedExtension
                   dataset={datasetCurrentlyDeleting}
@@ -1552,31 +1597,70 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
             : t('Please confirm')
         }
         description={
-          softDelete ? (
-            bulkIsRecoverable ? (
-              archiveConfirmDescription(datasetsLabelLower(), true)
+          <>
+            {softDelete ? (
+              bulkIsRecoverable ? (
+                archiveConfirmDescription(datasetsLabelLower(), true)
+              ) : (
+                <>
+                  {tn(
+                    '%s of the selected items is a semantic view, which cannot be archived: it will be deleted permanently and cannot be recovered.',
+                    '%s of the selected items are semantic views, which cannot be archived: they will be deleted permanently and cannot be recovered.',
+                    pendingBulkSemanticCount,
+                    pendingBulkSemanticCount,
+                  )}{' '}
+                  {t(
+                    'The remaining %s will be moved to Recently Archived.',
+                    datasetsLabelLower(),
+                  )}
+                </>
+              )
             ) : (
-              <>
-                {tn(
-                  '%s of the selected items is a semantic view, which cannot be archived: it will be deleted permanently and cannot be recovered.',
-                  '%s of the selected items are semantic views, which cannot be archived: they will be deleted permanently and cannot be recovered.',
-                  pendingBulkSemanticCount,
-                  pendingBulkSemanticCount,
-                )}{' '}
+              t(
+                'Are you sure you want to delete the selected %s?',
+                datasetsLabelLower(),
+              )
+            )}
+            {bulkRelatedLookup.status === 'loading' && (
+              <p>{t('Checking for affected charts and dashboards…')}</p>
+            )}
+            {bulkRelatedLookup.status === 'failed' && (
+              <p>
                 {t(
-                  'The remaining %s will be moved to Recently Archived.',
+                  'Could not check which charts and dashboards depend on the selected %s. Deleting them may break charts and dashboards.',
                   datasetsLabelLower(),
                 )}
-              </>
-            )
-          ) : (
-            t(
-              'Are you sure you want to delete the selected %s?',
-              datasetsLabelLower(),
-            )
-          )
+              </p>
+            )}
+            {bulkRelatedLookup.status === 'done' &&
+              (bulkRelatedLookup.related.charts.count > 0 ||
+              bulkRelatedLookup.related.dashboards.count > 0 ? (
+                <>
+                  <p>
+                    {t(
+                      'The selected %s are linked to %s charts that appear on %s dashboards. Deleting them will break those objects.',
+                      datasetsLabelLower(),
+                      bulkRelatedLookup.related.charts.count,
+                      bulkRelatedLookup.related.dashboards.count,
+                    )}
+                  </p>
+                  <AffectedObjectsList
+                    charts={bulkRelatedLookup.related.charts}
+                    dashboards={bulkRelatedLookup.related.dashboards}
+                  />
+                </>
+              ) : (
+                <p>
+                  {t(
+                    'No charts or dashboards depend on the selected %s.',
+                    datasetsLabelLower(),
+                  )}
+                </p>
+              ))}
+          </>
         }
         onConfirm={handleBulkDatasetDelete}
+        disablePrimaryButton={bulkRelatedLookup.status === 'loading'}
       >
         {confirmDelete => {
           const bulkActions: ListViewProps['bulkActions'] = [];
@@ -1588,6 +1672,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                 setPendingBulkSemanticCount(
                   selected.filter(isSemanticView).length,
                 );
+                fetchBulkRelatedObjects(selected);
                 confirmDelete(selected);
               },
               type: 'danger',

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -196,6 +196,7 @@ interface DatasetListProps {
 
 type RelatedObjects = {
   count: number;
+  restricted_count?: number;
   result: Array<Record<string, unknown>>;
 };
 
@@ -211,7 +212,8 @@ type BulkRelatedLookup =
 /**
  * The "Affected Dashboards" / "Affected Charts" lists rendered inside a dataset
  * delete confirmation, capped at 10 each with an overflow footer. Shared by the
- * single-row delete modal and the bulk-delete confirm.
+ * single-row delete modal and the bulk-delete confirm. `count` is the full
+ * number of dependents; `result` only holds the ones the user can see.
  */
 const AffectedObjectsList: FunctionComponent<DatasetRelatedObjects> = ({
   charts,
@@ -249,6 +251,16 @@ const AffectedObjectsList: FunctionComponent<DatasetRelatedObjects> = ({
             )
           }
         />
+        {(dashboards.restricted_count ?? 0) > 0 && (
+          <p>
+            {tn(
+              '%s additional restricted dashboard',
+              '%s additional restricted dashboards',
+              dashboards.restricted_count,
+              dashboards.restricted_count,
+            )}
+          </p>
+        )}
       </>
     )}
     {charts.count >= 1 && (
@@ -282,6 +294,16 @@ const AffectedObjectsList: FunctionComponent<DatasetRelatedObjects> = ({
             )
           }
         />
+        {(charts.restricted_count ?? 0) > 0 && (
+          <p>
+            {tn(
+              '%s additional restricted chart',
+              '%s additional restricted charts',
+              charts.restricted_count,
+              charts.restricted_count,
+            )}
+          </p>
+        )}
       </>
     )}
   </>

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -1661,10 +1661,20 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
                 <>
                   <p>
                     {t(
-                      'The selected %s are linked to %s charts that appear on %s dashboards. Deleting them will break those objects.',
+                      'The selected %s are linked to %s on %s. Deleting them will break those objects.',
                       datasetsLabelLower(),
-                      bulkRelatedLookup.related.charts.count,
-                      bulkRelatedLookup.related.dashboards.count,
+                      tn(
+                        '%s chart',
+                        '%s charts',
+                        bulkRelatedLookup.related.charts.count,
+                        bulkRelatedLookup.related.charts.count,
+                      ),
+                      tn(
+                        '%s dashboard',
+                        '%s dashboards',
+                        bulkRelatedLookup.related.dashboards.count,
+                        bulkRelatedLookup.related.dashboards.count,
+                      ),
                     )}
                   </p>
                   <AffectedObjectsList

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -134,6 +134,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "put": "write",
     "related": "read",
     "related_objects": "read",
+    "bulk_related_objects": "read",
     "tables": "read",
     "schemas": "read",
     "catalogs": "read",

--- a/superset/daos/dataset.py
+++ b/superset/daos/dataset.py
@@ -142,11 +142,22 @@ class DatasetDAO(BaseDAO[SqlaTable]):
             return None
 
     @staticmethod
-    def get_related_objects(database_id: int) -> dict[str, Any]:
+    def get_related_objects(dataset_id: int) -> dict[str, Any]:
+        return DatasetDAO.get_related_objects_for_datasets([dataset_id])
+
+    @staticmethod
+    def get_related_objects_for_datasets(dataset_ids: list[int]) -> dict[str, Any]:
+        """
+        Return the charts built on any of the datasets and the dashboards those
+        charts appear on. Each chart and dashboard is listed once even if it
+        depends on several of the datasets.
+        """
+        if not dataset_ids:
+            return {"charts": [], "dashboards": []}
         charts = (
             db.session.query(Slice)
             .filter(
-                Slice.datasource_id == database_id,
+                Slice.datasource_id.in_(dataset_ids),
                 Slice.datasource_type == DatasourceType.TABLE,
             )
             .all()

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -1187,7 +1187,9 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
           description: >-
             Aggregates the charts built on any of the requested datasets and the
             dashboards those charts appear on. Each chart and dashboard is listed
-            once even if it depends on several of the datasets.
+            once even if it depends on several of the datasets. Requested datasets
+            the user cannot see are ignored; the response is 404 only when none
+            of them are visible.
           parameters:
           - in: query
             name: q
@@ -1221,7 +1223,13 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
 
     @staticmethod
     def _related_objects_payload(data: dict[str, Any]) -> dict[str, Any]:
-        """Serialize related charts and dashboards the current user can access."""
+        """
+        Serialize related charts and dashboards.
+
+        ``count`` is the full number of dependents so the caller can warn about
+        the real blast radius; ``result`` only lists the ones the current user
+        can access and ``restricted_count`` says how many were withheld.
+        """
         charts = [
             {
                 "id": chart.id,
@@ -1242,8 +1250,16 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
             if security_manager.can_access_dashboard(dashboard)
         ]
         return {
-            "charts": {"count": len(charts), "result": charts},
-            "dashboards": {"count": len(dashboards), "result": dashboards},
+            "charts": {
+                "count": len(data["charts"]),
+                "restricted_count": len(data["charts"]) - len(charts),
+                "result": charts,
+            },
+            "dashboards": {
+                "count": len(data["dashboards"]),
+                "restricted_count": len(data["dashboards"]) - len(dashboards),
+                "result": dashboards,
+            },
         }
 
     @expose("/", methods=("DELETE",))

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -94,6 +94,7 @@ from superset.datasets.schemas import (
     get_delete_ids_schema,
     get_drill_info_schema,
     get_export_ids_schema,
+    get_related_objects_ids_schema,
     GetOrCreateDatasetSchema,
     openapi_spec_methods_override,
 )
@@ -176,6 +177,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         RouteMethod.RELATED,
         RouteMethod.DISTINCT,
         "bulk_delete",
+        "bulk_related_objects",
         "restore",
         "purge",
         "purge_impact",
@@ -411,6 +413,7 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
 
     apispec_parameter_schemas = {
         "get_export_ids_schema": get_export_ids_schema,
+        "get_related_objects_ids_schema": get_related_objects_ids_schema,
     }
     openapi_spec_component_schemas = (
         DatasetCacheWarmUpRequestSchema,
@@ -1163,6 +1166,62 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         if not dataset:
             return self.response_404()
         data = DatasetDAO.get_related_objects(dataset.id)
+        return self.response(200, **self._related_objects_payload(data))
+
+    @expose("/related_objects/", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @parse_rison(get_related_objects_ids_schema)
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.bulk_related_objects"
+        ),
+        log_to_statsd=False,
+    )
+    def bulk_related_objects(self, **kwargs: Any) -> Response:
+        """Get charts and dashboards associated to multiple datasets.
+        ---
+        get:
+          summary: Get charts and dashboards associated to multiple datasets
+          description: >-
+            Aggregates the charts built on any of the requested datasets and the
+            dashboards those charts appear on. Each chart and dashboard is listed
+            once even if it depends on several of the datasets.
+          parameters:
+          - in: query
+            name: q
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/get_related_objects_ids_schema'
+          responses:
+            200:
+              description: Query result
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/DatasetRelatedObjectsResponse"
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            404:
+              $ref: '#/components/responses/404'
+            500:
+              $ref: '#/components/responses/500'
+        """
+        datasets = DatasetDAO.find_by_ids(kwargs["rison"])
+        if not datasets:
+            return self.response_404()
+        data = DatasetDAO.get_related_objects_for_datasets(
+            [dataset.id for dataset in datasets]
+        )
+        return self.response(200, **self._related_objects_payload(data))
+
+    @staticmethod
+    def _related_objects_payload(data: dict[str, Any]) -> dict[str, Any]:
+        """Serialize related charts and dashboards the current user can access."""
         charts = [
             {
                 "id": chart.id,
@@ -1182,11 +1241,10 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
             for dashboard in data["dashboards"]
             if security_manager.can_access_dashboard(dashboard)
         ]
-        return self.response(
-            200,
-            charts={"count": len(charts), "result": charts},
-            dashboards={"count": len(dashboards), "result": dashboards},
-        )
+        return {
+            "charts": {"count": len(charts), "result": charts},
+            "dashboards": {"count": len(dashboards), "result": dashboards},
+        }
 
     @expose("/", methods=("DELETE",))
     @protect()

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -46,11 +46,7 @@ get_export_ids_schema = {
     "items": {"type": "integer"},
     "example": [1, 2, 3],
 }
-get_related_objects_ids_schema = {
-    "type": "array",
-    "items": {"type": "integer"},
-    "example": [1, 2, 3],
-}
+get_related_objects_ids_schema = get_delete_ids_schema
 get_drill_info_schema = {
     "type": "object",
     "properties": {
@@ -245,6 +241,9 @@ class DatasetRelatedDashboard(Schema):
 
 class DatasetRelatedCharts(Schema):
     count = fields.Integer(metadata={"description": "Chart count"})
+    restricted_count = fields.Integer(
+        metadata={"description": "Charts the current user cannot access"}
+    )
     result = fields.List(
         fields.Nested(DatasetRelatedChart),
         metadata={"description": "A list of dashboards"},
@@ -253,6 +252,9 @@ class DatasetRelatedCharts(Schema):
 
 class DatasetRelatedDashboards(Schema):
     count = fields.Integer(metadata={"description": "Dashboard count"})
+    restricted_count = fields.Integer(
+        metadata={"description": "Dashboards the current user cannot access"}
+    )
     result = fields.List(
         fields.Nested(DatasetRelatedDashboard),
         metadata={"description": "A list of dashboards"},

--- a/superset/datasets/schemas.py
+++ b/superset/datasets/schemas.py
@@ -46,6 +46,11 @@ get_export_ids_schema = {
     "items": {"type": "integer"},
     "example": [1, 2, 3],
 }
+get_related_objects_ids_schema = {
+    "type": "array",
+    "items": {"type": "integer"},
+    "example": [1, 2, 3],
+}
 get_drill_info_schema = {
     "type": "object",
     "properties": {

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -2614,6 +2614,88 @@ class TestDatasetApi(SupersetTestCase):
         rv = self.client.get(uri)
         assert rv.status_code == 404
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_get_datasets_bulk_related_objects(self):
+        """
+        Dataset API: Test bulk related objects matches the single lookup and
+        does not double count a dataset passed twice
+        """
+        self.login(ADMIN_USERNAME)
+        table = self.get_birth_names_dataset()
+        single = json.loads(
+            self.client.get(f"api/v1/dataset/{table.id}/related_objects").data
+        )
+
+        ids = rison.dumps([table.id, table.id])
+        uri = f"api/v1/dataset/related_objects/?q={ids}"
+        rv = self.get_assert_metric(uri, "bulk_related_objects")
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        assert response["charts"]["count"] == single["charts"]["count"]
+        assert response["dashboards"]["count"] == single["dashboards"]["count"]
+        assert {chart["id"] for chart in response["charts"]["result"]} == {
+            chart["id"] for chart in single["charts"]["result"]
+        }
+
+    @pytest.mark.usefixtures(
+        "load_birth_names_dashboard_with_slices", "load_energy_table_with_slice"
+    )
+    def test_get_datasets_bulk_related_objects_aggregates(self):
+        """
+        Dataset API: Test bulk related objects unions dependents across datasets
+        """
+        self.login(ADMIN_USERNAME)
+        birth_names = self.get_birth_names_dataset()
+        energy_usage = self.get_energy_usage_dataset()
+        singles = [
+            json.loads(
+                self.client.get(f"api/v1/dataset/{table.id}/related_objects").data
+            )
+            for table in (birth_names, energy_usage)
+        ]
+
+        ids = rison.dumps([birth_names.id, energy_usage.id])
+        uri = f"api/v1/dataset/related_objects/?q={ids}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 200
+        response = json.loads(rv.data.decode("utf-8"))
+        # A chart has exactly one datasource, so chart sets are disjoint.
+        assert response["charts"]["count"] == sum(
+            single["charts"]["count"] for single in singles
+        )
+        assert {chart["id"] for chart in response["charts"]["result"]} == {
+            chart["id"] for single in singles for chart in single["charts"]["result"]
+        }
+        # Dashboards can be shared, so the union is at most the sum.
+        expected_dashboards = {
+            dashboard["id"]
+            for single in singles
+            for dashboard in single["dashboards"]["result"]
+        }
+        assert {
+            dashboard["id"] for dashboard in response["dashboards"]["result"]
+        } == expected_dashboards
+        assert response["dashboards"]["count"] == len(expected_dashboards)
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_get_datasets_bulk_related_objects_not_found(self):
+        """
+        Dataset API: Test bulk related objects returns 404 when no requested
+        dataset is visible to the user
+        """
+        max_id = db.session.query(func.max(SqlaTable.id)).scalar()
+        uri = f"api/v1/dataset/related_objects/?q={rison.dumps([max_id + 1])}"
+        self.login(ADMIN_USERNAME)
+        rv = self.client.get(uri)
+        assert rv.status_code == 404
+        self.logout()
+
+        self.login(GAMMA_USERNAME)
+        table = self.get_birth_names_dataset()
+        uri = f"api/v1/dataset/related_objects/?q={rison.dumps([table.id])}"
+        rv = self.client.get(uri)
+        assert rv.status_code == 404
+
     @pytest.mark.usefixtures("create_datasets", "create_virtual_datasets")
     def test_get_datasets_custom_filter_sql(self):
         """

--- a/tests/integration_tests/datasets/api_tests.py
+++ b/tests/integration_tests/datasets/api_tests.py
@@ -41,6 +41,7 @@ from superset.models.core import Database
 from superset.models.slice import Slice
 from superset.subjects.models import Subject
 from superset.subjects.types import SubjectType
+from superset.subjects.utils import get_or_create_user_subject
 from superset.utils import json
 from superset.utils.core import backend, get_example_default_schema, shortid
 from superset.utils.database import get_example_database, get_main_database
@@ -2676,6 +2677,57 @@ class TestDatasetApi(SupersetTestCase):
             dashboard["id"] for dashboard in response["dashboards"]["result"]
         } == expected_dashboards
         assert response["dashboards"]["count"] == len(expected_dashboards)
+
+    def test_get_datasets_bulk_related_objects_keeps_restricted_in_count(self):
+        """
+        Dataset API: Test related objects report the full dependent count to a
+        non-admin editor while withholding the objects they cannot access
+        """
+        alpha = self.get_user(ALPHA_USERNAME)
+        database = Database(
+            database_name="db_related_restricted", sqlalchemy_uri="sqlite://"
+        )
+        db.session.add(database)
+        db.session.flush()
+        dataset = SqlaTable(
+            table_name="related_restricted",
+            database=database,
+            editors=[get_or_create_user_subject(alpha.id)],
+        )
+        db.session.add(dataset)
+        db.session.flush()
+        chart = Slice(
+            slice_name="restricted related chart",
+            datasource_id=dataset.id,
+            datasource_type="table",
+            viz_type="table",
+        )
+        db.session.add(chart)
+        db.session.commit()
+
+        try:
+            self.login(ALPHA_USERNAME)
+            with patch.object(security_manager, "can_access_chart", return_value=False):
+                bulk_rv = self.client.get(
+                    f"api/v1/dataset/related_objects/?q={rison.dumps([dataset.id])}"
+                )
+                single_rv = self.client.get(
+                    f"api/v1/dataset/{dataset.id}/related_objects"
+                )
+            for rv in (bulk_rv, single_rv):
+                assert rv.status_code == 200, rv.data
+                payload = json.loads(rv.data)
+                assert payload["charts"] == {
+                    "count": 1,
+                    "restricted_count": 1,
+                    "result": [],
+                }
+                assert "restricted related chart" not in rv.data.decode()
+        finally:
+            db.session.delete(chart)
+            db.session.delete(dataset)
+            db.session.delete(database)
+            db.session.commit()
 
     @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
     def test_get_datasets_bulk_related_objects_not_found(self):


### PR DESCRIPTION
### SUMMARY
Deleting a single dataset names the charts and dashboards that depend on it before asking for confirmation. Bulk delete showed only a generic "type DELETE to confirm" dialog, so the one flow with the largest blast radius had no warning at all.

This adds `GET /api/v1/dataset/related_objects/?q=!(ids)`, returning the union of dependent charts and dashboards across the requested datasets, de-duplicated and filtered to what the current user can access (ids are scoped through the DAO base filter; 404 when none are visible). The bulk confirm calls it once when the action fires, keeps the Delete button disabled until the lookup resolves, and renders the same Affected Charts / Affected Dashboards lists the single-row modal uses. A failed lookup is stated explicitly so "unknown" is never read as "nothing depends on these". Semantic views are skipped since they delete through their own endpoint.

`ConfirmStatusChange` gains a `disablePrimaryButton` passthrough to its `DeleteModal`. The affected-objects list markup is extracted into a component shared by both delete paths.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: bulk dialog reads only "Are you sure you want to delete the selected datasets? Type DELETE to confirm."
After: same dialog also shows "The selected datasets are linked to N charts that appear on M dashboards" followed by the named charts and dashboards, or "No charts or dashboards depend on the selected datasets."

<img width="1357" height="687" alt="image" src="https://github.com/user-attachments/assets/542cd4bd-da56-41f2-8758-40f68808b31e" />


### TESTING INSTRUCTIONS
1. Have one dataset with a chart on a dashboard and one dataset with no dependents.
2. Datasets list, Bulk select, tick both, click Delete.
3. The dialog names the affected chart and dashboard and counts them; Delete stays disabled until the lookup finishes.
4. Select only the clean dataset: the dialog says nothing depends on it.
5. Block `/api/v1/dataset/related_objects/` (devtools) and repeat: the dialog says the check could not be done; Delete still works after typing DELETE.

Automated: `pytest tests/integration_tests/datasets/api_tests.py -k related_objects` and `npm run test -- ConfirmStatusChange DatasetList.integration`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [x] Changes UI
- [ ] Includes DB Migration: No
- [x] Introduces new feature or API: `GET /api/v1/dataset/related_objects/`
- [ ] Removes existing feature or API: No