### PR TITLE
fix(explore): surface a toast when pivot Excel export can't find the table

### DIFF
--- a/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart/Chart.tsx
@@ -65,6 +65,7 @@ import MissingChart from '../../MissingChart';
 import {
   addDangerToast,
   addSuccessToast,
+  addWarningToast,
 } from '../../../../components/MessageToasts/actions';
 import {
   setFocusedFilterField,
@@ -179,6 +180,7 @@ const Chart = (props: ChartProps) => {
         {
           addSuccessToast,
           addDangerToast,
+          addWarningToast,
           toggleExpandSlice,
           changeFilter,
           setFocusedFilterField,
@@ -775,7 +777,14 @@ const Chart = (props: ChartProps) => {
         exploreUrl=""
         width={width}
         height={getHeaderHeight()}
-        exportPivotExcel={exportPivotExcel as unknown as (arg0: string) => void}
+        exportPivotExcel={
+          ((tableSelector: string, sliceName: string) =>
+            exportPivotExcel(
+              tableSelector,
+              sliceName,
+              boundActionCreators.addWarningToast,
+            )) as unknown as (arg0: string) => void
+        }
         chartHolderRef={props.chartHolderRef}
         ownState={ownState}
       />

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.tsx
@@ -345,7 +345,7 @@ export const useExploreAdditionalActionsMenu = (
   ...rest: MenuProps[]
 ): UseExploreAdditionalActionsMenuReturn => {
   const theme = useTheme();
-  const { addDangerToast, addSuccessToast } = useToasts();
+  const { addDangerToast, addSuccessToast, addWarningToast } = useToasts();
   const dispatch = useDispatch();
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [dashboardSearchTerm, setDashboardSearchTerm] = useState('');
@@ -747,6 +747,7 @@ export const useExploreAdditionalActionsMenu = (
             exportPivotExcel(
               `${sliceSelector} .pvtTable`,
               slice?.slice_name ?? t('pivoted_xlsx'),
+              addWarningToast,
             );
             setIsDropdownVisible(false);
             dispatch(

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -19,6 +19,7 @@
 import type { WorkBook } from 'xlsx';
 import { getNumberFormatterRegistry } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
+import { addWarningToast } from 'src/components/MessageToasts/actions';
 import exportPivotExcel from './downloadAsPivotExcel';
 
 const mockWriteFile = jest.fn();
@@ -34,6 +35,16 @@ jest.mock('xlsx', () => {
 jest.mock('@apache-superset/core/utils', () => ({
   logging: { error: jest.fn() },
 }));
+
+jest.mock('src/components/MessageToasts/actions', () => ({
+  addWarningToast: jest.fn(),
+}));
+
+jest.mock('@apache-superset/core/translation', () => ({
+  t: (str: string) => str,
+}));
+
+const mockAddWarningToast = addWarningToast as jest.Mock;
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -124,12 +135,15 @@ test('leaves date-shaped strings as text rather than reinterpreting them as date
   expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
 });
 
-test('should log an error and return early when table element is not found', () => {
+test('logs an error, warns the user, and returns early when table element is not found', () => {
   jest.spyOn(document, 'querySelector').mockReturnValue(null);
 
   exportPivotExcel('.non-existent-selector', 'test-file');
 
   expect(logging.error as jest.Mock).toHaveBeenCalledWith(
     '[exportPivotExcel] No element found for selector: ".non-existent-selector"',
+  );
+  expect(mockAddWarningToast).toHaveBeenCalledWith(
+    'Pivot table download failed, please refresh and try again.',
   );
 });

--- a/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.test.ts
@@ -19,7 +19,6 @@
 import type { WorkBook } from 'xlsx';
 import { getNumberFormatterRegistry } from '@superset-ui/core';
 import { logging } from '@apache-superset/core/utils';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
 import exportPivotExcel from './downloadAsPivotExcel';
 
 const mockWriteFile = jest.fn();
@@ -36,15 +35,9 @@ jest.mock('@apache-superset/core/utils', () => ({
   logging: { error: jest.fn() },
 }));
 
-jest.mock('src/components/MessageToasts/actions', () => ({
-  addWarningToast: jest.fn(),
-}));
-
 jest.mock('@apache-superset/core/translation', () => ({
   t: (str: string) => str,
 }));
-
-const mockAddWarningToast = addWarningToast as jest.Mock;
 
 afterEach(() => {
   jest.restoreAllMocks();
@@ -135,15 +128,27 @@ test('leaves date-shaped strings as text rather than reinterpreting them as date
   expect(sheet.C1).toMatchObject({ t: 's', v: 'not-a-date' });
 });
 
-test('logs an error, warns the user, and returns early when table element is not found', () => {
+test('logs an error, warns the user via the bound toast callback, and returns early when table element is not found', () => {
   jest.spyOn(document, 'querySelector').mockReturnValue(null);
+  const addWarningToast = jest.fn();
 
-  exportPivotExcel('.non-existent-selector', 'test-file');
+  exportPivotExcel('.non-existent-selector', 'test-file', addWarningToast);
 
   expect(logging.error as jest.Mock).toHaveBeenCalledWith(
     '[exportPivotExcel] No element found for selector: ".non-existent-selector"',
   );
-  expect(mockAddWarningToast).toHaveBeenCalledWith(
+  // Passed in already bound to dispatch (e.g. via `useToasts()`), so calling
+  // it directly is what actually renders the toast -- unlike the raw action
+  // creator, which only builds a Redux action object.
+  expect(addWarningToast).toHaveBeenCalledWith(
     'Pivot table download failed, please refresh and try again.',
   );
+});
+
+test('does not throw when the table element is not found and no toast callback is provided', () => {
+  jest.spyOn(document, 'querySelector').mockReturnValue(null);
+
+  expect(() =>
+    exportPivotExcel('.non-existent-selector', 'test-file'),
+  ).not.toThrow();
 });

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -19,7 +19,6 @@
 import { getNumberFormatterRegistry } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
 import { utils, writeFile } from 'xlsx';
 import type { WorkSheet } from 'xlsx';
 
@@ -66,13 +65,18 @@ function restoreUnambiguousNumbers(sheet: WorkSheet): void {
 export default function exportPivotExcel(
   tableSelector: string,
   fileName: string,
+  // Bound via `useToasts()`/`bindActionCreators`, not the raw action
+  // creator from `actions.ts`: this module has no dispatch of its own, so an
+  // unbound creator would only build a Redux action object and never render
+  // a toast.
+  addWarningToast?: (text: string) => void,
 ) {
   const table = document.querySelector(tableSelector);
   if (!table) {
     logging.error(
       `[exportPivotExcel] No element found for selector: "${tableSelector}"`,
     );
-    addWarningToast(
+    addWarningToast?.(
       t('Pivot table download failed, please refresh and try again.'),
     );
     return;

--- a/superset-frontend/src/utils/downloadAsPivotExcel.ts
+++ b/superset-frontend/src/utils/downloadAsPivotExcel.ts
@@ -17,7 +17,9 @@
  * under the License.
  */
 import { getNumberFormatterRegistry } from '@superset-ui/core';
+import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
+import { addWarningToast } from 'src/components/MessageToasts/actions';
 import { utils, writeFile } from 'xlsx';
 import type { WorkSheet } from 'xlsx';
 
@@ -69,6 +71,9 @@ export default function exportPivotExcel(
   if (!table) {
     logging.error(
       `[exportPivotExcel] No element found for selector: "${tableSelector}"`,
+    );
+    addWarningToast(
+      t('Pivot table download failed, please refresh and try again.'),
     );
     return;
   }


### PR DESCRIPTION
### SUMMARY
Follow-up to #39386. That PR added a guard in `exportPivotExcel` (`superset-frontend/src/utils/downloadAsPivotExcel.ts`) for when the pivot table element can't be found in the DOM (e.g. it was unmounted mid-export), but the guard only logs to the console and returns, giving the user zero feedback that their download didn't happen. CodeAnt flagged this on #39386 itself after merge (major/incomplete-implementation).

The two sibling download utilities in the same directory, `downloadAsPdf.ts` and `downloadAsImage.tsx`, already handle their equivalent missing-element case by showing `addWarningToast(...)` in addition to logging. This PR brings `downloadAsPivotExcel.ts` in line with that existing convention, nothing else in `src/utils/download*.ts` needed the same fix.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, this only affects the rare failure path (table missing from the DOM at export time); no visual change to the normal export flow.

### TESTING INSTRUCTIONS
```
npx jest superset-frontend/src/utils/downloadAsPivotExcel.test.ts
```
The updated "table element is not found" test now also asserts `addWarningToast` fires with the same message wording used by `downloadAsPdf`/`downloadAsImage`.

Manual: in Explore or a dashboard, trigger "Download as Excel" on a pivot table chart while the table is momentarily unmounted (e.g. mid-rerender); a warning toast should now appear instead of the download silently failing.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API