### PR TITLE
docs(handlebars): correct helper names that are not registered

### DIFF
--- a/docs/docs/using-superset/handlebars-chart.mdx
+++ b/docs/docs/using-superset/handlebars-chart.mdx
@@ -71,17 +71,17 @@ Parses a JSON string into an object that can be used in your template.
 
 ---
 
-#### `groupBy`
+#### `group`
 
-Groups an array of objects by a key, powered by [handlebars-group-by](https://github.com/nicktindall/handlebars-group-by).
+Groups an array of objects by a key, powered by [handlebars-group-by](https://github.com/nicktindall/handlebars-group-by). The key is passed as a `by` hash argument.
 
 ```handlebars
-{{#groupBy data 'department'}}
+{{#group data by="department"}}
   <h3>{{value}}</h3>
   {{#each items}}
     <p>{{this.name}}</p>
   {{/each}}
-{{/groupBy}}
+{{/group}}
 ```
 
 ---
@@ -90,6 +90,14 @@ Groups an array of objects by a key, powered by [handlebars-group-by](https://gi
 
 Superset also registers all helpers from the [just-handlebars-helpers](https://github.com/leapfrogtechnology/just-handlebars-helpers) library. These include a wide range of comparison, math, string, and conditional helpers. Commonly used ones include:
 
+:::note
+These names are specific to `just-handlebars-helpers` and differ from other
+Handlebars helper libraries — notably `handlebars-helpers`, which spells the
+math helpers `add`, `subtract`, `multiply` and `divide`. Calling a helper that
+is not registered raises `Missing helper: "..."`, which renders the chart blank,
+so it is worth checking a name against the tables below before using it.
+:::
+
 #### Comparison
 
 | Helper | Description           | Example                        |
@@ -97,6 +105,7 @@ Superset also registers all helpers from the [just-handlebars-helpers](https://g
 | `eq`   | Strict equality       | `{{#if (eq status "active")}}` |
 | `eqw`  | Weak equality         | `{{#if (eqw count "5")}}`      |
 | `neq`  | Strict inequality     | `{{#if (neq role "admin")}}`   |
+| `neqw` | Weak inequality       | `{{#if (neqw count "5")}}`     |
 | `lt`   | Less than             | `{{#if (lt score 50)}}`        |
 | `lte`  | Less than or equal    | `{{#if (lte score 100)}}`      |
 | `gt`   | Greater than          | `{{#if (gt price 0)}}`         |
@@ -114,25 +123,52 @@ Superset also registers all helpers from the [just-handlebars-helpers](https://g
 
 #### String
 
-| Helper       | Description                         | Example                           |
-| ------------ | ----------------------------------- | --------------------------------- |
-| `capitalize` | Capitalizes first letter            | `{{capitalize name}}`             |
-| `uppercase`  | Converts to uppercase               | `{{uppercase status}}`            |
-| `lowercase`  | Converts to lowercase               | `{{lowercase email}}`             |
-| `truncate`   | Truncates a string                  | `{{truncate description 100}}`    |
-| `contains`   | Checks if string contains substring | `{{#if (contains tag "urgent")}}` |
+| Helper            | Description                                     | Example                        |
+| ----------------- | ----------------------------------------------- | ------------------------------ |
+| `capitalizeFirst` | Capitalizes the first letter                    | `{{capitalizeFirst name}}`     |
+| `capitalizeEach`  | Capitalizes the first letter of each word       | `{{capitalizeEach title}}`     |
+| `uppercase`       | Converts to uppercase                           | `{{uppercase status}}`         |
+| `lowercase`       | Converts to lowercase                           | `{{lowercase email}}`          |
+| `excerpt`         | Truncates to a length and appends an ellipsis   | `{{excerpt description 100}}`  |
+| `sprintf`         | printf-style formatting                         | `{{sprintf "%.1f" score}}`     |
+| `concat`          | Concatenates values                             | `{{concat first " " last}}`    |
+| `join`            | Joins an array with a separator                 | `{{join tags ", "}}`           |
+| `first` / `last`  | First or last element of an array               | `{{first items}}`              |
+| `newLineToBr`     | Converts newlines to `<br>` (needs `{{{ }}}`)   | `{{{newLineToBr notes}}}`      |
 
 #### Math
 
-| Helper     | Description    | Example                       |
-| ---------- | -------------- | ----------------------------- |
-| `add`      | Addition       | `{{add a b}}`                 |
-| `subtract` | Subtraction    | `{{subtract total discount}}` |
-| `multiply` | Multiplication | `{{multiply price quantity}}` |
-| `divide`   | Division       | `{{divide total count}}`      |
-| `ceil`     | Ceiling        | `{{ceil value}}`              |
-| `floor`    | Floor          | `{{floor value}}`             |
-| `round`    | Round          | `{{round value}}`             |
+| Helper           | Description             | Example                              |
+| ---------------- | ----------------------- | ------------------------------------ |
+| `sum`            | Addition                | `{{sum a b}}`                        |
+| `difference`     | Subtraction             | `{{difference total discount}}`      |
+| `multiplication` | Multiplication          | `{{multiplication price quantity}}`  |
+| `division`       | Division                | `{{division total count}}`           |
+| `remainder`      | Modulo                  | `{{remainder index 2}}`              |
+| `abs`            | Absolute value          | `{{abs delta}}`                      |
+| `ceil`           | Ceiling                 | `{{ceil value}}`                     |
+| `floor`          | Floor                   | `{{floor value}}`                    |
+
+`sum` takes exactly two arguments — it adds a pair of numbers and does not total
+an array. There is no `round` helper; use `{{sprintf "%.0f" value}}` to round to
+a given number of decimal places.
+
+#### Arrays
+
+| Helper     | Description                        | Example                           |
+| ---------- | ---------------------------------- | --------------------------------- |
+| `includes` | Whether an array contains a value  | `{{#if (includes tags "urgent")}}` |
+| `empty`    | Whether an array is empty          | `{{#if (empty rows)}}`            |
+| `count`    | Number of items in an array        | `{{count rows}}`                  |
+
+`includes` tests array membership. It returns `false` for a string, so it cannot
+be used to check for a substring.
+
+#### Formatting
+
+| Helper           | Description                  | Example                          |
+| ---------------- | ---------------------------- | -------------------------------- |
+| `formatCurrency` | Formats a number as currency | `{{formatCurrency revenue "$"}}` |
 
 For the full list of available helpers, see the [just-handlebars-helpers documentation](https://github.com/leapfrogtechnology/just-handlebars-helpers).
 


### PR DESCRIPTION
### SUMMARY

The helper reference on the Handlebars Chart docs page lists nine helpers that
are not registered. Calling any of them raises `Missing helper: "..."`, which
renders the chart blank — so the page's own examples break the chart they are
teaching you to build.

The Math and String tables appear to have been written against
[`handlebars-helpers`](https://github.com/helpers/handlebars-helpers), a
different library. Superset registers
[`just-handlebars-helpers`](https://github.com/leapfrogtechnology/just-handlebars-helpers),
which spells them differently:

| Documented | Actually registered |
| --- | --- |
| `add` | `sum` |
| `subtract` | `difference` |
| `multiply` | `multiplication` |
| `divide` | `division` |
| `round` | *no equivalent* — use `sprintf "%.0f"` |
| `capitalize` | `capitalizeFirst` / `capitalizeEach` |
| `truncate` | `excerpt` |
| `contains` | *no equivalent* — see below |
| `groupBy` | `group`, and the key is a `by=` hash argument |

`contains` has no drop-in replacement. `includes` is array membership and
returns `false` for a string, so it cannot check for a substring — documenting
it as a `contains` equivalent would just move the bug. It is listed under a new
**Arrays** heading with its actual contract.

The change also:

- fixes the `groupBy` example, which used both the wrong helper name and
  positional-argument syntax instead of `by="..."`;
- adds a note explaining that the names differ from other Handlebars helper
  libraries, since that is the likely source of the original error;
- documents helpers that are registered and useful but were missing —
  `sprintf`, `formatCurrency`, `concat`, `join`, `first`/`last`, `newLineToBr`,
  `abs`, `remainder`, `neqw`, `empty`, `count`;
- notes that `sum` is binary and does not total an array, which is a common
  surprise when building totals in a template.

The Comparison and Logical tables were already correct and are unchanged apart
from the added `neqw` row.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable — documentation only.

### TESTING INSTRUCTIONS

Every helper name and inline example on the page was checked against the actual
registry rather than read off. To reproduce:

```bash
cd superset-frontend/plugins/plugin-chart-handlebars
node -e "
const hb = require('handlebars');
require('just-handlebars-helpers').registerHelpers(hb);
require('handlebars-group-by').register(hb);
for (const n of ['add','subtract','multiply','divide','round','capitalize','truncate','contains','groupBy']) {
  console.log((n in hb.helpers ? 'YES ' : 'NO  ') + n);
}
"
```

All nine print `NO` before this change. Rendering any of them throws
`Missing helper`, which blanks the chart.

To check the corrected names the same way, substitute `sum`, `difference`,
`multiplication`, `division`, `capitalizeFirst`, `capitalizeEach`, `excerpt`,
`includes` and `group` — all print `YES`, and every example in the updated
tables compiles and renders.

In the UI: create a Handlebars chart on any dataset and paste
`{{add 1 2}}` — the chart goes blank with `Missing helper: "add"` in the
console. `{{sum 1 2}}` renders `3`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
