### PR TITLE
fix(security): use self-repository syntax for setup-backend ref in unit-test workflow

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python unit tests


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert [#2670](https://github.com/apache/superset/security/code-scanning/2670) (`zizmor/self-repository`).

`superset-python-unittest.yml` referenced the in-repo `setup-backend` composite action via GitHub's older workspace-relative syntax (`uses: ./.github/actions/setup-backend/`). zizmor's `self-repository` audit flags this in favor of GitHub's dedicated self-repository syntax (`uses: $/...`), which:
- resolves the action at the exact commit the workflow is running, without depending on runtime filesystem state (e.g. an action that was cloned in a previous step), and
- is treated as a pinning mechanism by GitHub's own policy enforcement, unlike the workspace-relative form.

This matches the fix already applied to other workflows for the same rule (e.g. #43968, #43961, #43963). This PR is scoped to only the one flagged line/alert; a sibling `./...` reference in the same file's `changes` job (a separate, still-open alert) is left for its own PR to keep this diff minimal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow YAML only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-unittest.yml` passes, including the `zizmor` hook.
- `zizmor .github/workflows/superset-python-unittest.yml` no longer reports a `self-repository` finding at line 63.
- The `Python-Unit` workflow itself is unchanged in behavior; `$/...` resolves to the same in-repo action.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API