### PR TITLE
docs(scarf-404): replace dead links by the Scarf homepage

### DIFF
--- a/docs/admin_docs/installation/docker-compose.mdx
+++ b/docs/admin_docs/installation/docker-compose.mdx
@@ -215,7 +215,7 @@ If you have a good solution for this, let us know!
 :::
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry
 data. Knowing the installation counts for different Superset versions informs the project's
 decisions about patching and long-term support. Scarf purges personally identifiable information
 (PII) and provides only aggregated statistics.

--- a/docs/admin_docs/installation/kubernetes.mdx
+++ b/docs/admin_docs/installation/kubernetes.mdx
@@ -135,7 +135,7 @@ init:
 ```
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
 
 There are two independent telemetry channels:
 

--- a/docs/admin_docs_versioned_docs/version-6.1.0/installation/docker-compose.mdx
+++ b/docs/admin_docs_versioned_docs/version-6.1.0/installation/docker-compose.mdx
@@ -215,7 +215,7 @@ If you have a good solution for this, let us know!
 :::
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry
 data. Knowing the installation counts for different Superset versions informs the project's
 decisions about patching and long-term support. Scarf purges personally identifiable information
 (PII) and provides only aggregated statistics.

--- a/docs/admin_docs_versioned_docs/version-6.1.0/installation/kubernetes.mdx
+++ b/docs/admin_docs_versioned_docs/version-6.1.0/installation/kubernetes.mdx
@@ -135,7 +135,7 @@ init:
 ```
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
 
 To opt-out of this data collection in your Helm-based installation, edit the `repository:` line in your `helm/superset/values.yaml` file, replacing `apachesuperset.docker.scarf.sh/apache/superset` with `apache/superset` to pull the image directly from Docker Hub.
 :::

--- a/docs/user_docs_versioned_docs/version-6.0.0/installation/docker-compose.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/installation/docker-compose.mdx
@@ -215,7 +215,7 @@ If you have a good solution for this, let us know!
 :::
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry
 data. Knowing the installation counts for different Superset versions informs the project's
 decisions about patching and long-term support. Scarf purges personally identifiable information
 (PII) and provides only aggregated statistics.

--- a/docs/user_docs_versioned_docs/version-6.0.0/installation/kubernetes.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/installation/kubernetes.mdx
@@ -135,7 +135,7 @@ init:
 ```
 
 :::note
-Superset uses [Scarf Gateway](https://about.scarf.sh/scarf-gateway) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
+Superset uses [Scarf Gateway](https://about.scarf.sh/) to collect telemetry data. Knowing the installation counts for different Superset versions informs the project's decisions about patching and long-term support. Scarf purges personally identifiable information (PII) and provides only aggregated statistics.
 
 To opt-out of this data collection in your Helm-based installation, edit the `repository:` line in your `helm/superset/values.yaml` file, replacing `apachesuperset.docker.scarf.sh/apache/superset` with `apache/superset` to pull the image directly from Docker Hub.
 :::


### PR DESCRIPTION
### SUMMARY
I was reading the install instructions and I found a link that returned a 404 and after searching the project I found some more. I replaced it by the Scarf project's home (about) page. Maybe [this](https://about.scarf.sh/#how-it-works) url is an option too but it might break sooner.

### TESTING INSTRUCTIONS
Click on the updated urls and use curl/or the network tab in your browser to verify that they now return a 200 response.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
