### PR TITLE
fix(security): use self-repository syntax for change-detector action ref

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### SUMMARY
`.github/workflows/superset-python-unittest.yml` referenced the local `change-detector` composite action with the workspace-relative `uses: ./...` form. zizmor's `self-repository` audit flags this because the `./` form resolves against runtime filesystem state (it could theoretically load an action mutated by an earlier step) rather than a pinned ref. GitHub's dedicated `$/` self-repository syntax always resolves the action to the exact commit the workflow itself is running at, with no checkout required, and is treated by GitHub as a pinned reference.

This swaps the one flagged `uses: ./.github/actions/change-detector/` to `uses: $/.github/actions/change-detector/`, matching the fix already applied to other workflows in this repo (e.g. #43962, #43965, #43968, #43969).

Resolves code-scanning alert #2669 (https://github.com/apache/superset/security/code-scanning/2669).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow file only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-unittest.yml` passes (zizmor no longer flags the line)
- CI on this PR will exercise the `changes` job itself, confirming `$/.github/actions/change-detector/` resolves correctly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API