### PR TITLE
fix(versioning): edit-gate the version-history and activity endpoints

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -92,6 +92,7 @@ tags are included in asset export and import.
 
 Set `FEATURE_FLAGS = {"TAGGING_SYSTEM": False}` to restore the previous
 behavior. Existing tag rows are left untouched.
+- Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Related-entity visibility filtering inside the activity stream is unchanged.
 
 ### Global Async Queries re-platformed onto the Global Task Framework (breaking)
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -93,6 +93,7 @@ tags are included in asset export and import.
 Set `FEATURE_FLAGS = {"TAGGING_SYSTEM": False}` to restore the previous
 behavior. Existing tag rows are left untouched.
 - Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Related-entity visibility filtering inside the activity stream is unchanged.
+- Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Embedded guest-token principals are always refused on these endpoints, even when a role subject they hold has been granted editorship. Related-entity visibility filtering inside the activity stream is unchanged.
 
 ### Global Async Queries re-platformed onto the Global Task Framework (breaking)
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -92,8 +92,10 @@ tags are included in asset export and import.
 
 Set `FEATURE_FLAGS = {"TAGGING_SYSTEM": False}` to restore the previous
 behavior. Existing tag rows are left untouched.
-- Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Related-entity visibility filtering inside the activity stream is unchanged.
-- Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Embedded guest-token principals are always refused on these endpoints, even when a role subject they hold has been granted editorship. Related-entity visibility filtering inside the activity stream is unchanged.
+
+### Version-history and activity endpoints are edit-gated
+
+Version-history and activity endpoints (`GET /api/v1/{chart,dashboard,dataset}/<uuid>/versions/…` and `…/activity/`) are now edit-gated: they require object-level editorship (owner/editor/admin) of the entity, matching the UI's edit-gated Version history menu and the restore endpoint's gate. Read-only users who could previously retrieve the full change log (author identities, field-level before/after diffs) via the API now receive 403. Embedded guest-token principals are always refused on these endpoints, even when a role subject they hold has been granted editorship. Related-entity visibility filtering inside the activity stream is unchanged.
 
 ### Global Async Queries re-platformed onto the Global Task Framework (breaking)
 

--- a/superset/versioning/activity/orchestrator.py
+++ b/superset/versioning/activity/orchestrator.py
@@ -250,7 +250,7 @@ def get_activity(
 
     *resolved_entity*, when supplied, is the already-resolved live path
     entity (the endpoint resolves it once via ``resolve_endpoint_path_entity``
-    for the ``raise_for_access`` gate); passing it here skips a second
+    for the editorship gate); passing it here skips a second
     identical ``find_active_by_uuid`` lookup and the TOCTOU window between
     them. The count is post-visibility (silent visibility filter),
     post-include-filter, and — when ``q`` is supplied — post-

--- a/superset/versioning/activity/render.py
+++ b/superset/versioning/activity/render.py
@@ -183,8 +183,8 @@ def apply_record_decoration(
                 # "(deleted) <kind>" marker — so the stream stays honest
                 # about WHEN something changed without disclosing WHAT, WHO,
                 # or WHICH entity. Self-path tombstones are untouched: the
-                # endpoint already gated them via ``raise_for_access`` on the
-                # path entity.
+                # endpoint already gated them via ``raise_for_editorship``
+                # on the path entity (an edit gate, stricter than read).
                 label = API_KIND_LABEL.get(api_kind, api_kind)
                 record["entity_name"] = ""
                 record["summary"] = f"(deleted) {label}"

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -222,14 +222,22 @@ def concurrency_token_from(info: EntityVersionInfo) -> str | None:
     return info.version_uuid or unversioned_entity_token(info.entity_uuid)
 
 
-# The versioned model classes whose /versions/ and /activity/ endpoint
-# families are wired through ``resolve_endpoint_path_entity``. Kept as an
-# explicit allowlist so a future entity added to the versioning surface
-# without an authorization decision fails closed rather than silently
-# inheriting a gate.
-_VERSION_ENDPOINT_MODELS: frozenset[str] = frozenset(
-    {"Slice", "Dashboard", "SqlaTable"}
-)
+def _version_endpoint_models() -> tuple[type, ...]:
+    """The exact model classes wired for the version endpoint families.
+
+    An explicit allowlist so a future entity added to the versioning
+    surface without an authorization decision fails closed rather than
+    silently inheriting a gate. Compared by class IDENTITY, not name —
+    an unrelated class that happens to be called ``Slice`` /
+    ``Dashboard`` / ``SqlaTable`` must not slip through. Deferred
+    imports keep this module out of the model-import cycle.
+    """
+    # pylint: disable=import-outside-toplevel
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.models.dashboard import Dashboard
+    from superset.models.slice import Slice
+
+    return (Slice, Dashboard, SqlaTable)
 
 
 class PathEntityResponseError(Exception):
@@ -273,6 +281,14 @@ def resolve_endpoint_path_entity(
     ``api.response_400`` / ``api.response_403`` / ``api.response_404``
     on it. Pass ``self`` from the endpoint method.
     """
+    # Static wiring validation runs first: an unwired model must fail
+    # closed loudly before any parsing or database work, not surface as
+    # an incidental AttributeError inside the DAO lookup.
+    if model_cls not in _version_endpoint_models():
+        raise LookupError(
+            f"Model {model_cls.__name__!r} is not wired for version endpoints"
+        )
+
     try:
         entity_uuid = UUID(uuid_str)
     except ValueError as exc:
@@ -282,10 +298,14 @@ def resolve_endpoint_path_entity(
     if entity is None:
         raise PathEntityResponseError(api.response_404())
 
-    if model_cls.__name__ not in _VERSION_ENDPOINT_MODELS:
-        raise LookupError(
-            f"Model {model_cls.__name__!r} is not wired for version endpoints"
-        )
+    # M10 / SECURITY.md's guest row: an embedded guest's capability is
+    # reading the dashboards its token authorizes — never their change
+    # logs (author identities, field-level diffs). Denied explicitly
+    # BEFORE the editorship check: ``is_editor`` maps a guest's ROLE
+    # subjects into the editor set, so a role subject granted editorship
+    # would otherwise admit every guest holding that role.
+    if security_manager.is_guest_user():
+        raise PathEntityResponseError(api.response_403())
     # Version history is EDIT-gated, not read-gated (sc-120001 decision,
     # following the sc-103156 SIP): the full change log — author
     # identities, timestamps, field-level before/after diffs — is for

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -221,16 +221,14 @@ def concurrency_token_from(info: EntityVersionInfo) -> str | None:
     return info.version_uuid or unversioned_entity_token(info.entity_uuid)
 
 
-# Maps the versioned model class name to the keyword argument
-# ``security_manager.raise_for_access`` expects for the per-resource
-# gate. Slice → ``chart=``, Dashboard → ``dashboard=``, SqlaTable →
-# ``datasource=``. Centralised here so /versions/ and /activity/
-# endpoints share one source of truth for the dispatch.
-_RAISE_FOR_ACCESS_KWARG: dict[str, str] = {
-    "Slice": "chart",
-    "Dashboard": "dashboard",
-    "SqlaTable": "datasource",
-}
+# The versioned model classes whose /versions/ and /activity/ endpoint
+# families are wired through ``resolve_endpoint_path_entity``. Kept as an
+# explicit allowlist so a future entity added to the versioning surface
+# without an authorization decision fails closed rather than silently
+# inheriting a gate.
+_VERSION_ENDPOINT_MODELS: frozenset[str] = frozenset(
+    {"Slice", "Dashboard", "SqlaTable"}
+)
 
 
 class PathEntityResponseError(Exception):
@@ -238,7 +236,7 @@ class PathEntityResponseError(Exception):
 
     Endpoints catch it and return
     the carried response directly. The shape exists so the
-    UUID-parse + find-by-uuid + read-access check can live in one
+    UUID-parse + find-by-uuid + editorship check can live in one
     place across the ``/versions/`` and ``/activity/`` endpoint
     families."""
 
@@ -255,8 +253,8 @@ def resolve_endpoint_path_entity(
     1. Parse *uuid_str* into a UUID (or raise → 400).
     2. Look up the live entity via ``VersionDAO.find_active_by_uuid``
        (or raise → 404).
-    3. Run ``security_manager.raise_for_access`` with the resource-typed
-       kwarg (or raise → 403).
+    3. Enforce object-level editorship via
+       ``security_manager.raise_for_editorship`` (or raise → 403).
 
     Returns ``(entity, entity_uuid)`` on success — the parsed UUID is
     threaded out so callers don't re-parse the path-string. Raises
@@ -283,18 +281,22 @@ def resolve_endpoint_path_entity(
     if entity is None:
         raise PathEntityResponseError(api.response_404())
 
-    # Direct ``[…]`` would leak the unknown model name into a generic 500
-    # via the unhandled ``KeyError`` exception text. The three resource
-    # families wired today cover every key; a future entity added to the
-    # versioning surface without updating this dispatch table should fail
-    # closed (the test suite picks it up) rather than silently disclose.
-    kwarg = _RAISE_FOR_ACCESS_KWARG.get(model_cls.__name__)
-    if kwarg is None:
+    if model_cls.__name__ not in _VERSION_ENDPOINT_MODELS:
         raise LookupError(
-            f"No raise_for_access kwarg registered for {model_cls.__name__!r}"
+            f"Model {model_cls.__name__!r} is not wired for version endpoints"
         )
+    # Version history is EDIT-gated, not read-gated (sc-120001 decision,
+    # following the sc-103156 SIP): the full change log — author
+    # identities, timestamps, field-level before/after diffs — is for
+    # principals who may alter the entity, matching the UI's edit-gated
+    # menu and the restore command's gate. Object-level editorship
+    # (owner/editor/admin via ``raise_for_editorship``) rather than
+    # model-level ``can_write``, so a write-capable role cannot read the
+    # history of entities it does not own. Related-entity records inside
+    # the ACTIVITY stream additionally pass per-record read-visibility
+    # filtering (AV-008's silent filter), which is unchanged.
     try:
-        security_manager.raise_for_access(**{kwarg: entity})
+        security_manager.raise_for_editorship(entity)
     except SupersetSecurityException as exc:
         raise PathEntityResponseError(api.response_403()) from exc
 

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -19,8 +19,9 @@
 Each ``ChartRestApi`` / ``DashboardRestApi`` / ``DatasetRestApi`` carries
 the same read endpoint methods — ``list_versions`` and ``get_version`` —
 plus the ``activity`` endpoint on each resource. The bodies are
-byte-for-byte identical apart from the model class and the
-``security_manager.raise_for_access`` kwarg. Extracting the bodies here
+byte-for-byte identical apart from the model class; authorization is a
+single object-level editorship gate in ``resolve_endpoint_path_entity``
+(``security_manager.raise_for_editorship``). Extracting the bodies here
 lets each per-resource method collapse to a single delegation call, while
 the OpenAPI docstring + FAB decorators stay at the method site where they
 belong.

--- a/superset/versioning/restore.py
+++ b/superset/versioning/restore.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 #
 # Unknown models fail closed (``LookupError``) rather than defaulting to a
 # relation-less restore — a silently partial restore is worse than a loud
-# failure (mirrors ``_RAISE_FOR_ACCESS_KWARG`` in ``api_helpers``).
+# failure (mirrors ``_VERSION_ENDPOINT_MODELS`` in ``api_helpers``).
 _RESTORE_RELATIONS: dict[str, list[str]] = {
     "SqlaTable": ["columns", "metrics"],
     "Dashboard": [],

--- a/superset/versioning/restore.py
+++ b/superset/versioning/restore.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 #
 # Unknown models fail closed (``LookupError``) rather than defaulting to a
 # relation-less restore — a silently partial restore is worse than a loud
-# failure (mirrors ``_VERSION_ENDPOINT_MODELS`` in ``api_helpers``).
+# failure (mirrors ``_version_endpoint_models`` in ``api_helpers``).
 _RESTORE_RELATIONS: dict[str, list[str]] = {
     "SqlaTable": ["columns", "metrics"],
     "Dashboard": [],

--- a/tests/integration_tests/versioning/activity_view_tests.py
+++ b/tests/integration_tests/versioning/activity_view_tests.py
@@ -123,12 +123,12 @@ class TestDashboardActivityView(SupersetTestCase):
         rv = self._activity(str(dashboard.uuid), since="yesterday")
         assert rv.status_code == 400
 
-    def test_activity_allows_read_non_owner(self) -> None:
-        """Activity is a read endpoint: a non-owner with read access (Alpha,
-        which carries broad read + datasource access) can read a dashboard's
-        activity stream — ``raise_for_access(dashboard=)`` does not reject —
-        so the endpoint returns 200. Visibility of *related* rows is filtered
-        separately, inside the activity layer."""
+    def test_activity_denies_read_only_non_editor(self) -> None:
+        """sc-120001: activity is EDIT-gated. A non-editor with broad read +
+        datasource access (Alpha) is refused — the endpoint enforces
+        object-level editorship (``raise_for_editorship``), matching the
+        UI's edit-gated menu, not the read gate. Visibility filtering of
+        *related* rows (AV-008) still applies for editors."""
         _persist_fixture_state()
         dashboard = _get_birth_names_dashboard()
         assert dashboard is not None
@@ -136,7 +136,7 @@ class TestDashboardActivityView(SupersetTestCase):
 
         self.login(ALPHA_USERNAME)
         rv = self._activity(dashboard_uuid)
-        assert rv.status_code == 200
+        assert rv.status_code == 403
 
     def test_visibility_filter_silently_drops_inaccessible_related(self) -> None:
         """AV-008 security control: a related record whose entity the caller
@@ -922,16 +922,15 @@ class TestChartActivityView(SupersetTestCase):
         rv = self._activity(str(chart.uuid), include="upstream")
         assert rv.status_code == 400
 
-    def test_chart_activity_allows_read_non_owner(self) -> None:
-        """Same shape as the dashboard endpoint: a read-access non-owner
-        (Alpha) can read a chart's activity, so ``raise_for_access(chart=)``
-        does not reject and the endpoint returns 200."""
+    def test_chart_activity_denies_read_only_non_editor(self) -> None:
+        """sc-120001: same edit gate as the dashboard endpoint — a
+        read-access non-editor (Alpha) is refused with 403."""
         _persist_fixture_state()
         chart = self._get_birth_names_chart()
         assert chart is not None
         self.login(ALPHA_USERNAME)
         rv = self._activity(str(chart.uuid))
-        assert rv.status_code == 200
+        assert rv.status_code == 403
 
     # ---- 200 happy paths ----
 
@@ -1123,15 +1122,15 @@ class TestDatasetActivityView(SupersetTestCase):
         rv = self._activity(str(dataset.uuid), include="upstream")
         assert rv.status_code == 400
 
-    def test_dataset_activity_allows_read_non_owner(self) -> None:
-        """A read-access non-owner (Alpha) can read a dataset's activity
-        stream, so the read endpoint returns 200."""
+    def test_dataset_activity_denies_read_only_non_editor(self) -> None:
+        """sc-120001: the dataset activity endpoint shares the edit gate —
+        a read-access non-editor (Alpha) is refused with 403."""
         _persist_fixture_state()
         dataset = _get_birth_names_dataset()
         assert dataset is not None
         self.login(ALPHA_USERNAME)
         rv = self._activity(str(dataset.uuid))
-        assert rv.status_code == 200
+        assert rv.status_code == 403
 
     # ---- 200 happy paths ----
 

--- a/tests/integration_tests/versioning/activity_view_tests.py
+++ b/tests/integration_tests/versioning/activity_view_tests.py
@@ -124,7 +124,9 @@ class TestDashboardActivityView(SupersetTestCase):
         assert rv.status_code == 400
 
     def test_activity_denies_write_capable_non_editor(self) -> None:
-        """sc-120001: activity is EDIT-gated. A non-editor with broad read +
+        """sc-120001: activity is EDIT-gated.
+
+        A non-editor with broad read +
         datasource access (Alpha) is refused — the endpoint enforces
         object-level editorship (``raise_for_editorship``), matching the
         UI's edit-gated menu, not the read gate. Visibility filtering of
@@ -923,8 +925,9 @@ class TestChartActivityView(SupersetTestCase):
         assert rv.status_code == 400
 
     def test_chart_activity_denies_write_capable_non_editor(self) -> None:
-        """sc-120001: same edit gate as the dashboard endpoint — a
-        read-access non-editor (Alpha) is refused with 403."""
+        """The chart activity endpoint refuses a write-capable non-editor.
+
+        Same edit gate as the dashboard endpoint (sc-120001)."""
         _persist_fixture_state()
         chart = self._get_birth_names_chart()
         assert chart is not None
@@ -1123,8 +1126,9 @@ class TestDatasetActivityView(SupersetTestCase):
         assert rv.status_code == 400
 
     def test_dataset_activity_denies_write_capable_non_editor(self) -> None:
-        """sc-120001: the dataset activity endpoint shares the edit gate —
-        a read-access non-editor (Alpha) is refused with 403."""
+        """The dataset activity endpoint refuses a write-capable non-editor.
+
+        It shares the same edit gate (sc-120001)."""
         _persist_fixture_state()
         dataset = _get_birth_names_dataset()
         assert dataset is not None

--- a/tests/integration_tests/versioning/activity_view_tests.py
+++ b/tests/integration_tests/versioning/activity_view_tests.py
@@ -123,7 +123,7 @@ class TestDashboardActivityView(SupersetTestCase):
         rv = self._activity(str(dashboard.uuid), since="yesterday")
         assert rv.status_code == 400
 
-    def test_activity_denies_read_only_non_editor(self) -> None:
+    def test_activity_denies_write_capable_non_editor(self) -> None:
         """sc-120001: activity is EDIT-gated. A non-editor with broad read +
         datasource access (Alpha) is refused — the endpoint enforces
         object-level editorship (``raise_for_editorship``), matching the
@@ -922,7 +922,7 @@ class TestChartActivityView(SupersetTestCase):
         rv = self._activity(str(chart.uuid), include="upstream")
         assert rv.status_code == 400
 
-    def test_chart_activity_denies_read_only_non_editor(self) -> None:
+    def test_chart_activity_denies_write_capable_non_editor(self) -> None:
         """sc-120001: same edit gate as the dashboard endpoint — a
         read-access non-editor (Alpha) is refused with 403."""
         _persist_fixture_state()
@@ -1122,7 +1122,7 @@ class TestDatasetActivityView(SupersetTestCase):
         rv = self._activity(str(dataset.uuid), include="upstream")
         assert rv.status_code == 400
 
-    def test_dataset_activity_denies_read_only_non_editor(self) -> None:
+    def test_dataset_activity_denies_write_capable_non_editor(self) -> None:
         """sc-120001: the dataset activity endpoint shares the edit gate —
         a read-access non-editor (Alpha) is refused with 403."""
         _persist_fixture_state()

--- a/tests/integration_tests/versioning/versions_api_tests.py
+++ b/tests/integration_tests/versioning/versions_api_tests.py
@@ -172,14 +172,22 @@ class TestChartVersionsApi(SupersetTestCase):
 
     def test_list_versions_denies_unauthorized_user(self) -> None:
         """The per-object editorship gate (``raise_for_editorship``) must
-        refuse a user who is no editor — as a 403, or 404 if the object
+        refuse a user who is not an editor — as a 403, or 404 if the object
         isn't even visible to them."""
         chart_uuid = str(self._girls_chart().uuid)
         self.login(GAMMA_USERNAME)
         rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/")
         assert rv.status_code in (403, 404), rv.data
 
-    def test_list_versions_denies_read_only_non_editor_chart(self) -> None:
+    def _births_dashboard(self) -> Dashboard:
+        # Commit first so fixture state created in this test process is
+        # visible to the request-side session (same idiom as
+        # ``_girls_chart`` and the activity suite's
+        # ``_persist_fixture_state``).
+        db.session.commit()
+        return db.session.query(Dashboard).filter(Dashboard.slug == "births").one()
+
+    def test_list_versions_denies_write_capable_non_editor_chart(self) -> None:
         """sc-120001 pin: version history is EDIT-gated. Alpha carries broad
         read + datasource access — the OLD read gate admitted it — but is no
         editor/owner of this chart, so the endpoint must refuse with 403.
@@ -190,12 +198,11 @@ class TestChartVersionsApi(SupersetTestCase):
         rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/")
         assert rv.status_code == 403, rv.data
 
-    def test_list_versions_denies_read_only_non_editor_dashboard(self) -> None:
+    def test_list_versions_denies_write_capable_non_editor_dashboard(self) -> None:
         """sc-120001 pin, dashboard flavour — the same edit gate refuses a
         read-capable non-editor on the dashboard endpoint (this is QA
         TC-062/TC-066's leak, closed)."""
-        db.session.commit()
-        dashboard = db.session.query(Dashboard).filter(Dashboard.slug == "births").one()
+        dashboard = self._births_dashboard()
         self.login(ALPHA_USERNAME)
         rv = self.client.get(f"/api/v1/dashboard/{dashboard.uuid}/versions/")
         assert rv.status_code == 403, rv.data
@@ -212,8 +219,10 @@ class TestChartVersionsApi(SupersetTestCase):
         chart = self._girls_chart()
         chart_uuid = str(chart.uuid)
         gamma = security_manager.find_user(GAMMA_USERNAME)
+        gamma_subject = get_user_subject(gamma.id)
+        assert gamma_subject is not None, "gamma user has no USER subject row"
         original_editors = list(chart.editors)
-        chart.editors = [get_user_subject(gamma.id)]
+        chart.editors = [gamma_subject]
         db.session.commit()
         try:
             self.login(GAMMA_USERNAME)
@@ -228,7 +237,10 @@ class TestChartVersionsApi(SupersetTestCase):
         """sc-120001 / M10 pin: an embedded guest-token principal is never
         an editor, so the editorship gate the version endpoints run refuses
         it outright — guests read embedded dashboards, never their change
-        logs."""
+        logs. Deliberately pins the gate directly (guest HTTP-session
+        plumbing isn't worth the cost here); the endpoint→gate wiring is
+        pinned by the unit not-called test and the Alpha/Gamma HTTP
+        matrix."""
         # pylint: disable=import-outside-toplevel
         from unittest.mock import patch as mock_patch
 
@@ -434,6 +446,15 @@ class TestDatasetVersionsApi(SupersetTestCase):
                 f"/api/v1/dataset/{ds_id}",
                 json={"description": original},
             )
+
+    def test_list_versions_denies_write_capable_non_editor_dataset(self) -> None:
+        """sc-120001 pin, dataset flavour: Alpha carries all-datasource
+        access — the flavour where read-vs-edit confusion would most
+        plausibly regress — and is still refused as a non-editor."""
+        ds_uuid = str(self._dataset().uuid)
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(f"/api/v1/dataset/{ds_uuid}/versions/")
+        assert rv.status_code == 403, rv.data
 
     def test_put_override_columns_returns_version_fields(self) -> None:
         """The ``override_columns`` save is two commits / two Continuum

--- a/tests/integration_tests/versioning/versions_api_tests.py
+++ b/tests/integration_tests/versioning/versions_api_tests.py
@@ -42,7 +42,11 @@ from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
 from superset.utils import json
 from tests.integration_tests.base_tests import SupersetTestCase
-from tests.integration_tests.constants import ADMIN_USERNAME, GAMMA_USERNAME
+from tests.integration_tests.constants import (
+    ADMIN_USERNAME,
+    ALPHA_USERNAME,
+    GAMMA_USERNAME,
+)
 from tests.integration_tests.fixtures.birth_names_dashboard import (
     load_birth_names_dashboard_with_slices,  # noqa: F401
     load_birth_names_data,  # noqa: F401
@@ -167,13 +171,94 @@ class TestChartVersionsApi(SupersetTestCase):
         assert rv.status_code == 404, rv.data
 
     def test_list_versions_denies_unauthorized_user(self) -> None:
-        """The per-object access gate (``raise_for_access(chart=...)``) must
-        refuse a user without access — as a 403, or 404 if the object isn't
-        even visible to them."""
+        """The per-object editorship gate (``raise_for_editorship``) must
+        refuse a user who is no editor — as a 403, or 404 if the object
+        isn't even visible to them."""
         chart_uuid = str(self._girls_chart().uuid)
         self.login(GAMMA_USERNAME)
         rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/")
         assert rv.status_code in (403, 404), rv.data
+
+    def test_list_versions_denies_read_only_non_editor_chart(self) -> None:
+        """sc-120001 pin: version history is EDIT-gated. Alpha carries broad
+        read + datasource access — the OLD read gate admitted it — but is no
+        editor/owner of this chart, so the endpoint must refuse with 403.
+        (Reverted-gate control: with the read gate restored this test fails
+        with a 200.)"""
+        chart_uuid = str(self._girls_chart().uuid)
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/")
+        assert rv.status_code == 403, rv.data
+
+    def test_list_versions_denies_read_only_non_editor_dashboard(self) -> None:
+        """sc-120001 pin, dashboard flavour — the same edit gate refuses a
+        read-capable non-editor on the dashboard endpoint (this is QA
+        TC-062/TC-066's leak, closed)."""
+        db.session.commit()
+        dashboard = db.session.query(Dashboard).filter(Dashboard.slug == "births").one()
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(f"/api/v1/dashboard/{dashboard.uuid}/versions/")
+        assert rv.status_code == 403, rv.data
+
+    def test_list_versions_allows_object_editor(self) -> None:
+        """sc-120001 matrix: object-level editorship admits — Gamma made an
+        EDITOR of this one chart reads its history, while remaining unable
+        to read other charts' history (object-level, not model-level
+        can_write)."""
+        # pylint: disable=import-outside-toplevel
+        from superset import security_manager
+        from superset.subjects.utils import get_user_subject
+
+        chart = self._girls_chart()
+        chart_uuid = str(chart.uuid)
+        gamma = security_manager.find_user(GAMMA_USERNAME)
+        original_editors = list(chart.editors)
+        chart.editors = [get_user_subject(gamma.id)]
+        db.session.commit()
+        try:
+            self.login(GAMMA_USERNAME)
+            rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/")
+            assert rv.status_code == 200, rv.data
+        finally:
+            chart = self._girls_chart()
+            chart.editors = original_editors
+            db.session.commit()
+
+    def test_editorship_gate_refuses_guest_principal(self) -> None:
+        """sc-120001 / M10 pin: an embedded guest-token principal is never
+        an editor, so the editorship gate the version endpoints run refuses
+        it outright — guests read embedded dashboards, never their change
+        logs."""
+        # pylint: disable=import-outside-toplevel
+        from unittest.mock import patch as mock_patch
+
+        from superset import security_manager
+        from superset.exceptions import SupersetSecurityException
+        from superset.security.guest_token import GuestTokenResourceType
+        from superset.utils.core import override_user
+
+        dashboard = db.session.query(Dashboard).filter(Dashboard.slug == "births").one()
+        with mock_patch.dict(
+            "superset.extensions.feature_flag_manager._feature_flags",
+            EMBEDDED_SUPERSET=True,
+        ):
+            guest = security_manager.get_guest_user_from_token(
+                {
+                    "user": {},
+                    "iat": 0,
+                    "exp": 9999999999,
+                    "rls_rules": [],
+                    "resources": [
+                        {
+                            "type": GuestTokenResourceType.DASHBOARD,
+                            "id": str(dashboard.uuid),
+                        }
+                    ],
+                }
+            )
+            with override_user(guest):
+                with pytest.raises(SupersetSecurityException):
+                    security_manager.raise_for_editorship(dashboard)
 
     def test_put_non_numeric_pk_does_not_500_with_capture_on(self) -> None:
         """The PUT route is ``/<pk>`` (a string); with capture on, a

--- a/tests/integration_tests/versioning/versions_api_tests.py
+++ b/tests/integration_tests/versioning/versions_api_tests.py
@@ -188,7 +188,9 @@ class TestChartVersionsApi(SupersetTestCase):
         return db.session.query(Dashboard).filter(Dashboard.slug == "births").one()
 
     def test_list_versions_denies_write_capable_non_editor_chart(self) -> None:
-        """sc-120001 pin: version history is EDIT-gated. Alpha carries broad
+        """sc-120001 pin: version history is EDIT-gated.
+
+        Alpha carries broad
         read + datasource access — the OLD read gate admitted it — but is no
         editor/owner of this chart, so the endpoint must refuse with 403.
         (Reverted-gate control: with the read gate restored this test fails
@@ -199,19 +201,42 @@ class TestChartVersionsApi(SupersetTestCase):
         assert rv.status_code == 403, rv.data
 
     def test_list_versions_denies_write_capable_non_editor_dashboard(self) -> None:
-        """sc-120001 pin, dashboard flavour — the same edit gate refuses a
-        read-capable non-editor on the dashboard endpoint (this is QA
-        TC-062/TC-066's leak, closed)."""
+        """The dashboard endpoint refuses a write-capable non-editor.
+
+        This is QA TC-062/TC-066's leak, closed by the same shared edit
+        gate as the chart flavour."""
         dashboard = self._births_dashboard()
         self.login(ALPHA_USERNAME)
         rv = self.client.get(f"/api/v1/dashboard/{dashboard.uuid}/versions/")
         assert rv.status_code == 403, rv.data
 
+    def test_get_version_denies_write_capable_non_editor_chart(self) -> None:
+        """The chart get-one route runs the same edit gate before version
+        resolution.
+
+        The version uuid need not exist: the gate refuses the non-editor
+        before the snapshot is even looked up."""
+        chart_uuid = str(self._girls_chart().uuid)
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(f"/api/v1/chart/{chart_uuid}/versions/{MISSING_UUID}/")
+        assert rv.status_code == 403, rv.data
+
+    def test_get_version_denies_write_capable_non_editor_dashboard(self) -> None:
+        """The dashboard get-one route runs the same edit gate before
+        version resolution."""
+        dashboard = self._births_dashboard()
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(
+            f"/api/v1/dashboard/{dashboard.uuid}/versions/{MISSING_UUID}/"
+        )
+        assert rv.status_code == 403, rv.data
+
     def test_list_versions_allows_object_editor(self) -> None:
-        """sc-120001 matrix: object-level editorship admits — Gamma made an
-        EDITOR of this one chart reads its history, while remaining unable
-        to read other charts' history (object-level, not model-level
-        can_write)."""
+        """Object-level editorship admits (sc-120001 matrix positive case).
+
+        Gamma made an EDITOR of this one chart reads its history, while
+        remaining unable to read other charts' history (object-level,
+        not model-level can_write)."""
         # pylint: disable=import-outside-toplevel
         from superset import security_manager
         from superset.subjects.utils import get_user_subject
@@ -234,13 +259,14 @@ class TestChartVersionsApi(SupersetTestCase):
             db.session.commit()
 
     def test_editorship_gate_refuses_guest_principal(self) -> None:
-        """sc-120001 / M10 pin: an embedded guest-token principal is never
-        an editor, so the editorship gate the version endpoints run refuses
-        it outright — guests read embedded dashboards, never their change
-        logs. Deliberately pins the gate directly (guest HTTP-session
-        plumbing isn't worth the cost here); the endpoint→gate wiring is
-        pinned by the unit not-called test and the Alpha/Gamma HTTP
-        matrix."""
+        """Guest principals never read change logs (sc-120001 / M10 pin).
+
+        An embedded guest-token principal is never an editor, and the
+        editorship gate the version endpoints run refuses it outright —
+        guests read embedded dashboards, never their change logs.
+        Deliberately pins the gate directly (guest HTTP-session plumbing
+        isn't worth the cost here); the endpoint→gate wiring is pinned
+        by the unit not-called test and the Alpha/Gamma HTTP matrix."""
         # pylint: disable=import-outside-toplevel
         from unittest.mock import patch as mock_patch
 
@@ -271,6 +297,59 @@ class TestChartVersionsApi(SupersetTestCase):
             with override_user(guest):
                 with pytest.raises(SupersetSecurityException):
                     security_manager.raise_for_editorship(dashboard)
+
+    def test_versions_refuse_guest_even_when_guest_role_is_editor(self) -> None:
+        """A guest is refused even when its role subject holds editorship.
+
+        The cross-model round's M10 case: ``is_editor`` maps a guest's
+        ROLE subjects into the editor set, so without the explicit guest
+        deny at the choke point, granting a role subject editorship would
+        open every guest holding that role. Layered refusal is accepted
+        here (401 if guest header auth doesn't bind on this route, 403
+        from the deny) — the invariant pinned is never-200; the explicit
+        pre-editorship deny itself is unit-pinned
+        (test_preflight_denies_guest_principals_outright)."""
+        # pylint: disable=import-outside-toplevel
+        from unittest.mock import patch as mock_patch
+
+        from flask import current_app
+
+        from superset import security_manager
+        from superset.security.guest_token import GuestTokenResourceType
+        from superset.subjects.utils import subjects_from_roles
+
+        dashboard = self._births_dashboard()
+        guest_role = security_manager.find_role(current_app.config["GUEST_ROLE_NAME"])
+        assert guest_role is not None
+        role_subjects = list(subjects_from_roles([guest_role]))
+        assert role_subjects, "guest role has no subject row"
+        original_editors = list(dashboard.editors)
+        dashboard.editors = original_editors + role_subjects
+        db.session.commit()
+        try:
+            with mock_patch.dict(
+                "superset.extensions.feature_flag_manager._feature_flags",
+                EMBEDDED_SUPERSET=True,
+            ):
+                token = security_manager.create_guest_access_token(
+                    user={"username": "vh_guest"},
+                    resources=[
+                        {
+                            "type": GuestTokenResourceType.DASHBOARD,
+                            "id": str(dashboard.uuid),
+                        }
+                    ],
+                    rls=[],
+                )
+                rv = self.client.get(
+                    f"/api/v1/dashboard/{dashboard.uuid}/versions/",
+                    headers={current_app.config["GUEST_TOKEN_HEADER_NAME"]: token},
+                )
+            assert rv.status_code in (401, 403), rv.data
+        finally:
+            dashboard = self._births_dashboard()
+            dashboard.editors = original_editors
+            db.session.commit()
 
     def test_put_non_numeric_pk_does_not_500_with_capture_on(self) -> None:
         """The PUT route is ``/<pk>`` (a string); with capture on, a
@@ -448,12 +527,22 @@ class TestDatasetVersionsApi(SupersetTestCase):
             )
 
     def test_list_versions_denies_write_capable_non_editor_dataset(self) -> None:
-        """sc-120001 pin, dataset flavour: Alpha carries all-datasource
-        access — the flavour where read-vs-edit confusion would most
-        plausibly regress — and is still refused as a non-editor."""
+        """The dataset endpoint refuses a write-capable non-editor.
+
+        Alpha carries all-datasource access — the flavour where
+        read-vs-edit confusion would most plausibly regress — and is
+        still refused as a non-editor."""
         ds_uuid = str(self._dataset().uuid)
         self.login(ALPHA_USERNAME)
         rv = self.client.get(f"/api/v1/dataset/{ds_uuid}/versions/")
+        assert rv.status_code == 403, rv.data
+
+    def test_get_version_denies_write_capable_non_editor_dataset(self) -> None:
+        """The dataset get-one route runs the same edit gate before
+        version resolution."""
+        ds_uuid = str(self._dataset().uuid)
+        self.login(ALPHA_USERNAME)
+        rv = self.client.get(f"/api/v1/dataset/{ds_uuid}/versions/{MISSING_UUID}/")
         assert rv.status_code == 403, rv.data
 
     def test_put_override_columns_returns_version_fields(self) -> None:

--- a/tests/unit_tests/versioning/test_endpoint_gate.py
+++ b/tests/unit_tests/versioning/test_endpoint_gate.py
@@ -55,9 +55,10 @@ def _api() -> MagicMock:
 def test_preflight_enforces_editorship_not_read_access(
     mocker: MockerFixture, app_context: None
 ) -> None:
-    """The gate called is ``raise_for_editorship``; the read gate is never
-    consulted. (Reverted-gate control: restoring the read gate fails the
-    not-called assertion.)"""
+    """The preflight consults only the editorship gate.
+
+    The read gate must never run. (Reverted-gate control: restoring the
+    read gate fails the not-called assertion.)"""
     entity = SimpleNamespace(id=1)
     mocker.patch.object(
         api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
@@ -68,6 +69,7 @@ def test_preflight_enforces_editorship_not_read_access(
     # coroutines, so raising side_effects never fire on this synchronous
     # path.
     sm = MagicMock()
+    sm.is_guest_user.return_value = False
     mocker.patch.object(api_helpers, "security_manager", sm)
 
     resolved, _ = resolve_endpoint_path_entity(_api(), Dashboard, _UUID)
@@ -101,6 +103,7 @@ def test_preflight_maps_editorship_refusal_to_403(
         api_helpers,
         "security_manager",
         SimpleNamespace(
+            is_guest_user=lambda: False,
             raise_for_editorship=_deny,
             raise_for_access=_read_gate_must_not_run,
         ),
@@ -115,13 +118,16 @@ def test_preflight_maps_editorship_refusal_to_403(
 def test_preflight_fails_closed_for_unwired_models(
     mocker: MockerFixture, app_context: None
 ) -> None:
-    """A model outside the version-endpoint allowlist raises rather than
-    silently inheriting any gate."""
+    """Unwired models fail closed before any parsing or database work.
 
-    class Unwired:
+    The allowlist compares class IDENTITY: an unrelated class that
+    happens to be NAMED like a wired model must not slip through, and
+    the DAO is never consulted for it."""
+
+    class Slice:  # same __name__ as the wired model, different class
         pass
 
-    mocker.patch.object(
+    dao = mocker.patch.object(
         api_helpers.VersionDAO,
         "find_active_by_uuid",
         return_value=SimpleNamespace(id=1),
@@ -129,4 +135,38 @@ def test_preflight_fails_closed_for_unwired_models(
     mocker.patch.object(api_helpers, "security_manager")
 
     with pytest.raises(LookupError):
-        resolve_endpoint_path_entity(_api(), Unwired, _UUID)
+        resolve_endpoint_path_entity(_api(), Slice, _UUID)
+
+    dao.assert_not_called()
+
+
+def test_preflight_denies_guest_principals_outright(
+    mocker: MockerFixture, app_context: None
+) -> None:
+    """Guest principals are refused before any editorship evaluation.
+
+    A guest's ROLE subjects feed ``is_editor``, so a role subject granted
+    editorship would otherwise admit every guest holding that role — the
+    M10 case. Neither gate may even be consulted."""
+    entity = SimpleNamespace(id=1)
+    mocker.patch.object(
+        api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
+    )
+
+    def _gate_must_not_run(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("no gate may run for a guest principal")
+
+    mocker.patch.object(
+        api_helpers,
+        "security_manager",
+        SimpleNamespace(
+            is_guest_user=lambda: True,
+            raise_for_editorship=_gate_must_not_run,
+            raise_for_access=_gate_must_not_run,
+        ),
+    )
+
+    with pytest.raises(PathEntityResponseError) as exc:
+        resolve_endpoint_path_entity(_api(), Dashboard, _UUID)
+
+    assert exc.value.response == "resp-403"

--- a/tests/unit_tests/versioning/test_endpoint_gate.py
+++ b/tests/unit_tests/versioning/test_endpoint_gate.py
@@ -62,7 +62,13 @@ def test_preflight_enforces_editorship_not_read_access(
     mocker.patch.object(
         api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
     )
-    sm = mocker.patch.object(api_helpers, "security_manager")
+    # Explicit MagicMock: the module attribute is a werkzeug LocalProxy,
+    # whose attribute forwarding fools unittest.mock's async detection —
+    # a bare patch creates an AsyncMock whose calls return un-awaited
+    # coroutines, so raising side_effects never fire on this synchronous
+    # path.
+    sm = MagicMock()
+    mocker.patch.object(api_helpers, "security_manager", sm)
 
     resolved, _ = resolve_endpoint_path_entity(_api(), Dashboard, _UUID)
 
@@ -76,8 +82,10 @@ def test_preflight_maps_editorship_refusal_to_403(
 ) -> None:
     """A non-editor principal gets the 403 response, nothing else. The
     security manager is stubbed with a plain object whose gate raises the
-    real exception type (a MagicMock-based raising side_effect proved
-    unreliable in this suite's environment)."""
+    real exception type — and whose read gate raises AssertionError if
+    consulted, doubling as a not-called pin on the refusal path. (A bare
+    ``mocker.patch.object`` here would yield an AsyncMock — see the
+    LocalProxy note in the sibling test.)"""
     entity = SimpleNamespace(id=1)
     mocker.patch.object(
         api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
@@ -110,7 +118,7 @@ def test_preflight_fails_closed_for_unwired_models(
     """A model outside the version-endpoint allowlist raises rather than
     silently inheriting any gate."""
 
-    class Unwired:  # noqa: N801
+    class Unwired:
         pass
 
     mocker.patch.object(

--- a/tests/unit_tests/versioning/test_endpoint_gate.py
+++ b/tests/unit_tests/versioning/test_endpoint_gate.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""SC-120001: the version/activity endpoint families are EDIT-gated.
+
+The shared preflight (``resolve_endpoint_path_entity``) must enforce
+object-level editorship (``raise_for_editorship``) — never the read gate
+(``raise_for_access``) — per the sc-103156 SIP decision: the full change
+log is for principals who may alter the entity, matching the UI's
+edit-gated menu and the restore command's gate. These unit pins are the
+environment-independent half of the control; the integration role matrix
+(versions_api_tests / activity_view_tests) exercises it over HTTP.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from superset.exceptions import SupersetSecurityException
+from superset.models.dashboard import Dashboard
+from superset.versioning import api_helpers
+from superset.versioning.api_helpers import (
+    PathEntityResponseError,
+    resolve_endpoint_path_entity,
+)
+
+_UUID = "8b8c9f00-0000-4000-8000-000000000001"
+
+
+def _api() -> MagicMock:
+    api = MagicMock()
+    api.response_400.return_value = "resp-400"
+    api.response_403.return_value = "resp-403"
+    api.response_404.return_value = "resp-404"
+    return api
+
+
+def test_preflight_enforces_editorship_not_read_access(
+    mocker: MockerFixture, app_context: None
+) -> None:
+    """The gate called is ``raise_for_editorship``; the read gate is never
+    consulted. (Reverted-gate control: restoring the read gate fails the
+    not-called assertion.)"""
+    entity = SimpleNamespace(id=1)
+    mocker.patch.object(
+        api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
+    )
+    sm = mocker.patch.object(api_helpers, "security_manager")
+
+    resolved, _ = resolve_endpoint_path_entity(_api(), Dashboard, _UUID)
+
+    assert resolved is entity
+    sm.raise_for_editorship.assert_called_once_with(entity)
+    sm.raise_for_access.assert_not_called()
+
+
+def test_preflight_maps_editorship_refusal_to_403(
+    mocker: MockerFixture, app_context: None
+) -> None:
+    """A non-editor principal gets the 403 response, nothing else. The
+    security manager is stubbed with a plain object whose gate raises the
+    real exception type (a MagicMock-based raising side_effect proved
+    unreliable in this suite's environment)."""
+    entity = SimpleNamespace(id=1)
+    mocker.patch.object(
+        api_helpers.VersionDAO, "find_active_by_uuid", return_value=entity
+    )
+
+    def _deny(_entity: Any) -> None:
+        raise SupersetSecurityException(MagicMock())
+
+    def _read_gate_must_not_run(**_kwargs: Any) -> None:
+        raise AssertionError("read gate must not be consulted")
+
+    mocker.patch.object(
+        api_helpers,
+        "security_manager",
+        SimpleNamespace(
+            raise_for_editorship=_deny,
+            raise_for_access=_read_gate_must_not_run,
+        ),
+    )
+
+    with pytest.raises(PathEntityResponseError) as exc:
+        resolve_endpoint_path_entity(_api(), Dashboard, _UUID)
+
+    assert exc.value.response == "resp-403"
+
+
+def test_preflight_fails_closed_for_unwired_models(
+    mocker: MockerFixture, app_context: None
+) -> None:
+    """A model outside the version-endpoint allowlist raises rather than
+    silently inheriting any gate."""
+
+    class Unwired:  # noqa: N801
+        pass
+
+    mocker.patch.object(
+        api_helpers.VersionDAO,
+        "find_active_by_uuid",
+        return_value=SimpleNamespace(id=1),
+    )
+    mocker.patch.object(api_helpers, "security_manager")
+
+    with pytest.raises(LookupError):
+        resolve_endpoint_path_entity(_api(), Unwired, _UUID)

--- a/tests/unit_tests/versioning/test_restore.py
+++ b/tests/unit_tests/versioning/test_restore.py
@@ -87,7 +87,7 @@ def test_restore_version_fails_closed_for_unregistered_model(
     mock_db, mock_version_class
 ) -> None:
     """An unregistered model must raise, not silently restore without its
-    child relations (mirrors _RAISE_FOR_ACCESS_KWARG's fail-closed
+    child relations (mirrors _VERSION_ENDPOINT_MODELS's fail-closed
     dispatch)."""
     mock_db.session = _engine_with_target(MagicMock(operation_type=0))
     with pytest.raises(LookupError, match="SomeNewModel"):

--- a/tests/unit_tests/versioning/test_restore.py
+++ b/tests/unit_tests/versioning/test_restore.py
@@ -87,7 +87,7 @@ def test_restore_version_fails_closed_for_unregistered_model(
     mock_db, mock_version_class
 ) -> None:
     """An unregistered model must raise, not silently restore without its
-    child relations (mirrors _VERSION_ENDPOINT_MODELS's fail-closed
+    child relations (mirrors _version_endpoint_models's fail-closed
     dispatch)."""
     mock_db.session = _engine_with_target(MagicMock(operation_type=0))
     with pytest.raises(LookupError, match="SomeNewModel"):


### PR DESCRIPTION
### SUMMARY

Fixes SC-120001 (High, information disclosure): a user with read/view access but **no edit rights and no ownership** could retrieve an entity's complete version history — author identities, timestamps, and field-level before/after diffs — via `GET /api/v1/{chart,dashboard}/<uuid>/versions/` and `/activity/`, even though the UI correctly hides the Version history affordance for them. The endpoints enforced the object **read** gate (SC-107283 AV-008's posture); the governing SIP decision now supersedes that: **version history is edit-gated**.

The change is one choke point: `resolve_endpoint_path_entity` (`superset/versioning/api_helpers.py`), shared by all six endpoint bodies (chart/dashboard/dataset × versions list / get-one / activity), now enforces **object-level editorship** (`security_manager.raise_for_editorship` — owner/editor/admin), the same gate the restore command uses and the same condition the UI's `dash_edit_perm` mirrors. Deliberately object-level rather than model-level `can_write`, so a write-capable role cannot read the history of entities it does not own. The kwarg dispatch table becomes an explicit fail-closed allowlist (`_VERSION_ENDPOINT_MODELS`). **Related-entity visibility filtering inside the activity stream (AV-008's silent filter, QA TC-057) is unchanged.**

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API authorization change. Before: view-only user → 200 + full history (QA TC-062/064/066). After: 403; editors/owners/admins unchanged.

### TESTING INSTRUCTIONS

```bash
python -m pytest tests/unit_tests/versioning -q   # 148 passed
python -m pytest tests/integration_tests/versioning/versions_api_tests.py \
  tests/integration_tests/versioning/activity_view_tests.py
```

- **Unit pins** (`test_endpoint_gate.py`): the choke point consults `raise_for_editorship` and never `raise_for_access`; refusal maps to 403; unwired models fail closed.
- **Integration role matrix** (sc-120001 pins): Alpha — read-capable non-editor, the exact leaking principal — now 403s on both chart and dashboard `/versions/`; a per-object Gamma **editor** gets 200 (object-level, not model-level); a guest-token principal is refused by the gate (M10). The three former read-posture tests flip to editorship expectations.
- Reverted-gate control: restoring the read gate fails the not-called unit pin and the Alpha-403 pins.
- Note: this machine's integration env has a pre-existing fixture breakage (admin PUTs 404 — identical failure set with the fix stashed), so the integration matrix is CI-verified rather than locally.

### ADDITIONAL INFORMATION

- [x] Has associated issue: SC-120001 (decision per the SC-103156 SIP; supersedes SC-107283 AV-008's read wording — spec updated)
- [x] Required feature flags: `VERSION_HISTORY` / `ENABLE_VERSIONING_CAPTURE` (the gated endpoints)
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [x] Removes existing feature or API (read-only principals lose API access to version history — see UPDATING.md)

### REVIEWER NOTE (policy + guest mechanism, so it needn't be re-derived)

- **Why edit-gated**: the governing SC-103156 SIP decision supersedes SC-107283 AV-008's earlier read-posture wording (spec updated). The docs companion #44033 (merged) describes this gate; until this PR lands, the published docs briefly describe the stricter behavior ahead of the code — resolved as soon as this merges.
- **Why guests are refused outright, even when "granted" editorship**: `is_editor` maps a guest's ROLE subjects into the editor set, so a role subject granted editorship on an entity would admit every embedded guest holding that role. Version history (author identity, timestamps, field-level diffs) sits outside the guest capability row in SECURITY.md, so the gate refuses guest principals before the editorship check — pinned at unit level (neither gate may even be consulted for a guest) and by an HTTP regression in which the guest role's subject IS a dashboard editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW


