### PR TITLE
fix(security): use self-repository syntax for setup-backend action ref

### DIFF
--- a/.github/workflows/superset-translations.yml
+++ b/.github/workflows/superset-translations.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Setup Python
         if: steps.check.outputs.python == 'true' || steps.check.outputs.frontend == 'true'
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
 
       - name: Install gettext tools
         if: steps.check.outputs.python == 'true' || steps.check.outputs.frontend == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,7 +178,7 @@ repos:
         name: zizmor (GHA security audit)
         entry: zizmor
         language: python
-        additional_dependencies: [zizmor==1.25.2]
+        additional_dependencies: [zizmor==1.30.0]
         files: ^\.github/
         types: [yaml]
         pass_filenames: false


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2674 (zizmor/self-repository, note severity).

`superset-translations.yml` referenced the in-repo `setup-backend` composite
action with the legacy workspace-relative syntax
(`uses: ./.github/actions/setup-backend/`). GitHub now supports a dedicated
["self-repository" syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)
(`uses: $/...`) for same-repo actions/reusable workflows, which zizmor
recommends because it isn't subject to runtime filesystem state (it can't
be swapped out by an earlier step cloning something into that path) and is
treated as a pinned reference for "fully pinned" policy enforcement.

Also bumps the `zizmor` version pinned in `.pre-commit-config.yaml` from
1.25.2 to 1.30.0 (the first release that understands `$/...` refs — the
old pin fatal-errors trying to parse the new syntax, e.g. `malformed 'uses'
ref: missing '@<ref>' in $/...`). 1.30.0 is also the version GitHub's
code-scanning zizmor integration already runs, so this keeps local
pre-commit in sync with CI.

Only the one flagged line/instance is changed; three other `./`-style
local action refs remain in this same file (and many more exist
repo-wide) as separate open code-scanning alerts (#2671, #2672, #2673,
etc.) not covered by this PR, to keep the diff scoped to alert #2674.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-translations.yml .pre-commit-config.yaml` passes (zizmor hook green).
- Verified with `zizmor==1.30.0` directly that the self-repository finding
  on line 77 of `superset-translations.yml` no longer appears after the
  change (the three other pre-existing instances in the file, tracked as
  separate alerts, remain as expected).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2674: https://github.com/apache/superset/security/code-scanning/2674

🤖 Generated with [Claude Code](https://claude.com/claude-code)