### PR TITLE
fix(dataset): refresh the entity under the conditional-write row lock

### DIFF
--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -705,6 +705,9 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         # the live version, the command writes, and the two must not interleave
         # with another request's. Only a conditional save pays for the lock; an
         # unconditional PUT behaves exactly as it did before the guard existed.
+        # (On MySQL REPEATABLE READ the version read below is still a plain
+        # consistent read and can predate the lock; see the caveats on
+        # lock_entity_for_update.)
         if is_conditional_write():
             lock_entity_for_update(SqlaTable, pk)
 

--- a/superset/datasets/api.py
+++ b/superset/datasets/api.py
@@ -709,7 +709,12 @@ class DatasetRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         # consistent read and can predate the lock; see the caveats on
         # lock_entity_for_update.)
         if is_conditional_write():
-            lock_entity_for_update(SqlaTable, pk)
+            # Hold the locked entity for the rest of the request: the
+            # session's identity map references clean objects weakly, so
+            # discarding the return value could let the refreshed object
+            # be collected and the command's find_by_id re-read a stale
+            # row on MySQL REPEATABLE READ (see lock_entity_for_update).
+            _locked_entity = lock_entity_for_update(SqlaTable, pk)
 
         # Live version identifiers before the update (empty + query-free when
         # ``ENABLE_VERSIONING_CAPTURE`` is off).

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -188,7 +188,7 @@ def entity_concurrency_token(
 
 
 def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> None:
-    """Row-lock *entity* so a conditional write's check and its update are atomic.
+    """Row-lock *entity* and refresh its loaded state to committed data.
 
     ``If-Match`` is verified against a read taken before the update command
     runs. Without a lock two overlapping requests can both read the same live
@@ -197,7 +197,41 @@ def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> Non
     held until the command commits, because both run in the same scoped
     session.
 
+    An id-only locking ``SELECT`` would serialise writers without fixing
+    what this transaction can *see*: InnoDB's default REPEATABLE READ pins
+    every consistent read to the snapshot established by the transaction's
+    first read (the request's auth queries), so an entity load issued after
+    such a lock still returns the pre-lock snapshot -- and the ORM, which
+    only emits UPDATEs for attributes that differ from the *loaded* values,
+    can silently discard a concurrent commit that landed before the lock.
+
+    The lock is therefore taken as a full-entity ORM read.
+    ``with_for_update()`` makes it a locking read, exempt from the
+    REPEATABLE READ snapshot, returning current committed data;
+    ``populate_existing()`` writes that data into the identity-map object,
+    which a later plain lookup (e.g. the update command's ``find_by_id``)
+    returns without re-hydrating from its own stale row. Call this before
+    the session's entity is modified: the refresh overwrites pending
+    attribute state, and the query's autoflush would flush earlier
+    mutations mid-request.
+
+    The refresh covers the entity row itself. Lazy-loaded child
+    collections (columns, metrics) are still plain consistent reads
+    afterwards, as is the version-info read behind the ``If-Match``
+    comparison -- on MySQL REPEATABLE READ both can still observe the
+    pre-lock snapshot.
+
+    Postgres (READ COMMITTED) and SQLite are not exposed to the staleness,
+    and the refresh is harmless there. (Version restore has the same
+    staleness class; the matching locking-refresh fix is proposed in
+    apache/superset#44015.)
+
     Renders no ``FOR UPDATE`` on SQLite, which serialises writers anyway.
+
+    Missing rows are not this function's concern: the query result is
+    discarded (soft-deleted rows filter out like any ORM read), and
+    existence keeps being decided by the update command's own lookup (404
+    semantics unchanged).
     """
     try:
         # The PUT route declares ``/<pk>`` (a string segment), so a non-numeric
@@ -205,9 +239,9 @@ def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> Non
         entity_id = int(entity_id)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return
-    db.session.execute(
-        sa.select(model_cls.id).where(model_cls.id == entity_id).with_for_update()
-    )
+    db.session.query(model_cls).populate_existing().filter(
+        model_cls.id == entity_id
+    ).with_for_update().one_or_none()
 
 
 def concurrency_token_from(info: EntityVersionInfo) -> str | None:

--- a/superset/versioning/api_helpers.py
+++ b/superset/versioning/api_helpers.py
@@ -187,8 +187,10 @@ def entity_concurrency_token(
     ) or unversioned_entity_token(entity_uuid)
 
 
-def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> None:
-    """Row-lock *entity* and refresh its loaded state to committed data.
+def lock_entity_for_update(
+    model_cls: type[Model], entity_id: int | None
+) -> Model | None:
+    """Row-lock *entity*, refresh it to committed data, and return it.
 
     ``If-Match`` is verified against a read taken before the update command
     runs. Without a lock two overlapping requests can both read the same live
@@ -215,6 +217,14 @@ def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> Non
     attribute state, and the query's autoflush would flush earlier
     mutations mid-request.
 
+    The caller MUST hold the returned entity for as long as the refreshed
+    state matters (through the update command's run). The identity map
+    references clean persistent objects weakly, so a discarded return
+    value can be garbage-collected immediately -- after which the
+    command's lookup re-hydrates a new object from a plain read, which on
+    MySQL REPEATABLE READ is the pre-lock snapshot again, silently
+    undoing the refresh.
+
     The refresh covers the entity row itself. Lazy-loaded child
     collections (columns, metrics) are still plain consistent reads
     afterwards, as is the version-info read behind the ``If-Match``
@@ -228,20 +238,24 @@ def lock_entity_for_update(model_cls: type[Model], entity_id: int | None) -> Non
 
     Renders no ``FOR UPDATE`` on SQLite, which serialises writers anyway.
 
-    Missing rows are not this function's concern: the query result is
-    discarded (soft-deleted rows filter out like any ORM read), and
-    existence keeps being decided by the update command's own lookup (404
-    semantics unchanged).
+    Missing rows are not this function's concern: ``None`` is returned
+    (soft-deleted rows filter out like any ORM read), and existence keeps
+    being decided by the update command's own lookup (404 semantics
+    unchanged).
     """
     try:
         # The PUT route declares ``/<pk>`` (a string segment), so a non-numeric
         # id must not raise a SQL cast error ahead of the command's 404.
         entity_id = int(entity_id)  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        return
-    db.session.query(model_cls).populate_existing().filter(
-        model_cls.id == entity_id
-    ).with_for_update().one_or_none()
+        return None
+    return (
+        db.session.query(model_cls)
+        .populate_existing()
+        .filter(model_cls.id == entity_id)
+        .with_for_update()
+        .one_or_none()
+    )
 
 
 def concurrency_token_from(info: EntityVersionInfo) -> str | None:

--- a/tests/integration_tests/versioning/conditional_write_lock_tests.py
+++ b/tests/integration_tests/versioning/conditional_write_lock_tests.py
@@ -28,6 +28,9 @@ dialect-independent statement-shape pin lives in
 tests/unit_tests/versioning/test_lock_entity.py.
 """
 
+import gc
+import weakref
+
 import pytest
 import sqlalchemy as sa
 
@@ -77,8 +80,10 @@ class TestConditionalWriteLockRefresh(SupersetTestCase):
             pytest.skip("two-connection interleave is not expressible on SQLite")
 
     def test_lock_refreshes_entity_to_concurrently_committed_state(self) -> None:
-        """A commit landing between the entity load and the lock is visible
-        on the loaded entity once the lock is taken.
+        """A concurrent commit becomes visible once the lock is taken.
+
+        A commit landing between the entity load and the lock must show on
+        the loaded entity afterwards.
 
         Pre-fix, the id-only lock left ``dataset.description`` at the value
         loaded before the concurrent commit, and the update command's diff
@@ -113,10 +118,53 @@ class TestConditionalWriteLockRefresh(SupersetTestCase):
             db.session.rollback()
             _write_description_out_of_band(dataset_id, original)
 
+    def test_locked_entity_must_be_held_by_the_caller(self) -> None:
+        """The helper returns the entity, and the caller must keep it alive.
+
+        Two halves, mirroring the production PUT path (which loads nothing
+        before the lock): held, the returned reference makes the command's
+        ``DatasetDAO.find_by_id`` hand back the very same refreshed
+        instance; discarded, the object is weakly referenced by the
+        identity map and is collectible -- after which find_by_id would
+        re-hydrate from a plain read (on MySQL REPEATABLE READ: the
+        pre-lock snapshot), silently undoing the fix. That is why
+        ``datasets/api.py`` binds the return value.
+        """
+        self._skip_on_sqlite()
+        dataset_id = (
+            db.session.query(SqlaTable.id)
+            .filter(SqlaTable.table_name == "birth_names")
+            .scalar()
+        )
+
+        try:
+            locked = lock_entity_for_update(SqlaTable, dataset_id)
+            assert locked is not None
+            fetched = DatasetDAO.find_by_id(dataset_id)
+            assert fetched is locked
+        finally:
+            db.session.rollback()
+
+        try:
+            still_held = lock_entity_for_update(SqlaTable, dataset_id)
+            tracker = weakref.ref(still_held)
+            del still_held, locked, fetched
+            gc.collect()
+            assert tracker() is None, (
+                "locked entity survived without a caller-held reference; "
+                "if SQLAlchemy starts pinning it, the hold-the-return "
+                "contract (and this test) can be retired"
+            )
+        finally:
+            db.session.rollback()
+
     def test_lock_is_a_no_op_refresh_without_concurrent_writes(self) -> None:
-        """Quiet-path control: locking without an interleaved commit leaves
-        the loaded entity exactly as it was — the refresh only surfaces
-        state that actually changed underneath the session."""
+        """Quiet-path control: no interleaved commit, no observable change.
+
+        The refresh only surfaces state that actually changed underneath
+        the session; without a concurrent writer the entity is untouched
+        and nothing is dirtied.
+        """
         self._skip_on_sqlite()
         dataset = self._dataset()
         dataset_id = dataset.id

--- a/tests/integration_tests/versioning/conditional_write_lock_tests.py
+++ b/tests/integration_tests/versioning/conditional_write_lock_tests.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-120014: the conditional-write lock refreshes the entity it locks.
+
+Two-transaction behavioral proof for the ``lock_entity_for_update`` fix
+(mechanism documented on the helper itself). The staleness is
+*object-level* -- SQLAlchemy never refreshes an already-loaded entity from
+a later plain SELECT -- so the first test fails before the fix on every
+backend it runs on, not only on MySQL/InnoDB REPEATABLE READ where the
+underlying row read is stale too; the second test is a quiet-path control.
+SQLite is skipped: a second writer connection deadlocks against the open
+read transaction instead of modelling a concurrent request. The
+dialect-independent statement-shape pin lives in
+tests/unit_tests/versioning/test_lock_entity.py.
+"""
+
+import pytest
+import sqlalchemy as sa
+
+from superset import db
+from superset.connectors.sqla.models import SqlaTable
+from superset.daos.dataset import DatasetDAO
+from superset.versioning.api_helpers import lock_entity_for_update
+from tests.integration_tests.base_tests import SupersetTestCase
+from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
+    load_birth_names_dashboard_with_slices,
+    load_birth_names_data,
+)
+
+
+def _write_description_out_of_band(dataset_id: int, value: str | None) -> None:
+    """Commit a description change through a second connection.
+
+    A separate engine-level transaction stands in for the concurrent
+    request: it commits between this session's entity load and its lock,
+    exactly the window the fix closes. Core UPDATE (not ORM) so the write
+    is invisible to the scoped session until something re-reads the row.
+    """
+    with db.engine.begin() as conn:
+        conn.execute(
+            sa.update(SqlaTable.__table__)
+            .where(SqlaTable.__table__.c.id == dataset_id)
+            .values(description=value)
+        )
+
+
+@pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+class TestConditionalWriteLockRefresh(SupersetTestCase):
+    """The locking read must surface concurrently committed state."""
+
+    def _dataset(self) -> SqlaTable:
+        return (
+            db.session.query(SqlaTable)
+            .filter(SqlaTable.table_name == "birth_names")
+            .one()
+        )
+
+    def _skip_on_sqlite(self) -> None:
+        # SQLite serialises writers at the file level: the out-of-band
+        # engine transaction would deadlock against this session's open
+        # read transaction rather than model a concurrent request.
+        if db.session.get_bind().dialect.name == "sqlite":
+            pytest.skip("two-connection interleave is not expressible on SQLite")
+
+    def test_lock_refreshes_entity_to_concurrently_committed_state(self) -> None:
+        """A commit landing between the entity load and the lock is visible
+        on the loaded entity once the lock is taken.
+
+        Pre-fix, the id-only lock left ``dataset.description`` at the value
+        loaded before the concurrent commit, and the update command's diff
+        ran against that stale state — the silent-lost-update window this
+        pins shut. The command path is exercised too: ``DatasetDAO.find_by_id``
+        must hand back the refreshed identity-map instance rather than
+        re-hydrating from a (possibly stale) plain read.
+        """
+        self._skip_on_sqlite()
+        dataset = self._dataset()
+        dataset_id = dataset.id
+        original = dataset.description
+        assert original != "committed by a concurrent request"
+
+        try:
+            _write_description_out_of_band(
+                dataset_id, "committed by a concurrent request"
+            )
+
+            lock_entity_for_update(SqlaTable, dataset_id)
+
+            assert dataset.description == "committed by a concurrent request"
+            # Pins the coupling the fix relies on: BaseDAO._query only
+            # re-hydrates under force_fetch, so the command's lookup returns
+            # the refreshed object. If DatasetDAO ever flips force_fetch,
+            # this catches the fix being silently undone.
+            fetched = DatasetDAO.find_by_id(dataset_id)
+            assert fetched is dataset
+            assert fetched.description == "committed by a concurrent request"
+        finally:
+            # Release the row lock before restoring out-of-band.
+            db.session.rollback()
+            _write_description_out_of_band(dataset_id, original)
+
+    def test_lock_is_a_no_op_refresh_without_concurrent_writes(self) -> None:
+        """Quiet-path control: locking without an interleaved commit leaves
+        the loaded entity exactly as it was — the refresh only surfaces
+        state that actually changed underneath the session."""
+        self._skip_on_sqlite()
+        dataset = self._dataset()
+        dataset_id = dataset.id
+        original = dataset.description
+
+        try:
+            lock_entity_for_update(SqlaTable, dataset_id)
+
+            assert dataset.description == original
+            assert not db.session.dirty
+        finally:
+            db.session.rollback()

--- a/tests/integration_tests/versioning/conditional_write_lock_tests.py
+++ b/tests/integration_tests/versioning/conditional_write_lock_tests.py
@@ -26,6 +26,15 @@ SQLite is skipped: a second writer connection deadlocks against the open
 read transaction instead of modelling a concurrent request. The
 dialect-independent statement-shape pin lives in
 tests/unit_tests/versioning/test_lock_entity.py.
+
+Isolation note: the CI MySQL lane runs InnoDB's default REPEATABLE READ
+-- no ``isolation_level`` is configured in the test configs, and the
+app's READ COMMITTED defaulter (``set_db_default_isolation``) does not
+take effect -- so on that lane dropping ``with_for_update()`` also flips
+the interleave test at the row level (the plain re-read serves the stale
+snapshot). If the isolation default is ever made effective, that extra
+flip disappears and the unit shape pin remains the load-bearing guard,
+as designed.
 """
 
 import gc

--- a/tests/integration_tests/versioning/conditional_write_lock_tests.py
+++ b/tests/integration_tests/versioning/conditional_write_lock_tests.py
@@ -27,14 +27,12 @@ read transaction instead of modelling a concurrent request. The
 dialect-independent statement-shape pin lives in
 tests/unit_tests/versioning/test_lock_entity.py.
 
-Isolation note: the CI MySQL lane runs InnoDB's default REPEATABLE READ
--- no ``isolation_level`` is configured in the test configs, and the
-app's READ COMMITTED defaulter (``set_db_default_isolation``) does not
-take effect -- so on that lane dropping ``with_for_update()`` also flips
-the interleave test at the row level (the plain re-read serves the stale
-snapshot). If the isolation default is ever made effective, that extra
-flip disappears and the unit shape pin remains the load-bearing guard,
-as designed.
+Isolation note: CI pins the MySQL server to READ COMMITTED
+(.github/workflows/bashlib.sh) and PostgreSQL defaults to it, so the
+REPEATABLE READ staleness this fix targets is otherwise MASKED in CI —
+an RC re-read sees the concurrent commit even without the lock. The
+forced-RR test below closes that hole for the mutant that keeps
+``populate_existing()`` but drops ``with_for_update()``.
 """
 
 import gc
@@ -171,6 +169,40 @@ class TestConditionalWriteLockRefresh(SupersetTestCase):
             )
         finally:
             db.session.rollback()
+
+    def test_lock_refresh_survives_forced_repeatable_read(self) -> None:
+        """Forced-RR proof: the locking read defeats the snapshot itself.
+
+        CI pins the MySQL server to READ COMMITTED (bashlib.sh) and PG
+        defaults to it, so without forcing REPEATABLE READ here, a mutant
+        that keeps populate_existing() but drops with_for_update() would
+        still pass every lane — an RC re-read sees the concurrent commit
+        anyway. Under forced RR the unlocked re-read is a consistent read
+        served from the pre-commit snapshot (stale), while the locking
+        read is exempt and returns committed data. MySQL-only: under
+        PostgreSQL's REPEATABLE READ a locking read of a concurrently
+        updated row raises a serialization failure instead of returning
+        it, which is a different (also safe) outcome.
+        """
+        if db.session.get_bind().dialect.name != "mysql":
+            pytest.skip("forced-RR locking-read semantics are MySQL-specific")
+        db.session.rollback()
+        db.session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+        dataset = self._dataset()
+        dataset_id = dataset.id
+        original = dataset.description
+        assert original != "committed under forced RR"
+
+        try:
+            _write_description_out_of_band(dataset_id, "committed under forced RR")
+
+            locked = lock_entity_for_update(SqlaTable, dataset_id)
+
+            assert locked is not None
+            assert dataset.description == "committed under forced RR"
+        finally:
+            db.session.rollback()
+            _write_description_out_of_band(dataset_id, original)
 
     def test_lock_is_a_no_op_refresh_without_concurrent_writes(self) -> None:
         """Quiet-path control: no interleaved commit, no observable change.

--- a/tests/integration_tests/versioning/conditional_write_lock_tests.py
+++ b/tests/integration_tests/versioning/conditional_write_lock_tests.py
@@ -37,6 +37,7 @@ import sqlalchemy as sa
 from superset import db
 from superset.connectors.sqla.models import SqlaTable
 from superset.daos.dataset import DatasetDAO
+from superset.utils.core import override_user
 from superset.versioning.api_helpers import lock_entity_for_update
 from tests.integration_tests.base_tests import SupersetTestCase
 from tests.integration_tests.fixtures.birth_names_dashboard import (  # noqa: F401
@@ -109,8 +110,11 @@ class TestConditionalWriteLockRefresh(SupersetTestCase):
             # Pins the coupling the fix relies on: BaseDAO._query only
             # re-hydrates under force_fetch, so the command's lookup returns
             # the refreshed object. If DatasetDAO ever flips force_fetch,
-            # this catches the fix being silently undone.
-            fetched = DatasetDAO.find_by_id(dataset_id)
+            # this catches the fix being silently undone. The DAO's base
+            # filters read g.user, which a direct test-process call must
+            # supply.
+            with override_user(self.get_user("admin")):
+                fetched = DatasetDAO.find_by_id(dataset_id)
             assert fetched is dataset
             assert fetched.description == "committed by a concurrent request"
         finally:
@@ -140,7 +144,8 @@ class TestConditionalWriteLockRefresh(SupersetTestCase):
         try:
             locked = lock_entity_for_update(SqlaTable, dataset_id)
             assert locked is not None
-            fetched = DatasetDAO.find_by_id(dataset_id)
+            with override_user(self.get_user("admin")):
+                fetched = DatasetDAO.find_by_id(dataset_id)
             assert fetched is locked
         finally:
             db.session.rollback()

--- a/tests/unit_tests/versioning/test_lock_entity.py
+++ b/tests/unit_tests/versioning/test_lock_entity.py
@@ -47,14 +47,18 @@ def _mock_db(mocker: MockerFixture) -> MagicMock:
 
 
 def test_lock_is_a_populating_locking_read(mocker: MockerFixture) -> None:
-    """The lock statement is an ORM entity read chained through
-    populate_existing() AND with_for_update(), and its result is consumed
-    via one_or_none() (no exception for a missing row -- 404 semantics stay
-    with the update command's own lookup)."""
+    """The lock is a populating, locking ORM read that RETURNS the entity.
+
+    The chain must carry populate_existing() AND with_for_update(), consume
+    the result via one_or_none() (no exception for a missing row -- 404
+    semantics stay with the update command's own lookup), and hand the
+    entity back so the caller can hold a strong reference -- the identity
+    map alone holds it only weakly.
+    """
     db = _mock_db(mocker)
     model_cls = MagicMock()
 
-    lock_entity_for_update(model_cls, 42)
+    result = lock_entity_for_update(model_cls, 42)
 
     db.session.query.assert_called_once_with(model_cls)
     query = db.session.query.return_value
@@ -68,15 +72,20 @@ def test_lock_is_a_populating_locking_read(mocker: MockerFixture) -> None:
     filtered = populated.filter.return_value
     filtered.with_for_update.assert_called_once_with()
     filtered.with_for_update.return_value.one_or_none.assert_called_once_with()
+    assert result is filtered.with_for_update.return_value.one_or_none.return_value
 
 
 def test_non_numeric_id_skips_the_lock(mocker: MockerFixture) -> None:
-    """The PUT route declares /<pk> as a string segment; a non-numeric id
-    must not reach SQL (no cast error ahead of the command's 404)."""
+    """A non-numeric id never reaches SQL and returns None.
+
+    The PUT route declares /<pk> as a string segment; a cast error here
+    would pre-empt the command's 404.
+    """
     db = _mock_db(mocker)
 
-    lock_entity_for_update(MagicMock(), "not-a-pk")  # type: ignore[arg-type]
+    result = lock_entity_for_update(MagicMock(), "not-a-pk")  # type: ignore[arg-type]
 
+    assert result is None
     db.session.query.assert_not_called()
 
 

--- a/tests/unit_tests/versioning/test_lock_entity.py
+++ b/tests/unit_tests/versioning/test_lock_entity.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-120014: the conditional-write row lock must also refresh the entity.
+
+Dialect-independent statement-shape guards for ``lock_entity_for_update``:
+the lock must be taken as a full-entity ORM read carrying BOTH
+``populate_existing()`` and ``with_for_update()`` -- dropping either flag
+fails here on every backend. Why both flags matter is documented on the
+helper itself; the behavioral two-transaction proof against a real database
+lives in tests/integration_tests/versioning/conditional_write_lock_tests.py.
+(The restore path has the same staleness class; a matching pin is proposed
+in apache/superset#44015.)
+
+These are deliberate shape pins on the exact query chain: an equivalent
+refactor (a 2.0-style ``select()``, reordered chaining) should update the
+pinned chain -- but never drop ``populate_existing`` or ``with_for_update``.
+"""
+
+from unittest.mock import MagicMock
+
+from pytest_mock import MockerFixture
+
+from superset.versioning.api_helpers import lock_entity_for_update
+
+
+def _mock_db(mocker: MockerFixture) -> MagicMock:
+    """Replace the module-level ``db`` with an explicit MagicMock, so
+    ``mock.patch`` builds a plain sync mock rather than choosing the
+    replacement type itself."""
+    db = MagicMock()
+    mocker.patch("superset.versioning.api_helpers.db", new=db)
+    return db
+
+
+def test_lock_is_a_populating_locking_read(mocker: MockerFixture) -> None:
+    """The lock statement is an ORM entity read chained through
+    populate_existing() AND with_for_update(), and its result is consumed
+    via one_or_none() (no exception for a missing row -- 404 semantics stay
+    with the update command's own lookup)."""
+    db = _mock_db(mocker)
+    model_cls = MagicMock()
+
+    lock_entity_for_update(model_cls, 42)
+
+    db.session.query.assert_called_once_with(model_cls)
+    query = db.session.query.return_value
+    query.populate_existing.assert_called_once_with()
+    populated = query.populate_existing.return_value
+    # Arity-only on purpose: with a MagicMock model the criterion
+    # ``model_cls.id == 42`` is not introspectable, and a with-args assert
+    # would be trivially true. The right-row behavior is pinned by the
+    # integration tests on real backends.
+    populated.filter.assert_called_once()
+    filtered = populated.filter.return_value
+    filtered.with_for_update.assert_called_once_with()
+    filtered.with_for_update.return_value.one_or_none.assert_called_once_with()
+
+
+def test_non_numeric_id_skips_the_lock(mocker: MockerFixture) -> None:
+    """The PUT route declares /<pk> as a string segment; a non-numeric id
+    must not reach SQL (no cast error ahead of the command's 404)."""
+    db = _mock_db(mocker)
+
+    lock_entity_for_update(MagicMock(), "not-a-pk")  # type: ignore[arg-type]
+
+    db.session.query.assert_not_called()
+
+
+def test_missing_id_skips_the_lock(mocker: MockerFixture) -> None:
+    db = _mock_db(mocker)
+
+    lock_entity_for_update(MagicMock(), None)
+
+    db.session.query.assert_not_called()


### PR DESCRIPTION
### SUMMARY

The dataset PUT's conditional-write path (`If-Match` saves) serialises check-and-write by row-locking the entity first (`lock_entity_for_update`, called from `superset/datasets/api.py`). But the lock was an id-only `SELECT id ... FOR UPDATE` that discarded the row's values — it serialised writers without refreshing what the transaction can *see*:

- On MySQL/InnoDB default **REPEATABLE READ**, every consistent read in a transaction is pinned to the read view established by its first read (the request's auth queries run well before the lock). So the entity loaded after that id-only lock still reflected the **pre-lock snapshot**, and the ORM — which only emits `UPDATE`s for attributes that differ from the *loaded* values — could silently lose a concurrent commit that landed between the initial load and the lock. This is the same class as the version-restore partial-write fixed in #44015, on the ordinary update path.
- The staleness is also **object-level on every backend**: SQLAlchemy never refreshes an already-loaded entity from a later plain `SELECT`, so even where the row read is fresh (Postgres READ COMMITTED), the identity-map object the update command operates on stayed stale.

**Fix** (mirroring #44015's locking-refresh): take the lock as a full-entity ORM read — `db.session.query(model).populate_existing().filter(id).with_for_update().one_or_none()`. A locking read is exempt from the REPEATABLE READ snapshot and returns current committed data; `populate_existing()` writes it into the identity-map object, which the update command's later `find_by_id` returns without re-hydrating from its own (possibly stale) row.

**Two halves of one protection — merge-order note**: this PR closes the *entity-read* half of the MySQL REPEATABLE READ conditional-write race. The *validator-read* half (`current_entity_version_info` still being a plain snapshot read, so a stale `If-Match` token can pass) is closed by #44091 — the race is fully shut only with **both** merged, in either order (whichever lands second takes a small rebase in `datasets/api.py`; #44091's body carries the same note and the `_locked_entity`-preservation warning).

**Lifetime contract** (from the adversarial review round): the helper **returns the locked entity and the caller must hold it** — the identity map references clean persistent objects weakly, so a discarded result is collectible the moment the helper returns, after which `find_by_id` would re-hydrate from the stale snapshot and silently undo the fix on the production path (which loads nothing of its own before the lock). The dataset PUT binds the return value for the rest of the request. Missing-row semantics are unchanged: `None` is returned and existence keeps being decided by the command's own lookup (404 as before). Chart/dashboard PUTs have no conditional-write lock path, so the fix is dataset-scoped at the single shared helper.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — concurrency fix with no UI or response-shape change.

### TESTING INSTRUCTIONS

- `pytest tests/unit_tests/versioning/test_lock_entity.py` — 3 tests: the dialect-independent regression guard pins the statement shape (`populate_existing()` **and** `with_for_update()` both chained, result consumed via `one_or_none()`; dropping either fails on every backend — the analogue of #44015's `refresh(..., with_for_update=True)` pin), plus the non-numeric/None id early-outs that keep the `/<pk>` string route from raising a SQL cast error. Reverting the helper flips the shape test.
- `pytest tests/integration_tests/versioning/conditional_write_lock_tests.py` — the lifetime pin (held, `DatasetDAO.find_by_id` returns the very same refreshed instance; discarded, a `weakref` proves the object is collected — the identity map alone does not keep it alive) plus the two-transaction behavioral proof: a second engine-level connection commits a change between this session's entity load and the lock; after `lock_entity_for_update` the loaded entity must show the concurrently committed value (fails pre-fix on every backend, since the staleness is object-level), plus a quiet-path control asserting the refresh is a no-op (and dirties nothing) when nothing changed underneath. Skipped on SQLite, where a second writer connection deadlocks against the open read transaction instead of modelling a concurrent request — CI's Postgres/MySQL runs execute them (local env here is SQLite-backed, so these two are CI-verified).
- Manual (MySQL): open a dataset edit in one tab; from a second session commit a change to another field; save the first tab with `If-Match`. Before the fix the first save's flush could quietly discard the concurrent change on MySQL; after, the command diffs against committed state.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW
