### PR TITLE
fix(query_context): raise 422 not 500 on malformed Jinja in Query datasource access check

### DIFF
--- a/superset/commands/report/alert.py
+++ b/superset/commands/report/alert.py
@@ -193,9 +193,9 @@ class AlertCommand(BaseCommand):
         sql_template = jinja_context.get_template_processor(
             database=self._report_schedule.database
         )
-        rendered_sql = sql_template.process_template(self._report_schedule.sql)
 
         try:
+            rendered_sql = sql_template.process_template(self._report_schedule.sql)
             limited_rendered_sql = self._report_schedule.database.apply_limit_to_sql(
                 rendered_sql, ALERT_SQL_LIMIT
             )

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -24,6 +24,7 @@ from typing import Any, cast, ClassVar, Sequence, TYPE_CHECKING
 import pandas as pd
 from flask import current_app
 from flask_babel import gettext as _
+from jinja2.exceptions import TemplateError
 
 from superset.common.chart_data import ChartDataResultFormat
 from superset.common.db_query_status import QueryStatus
@@ -37,6 +38,7 @@ from superset.daos.chart import ChartDAO
 from superset.exceptions import (
     QueryObjectValidationError,
     SupersetException,
+    SupersetTemplateException,
 )
 from superset.explorables.base import Explorable
 from superset.extensions import cache_manager, security_manager
@@ -696,7 +698,10 @@ class QueryContextProcessor:
         # come first to avoid rendering caller-supplied input for a resource the
         # caller is not allowed to access.
         if self._qc_datasource.type == DatasourceType.QUERY:
-            security_manager.raise_for_access(query=self._qc_datasource)
+            try:
+                security_manager.raise_for_access(query=self._qc_datasource)
+            except TemplateError as ex:
+                raise SupersetTemplateException(str(ex)) from ex
         else:
             security_manager.raise_for_access(query_context=self._query_context)
 

--- a/tests/unit_tests/commands/report/alert_test.py
+++ b/tests/unit_tests/commands/report/alert_test.py
@@ -20,10 +20,12 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import pytest
+from jinja2.exceptions import TemplateError
 from pytest_mock import MockerFixture
 
 from superset.commands.report.alert import AlertCommand
 from superset.commands.report.exceptions import (
+    AlertQueryError,
     AlertValidatorConfigError,
     ReportScheduleExecutorNotFoundError,
 )
@@ -531,4 +533,34 @@ def test_execute_query_raises_when_executor_user_missing(
     )
 
     with pytest.raises(ReportScheduleExecutorNotFoundError, match="ghost_user"):
+        command._execute_query()
+
+
+def test_execute_query_wraps_template_rendering_error(
+    mocker: MockerFixture,
+) -> None:
+    """
+    A Jinja rendering error raised while templating the alert's SQL (e.g. an
+    undefined variable in the alert query) must surface as the documented
+    ``AlertQueryError``, not propagate as a raw ``jinja2.exceptions.TemplateError``.
+    """
+    template_processor_mock = mocker.Mock()
+    template_processor_mock.process_template.side_effect = TemplateError(
+        "'foo' is undefined"
+    )
+    mocker.patch(
+        "superset.commands.report.alert.jinja_context.get_template_processor",
+        return_value=template_processor_mock,
+    )
+
+    report_schedule_mock = mocker.Mock()
+    report_schedule_mock.id = 1
+    report_schedule_mock.sql = "SELECT {{ foo }} FROM metrics"
+
+    command = AlertCommand(
+        report_schedule=report_schedule_mock,
+        execution_id=uuid4(),
+    )
+
+    with pytest.raises(AlertQueryError):
         command._execute_query()

--- a/tests/unit_tests/common/test_query_context_processor.py
+++ b/tests/unit_tests/common/test_query_context_processor.py
@@ -2153,6 +2153,34 @@ def test_raise_for_access_evaluates_access_before_validate():
     query.validate.assert_not_called()
 
 
+def test_raise_for_access_wraps_template_error_for_query_datasource():
+    """
+    When the datasource is a SQL Lab Query and raise_for_access() Jinja-renders
+    malformed SQL, the raw jinja2 TemplateError must be wrapped in
+    SupersetTemplateException (422) instead of leaking as an unhandled 500.
+    """
+    from jinja2.exceptions import TemplateSyntaxError
+
+    from superset.exceptions import SupersetTemplateException
+    from superset.utils.core import DatasourceType
+
+    query = MagicMock()
+    query_context = MagicMock()
+    query_context.queries = [query]
+    query_context.datasource.type = DatasourceType.QUERY
+
+    processor = QueryContextProcessor(query_context)
+
+    with patch(
+        "superset.common.query_context_processor.security_manager.raise_for_access",
+        side_effect=TemplateSyntaxError("unexpected end of template", lineno=1),
+    ):
+        with pytest.raises(SupersetTemplateException):
+            processor.raise_for_access()
+
+    query.validate.assert_not_called()
+
+
 def test_grouping_sets_fallback_handles_adhoc_and_physical_columns() -> None:
     """
     The fallback used on engines without native GROUPING SETS support must


### PR DESCRIPTION
### SUMMARY

`QueryContextProcessor.raise_for_access()` calls `security_manager.raise_for_access(query=...)` when the datasource is a SQL Lab `Query` (i.e. `DatasourceType.QUERY` — the "explore/chart a SQL Lab result without saving a dataset" flow). That method internally Jinja-renders the query's SQL to resolve the tables it touches. If the SQL contains a malformed Jinja template, a raw `jinja2.TemplateError` propagates uncaught all the way to the Flask API layer, producing an opaque 500.

This wraps the call in `try/except TemplateError` → `SupersetTemplateException` (status 422), exactly matching the pattern already used in `superset/explore/utils.py::check_query_access()` for the same `security_manager.raise_for_access(query=...)` call. The global `SupersetException` error handler in `superset/views/error_handling.py` converts it to a proper JSON error response automatically.

Sibling fix in the same bug family: #43866 (`fix(sql_lab): raise 400 not 500 on malformed Jinja during CSV export access check`).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only error handling change.

### TESTING INSTRUCTIONS
1. New unit test `test_raise_for_access_wraps_template_error_for_query_datasource` in `tests/unit_tests/common/test_query_context_processor.py` — mirrors the existing `test_raise_for_access_evaluates_access_before_validate` test structure.
2. Verified empirically: test **fails** on pre-fix code (raw `TemplateSyntaxError` leaks), **passes** after the fix.
3. Existing sibling test `test_raise_for_access_evaluates_access_before_validate` continues to pass (no regression to the `DatasourceType.TABLE` path).

```bash
pytest tests/unit_tests/common/test_query_context_processor.py -k "test_raise_for_access" -v
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API