### PR TITLE
fix(security): suppress zizmor self-repository false positive for postgres celery worker step

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -169,7 +169,13 @@ jobs:
           run: |
             setup-postgres
       - name: Start Celery worker
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a git submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's gitlink. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: celery-worker
       - name: Python integration tests (PostgreSQL)


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2658 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2658)) on `.github/workflows/superset-python-integrationtest.yml:172`.

The `Start Celery worker` step in the `test-postgres` job references `.github/actions/cached-dependencies` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of the newer `uses: $/...` syntax. That mechanical rewrite can't be applied here: `cached-dependencies` is a real git submodule (see `.gitmodules`), and `$/...` resolves action files directly from the repository tree without performing a real, submodule-aware checkout — so it can't see past the submodule's gitlink into the actual `action.yml`.

This same constraint is already documented and suppressed for the other `cached-dependencies` references in this repo (e.g. the `Install dependencies` step in `superset-translations.yml`, and the sqlite-job steps in this same workflow file). This PR applies the identical `# zizmor: ignore[self-repository]` inline-suppression pattern to the one remaining unaddressed instance, the `test-postgres` job's `Start Celery worker` step.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes, including the `zizmor` hook (previously would have flagged this line).
- The `Python-Integration` workflow's runtime behavior is unchanged; only a trailing suppression comment and explanatory comment block were added.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2658