### PR TITLE
fix(security): allow schema_access holders to explore SQL Lab queries from other authors

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -371,6 +371,8 @@ class Query(
 
     @property
     def schema_perm(self) -> str:
+        if not self.database:
+            return ""
         return (
             security_manager.get_schema_perm(
                 self.database.database_name,

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -371,7 +371,14 @@ class Query(
 
     @property
     def schema_perm(self) -> str:
-        return f"{self.database.database_name}.{self.schema}"
+        return (
+            security_manager.get_schema_perm(
+                self.database.database_name,
+                getattr(self, "catalog", None),
+                self.schema,
+            )
+            or ""
+        )
 
     @property
     def perm(self) -> str:

--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -376,7 +376,7 @@ class Query(
         return (
             security_manager.get_schema_perm(
                 self.database.database_name,
-                getattr(self, "catalog", None),
+                self.catalog or self.database.get_default_catalog(),
                 self.schema,
             )
             or ""

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2253,17 +2253,19 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         # Explorable refactor and accidentally excluded Query, which is not a
         # BaseDatasource but does expose the same hierarchy.
         if isinstance(datasource, BaseDatasource) or (
-            hasattr(datasource, "database") and hasattr(datasource, "schema_perm")
+            getattr(datasource, "database", None) is not None
+            and hasattr(datasource, "schema_perm")
         ):
+            database = cast("Database", getattr(datasource, "database", None))
             # Database-level access grants all schemas
-            if self.can_access_database(datasource.database):
+            if self.can_access_database(database):
                 return True
 
             # Catalog-level access grants all schemas in catalog
             if (
                 hasattr(datasource, "catalog")
                 and datasource.catalog
-                and self.can_access_catalog(datasource.database, datasource.catalog)
+                and self.can_access_catalog(database, datasource.catalog)
             ):
                 return True
 

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2233,8 +2233,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         Return True if the user can access the schema associated with specified
         datasource, False otherwise.
 
-        For SQL datasources: Checks database → catalog → schema hierarchy
-        For other explorables: Only checks all_datasources permission
+        For SQL datasources and Query-like explorables: Checks database → catalog
+        → schema hierarchy.  For other explorables: Only checks
+        all_datasources permission.
 
         :param datasource: The datasource
         :returns: Whether the user can access the datasource's schema
@@ -2245,8 +2246,15 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if self.can_access_all_datasources():
             return True
 
-        # SQL-specific hierarchy checks
-        if isinstance(datasource, BaseDatasource):
+        # SQL-specific hierarchy checks.
+        # BaseDatasource always has database, catalog, and schema_perm.
+        # Explorable implementations (e.g. Query) may also carry these
+        # attributes — the isinstance gate below was introduced in the 6.1.0
+        # Explorable refactor and accidentally excluded Query, which is not a
+        # BaseDatasource but does expose the same hierarchy.
+        if isinstance(datasource, BaseDatasource) or (
+            hasattr(datasource, "database") and hasattr(datasource, "schema_perm")
+        ):
             # Database-level access grants all schemas
             if self.can_access_database(datasource.database):
                 return True
@@ -4738,6 +4746,8 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 raise SupersetSecurityException(
                     self.get_table_access_error_object(denied)
                 )
+
+            return
 
         # Guest users MUST not modify the payload so it's requesting a
         # different chart or different ad-hoc metrics from what's saved.

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask_appbuilder import Model
@@ -157,6 +157,49 @@ def _compile(column_element) -> str:
             compile_kwargs={"literal_binds": True},
         )
     )
+
+
+@pytest.mark.parametrize(
+    ("catalog", "schema", "database_name", "expected"),
+    [
+        (None, "s1", "db", "[db].[s1]"),
+        ("cat", "s1", "db", "[db].[cat].[s1]"),
+        (None, None, "db", ""),
+    ],
+)
+def test_query_schema_perm(catalog, schema, database_name, expected) -> None:
+    """Query.schema_perm yields the canonical bracketed permission string.
+
+    Regression test for the schema_access explore fix: the property must
+    delegate to security_manager.get_schema_perm (which produces the format
+    created by sync_permissions) so that can_access_schema can match granted
+    schema_access, and must not raise when the schema is unset.
+    """
+    database = MagicMock()
+    database.database_name = database_name
+    query = Query(sql="SELECT * FROM t1", schema=schema, catalog=catalog)
+    query.database = database
+    with patch.object(
+        sql_lab_module.security_manager,
+        "get_schema_perm",
+        return_value=expected or None,
+    ) as mock_get_schema_perm:
+        result = query.schema_perm
+        assert result == expected
+        if expected:
+            mock_get_schema_perm.assert_called_once_with(database_name, catalog, schema)
+        else:
+            mock_get_schema_perm.assert_called_once_with(database_name, catalog, schema)
+
+
+def test_query_schema_perm_guards_unset_database() -> None:
+    """schema_perm returns "" instead of raising when the database is unset.
+
+    Transient queries may be built from just a database_id with the relationship
+    never loaded; accessing database.database_name would raise AttributeError.
+    """
+    query = Query(sql="SELECT * FROM t1", schema="s1", database_id=1)
+    assert query.schema_perm == ""
 
 
 def test_adhoc_column_to_sqla_applies_time_grain_for_unsaved_dataset() -> None:

--- a/tests/unit_tests/models/sql_lab_test.py
+++ b/tests/unit_tests/models/sql_lab_test.py
@@ -160,23 +160,40 @@ def _compile(column_element) -> str:
 
 
 @pytest.mark.parametrize(
-    ("catalog", "schema", "database_name", "expected"),
+    (
+        "catalog",
+        "schema",
+        "database_name",
+        "default_catalog",
+        "expected",
+    ),
     [
-        (None, "s1", "db", "[db].[s1]"),
-        ("cat", "s1", "db", "[db].[cat].[s1]"),
-        (None, None, "db", ""),
+        (None, "s1", "db", None, "[db].[s1]"),
+        ("cat", "s1", "db", None, "[db].[cat].[s1]"),
+        (None, "s1", "db", "defcat", "[db].[defcat].[s1]"),
+        (None, None, "db", None, ""),
     ],
 )
-def test_query_schema_perm(catalog, schema, database_name, expected) -> None:
+def test_query_schema_perm(
+    catalog,
+    schema,
+    database_name,
+    default_catalog,
+    expected,
+) -> None:
     """Query.schema_perm yields the canonical bracketed permission string.
 
     Regression test for the schema_access explore fix: the property must
     delegate to security_manager.get_schema_perm (which produces the format
     created by sync_permissions) so that can_access_schema can match granted
-    schema_access, and must not raise when the schema is unset.
+    schema_access, and must not raise when the schema is unset. When the
+    query's catalog is unset, the database default catalog is used so the
+    produced perm agrees with the catalog-qualified form granted by
+    sync_permissions.
     """
     database = MagicMock()
     database.database_name = database_name
+    database.get_default_catalog.return_value = default_catalog
     query = Query(sql="SELECT * FROM t1", schema=schema, catalog=catalog)
     query.database = database
     with patch.object(
@@ -186,10 +203,10 @@ def test_query_schema_perm(catalog, schema, database_name, expected) -> None:
     ) as mock_get_schema_perm:
         result = query.schema_perm
         assert result == expected
-        if expected:
-            mock_get_schema_perm.assert_called_once_with(database_name, catalog, schema)
-        else:
-            mock_get_schema_perm.assert_called_once_with(database_name, catalog, schema)
+        effective_catalog = catalog if catalog is not None else default_catalog
+        mock_get_schema_perm.assert_called_once_with(
+            database_name, effective_catalog, schema
+        )
 
 
 def test_query_schema_perm_guards_unset_database() -> None:

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1157,6 +1157,61 @@ def test_raise_for_access_jinja_sql(mocker: MockerFixture, app_context: None) ->
     get_table_access_error_object.assert_called_with({Table("ab_user", "public", None)})
 
 
+def test_can_access_schema_query_schema_access(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """A schema_access holder can access a Query's schema via can_access_schema.
+
+    Regression test for the widened isinstance gate: Query is not a
+    BaseDatasource but exposes ``database`` and ``schema_perm``, so the
+    catalog/schema hierarchy checks must still run for it. Previously the
+    6.1.0 Explorable refactor's ``isinstance(datasource, BaseDatasource)``
+    gate caused ``can_access_schema(Query)`` to always return False.
+    """
+    from superset.models.sql_lab import Query
+
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(
+        sm,
+        "can_access",
+        side_effect=lambda perm, view: (
+            perm == "schema_access" and view == "[examples].[main]"
+        ),
+    )
+
+    database = mocker.MagicMock()
+    database.database_name = "examples"
+    database.get_default_catalog.return_value = None
+    query = Query(sql="SELECT * FROM t1", schema="main", catalog=None)
+    query.database = database
+
+    assert sm.can_access_schema(query) is True
+
+
+def test_can_access_schema_query_denied_ungranted_schema(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """can_access_schema(Query) is False when the schema is not granted."""
+    from superset.models.sql_lab import Query
+
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "can_access", return_value=False)
+
+    database = mocker.MagicMock()
+    database.database_name = "examples"
+    database.get_default_catalog.return_value = None
+    query = Query(sql="SELECT * FROM t1", schema="other", catalog=None)
+    query.database = database
+
+    assert sm.can_access_schema(query) is False
+
+
 def test_raise_for_access_chart_for_datasource_permission(
     mocker: MockerFixture,
     app_context: None,

--- a/tests/unit_tests/security/manager_test.py
+++ b/tests/unit_tests/security/manager_test.py
@@ -1212,6 +1212,28 @@ def test_can_access_schema_query_denied_ungranted_schema(
     assert sm.can_access_schema(query) is False
 
 
+def test_can_access_schema_transient_query_no_database(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """can_access_schema(Query) must not crash when database is None.
+
+    A transient Query built from just a ``database_id`` (the ORM relationship
+    was never loaded) has ``database = None``.  The widened gate must reject
+    it rather than passing it through to ``can_access_database(None)``, which
+    would crash.
+    """
+    from superset.models.sql_lab import Query
+
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+
+    query = Query(sql="SELECT * FROM t1", schema="main", catalog=None, database_id=1)
+    query.database = None
+
+    assert sm.can_access_schema(query) is False
+
+
 def test_raise_for_access_chart_for_datasource_permission(
     mocker: MockerFixture,
     app_context: None,

--- a/tests/unit_tests/subjects/test_raise_for_access.py
+++ b/tests/unit_tests/subjects/test_raise_for_access.py
@@ -369,6 +369,88 @@ def test_raise_for_access_datasource_chart_viewer_no_promiscuous_denies(
 # -- GetExploreCommand access check tests --
 
 
+# -- Query schema_access path tests --
+
+
+def test_raise_for_access_query_schema_access_non_author(app_context):
+    """A schema_access holder can explore another author's SQL Lab query.
+    Mirrors _authorize_datasource in superset/commands/explore/get.py,
+    which passes the Query under both ``query=`` and ``datasource=``.
+    """
+    from superset.models.sql_lab import Query
+    from superset.sql.parse import Table
+
+    sm = _make_sm()
+    database = MagicMock()
+    database.database_name = "examples"
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "main"
+    query = Query(sql="SELECT * FROM t1", schema="main", catalog=None, user_id=2)
+    object.__setattr__(query, "database", database)
+    query.status = "success"
+    query.id = 42
+
+    def schema_access_main_only(permission_name, view_name):
+        return permission_name == "schema_access" and view_name == "[examples].[main]"
+
+    parse_result = MagicMock()
+    parse_result.tables = {Table("t1", "main", None)}
+
+    with (
+        patch.object(sm, "can_access_all_datasources", return_value=False),
+        patch.object(sm, "can_access_all_databases", return_value=False),
+        patch.object(sm, "can_access", side_effect=schema_access_main_only),
+        patch.object(sm, "is_editor", return_value=False),
+        patch("superset.security.manager.get_user_id", return_value=999),
+        patch("superset.security.manager.process_jinja_sql", return_value=parse_result),
+    ):
+        sm.raise_for_access(
+            query=query,
+            datasource=query,
+            allow_query_authorship_bypass=True,
+        )
+
+
+def test_raise_for_access_query_schema_access_denied_ungranted_schema(app_context):
+    """A schema_access holder is denied when SQL references an ungranted schema."""
+    from superset.models.sql_lab import Query
+    from superset.sql.parse import Table
+
+    sm = _make_sm()
+    database = MagicMock()
+    database.database_name = "examples"
+    database.get_default_catalog.return_value = None
+    database.get_default_schema_for_query.return_value = "main"
+    query = Query(sql="SELECT * FROM t1", schema="main", catalog=None, user_id=2)
+    object.__setattr__(query, "database", database)
+    query.status = "success"
+    query.id = 42
+
+    parse_result = MagicMock()
+    # SQL touches a table in "other" schema, not the granted "main" schema.
+    parse_result.tables = {Table("t1", "other", None)}
+
+    with (
+        patch.object(sm, "can_access_all_datasources", return_value=False),
+        patch.object(sm, "can_access_all_databases", return_value=False),
+        patch.object(sm, "can_access", return_value=False),
+        patch.object(sm, "is_editor", return_value=False),
+        patch.object(sm, "get_table_access_error_object", return_value=MagicMock()),
+        patch(
+            "superset.connectors.sqla.models.SqlaTable.query_datasources_by_name",
+            return_value=[],
+        ),
+        patch("superset.security.manager.get_user_id", return_value=999),
+        patch("superset.security.manager.process_jinja_sql", return_value=parse_result),
+    ):
+        with pytest.raises(SupersetSecurityException):
+            sm.raise_for_access(
+                query=query,
+                datasource=query,
+                allow_query_authorship_bypass=True,
+            )
+
+
 def test_explore_command_uses_chart_access_when_slice_exists(app_context):
     """GetExploreCommand checks chart access when a chart exists."""
     from superset.commands.explore.get import GetExploreCommand


### PR DESCRIPTION
### SUMMARY

Fix three interrelated bugs that caused a 403 error when a non-admin user holding only `schema_access` (or `catalog_access`) on a query's schema tried to create a chart from a SQL Lab query authored by a different user.

**Root cause:** The query branch of `raise_for_access()` lacked a terminal `return`, so a cleared Query fell through to the generic `datasource=` branch whose synthetic permission string could never match. Additionally, a 6.1.0 refactor added an `isinstance` gate in `can_access_schema()` that excluded `Query` objects, and `Query.schema_perm` produced a non-canonical format that never matched granted permissions.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A

### TESTING INSTRUCTIONS

1. Register a database connection with a schema.
2. Create a Gamma + sql_lab role with `schema_access` on that schema only (no `database_access`). Assign it to a test user.
3. Have a **different** user run a query in SQL Lab against that schema.
4. As the test user, open that query and click **Create chart**.
5. Before this fix: 403 error. After this fix: Explore opens.

Also run the existing security test suite:

```bash
pytest tests/unit_tests/security/ -x -v
pytest tests/unit_tests/explore/ -x -v
pytest tests/unit_tests/subjects/test_raise_for_access.py -x -v
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43987
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### Changes

**`superset/security/manager.py`**

1. **`raise_for_access()` (line 4751):** Added `return` after the per-table loop succeeds with no denied tables. Without this, the method fell through to the generic `datasource=` branch which checks `Query.perm` — a synthetic string no role is ever granted — and always raises 403.

2. **`can_access_schema()` (line 2255):** Widened the isinstance check from `BaseDatasource` only to also accept any object with `database` and `schema_perm` attributes. This undoes the 6.1.0 regression where the Explorable refactor added a type gate that `Query` (which inherits from `ExploreMixin`, not `BaseDatasource`) fails, causing `can_access_schema()` to always return False for queries.

**`superset/models/sql_lab.py`**

3. **`Query.schema_perm` (line 373):** Changed from `f"{database_name}.{schema}"` to delegate to `security_manager.get_schema_perm()`, which produces the canonical bracketed format `[database].[catalog].[schema]` that matches the permissions created by `sync_permissions`.
