### PR TITLE
ci: bump ASF allowlist-check to v1.0.1 for self-repository syntax support

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Check action refs against the ASF allowlist
-        uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0 # allowlist-check/v1.0.0
+        uses: apache/infrastructure-actions/allowlist-check@df54e48ff76152790f317934c691cfa7fd7a1a46 # allowlist-check/v1.0.1
         with:
           # Default scan-glob is .github/**/*.yml, which misses .yaml files.
           scan-glob: ".github/**/*.y*ml"


### PR DESCRIPTION
### SUMMARY
#43844 added a required **ASF Allowlist Check** (`apache/infrastructure-actions`'s `allowlist-check`) that scans every `uses:` ref under `.github/` and fails the build if the ref isn't on the ASF-approved allowlist. Its skip logic only recognized the legacy `./` local-action prefix, with no notion of GitHub's newer `$/` self-repository syntax, so the three local composite-action refs migrated to `$/` by #43969 (`change-detector`, `setup-backend`, `setup-supersetbot`) got misclassified as external actions needing ASF allowlist approval — hard-failing the check on **every** PR that touches `.github/**`, regardless of what the PR actually changes. See e.g. #44002.

`apache/infrastructure-actions#1254` (merged) fixed this upstream by adding `$/` to `SKIPPED_PREFIXES`, tagged as `allowlist-check/v1.0.1`. This PR bumps our pinned ref to pick up the fix, so the three affected files can stay on `$/` as-is — no revert needed.

(This PR previously reverted those three refs back to `./` as a stopgap before the upstream fix merged; that approach is no longer needed now that the real fix has landed.)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only.

### TESTING INSTRUCTIONS
- Fetched `check_asf_allowlist.py` pinned to the new SHA (`df54e48ff76152790f317934c691cfa7fd7a1a46`) plus the latest `approved_patterns.yml`/`actions.yml`, and ran it locally against this repo's current `.github/` tree (which still has all three refs on `$/`):
  ```
  Checking 37 unique action ref(s) against the ASF allowlist:
  ...
  All 37 unique action refs are on the ASF allowlist
  ```
- `pre-commit run --files .github/workflows/asf-allowlist-check.yml` passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)