### PR TITLE
fix(security): grant schema_access and catalog_access holders access to SQL Lab Explore

### DIFF
--- a/superset/models/sql_lab.py
+++ b/superset/models/sql_lab.py
@@ -371,7 +371,18 @@ class Query(
 
     @property
     def schema_perm(self) -> str:
-        return f"{self.database.database_name}.{self.schema}"
+        # Use the canonical bracketed form ([db].[schema] / [db].[cat].[schema])
+        # so it matches what sync_permissions stores and can_access() can find it.
+        from superset.extensions import security_manager as sm
+
+        return (
+            sm.get_schema_perm(
+                self.database.database_name,
+                self.catalog,
+                self.schema,
+            )
+            or ""
+        )
 
     @property
     def perm(self) -> str:

--- a/superset/security/manager.py
+++ b/superset/security/manager.py
@@ -2245,8 +2245,9 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
         if self.can_access_all_datasources():
             return True
 
-        # SQL-specific hierarchy checks
-        if isinstance(datasource, BaseDatasource):
+        # Also accept SQL Lab Query objects, which carry .database but are not
+        # BaseDatasource subclasses.
+        if isinstance(datasource, BaseDatasource) or hasattr(datasource, "database"):
             # Database-level access grants all schemas
             if self.can_access_database(datasource.database):
                 return True
@@ -2259,11 +2260,10 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
             ):
                 return True
 
-            # Schema-level permission (SQL only)
+            # Schema-level access
             if self.can_access("schema_access", datasource.schema_perm or ""):
                 return True
 
-        # Non-SQL explorables don't have schema hierarchy
         return False
 
     def _semantic_layer_grant_allows(
@@ -4738,6 +4738,11 @@ class SupersetSecurityManager(  # pylint: disable=too-many-public-methods
                 raise SupersetSecurityException(
                     self.get_table_access_error_object(denied)
                 )
+
+            # The query branch has fully decided access; don't fall into the
+            # datasource= tail below, which a Query object cannot satisfy.
+            if query:
+                return
 
         # Guest users MUST not modify the payload so it's requesting a
         # different chart or different ad-hoc metrics from what's saved.

--- a/tests/unit_tests/security/test_sqllab_explore_access_43987.py
+++ b/tests/unit_tests/security/test_sqllab_explore_access_43987.py
@@ -1,0 +1,283 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for SQL Lab query access in the Explore view.
+
+Covers the case where a non-Admin holds schema_access or catalog_access on the
+schema a SQL Lab query ran against but is not the query author and does not hold
+database_access. Verifies that raise_for_access(), can_access_schema(), and
+Query.schema_perm all correctly honour those grants.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.exceptions import SupersetSecurityException
+from superset.extensions import appbuilder
+from superset.security.manager import SupersetSecurityManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_query_mock(mocker: MockerFixture, *, catalog: str | None = None) -> object:
+    """Return a MagicMock shaped like a SQL Lab Query object."""
+    database = mocker.MagicMock()
+    database.database_name = "analytics_db"
+    database.get_default_catalog.return_value = catalog
+    database.get_default_schema_for_query.return_value = "sales"
+
+    query = mocker.MagicMock()
+    query.database = database
+    query.catalog = catalog
+    query.schema = "sales"
+    query.sql = "SELECT * FROM orders"
+    query.executed_sql = None
+    if catalog:
+        query.schema_perm = f"[analytics_db].[{catalog}].[sales]"
+    else:
+        query.schema_perm = "[analytics_db].[sales]"
+    query.perm = "[analytics_db].[repro tab](id:4)"
+    return query
+
+
+# ---------------------------------------------------------------------------
+# Fix A — raise_for_access(datasource=query) no longer falls through
+# ---------------------------------------------------------------------------
+
+
+def test_raise_for_access_schema_access_non_author_passes(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    A non-author with schema_access on the queried schema must be allowed.
+    This is the exact scenario from issue #43987.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "is_editor", return_value=False)
+    mocker.patch.object(sm, "get_schema_perm", return_value="[analytics_db].[sales]")
+    mocker.patch.object(sm, "get_catalog_perm", return_value=None)
+
+    def _can_access(perm_name: str, view_name: str) -> bool:
+        return perm_name == "schema_access" and view_name == "[analytics_db].[sales]"
+
+    mocker.patch.object(sm, "can_access", side_effect=_can_access)
+    SqlaTable = mocker.patch("superset.connectors.sqla.models.SqlaTable")  # noqa: N806
+    SqlaTable.query_datasources_by_name.return_value = []
+
+    query = _make_query_mock(mocker)
+
+    # Must NOT raise — schema_access holder can open Explore
+    result = sm.raise_for_access(  # type: ignore[call-arg]
+        database=None,
+        datasource=query,
+        query=None,
+        query_context=None,
+        table=None,
+    )
+    assert result is None
+
+
+def test_raise_for_access_schema_access_via_query_kwarg_passes(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """Passing Query as query= (explore/utils.py path) must also pass."""
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "get_schema_perm", return_value="[analytics_db].[sales]")
+    mocker.patch.object(sm, "get_catalog_perm", return_value=None)
+
+    def _can_access(perm_name: str, view_name: str) -> bool:
+        return perm_name == "schema_access" and view_name == "[analytics_db].[sales]"
+
+    mocker.patch.object(sm, "can_access", side_effect=_can_access)
+    SqlaTable = mocker.patch("superset.connectors.sqla.models.SqlaTable")  # noqa: N806
+    SqlaTable.query_datasources_by_name.return_value = []
+
+    query = _make_query_mock(mocker)
+
+    result = sm.raise_for_access(  # type: ignore[call-arg]
+        database=None,
+        datasource=None,
+        query=query,
+        query_context=None,
+        table=None,
+    )
+    assert result is None
+
+
+def test_raise_for_access_catalog_access_non_author_passes(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """catalog_access holders must also be permitted (same fall-through bug)."""
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "is_editor", return_value=False)
+
+    catalog_perm = "[analytics_db].[analytics]"
+    mocker.patch.object(sm, "get_catalog_perm", return_value=catalog_perm)
+    mocker.patch.object(
+        sm, "get_schema_perm", return_value="[analytics_db].[analytics].[sales]"
+    )
+
+    def _can_access(perm_name: str, view_name: str) -> bool:
+        return perm_name == "catalog_access" and view_name == catalog_perm
+
+    mocker.patch.object(sm, "can_access", side_effect=_can_access)
+    SqlaTable = mocker.patch("superset.connectors.sqla.models.SqlaTable")  # noqa: N806
+    SqlaTable.query_datasources_by_name.return_value = []
+
+    query = _make_query_mock(mocker, catalog="analytics")
+
+    result = sm.raise_for_access(  # type: ignore[call-arg]
+        database=None,
+        datasource=query,
+        query=None,
+        query_context=None,
+        table=None,
+    )
+    assert result is None
+
+
+def test_raise_for_access_no_grant_is_denied(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """A user with no relevant grant must still receive a 403."""
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "is_guest_user", return_value=False)
+    mocker.patch.object(sm, "is_editor", return_value=False)
+    mocker.patch.object(sm, "get_catalog_perm", return_value=None)
+    mocker.patch.object(sm, "get_schema_perm", return_value="[analytics_db].[sales]")
+    mocker.patch.object(sm, "can_access", return_value=False)
+
+    SqlaTable = mocker.patch("superset.connectors.sqla.models.SqlaTable")  # noqa: N806
+    SqlaTable.query_datasources_by_name.return_value = []
+
+    query = _make_query_mock(mocker)
+
+    with pytest.raises(SupersetSecurityException):
+        sm.raise_for_access(  # type: ignore[call-arg]
+            database=None,
+            datasource=query,
+            query=None,
+            query_context=None,
+            table=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix C — can_access_schema() accepts Query objects
+# ---------------------------------------------------------------------------
+
+
+def test_can_access_schema_query_with_schema_access(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """
+    can_access_schema() must return True for a SQL Lab Query when the user
+    holds schema_access. Before Fix C the isinstance guard blocked this.
+    """
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "can_access_catalog", return_value=False)
+
+    query = _make_query_mock(mocker)  # schema_perm = "[analytics_db].[sales]"
+
+    def _can_access(perm_name: str, view_name: str) -> bool:
+        return perm_name == "schema_access" and view_name == "[analytics_db].[sales]"
+
+    mocker.patch.object(sm, "can_access", side_effect=_can_access)
+
+    assert sm.can_access_schema(query) is True  # type: ignore[arg-type]
+
+
+def test_can_access_schema_query_no_grant(
+    mocker: MockerFixture,
+    app_context: None,
+) -> None:
+    """can_access_schema() must return False when the user holds no grant."""
+    sm = SupersetSecurityManager(appbuilder)
+    mocker.patch.object(sm, "can_access_all_datasources", return_value=False)
+    mocker.patch.object(sm, "can_access_database", return_value=False)
+    mocker.patch.object(sm, "can_access_catalog", return_value=False)
+    mocker.patch.object(sm, "can_access", return_value=False)
+
+    query = _make_query_mock(mocker)
+
+
+    assert sm.can_access_schema(query) is False  # type: ignore[arg-type]
+
+
+# Fix B — Query.schema_perm canonical format
+
+def test_query_schema_perm_no_catalog(mocker: MockerFixture) -> None:
+    """Query.schema_perm without catalog must produce [db].[schema]."""
+    from superset.models.sql_lab import Query
+
+    q = mocker.MagicMock(spec=Query)
+    q.schema = "sales"
+    q.catalog = None
+    database = mocker.MagicMock()
+    database.database_name = "analytics_db"
+    q.database = database
+
+    mock_sm = mocker.patch("superset.models.sql_lab.security_manager")
+    mock_sm.get_schema_perm.return_value = "[analytics_db].[sales]"
+
+    result = Query.schema_perm.fget(q)  # type: ignore[union-attr]
+
+    mock_sm.get_schema_perm.assert_called_once_with("analytics_db", None, "sales")
+    assert result == "[analytics_db].[sales]"
+    assert result != "analytics_db.sales"  # must not be the old broken format
+
+
+def test_query_schema_perm_with_catalog(mocker: MockerFixture) -> None:
+    """Query.schema_perm with catalog must produce [db].[catalog].[schema]."""
+    from superset.models.sql_lab import Query
+
+    q = mocker.MagicMock(spec=Query)
+    q.schema = "sales"
+    q.catalog = "analytics"
+    database = mocker.MagicMock()
+    database.database_name = "analytics_db"
+    q.database = database
+
+    mock_sm = mocker.patch("superset.models.sql_lab.security_manager")
+    mock_sm.get_schema_perm.return_value = "[analytics_db].[analytics].[sales]"
+
+    result = Query.schema_perm.fget(q)  # type: ignore[union-attr]
+
+    mock_sm.get_schema_perm.assert_called_once_with("analytics_db", "analytics", "sales")
+    assert result == "[analytics_db].[analytics].[sales]"


### PR DESCRIPTION
Fixes #43987.

Users with `schema_access` or `catalog_access` permissions could not open Explore from a SQL Lab result when they were not the query author and did not have `database_access`.

The SQL Lab query itself could be executed successfully, but clicking **Create chart** resulted in:

```text
403 DATASOURCE_SECURITY_ACCESS_ERROR
```

This was caused by three issues in the SQL Lab access-checking path:

* `raise_for_access()` did not return after completing the query-specific access check, causing `Query` objects to fall through to the generic datasource check.
* `can_access_schema()` only handled `BaseDatasource` instances, excluding SQL Lab `Query` objects.
* `Query.schema_perm` generated a permission string that did not match the format used by `sync_permissions()`.

This change fixes the query access flow, allows schema access checks for SQL Lab queries, and uses the canonical schema permission format.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. This is a backend security/access-control fix and does not change the UI.

### TESTING INSTRUCTIONS

Run the regression tests:

```bash
pytest tests/unit_tests/security/test_sqllab_explore_access_43987.py -v
```

The tests cover:

* `schema_access` for a non-query author
* `catalog_access` for a non-query author
* users without the required access
* schema access checks for SQL Lab `Query` objects
* `Query.schema_perm` with and without a catalog

Manual verification:

1. Create a role with `sql_lab` and `schema_access` for a specific schema.
2. Do not grant `database_access` or `all_datasource_access`.
3. Run a SQL Lab query against that schema as another user.
4. Open the query as the user with `schema_access`.
5. Click **Create chart**.
6. Explore should open successfully.

### ADDITIONAL INFORMATION

* [x] Has associated issue: Fixes #43987
* [ ] Required feature flags
* [ ] Changes UI
* [ ] Includes DB Migration
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API
