### PR TITLE
fix(ci): use self-repository syntax for local actions in presto-hive workflow

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -80,13 +80,13 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Start Celery worker
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)
@@ -141,13 +141,13 @@ jobs:
       - name: Start hadoop and hive
         run: docker compose -f scripts/databases/hive/docker-compose.yml up -d
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Start Celery worker
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)

--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -82,11 +82,11 @@ jobs:
       - name: Setup Python
         uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
-        uses: $/.github/actions/cached-dependencies
+        uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Start Celery worker
-        uses: $/.github/actions/cached-dependencies
+        uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)
@@ -143,11 +143,11 @@ jobs:
       - name: Setup Python
         uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
-        uses: $/.github/actions/cached-dependencies
+        uses: ./.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Start Celery worker
-        uses: $/.github/actions/cached-dependencies
+        uses: ./.github/actions/cached-dependencies
         with:
           run: celery-worker
       - name: Python unit tests (PostgreSQL)


### PR DESCRIPTION
### SUMMARY
`zizmor`'s `self-repository` audit flags `uses: ./...` references to in-repo composite actions because that workspace-relative form isn't recognized as a "pinned" reference and, unlike GitHub's dedicated self-repository syntax (`uses: $/...`), can be influenced by whatever a prior step has checked out into the workspace. This PR switches the local action references in `superset-python-presto-hive.yml` to the `$/...` form (generated via `zizmor --fix`).

Resolves code-scanning alert #2667 (and sibling `self-repository` alerts #2662, #2663, #2664, #2665, #2666, #2668, which point at the same file).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (workflow YAML only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-presto-hive.yml` passes (includes the `zizmor` hook)
- `zizmor .github/workflows/superset-python-presto-hive.yml` reports 0 `self-repository` findings after the change
- CI should trigger and run this workflow the same as before, since `$/...` and `./...` resolve to the same in-repo action content

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API