### PR TITLE
perf(security): memoise the user subject lookup within a request

### DIFF
--- a/superset/subjects/utils.py
+++ b/superset/subjects/utils.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from flask_appbuilder.security.sqla.models import Group, Role, User
     from sqlalchemy.sql import CompoundSelect, Select
 
-from flask import has_app_context
+from flask import g, has_app_context, has_request_context
 from sqlalchemy import select, union_all
 
 from superset import db
@@ -206,7 +206,23 @@ def get_user_subject_ids(user_id: int) -> list[int]:
     1. The user's own USER-type subject
     2. ROLE-type subjects for all direct and group-derived roles the user has
     3. GROUP-type subjects for all groups the user belongs to
+
+    Memoised for the duration of the request, keyed by user id. Authorization
+    calls this once per object checked -- ``is_editor``/``is_viewer`` run it for
+    every chart on a dashboard. Nothing reads a user's subjects after changing
+    them within a single request, so the cached set cannot go stale in place.
     """
+    if not has_request_context():
+        return _query_user_subject_ids(user_id)
+    cache: dict[int, list[int]] = g.setdefault("_user_subject_ids", {})
+    if user_id not in cache:
+        cache[user_id] = _query_user_subject_ids(user_id)
+    # Copy: callers hand this list on, and one of them puts it in the bootstrap
+    # payload that COMMON_BOOTSTRAP_OVERRIDES_FUNC can edit.
+    return list(cache[user_id])
+
+
+def _query_user_subject_ids(user_id: int) -> list[int]:
     result = db.session.execute(get_user_subject_ids_subquery(user_id))
     return [row[0] for row in result]
 

--- a/tests/unit_tests/subjects/test_utils.py
+++ b/tests/unit_tests/subjects/test_utils.py
@@ -34,6 +34,7 @@ from superset.subjects.utils import (
     get_or_create_group_subject,
     get_or_create_role_subject,
     get_user_group_subjects,
+    get_user_subject_ids,
     get_user_subject_ids_subquery,
 )
 
@@ -615,8 +616,6 @@ def test_compute_subjects_all_variants(mock_compute):
 
 def test_get_user_subject_ids_memoises_within_a_request(app) -> None:
     """The subject lookup runs once per user per request, not once per check."""
-    from superset.subjects.utils import get_user_subject_ids
-
     with patch(
         "superset.subjects.utils._query_user_subject_ids", return_value=[7, 8]
     ) as query:
@@ -642,8 +641,6 @@ def test_get_user_subject_ids_memoises_within_a_request(app) -> None:
 
 def test_get_user_subject_ids_not_cached_outside_a_request(app_context) -> None:
     """Background tasks and CLI commands keep the uncached behaviour."""
-    from superset.subjects.utils import get_user_subject_ids
-
     with patch(
         "superset.subjects.utils._query_user_subject_ids", return_value=[7]
     ) as query:
@@ -654,8 +651,6 @@ def test_get_user_subject_ids_not_cached_outside_a_request(app_context) -> None:
 
 def test_get_user_subject_ids_returns_a_copy(app) -> None:
     """Callers hand this list on, so mutating it must not poison the cache."""
-    from superset.subjects.utils import get_user_subject_ids
-
     with patch("superset.subjects.utils._query_user_subject_ids", return_value=[7]):
         with app.test_request_context("/"):
             first = get_user_subject_ids(1)

--- a/tests/unit_tests/subjects/test_utils.py
+++ b/tests/unit_tests/subjects/test_utils.py
@@ -611,3 +611,53 @@ def test_compute_subjects_all_variants(mock_compute):
         ensure_no_lockout=True,
         field_name="editors",
     )
+
+
+def test_get_user_subject_ids_memoises_within_a_request(app) -> None:
+    """The subject lookup runs once per user per request, not once per check."""
+    from superset.subjects.utils import get_user_subject_ids
+
+    with patch(
+        "superset.subjects.utils._query_user_subject_ids", return_value=[7, 8]
+    ) as query:
+        with app.test_request_context("/"):
+            assert get_user_subject_ids(1) == [7, 8]
+            assert get_user_subject_ids(1) == [7, 8]
+            assert query.call_count == 1
+
+            # A different principal is a different cache entry.
+            get_user_subject_ids(2)
+            assert query.call_count == 2
+
+    # The cache lives on ``g``, so it is bounded by the app context. A fresh
+    # one starts empty and the lookup runs again.
+    with app.app_context():
+        with patch(
+            "superset.subjects.utils._query_user_subject_ids", return_value=[7, 8]
+        ) as query:
+            with app.test_request_context("/"):
+                get_user_subject_ids(1)
+                assert query.call_count == 1
+
+
+def test_get_user_subject_ids_not_cached_outside_a_request(app_context) -> None:
+    """Background tasks and CLI commands keep the uncached behaviour."""
+    from superset.subjects.utils import get_user_subject_ids
+
+    with patch(
+        "superset.subjects.utils._query_user_subject_ids", return_value=[7]
+    ) as query:
+        get_user_subject_ids(1)
+        get_user_subject_ids(1)
+        assert query.call_count == 2
+
+
+def test_get_user_subject_ids_returns_a_copy(app) -> None:
+    """Callers hand this list on, so mutating it must not poison the cache."""
+    from superset.subjects.utils import get_user_subject_ids
+
+    with patch("superset.subjects.utils._query_user_subject_ids", return_value=[7]):
+        with app.test_request_context("/"):
+            first = get_user_subject_ids(1)
+            first.append(999)
+            assert get_user_subject_ids(1) == [7]


### PR DESCRIPTION
### SUMMARY

`is_editor` and `is_viewer` both start by resolving the current user's subject IDs, and both take a single resource. Anything that checks a list of objects calls them in a loop, so the subject lookup runs once per object.

The lookup isn't cheap — `get_user_subject_ids_subquery` is a three-way `UNION ALL` over the user's own subject, their direct and group-derived roles, and their groups. Loading a dashboard runs `can_access_chart` per chart, which is where I noticed it.

Counting the union queries while checking 40 charts as a non-admin:

| | subject-union queries |
|---|---|
| master | 80 |
| this branch | 1 |

Two per chart, because the editor check and the viewer check each do their own lookup.

The fix memoises the result on `g`, keyed by user id. Nothing in a request reads a user's own subjects after changing them, so the entry can't go stale underneath a caller.

Two things I was deliberate about:

- **Outside a request context the behaviour is unchanged.** It's guarded by `has_request_context()`, so Celery tasks and CLI commands keep reading through every time. That matters because `g` is bound to the app context, not the request, and a worker can hold one open for a long time.
- **It returns a copy.** One caller hands the list into the bootstrap payload that `COMMON_BOOTSTRAP_OVERRIDES_FUNC` is allowed to edit, so handing out the cached list itself would let a customisation hook corrupt it.

Happy to change the cache key or drop it behind a config flag if you'd rather — this seemed like the smallest version that works.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/subjects tests/unit_tests/commands tests/unit_tests/dao` — 1237 passed.

Three new tests in `tests/unit_tests/subjects/test_utils.py` cover the cases I cared about: it runs once per user per request, a second user is a separate entry, it still reads through with no request context, and mutating the returned list doesn't poison the cache.

`ruff check`, `ruff format --check` and `mypy` are clean on both files.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
