### PR TITLE
fix(security): vary SQL Lab ad-hoc query cache key by effective RLS predicates

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -382,7 +382,34 @@ class Query(
         return ""
 
     def get_extra_cache_keys(self, query_obj: QueryObjectDict) -> list[Hashable]:
-        return []
+        """
+        Include the RLS predicates that apply to this ad-hoc query's
+        underlying tables in the cache key, mirroring what
+        ``SqlaTable.get_extra_cache_keys`` already does for virtual datasets.
+
+        ``is_rls_supported`` is ``False`` for a SQL Lab query (it has no RLS
+        rules of its own to look up via ``get_rls_cache_key``), which left
+        ``security_manager.get_rls_cache_key()`` contributing nothing here.
+        Without this, two viewers of the same not-yet-saved query-backed
+        chart (e.g. via a shared Explore permalink) with different RLS on
+        the tables the query references would collide on the same cache
+        entry, regardless of their own access.
+        """
+        if not self.sql:
+            return []
+        from superset.utils.rls import (  # pylint: disable=import-outside-toplevel
+            collect_rls_predicates_for_sql,
+        )
+
+        default_schema = self.database.get_default_schema(self.catalog)
+        return list(
+            collect_rls_predicates_for_sql(
+                self.sql,
+                self.database,
+                self.catalog,
+                self.schema or default_schema or "",
+            )
+        )
 
     def get_time_grains(self) -> list[TimeGrainDict]:
         """

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -25,6 +25,7 @@ import rison
 
 from superset import db, security_manager
 from superset.connectors.sqla.models import RowLevelSecurityFilter, SqlaTable
+from superset.models.sql_lab import Query
 from superset.subjects.models import Subject
 from superset.subjects.types import SubjectType
 from superset.security.guest_token import (
@@ -32,6 +33,7 @@ from superset.security.guest_token import (
     GuestUser,
 )
 from superset.utils import json
+from superset.utils.core import shortid
 from flask_babel import lazy_gettext as _  # noqa: F401
 from flask_appbuilder.models.sqla import filters
 from tests.integration_tests.base_tests import SupersetTestCase
@@ -993,6 +995,114 @@ def test_rls_filter_applies_to_virtual_dataset_with_join():
         # Cleanup
         db.session.delete(virtual_dataset)
         db.session.commit()
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "rls_filters")
+def test_rls_filter_applies_to_sqllab_adhoc_query():
+    """
+    Regression test for GH #33346: creating a chart directly from a SQL Lab
+    query -- without first saving it as a dataset -- must not bypass RLS.
+
+    "Create Chart" in SQL Lab builds an Explore request against a
+    ``<query_id>__query`` datasource, which the backend resolves to a
+    ``superset.models.sql_lab.Query`` row (see
+    ``DatasourceDAO.sources[DatasourceType.QUERY]``), not a ``SqlaTable``.
+    ``Query.is_rls_supported`` is (deliberately) ``False``, since a raw SQL
+    Lab query has no RLS rules of its own -- but that must not be confused
+    with the underlying-table RLS rewrite that ``get_from_clause`` applies
+    to any raw-SQL-backed datasource (virtual dataset *or* ad-hoc Query)
+    via ``apply_rls``/``get_predicates_for_table``. This test builds the
+    chart SQL for a ``Query`` the same way ``get_query_str_extended`` /
+    ``ChartDataCommand`` would, and asserts the RLS predicate on the
+    underlying physical table (``birth_names``) still ends up in it.
+    """
+    physical_table = _get_table(name="birth_names")
+
+    # An ad-hoc SQL Lab query, never saved as a dataset -- this is exactly
+    # what backs the `<query_id>__query` datasource used by "Create Chart".
+    ad_hoc_query = Query(
+        client_id=shortid()[:10],
+        database=physical_table.database,
+        sql="SELECT * FROM birth_names",
+        schema=physical_table.schema,
+        catalog=physical_table.catalog,
+        user_id=_get_user(username="gamma").id,
+    )
+
+    try:
+        # Restricted user: RLS predicates from the underlying birth_names
+        # table must be injected into the ad-hoc query's chart SQL.
+        g.user = _get_user(username="gamma")
+        sql = ad_hoc_query.get_query_str(QUERY_OBJ)
+        sql_lower = sql.lower()
+        assert "name like 'a%" in sql_lower or "name like 'q%" in sql_lower, (
+            f"RLS name filters not found in SQL Lab ad-hoc query chart SQL: {sql}"
+        )
+        assert "gender = 'boy'" in sql_lower, (
+            f"RLS gender filter not found in SQL Lab ad-hoc query chart SQL: {sql}"
+        )
+
+        # Unrestricted user: no RLS predicates should be added.
+        g.user = _get_user(username="admin")
+        sql = ad_hoc_query.get_query_str(QUERY_OBJ)
+        assert not NAMES_A_REGEX.search(sql)
+        assert not NAMES_B_REGEX.search(sql)
+        assert not NAMES_Q_REGEX.search(sql)
+        assert not BASE_FILTER_REGEX.search(sql)
+    finally:
+        db.session.rollback()
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "rls_filters")
+def test_rls_filter_in_sqllab_adhoc_query_cache_key():
+    """
+    Regression test for a cache-key gap adjacent to GH #33346.
+
+    A chart built from a SQL Lab ad-hoc query can never be *saved* as a
+    Slice (``CreateChartCommand.validate()`` rejects any
+    ``datasource_type != TABLE``), but it can be viewed by more than one
+    user via a shared Explore permalink, since ``check_query_access``
+    grants non-authors the same catalog/schema/``datasource_access`` checks
+    as any other datasource. If query-result caching is enabled (as
+    Superset's docs recommend via ``DATA_CACHE_CONFIG``/Redis for
+    production), two viewers with different RLS on the query's underlying
+    tables must not collide on the same cache entry.
+
+    ``SqlaTable.get_extra_cache_keys()`` already includes RLS predicates
+    from the underlying tables of a *virtual* dataset in its cache key via
+    ``collect_rls_predicates_for_sql()``. ``Query.get_extra_cache_keys()``
+    must do the same for ad-hoc SQL Lab queries.
+    """
+    physical_table = _get_table(name="birth_names")
+
+    ad_hoc_query = Query(
+        client_id=shortid()[:10],
+        database=physical_table.database,
+        sql="SELECT * FROM birth_names",
+        schema=physical_table.schema,
+        catalog=physical_table.catalog,
+        user_id=_get_user(username="admin").id,
+    )
+
+    try:
+        g.user = _get_user(username="gamma")
+        gamma_keys = ad_hoc_query.get_extra_cache_keys({})
+
+        g.user = _get_user(username="admin")
+        admin_keys = ad_hoc_query.get_extra_cache_keys({})
+
+        assert gamma_keys, (
+            "Expected the RLS-restricted viewer's extra cache keys to be "
+            "non-empty (predicates on birth_names should show up here)."
+        )
+        assert gamma_keys != admin_keys, (
+            f"Query.get_extra_cache_keys() must differ between an "
+            f"RLS-restricted viewer ({gamma_keys!r}) and an unrestricted "
+            f"one ({admin_keys!r}), or a cache hit from one viewer could "
+            f"be served to the other regardless of their own RLS."
+        )
+    finally:
+        db.session.rollback()
 
 
 # ===========================================================================


### PR DESCRIPTION
### SUMMARY

`Query.get_extra_cache_keys()` (superset/models/sql_lab.py) — the method that
supplies extra, RLS-sensitive cache-key material for a SQL Lab ad-hoc query
used as a chart's datasource — unconditionally returned `[]`. `SqlaTable`
already includes RLS predicates from a virtual dataset's underlying tables
in its own `get_extra_cache_keys()` via `collect_rls_predicates_for_sql()`;
`Query` never got the same treatment.

This is adjacent to, but distinct from, #33346. **The original #33346
query-execution vulnerability is already fixed** on current master:
`ExploreMixin.get_from_clause` (shared by `SqlaTable` virtual datasets and
`Query` alike) parses the raw SQL for referenced tables and injects those
tables' RLS predicates at query-construction time, and fails closed rather
than running unfiltered if that can't be safely resolved. That fix was not
tied to #33346 in its commit history. A regression test for that
already-fixed path is added here since none existed for the `Query`
datasource type specifically. This PR fixes an adjacent RLS cache-key
isolation gap affecting the same SQL Lab ad-hoc query flow.

`Query.is_rls_supported` is (correctly) `False`: an ad-hoc SQL Lab query has
no RLS rules directly attached to it as a dataset, so the dataset-level
`security_manager.get_rls_cache_key()` mechanism correctly contributes
nothing. But that's a different axis from "the RLS applicable to the
*tables this query's SQL references*" cache-key material, which `Query` was
simply missing.

**Why this matters**: a chart built from a SQL Lab query can never be
*saved* as a Slice/dashboard — `CreateChartCommand.validate()` explicitly
rejects any `datasource_type != TABLE` for exactly this reason (it can't
render on reload). It *can*, however, be viewed by a second user via a
shared Explore permalink: `check_query_access` grants a non-author the
same catalog/schema/`datasource_access` checks as any other datasource,
not a free pass. If two such viewers have different RLS on the query's
underlying tables, and query-result caching is enabled (the docs recommend
`DATA_CACHE_CONFIG`/Redis for production), the second viewer's request
could hit the first viewer's cache entry.

**Fix**: wire `Query.get_extra_cache_keys()` up to
`collect_rls_predicates_for_sql()` — the same helper `SqlaTable` already
uses for virtual datasets — mirroring that existing pattern exactly. No new
abstractions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (backend-only, no UI change). Before/after values of
`Query.get_extra_cache_keys()` for two viewers with differing RLS on the
same underlying table, verified live on Postgres:

| | gamma (restricted) | admin (unrestricted) |
|---|---|---|
| Before | `[]` | `[]` |
| After | `["(col2 = 'a')"]` | `[]` |

### TESTING INSTRUCTIONS

```
pytest tests/integration_tests/security/row_level_security_tests.py::test_rls_filter_applies_to_sqllab_adhoc_query
pytest tests/integration_tests/security/row_level_security_tests.py::test_rls_filter_in_sqllab_adhoc_query_cache_key
```

- `test_rls_filter_applies_to_sqllab_adhoc_query`: regression coverage for
  #33346's already-fixed query-construction path (previously untested for
  the `Query` datasource type specifically).
- `test_rls_filter_in_sqllab_adhoc_query_cache_key`: regression coverage for
  this fix; fails without it (`Query.get_extra_cache_keys()` returns `[]`
  for both a restricted and unrestricted viewer), passes with it.

Verified on real Postgres via the project's `pytest-runner` CI-parity
environment, before and after the fix. Full
`row_level_security_tests.py` suite: 51 passed (1 pre-existing, unrelated
failure confirmed identical without this change). `sql_lab_test.py` +
`rls_test.py` unit suites: 27 passed, including a test that documents real
RLS enforcement never goes through this cache-key helper — confirming this
change cannot affect query correctness, only cache isolation. `ruff
format`/`ruff check`: clean. `pylint`: 10.00/10. `mypy`: no new errors
introduced.

### ADDITIONAL INFORMATION

- [ ] Has associated issue: adjacent to #33346
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### SCOPE LIMITATIONS

- Does not change `Query.cache_timeout` (`0`, which Superset's caching
  layer treats as "never expire," not "disabled" — only `-1` disables
  caching). A stale-but-now-correctly-isolated cache entry can still
  outlive its RLS context if a user's own role changes later; that's a
  separate, broader caching-freshness question, not a cross-user bypass,
  and is out of scope here.
- Does not address a separate, pre-existing case-sensitivity gap in
  `get_predicates_for_table`'s table-name matching (confirmed to affect
  virtual datasets too, not specific to this code path) — tracked
  separately, not touched by this PR.
