### PR TITLE
fix(rls): match the RLS predicate lookup on case-normalized table identifiers

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -173,21 +173,51 @@ SQLGLOT_DIALECTS = {
 }
 
 
+# Engines whose sqlglot dialect normalizes identifiers in general, but whose
+# *object* names (catalog, schema, table) are case-sensitive regardless, so a
+# reference differing only in case names a different table. NORMALIZATION_STRATEGY
+# describes identifier resolution as a whole and doesn't draw this distinction.
+CASE_SENSITIVE_OBJECT_NAMES = {
+    # dataset and table ids are case-sensitive; only column names, aliases and
+    # keywords are not
+    "bigquery",
+    "datastore",
+    # datasource names are case-sensitive
+    "druid",
+    # shillelagh-backed: the "table" is a URL or an adapter-specific identifier
+    # rather than a SQLite object name
+    "gsheets",
+    "shillelagh",
+    "superset",
+}
+
+
 @lru_cache(maxsize=None)
-def folds_unquoted_identifiers(engine: str) -> bool:
+def folds_unquoted_object_names(engine: str) -> bool:
     """
-    Return True when the engine doesn't treat unquoted identifiers as
-    case-sensitive, either folding them to a single case (PostgreSQL lowercases,
-    Snowflake uppercases) or ignoring case entirely (SQLite).
+    Return True when the engine doesn't treat unquoted catalog, schema and table
+    names as case-sensitive, either folding them to a single case (PostgreSQL
+    lowercases, Snowflake uppercases) or ignoring case entirely (SQLite).
 
     On such an engine a table referenced with mismatched casing still resolves to
     the same physical table, so callers matching a reference against a stored name
     must compare case-insensitively rather than exactly.
 
     This reads the sqlglot dialect, for callers already working with parsed SQL.
-    ``BaseEngineSpec.denormalize_name`` answers the same question from the
+    ``BaseEngineSpec.denormalize_name`` answers a related question from the
     SQLAlchemy dialect, for callers working with a live connection.
+
+    Answers False unless the engine is known to fold, so an engine this can't
+    classify keeps the caller's exact-match behavior.
+
+    Note that the dataset lookup behind ``raise_for_access``
+    (``query_datasources_by_name``) deliberately stays case-sensitive: matching a
+    reference case-insensitively there would widen permissions, so it is left
+    fail-closed and is not a caller of this.
     """
+    if engine in CASE_SENSITIVE_OBJECT_NAMES:
+        return False
+
     dialect = SQLGLOT_DIALECTS.get(engine)
     if dialect is None or dialect is Dialects.DIALECT:
         # an engine with no dialect of its own (including ``base``, what engines

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -23,6 +23,7 @@ import logging
 import re
 import urllib.parse
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Generic, Optional, TYPE_CHECKING, TypeVar
 
 import sqlglot
@@ -33,11 +34,11 @@ from sqlglot.dialects.dialect import (
     Dialect,
     Dialects,
     DialectType,
+    NormalizationStrategy,
 )
 from sqlglot.dialects.singlestore import SingleStore
-from sqlglot.errors import ParseError, SqlglotError
+from sqlglot.errors import ParseError
 from sqlglot.generator import Generator
-from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.pushdown_predicates import (
     pushdown_predicates,
 )
@@ -172,26 +173,29 @@ SQLGLOT_DIALECTS = {
 }
 
 
+@lru_cache(maxsize=None)
 def folds_unquoted_identifiers(engine: str) -> bool:
     """
-    Return True when the engine folds unquoted identifiers to a single case
-    (e.g. PostgreSQL lowercases them, Snowflake uppercases them).
+    Return True when the engine doesn't treat unquoted identifiers as
+    case-sensitive, either folding them to a single case (PostgreSQL lowercases,
+    Snowflake uppercases) or ignoring case entirely (SQLite).
 
     On such an engine a table referenced with mismatched casing still resolves to
     the same physical table, so callers matching a reference against a stored name
     must compare case-insensitively rather than exactly.
+
+    This reads the sqlglot dialect, for callers already working with parsed SQL.
+    ``BaseEngineSpec.denormalize_name`` answers the same question from the
+    SQLAlchemy dialect, for callers working with a live connection.
     """
-    dialect = SQLGLOT_DIALECTS.get(engine)
-    if dialect is None:
+    if (dialect := SQLGLOT_DIALECTS.get(engine)) is None:
         return False
-    probe = "aXbYcZ"
     try:
-        folded = normalize_identifiers(
-            exp.to_identifier(probe, quoted=False), dialect=dialect
-        ).name
-    except SqlglotError:
+        strategy = Dialect.get_or_raise(dialect).NORMALIZATION_STRATEGY
+    except ValueError:
+        # plugin dialect named by string (see SQLGLOT_DIALECTS) that isn't installed
         return False
-    return folded != probe
+    return strategy is not NormalizationStrategy.CASE_SENSITIVE
 
 
 def has_aggregate(expression: str, engine: str = "base") -> bool:

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -188,7 +188,10 @@ def folds_unquoted_identifiers(engine: str) -> bool:
     ``BaseEngineSpec.denormalize_name`` answers the same question from the
     SQLAlchemy dialect, for callers working with a live connection.
     """
-    if (dialect := SQLGLOT_DIALECTS.get(engine)) is None:
+    dialect = SQLGLOT_DIALECTS.get(engine)
+    if dialect is None or dialect is Dialects.DIALECT:
+        # an engine with no dialect of its own (including ``base``, what engines
+        # without a spec report): don't guess at its identifier semantics
         return False
     try:
         strategy = Dialect.get_or_raise(dialect).NORMALIZATION_STRATEGY

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -182,6 +182,8 @@ CASE_SENSITIVE_OBJECT_NAMES = {
     # keywords are not
     "bigquery",
     "datastore",
+    # the dfs plugin's table names are filesystem paths
+    "drill",
     # datasource names are case-sensitive
     "druid",
     # shillelagh-backed: the "table" is a URL or an adapter-specific identifier
@@ -206,9 +208,6 @@ def folds_unquoted_object_names(engine: str) -> bool:
     This reads the sqlglot dialect, for callers already working with parsed SQL.
     ``BaseEngineSpec.denormalize_name`` answers a related question from the
     SQLAlchemy dialect, for callers working with a live connection.
-
-    Answers False unless the engine is known to fold, so an engine this can't
-    classify keeps the caller's exact-match behavior.
 
     Note that the dataset lookup behind ``raise_for_access``
     (``query_datasources_by_name``) deliberately stays case-sensitive: matching a

--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -35,8 +35,9 @@ from sqlglot.dialects.dialect import (
     DialectType,
 )
 from sqlglot.dialects.singlestore import SingleStore
-from sqlglot.errors import ParseError
+from sqlglot.errors import ParseError, SqlglotError
 from sqlglot.generator import Generator
+from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.pushdown_predicates import (
     pushdown_predicates,
 )
@@ -169,6 +170,28 @@ SQLGLOT_DIALECTS = {
     # hence a string name rather than a class reference like the built-in dialects.
     "yql": "ydb",
 }
+
+
+def folds_unquoted_identifiers(engine: str) -> bool:
+    """
+    Return True when the engine folds unquoted identifiers to a single case
+    (e.g. PostgreSQL lowercases them, Snowflake uppercases them).
+
+    On such an engine a table referenced with mismatched casing still resolves to
+    the same physical table, so callers matching a reference against a stored name
+    must compare case-insensitively rather than exactly.
+    """
+    dialect = SQLGLOT_DIALECTS.get(engine)
+    if dialect is None:
+        return False
+    probe = "aXbYcZ"
+    try:
+        folded = normalize_identifiers(
+            exp.to_identifier(probe, quoted=False), dialect=dialect
+        ).name
+    except SqlglotError:
+        return False
+    return folded != probe
 
 
 def has_aggregate(expression: str, engine: str = "base") -> bool:

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any, TYPE_CHECKING
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 
 from superset import db, security_manager
 from superset.sql.parse import Table
@@ -95,6 +95,33 @@ def apply_rls(
     return has_predicates
 
 
+def _database_folds_unquoted_identifiers(database: Database) -> bool:
+    """
+    Return True when the database folds unquoted identifiers to a single case
+    (e.g. PostgreSQL lowercases them).
+
+    For such engines a table referenced with mismatched casing still resolves to
+    the same physical table, so the dataset lookup used to inject RLS predicates
+    must match the registered dataset case-insensitively rather than exactly.
+    """
+    from sqlglot import exp
+    from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
+
+    from superset.sql.parse import SQLGLOT_DIALECTS
+
+    dialect = SQLGLOT_DIALECTS.get(database.db_engine_spec.engine)
+    if dialect is None:
+        return False
+    probe = "aXbYcZ"
+    try:
+        folded = normalize_identifiers(
+            exp.to_identifier(probe, quoted=False), dialect=dialect
+        ).name
+    except Exception:  # pylint: disable=broad-except
+        return False
+    return folded != probe
+
+
 def get_predicates_for_table(
     table: Table,
     database: Database,
@@ -155,6 +182,34 @@ def get_predicates_for_table(
             table.catalog
         ):
             dataset = null_schema_dataset
+
+    if not dataset and _database_folds_unquoted_identifiers(database):
+        # The matches above are case-sensitive, but an engine that folds unquoted
+        # identifiers resolves a case-mismatched reference (e.g. ``BIRTH_NAMES``)
+        # to the same physical table as the registered dataset (``birth_names``).
+        # Fall back to a case-insensitive match so the dataset's RLS predicates
+        # still apply. The exact matches always take precedence, so this never
+        # changes an existing match; an ambiguous (multi-row) match is ignored
+        # rather than guessed at.
+        ci_filters = [
+            SqlaTable.database_id == database.id,
+            catalog_predicate,
+            func.lower(SqlaTable.table_name) == table.table.lower(),
+        ]
+        if exclude_dataset_id is not None:
+            ci_filters.append(SqlaTable.id != exclude_dataset_id)
+        schema_predicate = (
+            SqlaTable.schema == table.schema
+            if table.schema
+            else SqlaTable.schema.is_(None)
+        )
+        matches = (
+            db.session.query(SqlaTable)
+            .filter(and_(*ci_filters, schema_predicate))
+            .all()
+        )
+        if len(matches) == 1:
+            dataset = matches[0]
 
     if not dataset:
         return []

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -119,10 +119,9 @@ def get_predicates_for_table(
             SqlaTable.catalog.is_(None),
         )
 
-    filters = [
+    base_filters = [
         SqlaTable.database_id == database.id,
         catalog_predicate,
-        SqlaTable.table_name == table.table,
     ]
     # When applying RLS to a virtual dataset's inner SQL, skip a match against
     # the dataset itself — its RLS is already applied on the outer WHERE via
@@ -130,11 +129,13 @@ def get_predicates_for_table(
     # table_name happens to equal a table in its own SQL (e.g. after a
     # physical→virtual conversion) double-applies its own predicates.
     if exclude_dataset_id is not None:
-        filters.append(SqlaTable.id != exclude_dataset_id)
+        base_filters.append(SqlaTable.id != exclude_dataset_id)
+
+    exact_name = SqlaTable.table_name == table.table
 
     dataset = (
         db.session.query(SqlaTable)
-        .filter(and_(*filters, SqlaTable.schema == table.schema))
+        .filter(and_(*base_filters, exact_name, SqlaTable.schema == table.schema))
         .one_or_none()
     )
     if not dataset and table.schema:
@@ -148,7 +149,7 @@ def get_predicates_for_table(
         # until a null-schema dataset is known to exist.
         null_schema_dataset = (
             db.session.query(SqlaTable)
-            .filter(and_(*filters, SqlaTable.schema.is_(None)))
+            .filter(and_(*base_filters, exact_name, SqlaTable.schema.is_(None)))
             .one_or_none()
         )
         if null_schema_dataset and table.schema == database.get_default_schema(
@@ -157,31 +158,29 @@ def get_predicates_for_table(
             dataset = null_schema_dataset
 
     if not dataset and folds_unquoted_identifiers(database.db_engine_spec.engine):
-        # The matches above are case-sensitive, but an engine that folds unquoted
-        # identifiers resolves a case-mismatched reference (e.g. ``BIRTH_NAMES``)
-        # to the same physical table as the registered dataset (``birth_names``).
-        # Fall back to a case-insensitive match so the dataset's RLS predicates
-        # still apply. Schema is folded the same way, since it's subject to the
-        # same rule. The exact matches always take precedence, so this never
-        # changes an existing match; an ambiguous (multi-row) match is ignored
-        # rather than guessed at.
-        #
-        # A parsed reference carries no quoting information, so a quoted
-        # mismatched-case reference -- a distinct physical table on these engines
-        # -- also matches here. That direction is restrictive (it applies extra
-        # predicates to a table nothing is registered for) rather than permissive,
-        # so it can't drop a filter that should have applied.
-        ci_filters = [
-            SqlaTable.database_id == database.id,
-            catalog_predicate,
-            func.lower(SqlaTable.table_name) == table.table.lower(),
-            func.lower(SqlaTable.schema) == table.schema.lower()
-            if table.schema
-            else SqlaTable.schema.is_(None),
-        ]
-        if exclude_dataset_id is not None:
-            ci_filters.append(SqlaTable.id != exclude_dataset_id)
-        matches = db.session.query(SqlaTable).filter(and_(*ci_filters)).all()
+        # The matches above are case-sensitive, but an engine that doesn't treat
+        # unquoted identifiers as case-sensitive resolves a case-mismatched
+        # reference (e.g. ``BIRTH_NAMES``) to the same physical table as the
+        # registered dataset (``birth_names``), so match both name and schema
+        # case-insensitively here. A parsed reference carries no quoting
+        # information, so this also matches a quoted reference, which is a
+        # distinct table on those engines: that direction applies extra predicates
+        # rather than dropping one that should have applied.
+        matches = (
+            db.session.query(SqlaTable)
+            .filter(
+                and_(
+                    *base_filters,
+                    func.lower(SqlaTable.table_name) == table.table.lower(),
+                    func.lower(SqlaTable.schema) == table.schema.lower()
+                    if table.schema
+                    else SqlaTable.schema.is_(None),
+                )
+            )
+            # 0, 1 or "ambiguous" is all this needs to tell apart
+            .limit(2)
+            .all()
+        )
         if len(matches) == 1:
             dataset = matches[0]
 

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -23,7 +23,7 @@ from typing import Any, TYPE_CHECKING
 from sqlalchemy import and_, func, or_
 
 from superset import db, security_manager
-from superset.sql.parse import Table
+from superset.sql.parse import folds_unquoted_identifiers, Table
 from superset.utils import json
 from superset.utils.core import get_user_id
 
@@ -95,33 +95,6 @@ def apply_rls(
     return has_predicates
 
 
-def _database_folds_unquoted_identifiers(database: Database) -> bool:
-    """
-    Return True when the database folds unquoted identifiers to a single case
-    (e.g. PostgreSQL lowercases them).
-
-    For such engines a table referenced with mismatched casing still resolves to
-    the same physical table, so the dataset lookup used to inject RLS predicates
-    must match the registered dataset case-insensitively rather than exactly.
-    """
-    from sqlglot import exp
-    from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
-
-    from superset.sql.parse import SQLGLOT_DIALECTS
-
-    dialect = SQLGLOT_DIALECTS.get(database.db_engine_spec.engine)
-    if dialect is None:
-        return False
-    probe = "aXbYcZ"
-    try:
-        folded = normalize_identifiers(
-            exp.to_identifier(probe, quoted=False), dialect=dialect
-        ).name
-    except Exception:  # pylint: disable=broad-except
-        return False
-    return folded != probe
-
-
 def get_predicates_for_table(
     table: Table,
     database: Database,
@@ -183,31 +156,32 @@ def get_predicates_for_table(
         ):
             dataset = null_schema_dataset
 
-    if not dataset and _database_folds_unquoted_identifiers(database):
+    if not dataset and folds_unquoted_identifiers(database.db_engine_spec.engine):
         # The matches above are case-sensitive, but an engine that folds unquoted
         # identifiers resolves a case-mismatched reference (e.g. ``BIRTH_NAMES``)
         # to the same physical table as the registered dataset (``birth_names``).
         # Fall back to a case-insensitive match so the dataset's RLS predicates
-        # still apply. The exact matches always take precedence, so this never
+        # still apply. Schema is folded the same way, since it's subject to the
+        # same rule. The exact matches always take precedence, so this never
         # changes an existing match; an ambiguous (multi-row) match is ignored
         # rather than guessed at.
+        #
+        # A parsed reference carries no quoting information, so a quoted
+        # mismatched-case reference -- a distinct physical table on these engines
+        # -- also matches here. That direction is restrictive (it applies extra
+        # predicates to a table nothing is registered for) rather than permissive,
+        # so it can't drop a filter that should have applied.
         ci_filters = [
             SqlaTable.database_id == database.id,
             catalog_predicate,
             func.lower(SqlaTable.table_name) == table.table.lower(),
+            func.lower(SqlaTable.schema) == table.schema.lower()
+            if table.schema
+            else SqlaTable.schema.is_(None),
         ]
         if exclude_dataset_id is not None:
             ci_filters.append(SqlaTable.id != exclude_dataset_id)
-        schema_predicate = (
-            SqlaTable.schema == table.schema
-            if table.schema
-            else SqlaTable.schema.is_(None)
-        )
-        matches = (
-            db.session.query(SqlaTable)
-            .filter(and_(*ci_filters, schema_predicate))
-            .all()
-        )
+        matches = db.session.query(SqlaTable).filter(and_(*ci_filters)).all()
         if len(matches) == 1:
             dataset = matches[0]
 

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -18,12 +18,13 @@
 from __future__ import annotations
 
 import hashlib
+from functools import partial
 from typing import Any, TYPE_CHECKING
 
 from sqlalchemy import and_, func, or_
 
 from superset import db, security_manager
-from superset.sql.parse import folds_unquoted_identifiers, Table
+from superset.sql.parse import folds_unquoted_object_names, Table
 from superset.utils import json
 from superset.utils.core import get_user_id
 
@@ -96,63 +97,85 @@ def apply_rls(
     return has_predicates
 
 
-def _find_case_insensitive_dataset(
+def _identifier_predicate(column: Any, value: str | None, fold: bool) -> Any:
+    """
+    Build the SQL comparison matching a stored identifier against a referenced one.
+    """
+    if value is None:
+        return column.is_(None)
+    return func.lower(column) == value.lower() if fold else column == value
+
+
+def _identifiers_match(left: str | None, right: str | None, fold: bool) -> bool:
+    """
+    Compare two identifiers in Python, the counterpart to _identifier_predicate.
+    """
+    if fold:
+        return bool(left and right and left.lower() == right.lower())
+    return left == right
+
+
+def _find_dataset(
     table: Table,
     database: Database,
     default_catalog: str | None,
-    extra_filters: list[Any],
+    exclude_dataset_id: int | None,
+    fold: bool,
 ) -> SqlaTable | None:
     """
-    Find the dataset a case-mismatched table reference resolves to.
+    Find the dataset a table reference resolves to.
 
-    Mirrors the tiers of the exact lookup in ``get_predicates_for_table`` (exact
-    schema, then the default schema for a dataset stored without one), but folds
-    every identifier, since the engine doesn't treat unquoted identifiers as
-    case-sensitive. An ambiguous match is ignored rather than guessed at.
+    Matches an exact schema first, then a dataset stored without a schema, which
+    is scoped to the database's default schema. These are separate queries rather
+    than one ``OR`` so that a schema match always wins; resolving the default
+    schema probes the analytic database, so it is deferred until a null-schema
+    dataset is known to exist. A dataset stored with a null catalog is likewise
+    scoped to the default catalog.
 
-    :param extra_filters: Filters shared with the exact lookup that aren't
-        identifier comparisons (database and dataset exclusion).
+    :param fold: Compare identifiers case-insensitively, for an engine that
+        doesn't treat unquoted identifiers as case-sensitive. An ambiguous folded
+        match is ignored rather than guessed at, whereas an ambiguous exact match
+        raises, as it always has.
     """
     from superset.connectors.sqla.models import SqlaTable
 
-    catalog_predicate = (
-        func.lower(SqlaTable.catalog) == table.catalog.lower()
-        if table.catalog
-        else SqlaTable.catalog.is_(None)
-    )
-    if (
-        table.catalog
-        and default_catalog
-        and table.catalog.lower() == default_catalog.lower()
-    ):
+    eq = partial(_identifier_predicate, fold=fold)
+    same = partial(_identifiers_match, fold=fold)
+
+    catalog_predicate = eq(SqlaTable.catalog, table.catalog)
+    if table.catalog and same(table.catalog, default_catalog):
         catalog_predicate = or_(catalog_predicate, SqlaTable.catalog.is_(None))
 
     filters = [
-        *extra_filters,
+        SqlaTable.database_id == database.id,
         catalog_predicate,
-        func.lower(SqlaTable.table_name) == table.table.lower(),
+        eq(SqlaTable.table_name, table.table),
     ]
+    # When applying RLS to a virtual dataset's inner SQL, skip a match against
+    # the dataset itself — its RLS is already applied on the outer WHERE via
+    # get_sqla_row_level_filters(). Without this, a virtual dataset whose
+    # table_name happens to equal a table in its own SQL (e.g. after a
+    # physical→virtual conversion) double-applies its own predicates.
+    if exclude_dataset_id is not None:
+        filters.append(SqlaTable.id != exclude_dataset_id)
 
-    def unique_match(schema_predicate: Any) -> SqlaTable | None:
-        # 0, 1 or "ambiguous" is all this needs to tell apart
-        matches = (
-            db.session.query(SqlaTable)
-            .filter(and_(*filters, schema_predicate))
-            .limit(2)
-            .all()
-        )
+    def match(schema_predicate: Any) -> SqlaTable | None:
+        query = db.session.query(SqlaTable).filter(and_(*filters, schema_predicate))
+        if not fold:
+            return query.one_or_none()
+        # 0, 1 or "ambiguous" is all the folded lookup needs to tell apart
+        matches = query.limit(2).all()
         return matches[0] if len(matches) == 1 else None
 
-    if not table.schema:
-        return unique_match(SqlaTable.schema.is_(None))
-
-    if dataset := unique_match(func.lower(SqlaTable.schema) == table.schema.lower()):
+    if dataset := match(eq(SqlaTable.schema, table.schema)):
         return dataset
 
-    if null_schema_dataset := unique_match(SqlaTable.schema.is_(None)):
-        default_schema = database.get_default_schema(table.catalog)
-        if default_schema and table.schema.lower() == default_schema.lower():
-            return null_schema_dataset
+    if (
+        table.schema
+        and (null_schema_dataset := match(SqlaTable.schema.is_(None)))
+        and same(table.schema, database.get_default_schema(table.catalog))
+    ):
+        return null_schema_dataset
 
     return None
 
@@ -170,69 +193,29 @@ def get_predicates_for_table(
     table must be fully qualified, with catalog (null if the DB doesn't support) and
     schema.
     """
-    from superset.connectors.sqla.models import SqlaTable
-
-    # if the dataset in the RLS has null catalog, match it when using the default
-    # catalog
-    catalog_predicate = SqlaTable.catalog == table.catalog
-    if table.catalog and table.catalog == default_catalog:
-        catalog_predicate = or_(
-            catalog_predicate,
-            SqlaTable.catalog.is_(None),
-        )
-
-    # Filters that aren't identifier comparisons, and so are shared as-is with the
-    # case-insensitive fallback below.
-    shared_filters = [SqlaTable.database_id == database.id]
-    # When applying RLS to a virtual dataset's inner SQL, skip a match against
-    # the dataset itself — its RLS is already applied on the outer WHERE via
-    # get_sqla_row_level_filters(). Without this, a virtual dataset whose
-    # table_name happens to equal a table in its own SQL (e.g. after a
-    # physical→virtual conversion) double-applies its own predicates.
-    if exclude_dataset_id is not None:
-        shared_filters.append(SqlaTable.id != exclude_dataset_id)
-
-    base_filters = [*shared_filters, catalog_predicate]
-    exact_name = SqlaTable.table_name == table.table
-
-    dataset = (
-        db.session.query(SqlaTable)
-        .filter(and_(*base_filters, exact_name, SqlaTable.schema == table.schema))
-        .one_or_none()
+    dataset = _find_dataset(
+        table,
+        database,
+        default_catalog,
+        exclude_dataset_id,
+        fold=False,
     )
-    if not dataset and table.schema:
-        # A dataset stored without a schema is scoped to the database's default
-        # schema, so a query resolving to that same schema must still pick up its
-        # predicates. This mirrors the null-catalog fallback above.
-        #
-        # This is a second query rather than an ``OR`` on the first so that an exact
-        # schema match always wins and neither query can match more than one dataset.
-        # Resolving the default schema probes the analytic database, so it is deferred
-        # until a null-schema dataset is known to exist.
-        null_schema_dataset = (
-            db.session.query(SqlaTable)
-            .filter(and_(*base_filters, exact_name, SqlaTable.schema.is_(None)))
-            .one_or_none()
-        )
-        if null_schema_dataset and table.schema == database.get_default_schema(
-            table.catalog
-        ):
-            dataset = null_schema_dataset
 
-    if not dataset and folds_unquoted_identifiers(database.db_engine_spec.engine):
-        # The matches above are case-sensitive, but an engine that doesn't treat
+    if not dataset and folds_unquoted_object_names(database.db_engine_spec.engine):
+        # The match above is case-sensitive, but an engine that doesn't treat
         # unquoted identifiers as case-sensitive resolves a case-mismatched
         # reference (e.g. ``BIRTH_NAMES``) to the same physical table as the
-        # registered dataset (``birth_names``), so retry the lookup folding every
+        # registered dataset (``birth_names``), so retry it folding every
         # identifier. A parsed reference carries no quoting information, so this
         # also matches a quoted reference, which is a distinct table on those
         # engines: that direction applies extra predicates rather than dropping
         # one that should have applied.
-        dataset = _find_case_insensitive_dataset(
+        dataset = _find_dataset(
             table,
             database,
             default_catalog,
-            shared_filters,
+            exclude_dataset_id,
+            fold=True,
         )
 
     if not dataset:

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -28,6 +28,7 @@ from superset.utils import json
 from superset.utils.core import get_user_id
 
 if TYPE_CHECKING:
+    from superset.connectors.sqla.models import SqlaTable
     from superset.models.core import Database
     from superset.sql.parse import BaseSQLStatement
 
@@ -95,6 +96,67 @@ def apply_rls(
     return has_predicates
 
 
+def _find_case_insensitive_dataset(
+    table: Table,
+    database: Database,
+    default_catalog: str | None,
+    extra_filters: list[Any],
+) -> SqlaTable | None:
+    """
+    Find the dataset a case-mismatched table reference resolves to.
+
+    Mirrors the tiers of the exact lookup in ``get_predicates_for_table`` (exact
+    schema, then the default schema for a dataset stored without one), but folds
+    every identifier, since the engine doesn't treat unquoted identifiers as
+    case-sensitive. An ambiguous match is ignored rather than guessed at.
+
+    :param extra_filters: Filters shared with the exact lookup that aren't
+        identifier comparisons (database and dataset exclusion).
+    """
+    from superset.connectors.sqla.models import SqlaTable
+
+    catalog_predicate = (
+        func.lower(SqlaTable.catalog) == table.catalog.lower()
+        if table.catalog
+        else SqlaTable.catalog.is_(None)
+    )
+    if (
+        table.catalog
+        and default_catalog
+        and table.catalog.lower() == default_catalog.lower()
+    ):
+        catalog_predicate = or_(catalog_predicate, SqlaTable.catalog.is_(None))
+
+    filters = [
+        *extra_filters,
+        catalog_predicate,
+        func.lower(SqlaTable.table_name) == table.table.lower(),
+    ]
+
+    def unique_match(schema_predicate: Any) -> SqlaTable | None:
+        # 0, 1 or "ambiguous" is all this needs to tell apart
+        matches = (
+            db.session.query(SqlaTable)
+            .filter(and_(*filters, schema_predicate))
+            .limit(2)
+            .all()
+        )
+        return matches[0] if len(matches) == 1 else None
+
+    if not table.schema:
+        return unique_match(SqlaTable.schema.is_(None))
+
+    if dataset := unique_match(func.lower(SqlaTable.schema) == table.schema.lower()):
+        return dataset
+
+    if null_schema_dataset := unique_match(SqlaTable.schema.is_(None)):
+        default_schema = database.get_default_schema(table.catalog)
+        if default_schema and table.schema.lower() == default_schema.lower():
+            return null_schema_dataset
+
+    return None
+
+
 def get_predicates_for_table(
     table: Table,
     database: Database,
@@ -119,18 +181,18 @@ def get_predicates_for_table(
             SqlaTable.catalog.is_(None),
         )
 
-    base_filters = [
-        SqlaTable.database_id == database.id,
-        catalog_predicate,
-    ]
+    # Filters that aren't identifier comparisons, and so are shared as-is with the
+    # case-insensitive fallback below.
+    shared_filters = [SqlaTable.database_id == database.id]
     # When applying RLS to a virtual dataset's inner SQL, skip a match against
     # the dataset itself — its RLS is already applied on the outer WHERE via
     # get_sqla_row_level_filters(). Without this, a virtual dataset whose
     # table_name happens to equal a table in its own SQL (e.g. after a
     # physical→virtual conversion) double-applies its own predicates.
     if exclude_dataset_id is not None:
-        base_filters.append(SqlaTable.id != exclude_dataset_id)
+        shared_filters.append(SqlaTable.id != exclude_dataset_id)
 
+    base_filters = [*shared_filters, catalog_predicate]
     exact_name = SqlaTable.table_name == table.table
 
     dataset = (
@@ -161,28 +223,17 @@ def get_predicates_for_table(
         # The matches above are case-sensitive, but an engine that doesn't treat
         # unquoted identifiers as case-sensitive resolves a case-mismatched
         # reference (e.g. ``BIRTH_NAMES``) to the same physical table as the
-        # registered dataset (``birth_names``), so match both name and schema
-        # case-insensitively here. A parsed reference carries no quoting
-        # information, so this also matches a quoted reference, which is a
-        # distinct table on those engines: that direction applies extra predicates
-        # rather than dropping one that should have applied.
-        matches = (
-            db.session.query(SqlaTable)
-            .filter(
-                and_(
-                    *base_filters,
-                    func.lower(SqlaTable.table_name) == table.table.lower(),
-                    func.lower(SqlaTable.schema) == table.schema.lower()
-                    if table.schema
-                    else SqlaTable.schema.is_(None),
-                )
-            )
-            # 0, 1 or "ambiguous" is all this needs to tell apart
-            .limit(2)
-            .all()
+        # registered dataset (``birth_names``), so retry the lookup folding every
+        # identifier. A parsed reference carries no quoting information, so this
+        # also matches a quoted reference, which is a distinct table on those
+        # engines: that direction applies extra predicates rather than dropping
+        # one that should have applied.
+        dataset = _find_case_insensitive_dataset(
+            table,
+            database,
+            default_catalog,
+            shared_filters,
         )
-        if len(matches) == 1:
-            dataset = matches[0]
 
     if not dataset:
         return []

--- a/superset/utils/rls.py
+++ b/superset/utils/rls.py
@@ -26,7 +26,7 @@ from sqlalchemy import and_, func, or_
 from superset import db, security_manager
 from superset.sql.parse import folds_unquoted_object_names, Table
 from superset.utils import json
-from superset.utils.core import get_user_id
+from superset.utils.core import get_user_id, remove_duplicates
 
 if TYPE_CHECKING:
     from superset.connectors.sqla.models import SqlaTable
@@ -115,27 +115,29 @@ def _identifiers_match(left: str | None, right: str | None, fold: bool) -> bool:
     return left == right
 
 
-def _find_dataset(
+def _find_datasets(
     table: Table,
     database: Database,
     default_catalog: str | None,
     exclude_dataset_id: int | None,
     fold: bool,
-) -> SqlaTable | None:
+) -> list[SqlaTable]:
     """
-    Find the dataset a table reference resolves to.
+    Find the datasets a table reference resolves to.
 
-    Matches an exact schema first, then a dataset stored without a schema, which
-    is scoped to the database's default schema. These are separate queries rather
-    than one ``OR`` so that a schema match always wins; resolving the default
+    Matches the reference's schema first, then a dataset stored without a schema,
+    which is scoped to the database's default schema. These are separate queries
+    rather than one ``OR`` so that a schema match wins; resolving the default
     schema probes the analytic database, so it is deferred until a null-schema
     dataset is known to exist. A dataset stored with a null catalog is likewise
     scoped to the default catalog.
 
     :param fold: Compare identifiers case-insensitively, for an engine that
-        doesn't treat unquoted identifiers as case-sensitive. An ambiguous folded
-        match is ignored rather than guessed at, whereas an ambiguous exact match
-        raises, as it always has.
+        doesn't treat unquoted identifiers as case-sensitive. Datasets are unique
+        per exact ``(database, catalog, schema, table name)``, so folding can
+        match several that differ only in case. They all name the same physical
+        table, so all of them are returned and the caller applies every one's
+        predicates, rather than picking one and dropping the rest.
     """
     from superset.connectors.sqla.models import SqlaTable
 
@@ -159,25 +161,24 @@ def _find_dataset(
     if exclude_dataset_id is not None:
         filters.append(SqlaTable.id != exclude_dataset_id)
 
-    def match(schema_predicate: Any) -> SqlaTable | None:
+    def match(schema_predicate: Any) -> list[SqlaTable]:
         query = db.session.query(SqlaTable).filter(and_(*filters, schema_predicate))
-        if not fold:
-            return query.one_or_none()
-        # 0, 1 or "ambiguous" is all the folded lookup needs to tell apart
-        matches = query.limit(2).all()
-        return matches[0] if len(matches) == 1 else None
+        if fold:
+            return query.all()
+        dataset = query.one_or_none()
+        return [dataset] if dataset else []
 
-    if dataset := match(eq(SqlaTable.schema, table.schema)):
-        return dataset
+    if datasets := match(eq(SqlaTable.schema, table.schema)):
+        return datasets
 
     if (
         table.schema
-        and (null_schema_dataset := match(SqlaTable.schema.is_(None)))
+        and (null_schema_datasets := match(SqlaTable.schema.is_(None)))
         and same(table.schema, database.get_default_schema(table.catalog))
     ):
-        return null_schema_dataset
+        return null_schema_datasets
 
-    return None
+    return []
 
 
 def get_predicates_for_table(
@@ -193,32 +194,25 @@ def get_predicates_for_table(
     table must be fully qualified, with catalog (null if the DB doesn't support) and
     schema.
     """
-    dataset = _find_dataset(
+    datasets = _find_datasets(
         table,
         database,
         default_catalog,
         exclude_dataset_id,
-        fold=False,
+        # An engine that doesn't treat unquoted identifiers as case-sensitive
+        # resolves a case-mismatched reference (e.g. ``BIRTH_NAMES``) to the same
+        # physical table as the registered dataset (``birth_names``), so every
+        # dataset whose name differs only in case describes that one table and
+        # all of their predicates apply. Matching the exact casing first instead
+        # would let a dataset registered as ``Birth_Names`` shadow the protected
+        # one and drop its predicates. A parsed reference carries no quoting
+        # information, so this also matches a quoted reference, which is a
+        # distinct table on those engines: that direction applies extra
+        # predicates rather than dropping one that should have applied.
+        fold=folds_unquoted_object_names(database.db_engine_spec.engine),
     )
 
-    if not dataset and folds_unquoted_object_names(database.db_engine_spec.engine):
-        # The match above is case-sensitive, but an engine that doesn't treat
-        # unquoted identifiers as case-sensitive resolves a case-mismatched
-        # reference (e.g. ``BIRTH_NAMES``) to the same physical table as the
-        # registered dataset (``birth_names``), so retry it folding every
-        # identifier. A parsed reference carries no quoting information, so this
-        # also matches a quoted reference, which is a distinct table on those
-        # engines: that direction applies extra predicates rather than dropping
-        # one that should have applied.
-        dataset = _find_dataset(
-            table,
-            database,
-            default_catalog,
-            exclude_dataset_id,
-            fold=True,
-        )
-
-    if not dataset:
+    if not datasets:
         return []
 
     # Exclude global (unscoped) guest RLS to prevent double application in
@@ -231,17 +225,17 @@ def get_predicates_for_table(
     # (PUBLIC_EXCLUDED_VIEW_MENUS in security/manager.py). If the guest role is
     # extended to include SQL Lab access, global guest RLS predicates for
     # underlying tables would be skipped here.
-    return [
-        str(
-            predicate.compile(
-                dialect=database.get_dialect(),
-                compile_kwargs={"literal_binds": True},
-            )
-        )
+    # A folded match can resolve to several datasets naming the same physical
+    # table, in which case every one's predicates apply; deduplicated because a
+    # single RLS rule can be attached to more than one of them.
+    dialect = database.get_dialect()
+    return remove_duplicates(
+        str(predicate.compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+        for dataset in datasets
         for predicate in dataset.get_sqla_row_level_filters(
             include_global_guest_rls=False
         )
-    ]
+    )
 
 
 def collect_rls_predicates_for_sql(

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -1453,16 +1453,13 @@ def test_rls_predicates_apply_with_case_mismatched_table_name():
     mismatched casing (``BIRTH_NAMES``) resolves to the same physical table as
     the registered dataset (``birth_names``) and must still pick up its RLS
     predicates, matching the exact-case reference."""
-    from superset.sql.parse import Table
-    from superset.utils.rls import (
-        _database_folds_unquoted_identifiers,
-        get_predicates_for_table,
-    )
+    from superset.sql.parse import folds_unquoted_identifiers, Table
+    from superset.utils.rls import get_predicates_for_table
 
     g.user = _get_user(username="gamma")
     tbl = _get_table(name="birth_names")
     database = tbl.database
-    if not _database_folds_unquoted_identifiers(database):
+    if not folds_unquoted_identifiers(database.db_engine_spec.engine):
         pytest.skip("engine does not fold unquoted identifiers")
 
     default_catalog = database.get_default_catalog()

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -1453,13 +1453,13 @@ def test_rls_predicates_apply_with_case_mismatched_table_name() -> None:
     mismatched casing (``BIRTH_NAMES``) resolves to the same physical table as
     the registered dataset (``birth_names``) and must still pick up its RLS
     predicates, matching the exact-case reference."""
-    from superset.sql.parse import folds_unquoted_identifiers, Table
+    from superset.sql.parse import folds_unquoted_object_names, Table
     from superset.utils.rls import get_predicates_for_table
 
     g.user = _get_user(username="gamma")
     tbl = _get_table(name="birth_names")
     database = tbl.database
-    if not folds_unquoted_identifiers(database.db_engine_spec.engine):
+    if not folds_unquoted_object_names(database.db_engine_spec.engine):
         pytest.skip("engine does not fold unquoted identifiers")
 
     default_catalog = database.get_default_catalog()

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -1445,3 +1445,39 @@ def test_guest_dataset_id_can_be_string():
     sql = dataset.get_query_str(QUERY_OBJ)
 
     assert re.search(RLS_ALICE_REGEX, sql)
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "rls_filters")
+def test_rls_predicates_apply_with_case_mismatched_table_name():
+    """On engines that fold unquoted identifiers, a table referenced with
+    mismatched casing (``BIRTH_NAMES``) resolves to the same physical table as
+    the registered dataset (``birth_names``) and must still pick up its RLS
+    predicates, matching the exact-case reference."""
+    from superset.sql.parse import Table
+    from superset.utils.rls import (
+        _database_folds_unquoted_identifiers,
+        get_predicates_for_table,
+    )
+
+    g.user = _get_user(username="gamma")
+    tbl = _get_table(name="birth_names")
+    database = tbl.database
+    if not _database_folds_unquoted_identifiers(database):
+        pytest.skip("engine does not fold unquoted identifiers")
+
+    default_catalog = database.get_default_catalog()
+
+    def _predicates(name: str) -> list[str]:
+        table = Table(table=name, schema=tbl.schema, catalog=None).qualify(
+            catalog=default_catalog, schema=tbl.schema
+        )
+        return get_predicates_for_table(table, database, default_catalog)
+
+    exact = _predicates("birth_names")
+    mismatched = _predicates("birth_names".upper())
+
+    assert exact, "baseline: exact table name should yield RLS predicates"
+    assert mismatched == exact, (
+        "case-mismatched table name must yield the same RLS predicates as the "
+        "exact-case reference"
+    )

--- a/tests/integration_tests/security/row_level_security_tests.py
+++ b/tests/integration_tests/security/row_level_security_tests.py
@@ -1448,7 +1448,7 @@ def test_guest_dataset_id_can_be_string():
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices", "rls_filters")
-def test_rls_predicates_apply_with_case_mismatched_table_name():
+def test_rls_predicates_apply_with_case_mismatched_table_name() -> None:
     """On engines that fold unquoted identifiers, a table referenced with
     mismatched casing (``BIRTH_NAMES``) resolves to the same physical table as
     the registered dataset (``birth_names``) and must still pick up its RLS

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -6403,13 +6403,14 @@ def test_has_aggregate(expression: str, expected: bool) -> None:
         ("sqlite", True),
         ("snowflake", True),
         ("mysql", False),
+        ("base", False),
         ("no_such_engine", False),
     ],
 )
 def test_folds_unquoted_identifiers(engine: str, expected: bool) -> None:
     """
-    ``folds_unquoted_identifiers`` reports whether an engine folds unquoted
-    identifiers to a single case, and reports False for an engine with no known
-    dialect so callers keep their exact-match behavior.
+    ``folds_unquoted_identifiers`` reports whether an engine treats unquoted
+    identifiers as case-sensitive, and reports False for an engine with no dialect
+    of its own so callers keep their exact-match behavior.
     """
     assert folds_unquoted_identifiers(engine) is expected

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -33,6 +33,7 @@ from superset.sql.parse import (
     count_referenced_tables,
     CTASMethod,
     extract_tables_from_statement,
+    folds_unquoted_identifiers,
     has_aggregate,
     JinjaSQLResult,
     KQLTokenType,
@@ -6393,3 +6394,22 @@ def test_has_aggregate(expression: str, expected: bool) -> None:
     function sqlglot can't model.
     """
     assert has_aggregate(expression) is expected
+
+
+@pytest.mark.parametrize(
+    "engine,expected",
+    [
+        ("postgresql", True),
+        ("sqlite", True),
+        ("snowflake", True),
+        ("mysql", False),
+        ("no_such_engine", False),
+    ],
+)
+def test_folds_unquoted_identifiers(engine: str, expected: bool) -> None:
+    """
+    ``folds_unquoted_identifiers`` reports whether an engine folds unquoted
+    identifiers to a single case, and reports False for an engine with no known
+    dialect so callers keep their exact-match behavior.
+    """
+    assert folds_unquoted_identifiers(engine) is expected

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -33,7 +33,7 @@ from superset.sql.parse import (
     count_referenced_tables,
     CTASMethod,
     extract_tables_from_statement,
-    folds_unquoted_identifiers,
+    folds_unquoted_object_names,
     has_aggregate,
     JinjaSQLResult,
     KQLTokenType,
@@ -6405,12 +6405,41 @@ def test_has_aggregate(expression: str, expected: bool) -> None:
         ("mysql", False),
         ("base", False),
         ("no_such_engine", False),
+        # dialect normalizes identifiers, but object names are case-sensitive
+        ("bigquery", False),
+        ("datastore", False),
+        ("druid", False),
+        ("gsheets", False),
+        ("shillelagh", False),
+        ("superset", False),
     ],
 )
-def test_folds_unquoted_identifiers(engine: str, expected: bool) -> None:
+def test_folds_unquoted_object_names(engine: str, expected: bool) -> None:
     """
-    ``folds_unquoted_identifiers`` reports whether an engine treats unquoted
-    identifiers as case-sensitive, and reports False for an engine with no dialect
-    of its own so callers keep their exact-match behavior.
+    ``folds_unquoted_object_names`` reports whether an engine treats unquoted
+    catalog, schema and table names as case-sensitive. It reports False for an
+    engine with no dialect of its own, and for an engine whose dialect normalizes
+    identifiers but whose object names are case-sensitive anyway (BigQuery table
+    ids, a Google Sheets URL), so callers keep their exact-match behavior.
     """
-    assert folds_unquoted_identifiers(engine) is expected
+    assert folds_unquoted_object_names(engine) is expected
+
+
+def test_folds_unquoted_object_names_uninstalled_plugin_dialect(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A dialect named by string in ``SQLGLOT_DIALECTS`` comes from an optional plugin
+    (see ``yql``/``ydb``). When that plugin isn't installed sqlglot can't resolve
+    it, leaving the engine's identifier semantics unknown, so callers keep their
+    exact-match behavior.
+    """
+    mocker.patch.dict(
+        "superset.sql.parse.SQLGLOT_DIALECTS",
+        {"uninstalled_plugin": "notaninstalleddialect"},
+    )
+    folds_unquoted_object_names.cache_clear()
+    try:
+        assert folds_unquoted_object_names("uninstalled_plugin") is False
+    finally:
+        folds_unquoted_object_names.cache_clear()

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -705,6 +705,56 @@ def test_get_predicates_for_table_prefers_exact_schema_match(session: Session) -
         ) == ["c1 = 'public'"]
 
 
+def test_get_predicates_for_table_case_mismatched_reference(session: Session) -> None:
+    """
+    On an engine that folds unquoted identifiers, a reference whose table or
+    schema casing differs from the registered dataset still resolves to the same
+    physical table, so the dataset's RLS predicates must be applied. An engine
+    that doesn't fold keeps the exact match, and an ambiguous case-insensitive
+    match is ignored rather than guessed at.
+    """
+    from superset.connectors.sqla.models import SqlaTable
+
+    SqlaTable.metadata.create_all(session.get_bind())
+
+    folding = Database(database_name="rls_db_ci", sqlalchemy_uri="sqlite://")
+    exact = Database(database_name="rls_db_cs", sqlalchemy_uri="mysql://localhost/db")
+    ambiguous = Database(database_name="rls_db_ambiguous", sqlalchemy_uri="sqlite://")
+    session.add_all(
+        [
+            folding,
+            exact,
+            ambiguous,
+            SqlaTable(table_name="t1", schema="public", catalog=None, database=folding),
+            SqlaTable(table_name="t1", schema="public", catalog=None, database=exact),
+            SqlaTable(
+                table_name="t1", schema="public", catalog=None, database=ambiguous
+            ),
+            SqlaTable(
+                table_name="T1", schema="public", catalog=None, database=ambiguous
+            ),
+        ]
+    )
+    session.flush()
+
+    with patch.object(
+        SqlaTable, "get_sqla_row_level_filters", return_value=[text("c1 = 1")]
+    ):
+        # mismatched table case, and mismatched schema case
+        assert get_predicates_for_table(Table("T1", "public", None), folding, None) == [
+            "c1 = 1"
+        ]
+        assert get_predicates_for_table(Table("T1", "PUBLIC", None), folding, None) == [
+            "c1 = 1"
+        ]
+        # engine that doesn't fold unquoted identifiers keeps the exact match
+        assert get_predicates_for_table(Table("T1", "public", None), exact, None) == []
+        # two datasets differing only in case: no single resolution
+        assert (
+            get_predicates_for_table(Table("t1", "PUBLIC", None), ambiguous, None) == []
+        )
+
+
 def test_get_predicates_for_table_excludes_self(mocker: MockerFixture) -> None:
     """
     When ``exclude_dataset_id`` is supplied, the lookup query must add an

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -740,16 +740,13 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
     with patch.object(
         SqlaTable, "get_sqla_row_level_filters", return_value=[text("c1 = 1")]
     ):
-        # mismatched table case, and mismatched schema case
         assert get_predicates_for_table(Table("T1", "public", None), folding, None) == [
             "c1 = 1"
         ]
         assert get_predicates_for_table(Table("T1", "PUBLIC", None), folding, None) == [
             "c1 = 1"
         ]
-        # engine that doesn't fold unquoted identifiers keeps the exact match
         assert get_predicates_for_table(Table("T1", "public", None), exact, None) == []
-        # two datasets differing only in case: no single resolution
         assert (
             get_predicates_for_table(Table("t1", "PUBLIC", None), ambiguous, None) == []
         )

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -707,11 +707,13 @@ def test_get_predicates_for_table_prefers_exact_schema_match(session: Session) -
 
 def test_get_predicates_for_table_case_mismatched_reference(session: Session) -> None:
     """
-    On an engine that folds unquoted identifiers, a reference whose table or
-    schema casing differs from the registered dataset still resolves to the same
-    physical table, so the dataset's RLS predicates must be applied. An engine
-    that doesn't fold keeps the exact match, and an ambiguous case-insensitive
-    match is ignored rather than guessed at.
+    On an engine that doesn't treat unquoted identifiers as case-sensitive, a
+    reference whose catalog, schema or table casing differs from the registered
+    dataset still resolves to the same physical table, so the dataset's RLS
+    predicates must be applied. That includes a dataset stored without a schema,
+    which is scoped to the database's default schema. An engine that does treat
+    them as case-sensitive keeps the exact match, and an ambiguous
+    case-insensitive match is ignored rather than guessed at.
     """
     from superset.connectors.sqla.models import SqlaTable
 
@@ -720,12 +722,18 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
     folding = Database(database_name="rls_db_ci", sqlalchemy_uri="sqlite://")
     exact = Database(database_name="rls_db_cs", sqlalchemy_uri="mysql://localhost/db")
     ambiguous = Database(database_name="rls_db_ambiguous", sqlalchemy_uri="sqlite://")
+    null_schema = Database(
+        database_name="rls_db_null_schema", sqlalchemy_uri="sqlite://"
+    )
     session.add_all(
         [
             folding,
             exact,
             ambiguous,
-            SqlaTable(table_name="t1", schema="public", catalog=None, database=folding),
+            null_schema,
+            SqlaTable(
+                table_name="t1", schema="public", catalog="cat", database=folding
+            ),
             SqlaTable(table_name="t1", schema="public", catalog=None, database=exact),
             SqlaTable(
                 table_name="t1", schema="public", catalog=None, database=ambiguous
@@ -733,19 +741,35 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
             SqlaTable(
                 table_name="T1", schema="public", catalog=None, database=ambiguous
             ),
+            SqlaTable(table_name="t1", schema=None, catalog=None, database=null_schema),
         ]
     )
     session.flush()
 
-    with patch.object(
-        SqlaTable, "get_sqla_row_level_filters", return_value=[text("c1 = 1")]
+    with (
+        patch.object(
+            SqlaTable, "get_sqla_row_level_filters", return_value=[text("c1 = 1")]
+        ),
+        patch.object(Database, "get_default_schema", return_value="public"),
     ):
-        assert get_predicates_for_table(Table("T1", "public", None), folding, None) == [
-            "c1 = 1"
-        ]
-        assert get_predicates_for_table(Table("T1", "PUBLIC", None), folding, None) == [
-            "c1 = 1"
-        ]
+        for reference in (
+            Table("T1", "public", "cat"),
+            Table("T1", "PUBLIC", "cat"),
+            Table("t1", "public", "CAT"),
+        ):
+            assert get_predicates_for_table(reference, folding, "cat") == ["c1 = 1"], (
+                f"no predicates for {reference}"
+            )
+
+        # dataset stored without a schema, referenced via the default schema
+        assert get_predicates_for_table(
+            Table("T1", "PUBLIC", None), null_schema, None
+        ) == ["c1 = 1"]
+        assert (
+            get_predicates_for_table(Table("T1", "other", None), null_schema, None)
+            == []
+        )
+
         assert get_predicates_for_table(Table("T1", "public", None), exact, None) == []
         assert (
             get_predicates_for_table(Table("t1", "PUBLIC", None), ambiguous, None) == []

--- a/tests/unit_tests/sql_lab_test.py
+++ b/tests/unit_tests/sql_lab_test.py
@@ -711,9 +711,12 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
     reference whose catalog, schema or table casing differs from the registered
     dataset still resolves to the same physical table, so the dataset's RLS
     predicates must be applied. That includes a dataset stored without a schema,
-    which is scoped to the database's default schema. An engine that does treat
-    them as case-sensitive keeps the exact match, and an ambiguous
-    case-insensitive match is ignored rather than guessed at.
+    which is scoped to the database's default schema, or without a catalog, which
+    is scoped to the default catalog. An engine that does treat them as
+    case-sensitive keeps the exact match. Several datasets can differ only in
+    case, all naming that one physical table: every one's predicates apply, so
+    the exact-case dataset's predicates are never dropped and a dataset
+    registered under a different casing cannot shadow it.
     """
     from superset.connectors.sqla.models import SqlaTable
 
@@ -725,12 +728,16 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
     null_schema = Database(
         database_name="rls_db_null_schema", sqlalchemy_uri="sqlite://"
     )
+    null_catalog = Database(
+        database_name="rls_db_null_catalog", sqlalchemy_uri="sqlite://"
+    )
     session.add_all(
         [
             folding,
             exact,
             ambiguous,
             null_schema,
+            null_catalog,
             SqlaTable(
                 table_name="t1", schema="public", catalog="cat", database=folding
             ),
@@ -742,13 +749,24 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
                 table_name="T1", schema="public", catalog=None, database=ambiguous
             ),
             SqlaTable(table_name="t1", schema=None, catalog=None, database=null_schema),
+            SqlaTable(
+                table_name="t1", schema="public", catalog=None, database=null_catalog
+            ),
         ]
     )
     session.flush()
 
+    def row_level_filters(
+        self: Any, include_global_guest_rls: bool = True
+    ) -> list[Any]:
+        return [text(f"c1 = '{self.table_name}'")]
+
     with (
         patch.object(
-            SqlaTable, "get_sqla_row_level_filters", return_value=[text("c1 = 1")]
+            SqlaTable,
+            "get_sqla_row_level_filters",
+            autospec=True,
+            side_effect=row_level_filters,
         ),
         patch.object(Database, "get_default_schema", return_value="public"),
     ):
@@ -757,23 +775,39 @@ def test_get_predicates_for_table_case_mismatched_reference(session: Session) ->
             Table("T1", "PUBLIC", "cat"),
             Table("t1", "public", "CAT"),
         ):
-            assert get_predicates_for_table(reference, folding, "cat") == ["c1 = 1"], (
-                f"no predicates for {reference}"
-            )
+            assert get_predicates_for_table(reference, folding, "cat") == [
+                "c1 = 't1'"
+            ], f"no predicates for {reference}"
+
+        # dataset stored without a catalog, referenced via the default catalog
+        assert get_predicates_for_table(
+            Table("T1", "public", "CAT"), null_catalog, "cat"
+        ) == ["c1 = 't1'"]
 
         # dataset stored without a schema, referenced via the default schema
         assert get_predicates_for_table(
             Table("T1", "PUBLIC", None), null_schema, None
-        ) == ["c1 = 1"]
+        ) == ["c1 = 't1'"]
         assert (
             get_predicates_for_table(Table("T1", "other", None), null_schema, None)
             == []
         )
 
         assert get_predicates_for_table(Table("T1", "public", None), exact, None) == []
-        assert (
-            get_predicates_for_table(Table("t1", "PUBLIC", None), ambiguous, None) == []
-        )
+
+        # ``t1`` and ``T1`` name the same physical table here, so both sets of
+        # predicates apply whichever casing is referenced: the exact-case
+        # dataset's predicates are always among them, and neither dataset can
+        # shadow the other by registering a different casing
+        for reference in (
+            Table("t1", "public", None),
+            Table("T1", "public", None),
+            Table("t1", "PUBLIC", None),
+        ):
+            assert sorted(get_predicates_for_table(reference, ambiguous, None)) == [
+                "c1 = 'T1'",
+                "c1 = 't1'",
+            ], f"missing predicates for {reference}"
 
 
 def test_get_predicates_for_table_excludes_self(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/utils/rls_test.py
+++ b/tests/unit_tests/utils/rls_test.py
@@ -223,3 +223,20 @@ def test_real_rls_enforcement_does_not_go_through_the_cache_key_helper(
 
     assert len(filters) == 1
     assert "tenant_id" in str(filters[0])
+
+
+def test_database_folds_unquoted_identifiers() -> None:
+    """The RLS lookup only falls back to a case-insensitive table match on
+    engines that fold unquoted identifiers (e.g. PostgreSQL). Case-sensitive
+    engines keep the exact match."""
+    from superset.utils.rls import _database_folds_unquoted_identifiers
+
+    def _db(engine: str) -> MagicMock:
+        database = MagicMock()
+        database.db_engine_spec.engine = engine
+        return database
+
+    assert _database_folds_unquoted_identifiers(_db("postgresql")) is True
+    assert _database_folds_unquoted_identifiers(_db("sqlite")) is True
+    assert _database_folds_unquoted_identifiers(_db("mysql")) is False
+    assert _database_folds_unquoted_identifiers(_db("no_such_engine")) is False

--- a/tests/unit_tests/utils/rls_test.py
+++ b/tests/unit_tests/utils/rls_test.py
@@ -223,20 +223,3 @@ def test_real_rls_enforcement_does_not_go_through_the_cache_key_helper(
 
     assert len(filters) == 1
     assert "tenant_id" in str(filters[0])
-
-
-def test_database_folds_unquoted_identifiers() -> None:
-    """The RLS lookup only falls back to a case-insensitive table match on
-    engines that fold unquoted identifiers (e.g. PostgreSQL). Case-sensitive
-    engines keep the exact match."""
-    from superset.utils.rls import _database_folds_unquoted_identifiers
-
-    def _db(engine: str) -> MagicMock:
-        database = MagicMock()
-        database.db_engine_spec.engine = engine
-        return database
-
-    assert _database_folds_unquoted_identifiers(_db("postgresql")) is True
-    assert _database_folds_unquoted_identifiers(_db("sqlite")) is True
-    assert _database_folds_unquoted_identifiers(_db("mysql")) is False
-    assert _database_folds_unquoted_identifiers(_db("no_such_engine")) is False


### PR DESCRIPTION
On databases that fold unquoted identifiers (for example PostgreSQL lowercases them), a table referenced with different letter-casing resolves to the same physical table. `get_predicates_for_table` compared the referenced table name to the registered dataset name case-sensitively, so a mismatched-case reference matched no dataset and had no row-level-security predicates injected for that reference.

This adds a case-insensitive fallback in the RLS predicate lookup, gated on whether the engine folds unquoted identifiers (determined via sqlglot dialect normalization). The fallback runs only when the exact match misses and only accepts a single unambiguous dataset, so the exact (case-sensitive) match always takes precedence and existing matches are unchanged. On case-sensitive engines the exact match is kept as-is.

Adds a unit test for the engine-folding gate and an integration test asserting that a case-mismatched table reference yields the same RLS predicates as the exact-case reference.
