### PR TITLE
fix(mcp): honor forwarded active dashboard filters in get_chart_preview and get_chart_info

### DIFF
--- a/superset/mcp_service/chart/schemas.py
+++ b/superset/mcp_service/chart/schemas.py
@@ -342,6 +342,16 @@ class GetChartInfoRequest(BaseModel):
             "and the caller to have dashboard access."
         ),
     )
+    extra_form_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Active dashboard filters the user currently has applied to this chart, "
+            "forwarded so the response reports the chart as the user actually views "
+            "it. Surfaced under filters.active_filters; this is not a query "
+            "(get_chart_info returns metadata only). Format: "
+            '{"filters": [{"col": "country", "op": "IN", "val": ["US"]}]}'
+        ),
+    )
     select_columns: Annotated[
         List[str],
         Field(
@@ -3165,6 +3175,14 @@ class GetChartPreviewRequest(QueryCacheControl):
     ascii_height: int | None = Field(
         default=20, description="ASCII chart height in lines (for ascii format)"
     )
+    extra_form_data: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Extra form data to merge into the preview query, typically from "
+            "dashboard native filters, so the preview reflects the filtered view. "
+            'Format: {"filters": [{"col": "country", "op": "IN", "val": ["US"]}]}'
+        ),
+    )
 
 
 # Discriminated union preview formats for type safety
@@ -3504,6 +3522,28 @@ class ChartFiltersInfo(BaseModel):
             "dashboard passed via get_chart_info's dashboard_id argument. Empty "
             "when no dashboard_id was provided or no native filter targets this "
             "chart."
+        ),
+    )
+    active_filters: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Dashboard native filters the user currently has ACTIVE on this chart "
+            "(live selections forwarded from the dashboard via extra_form_data), "
+            "distinct from the chart's own saved filters and from dashboard_filters "
+            "(the dashboard's default/configured state). A non-empty list means the "
+            "chart is being viewed filtered; report these as the active filters. "
+            "Column-based and adhoc filters exactly as forwarded, in their "
+            "original shapes; an active time-range filter is reported "
+            "separately under active_time_range."
+        ),
+    )
+    active_time_range: str | None = Field(
+        None,
+        description=(
+            "Dashboard time-range filter the user currently has ACTIVE on this "
+            "chart (forwarded via extra_form_data.time_range), distinct from the "
+            "chart's own saved time_range. Set when the active view includes a "
+            "time filter."
         ),
     )
 

--- a/superset/mcp_service/chart/tool/get_chart_info.py
+++ b/superset/mcp_service/chart/tool/get_chart_info.py
@@ -150,6 +150,33 @@ async def _attach_dashboard_filters(
     return None
 
 
+def _attach_active_filters(result: ChartInfo, extra_form_data: dict[str, Any]) -> None:
+    """Surface the user's live dashboard filters (forwarded as extra_form_data)
+    under result.filters, so a metadata caller reports the chart as it is currently
+    viewed rather than as the full unfiltered dataset. Column-based and adhoc
+    filters go to active_filters and a time-range filter to active_time_range. No
+    query is run; the values are echoed for awareness."""
+    active: list[dict[str, Any]] = [
+        clause
+        for clause in (extra_form_data.get("filters") or [])
+        if isinstance(clause, dict)
+    ]
+    active += [
+        clause
+        for clause in (extra_form_data.get("adhoc_filters") or [])
+        if isinstance(clause, dict)
+    ]
+    time_range = extra_form_data.get("time_range")
+    if not active and not time_range:
+        return
+    if result.filters is None:
+        result.filters = ChartFiltersInfo()
+    if active:
+        result.filters.active_filters = active
+    if time_range:
+        result.filters.active_time_range = time_range
+
+
 def _apply_unsaved_state_override(result: ChartInfo, form_data_key: str) -> None:
     """Override a ChartInfo's form_data with cached unsaved state."""
     from superset.utils import json as utils_json
@@ -204,7 +231,7 @@ def _apply_unsaved_state_override(result: ChartInfo, form_data_key: str) -> None
         openWorldHint=False,
     ),
 )
-async def get_chart_info(
+async def get_chart_info(  # noqa: C901
     request: GetChartInfoRequest, ctx: Context
 ) -> dict[str, Any] | ChartError:
     """Get chart metadata by ID or UUID.
@@ -274,6 +301,8 @@ async def get_chart_info(
                 return result
             if not can_view_data_model_metadata:
                 result = redact_chart_data_model_fields(result)
+            if request.extra_form_data:
+                _attach_active_filters(result, request.extra_form_data)
             return result.model_dump(
                 mode="json",
                 context={"select_columns": request.select_columns},
@@ -333,6 +362,9 @@ async def get_chart_info(
             error = await _attach_dashboard_filters(result, request.dashboard_id, ctx)
             if error is not None:
                 return error
+
+        if request.extra_form_data:
+            _attach_active_filters(result, request.extra_form_data)
 
         return result.model_dump(
             mode="json",

--- a/superset/mcp_service/chart/tool/get_chart_preview.py
+++ b/superset/mcp_service/chart/tool/get_chart_preview.py
@@ -265,6 +265,7 @@ class ASCIIPreviewStrategy(PreviewFormatStrategy):
             query_context = build_query_context_from_form_data(
                 form_data,
                 chart=self.chart,
+                extra_form_data=self.request.extra_form_data,
                 row_limit=_preview_row_limit(form_data, 50),
                 order_desc=True,
                 force=False,
@@ -344,6 +345,7 @@ class TablePreviewStrategy(PreviewFormatStrategy):
             query_context = build_query_context_from_form_data(
                 form_data,
                 chart=self.chart,
+                extra_form_data=self.request.extra_form_data,
                 row_limit=_preview_row_limit(form_data, 20),
                 order_desc=True,
                 force=False,
@@ -445,6 +447,7 @@ class VegaLitePreviewStrategy(PreviewFormatStrategy):
             query_context = build_query_context_from_form_data(
                 form_data,
                 chart=self.chart,
+                extra_form_data=self.request.extra_form_data,
                 row_limit=_preview_row_limit(form_data, 1000),
                 order_desc=True,
                 force=self.request.force_refresh,
@@ -1425,6 +1428,9 @@ async def get_chart_preview(
     """Get chart preview by ID or UUID.
 
     Returns preview URL or formatted content (ascii, table, vega_lite).
+
+    Pass extra_form_data (e.g. a dashboard's active native filters) to render
+    the preview over the filtered data rather than the full dataset.
 
     When format includes 'url', the returned preview_url uses the same scheme
     as the configured instance URL (HTTPS in production/staging, HTTP in local

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
@@ -96,6 +96,81 @@ class TestGetChartInfoRequestSchema:
         assert request.dashboard_id == 42
 
 
+class TestAttachActiveFilters:
+    """_attach_active_filters surfaces the caller's forwarded live dashboard
+    filters under result.filters.active_filters, so a metadata answer reflects
+    the filtered view rather than the full dataset. No query is run."""
+
+    def test_filters_are_surfaced_as_active_filters(self):
+        result = _make_chart_info()
+        get_chart_info_module._attach_active_filters(
+            result, {"filters": [{"col": "gender", "op": "IN", "val": ["Female"]}]}
+        )
+        assert result.filters.active_filters == [
+            {"col": "gender", "op": "IN", "val": ["Female"]}
+        ]
+
+    def test_adhoc_filters_are_included(self):
+        result = _make_chart_info()
+        get_chart_info_module._attach_active_filters(
+            result,
+            {
+                "filters": [{"col": "gender", "op": "IN", "val": ["Female"]}],
+                "adhoc_filters": [
+                    {"expressionType": "SQL", "sqlExpression": "age > 18"}
+                ],
+            },
+        )
+        assert {
+            "col": "gender",
+            "op": "IN",
+            "val": ["Female"],
+        } in result.filters.active_filters
+        assert {
+            "expressionType": "SQL",
+            "sqlExpression": "age > 18",
+        } in result.filters.active_filters
+
+    def test_time_range_is_surfaced_as_active_time_range(self):
+        result = _make_chart_info()
+        get_chart_info_module._attach_active_filters(
+            result,
+            {
+                "filters": [{"col": "gender", "op": "IN", "val": ["Female"]}],
+                "time_range": "Last year",
+            },
+        )
+        assert result.filters.active_time_range == "Last year"
+        assert result.filters.active_filters == [
+            {"col": "gender", "op": "IN", "val": ["Female"]}
+        ]
+
+    def test_time_range_only_still_surfaced(self):
+        result = _make_chart_info()
+        get_chart_info_module._attach_active_filters(
+            result, {"time_range": "Last 7 days"}
+        )
+        assert result.filters.active_time_range == "Last 7 days"
+        assert result.filters.active_filters == []
+
+    def test_empty_extra_form_data_leaves_active_filters_empty(self):
+        result = _make_chart_info()
+        get_chart_info_module._attach_active_filters(result, {"filters": []})
+        assert result.filters.active_filters == []
+        assert result.filters.active_time_range is None
+
+    def test_creates_filters_container_when_absent(self):
+        result = _make_chart_info()
+        result.filters = None
+        get_chart_info_module._attach_active_filters(
+            result, {"filters": [{"col": "gender", "op": "IN", "val": ["Female"]}]}
+        )
+        assert result.filters is not None
+        assert result.filters.active_filters == [
+            {"col": "gender", "op": "IN", "val": ["Female"]}
+        ]
+
+
 class TestResolveFilterOperatorAndValue:
     def test_matches_adhoc_filter_by_subject(self):
         efd = {
@@ -366,6 +441,59 @@ class TestGetChartInfoPrivacy:
         # form_data is excluded from default select_columns, so it won't be in result
         assert "form_data" not in result
 
+    @pytest.mark.asyncio
+    async def test_extra_form_data_surfaces_active_filters(self, mcp_server) -> None:
+        """Forwarded extra_form_data is echoed under filters.active_filters and
+        filters.active_time_range through the full tool path."""
+        chart_info = _make_chart_info()
+
+        with (
+            patch.object(
+                get_chart_info_module.event_logger,
+                "log_context",
+                return_value=nullcontext(),
+            ),
+            patch.object(
+                get_chart_info_module.ModelGetInfoCore,
+                "run_tool",
+                return_value=chart_info,
+            ),
+            patch.object(
+                get_chart_info_module,
+                "user_can_view_data_model_metadata",
+                return_value=True,
+                create=True,
+            ),
+            patch.object(
+                get_chart_info_module,
+                "validate_chart_dataset",
+                return_value=SimpleNamespace(is_valid=True, warnings=[]),
+            ),
+            patch("superset.daos.chart.ChartDAO.find_by_id", return_value=Mock()),
+            patch("superset.mcp_service.auth.check_tool_permission", return_value=True),
+        ):
+            async with Client(mcp_server) as client:
+                response = await client.call_tool(
+                    "get_chart_info",
+                    {
+                        "request": GetChartInfoRequest(
+                            identifier=123,
+                            extra_form_data={
+                                "filters": [
+                                    {"col": "gender", "op": "IN", "val": ["Female"]}
+                                ],
+                                "time_range": "Last year",
+                            },
+                        ).model_dump()
+                    },
+                )
+
+        result = json.loads(response.content[0].text)
+        assert result["filters"]["active_filters"] == [
+            {"col": "gender", "op": "IN", "val": ["Female"]}
+        ]
+        assert result["filters"]["active_time_range"] == "Last year"
+
     def test_form_data_override_preserves_saved_values(self) -> None:
         """Saved chart fields remain exact after unsaved overrides."""
         result = ChartInfo(
@@ -568,6 +696,45 @@ class TestGetChartInfoPrivacy:
             )
 
         assert result is error
+
+    @pytest.mark.asyncio
+    async def test_unsaved_chart_surfaces_active_filters(self) -> None:
+        """The form_data_key-only path also echoes forwarded extra_form_data under
+        active_filters, so an unsaved chart viewed filtered is not reported as the
+        full unfiltered dataset."""
+        with (
+            patch.object(
+                get_chart_info_module.event_logger,
+                "log_context",
+                return_value=nullcontext(),
+            ),
+            patch.object(
+                get_chart_info_module,
+                "user_can_view_data_model_metadata",
+                return_value=True,
+                create=True,
+            ),
+            patch.object(
+                get_chart_info_module,
+                "_build_unsaved_chart_info",
+                return_value=_make_chart_info(),
+            ),
+        ):
+            result = await get_chart_info_module.get_chart_info(
+                request=GetChartInfoRequest(
+                    form_data_key="cached-key",
+                    extra_form_data={
+                        "filters": [{"col": "gender", "op": "IN", "val": ["Female"]}],
+                        "time_range": "Last year",
+                    },
+                ),
+                ctx=SimpleNamespace(info=AsyncMock()),
+            )
+
+        assert result["filters"]["active_filters"] == [
+            {"col": "gender", "op": "IN", "val": ["Female"]}
+        ]
+        assert result["filters"]["active_time_range"] == "Last year"
 
 
 def test_apply_unsaved_state_override_updates_display_name_for_new_viz_type() -> None:

--- a/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
+++ b/tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py
@@ -861,6 +861,137 @@ class TestGetChartPreview:
         assert query["filters"] == [{"col": "gender", "op": "==", "val": "boy"}]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("preview_format", ["table", "ascii", "vega_lite"])
+    async def test_extra_form_data_filters_reach_preview_query(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        preview_format: str,
+    ) -> None:
+        """extra_form_data (e.g. a dashboard's active native filters) must merge
+        into the preview query so the preview reflects the filtered view, for
+        every render format (each strategy builds its own query context)."""
+        from contextlib import nullcontext
+
+        get_chart_preview_module = importlib.import_module(
+            "superset.mcp_service.chart.tool.get_chart_preview"
+        )
+        query_context_factory_module = importlib.import_module(
+            "superset.common.query_context_factory"
+        )
+        get_data_command_module = importlib.import_module(
+            "superset.commands.chart.data.get_data_command"
+        )
+
+        class AsyncContext:
+            async def debug(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def error(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def info(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def report_progress(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            async def warning(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+        captured_query_contexts: list[dict[str, Any]] = []
+
+        class QueryContextFactory:
+            def create(self, **kwargs: Any) -> object:
+                captured_query_contexts.append(kwargs)
+                return object()
+
+        class ChartDataCommand:
+            def __init__(self, query_context: object) -> None:
+                self.query_context = query_context
+
+            def validate(self) -> None:
+                pass
+
+            def run(self) -> dict[str, Any]:
+                return {
+                    "queries": [
+                        {
+                            "data": [{"gender": "girl", "count": 1}],
+                            "colnames": ["gender", "count"],
+                            "rowcount": 1,
+                        }
+                    ]
+                }
+
+        chart = SimpleNamespace(
+            id=42,
+            slice_name="Saved Chart Preview",
+            viz_type="table",
+            datasource_id=1,
+            datasource_type="table",
+            params=utils_json.dumps(
+                {
+                    "viz_type": "table",
+                    "groupby": ["gender"],
+                    "metrics": ["count"],
+                    "adhoc_filters": [],
+                }
+            ),
+        )
+
+        monkeypatch.setattr(
+            get_chart_preview_module,
+            "find_chart_by_identifier",
+            lambda identifier: chart,
+        )
+        monkeypatch.setattr(
+            get_chart_preview_module,
+            "validate_chart_dataset",
+            lambda *args, **kwargs: SimpleNamespace(
+                is_valid=True,
+                warnings=[],
+                error=None,
+            ),
+        )
+        monkeypatch.setattr(
+            get_chart_preview_module.db.session,
+            "refresh",
+            lambda chart: None,
+        )
+        monkeypatch.setattr(
+            get_chart_preview_module.event_logger,
+            "log_context",
+            lambda **kwargs: nullcontext(),
+        )
+        monkeypatch.setattr(
+            query_context_factory_module,
+            "QueryContextFactory",
+            QueryContextFactory,
+        )
+        monkeypatch.setattr(
+            get_data_command_module,
+            "ChartDataCommand",
+            ChartDataCommand,
+        )
+
+        await get_chart_preview_module._get_chart_preview_internal(
+            GetChartPreviewRequest(
+                identifier=42,
+                format=preview_format,
+                extra_form_data={
+                    "filters": [{"col": "gender", "op": "==", "val": "girl"}]
+                },
+            ),
+            AsyncContext(),
+        )
+
+        # Each strategy builds its own query context; assert the forwarded filter
+        # reached the query regardless of render format (the capture happens before
+        # any format-specific rendering).
+        query = captured_query_contexts[0]["queries"][0]
+        assert {"col": "gender", "op": "==", "val": "girl"} in query["filters"]
+
+    @pytest.mark.asyncio
     async def test_preview_dimensions(self):
         """Test preview dimensions in response."""
         # Standard dimensions that may appear in preview responses


### PR DESCRIPTION
### SUMMARY

`get_chart_preview` silently dropped forwarded `extra_form_data`, so a preview always rendered the full dataset even when the caller passed the dashboard filters the user is currently viewing.

This threads `extra_form_data` into the ASCII, Table, and VegaLite preview strategies via `build_query_context_from_form_data(..., extra_form_data=...)`, so the preview reflects the filtered view.

It mirrors the pattern `get_chart_data` and `get_chart_sql` already follow (#43478).
The URL strategy runs no query and is unchanged.

`get_chart_info` gains an optional `extra_form_data` input and reports the forwarded active filters under `filters.active_filters` (column based) and `filters.active_time_range` (time filter), kept distinct from the chart's own saved filters and from `dashboard_filters` (the configured dashboard state).
It runs no query; the values are echoed for awareness so a metadata answer reflects the chart as currently viewed, mirroring the `filter_state` echo on `get_dashboard_info` (#43688).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (MCP tool behavior, no UI).

### TESTING INSTRUCTIONS

```
pytest tests/unit_tests/mcp_service/chart/tool/test_get_chart_preview.py \
       tests/unit_tests/mcp_service/chart/tool/test_get_chart_info.py
```

* `test_extra_form_data_filters_reach_preview_query` builds a real query context and asserts the forwarded filter reaches the executed query.
* `TestAttachActiveFilters` covers column filters, adhoc filters, an active time range, time range only, and the empty case.

Manual: call `get_chart_preview` with `extra_form_data={"filters": [{"col": "gender", "op": "IN", "val": ["Female"]}]}` and confirm the rendered data is filtered; call `get_chart_info` with the same payload and confirm `filters.active_filters` reflects it.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
