### PR TITLE
feat(sqllab): settle async queries via GTF task.status realtime push

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Query.ts
@@ -356,6 +356,10 @@ export type Query = {
   type: DatasourceType;
   columns: QueryColumn[];
   runAsync?: boolean;
+  // The GTF task uuid an async SQL Lab query runs under, captured from the
+  // execute 202 (async_job.task_id). Used to settle the query immediately on its
+  // terminal `task.status` websocket push.
+  taskId?: string;
 };
 
 export type QueryResults = {

--- a/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.test.ts
@@ -553,6 +553,37 @@ describe('async actions', () => {
       });
     });
 
+    test('sends the tab id in the request body', () =>
+      makeRequest().then(() => {
+        const call = fetchMock.callHistory.calls(runQueryEndpoint)[0];
+        const body = JSON.parse(call.options.body as string);
+        expect(body.tab_id).toBeDefined();
+      }));
+
+    test('stores the async task id from the 202 response', () => {
+      expect.assertions(2);
+
+      fetchMock.removeRoute(runQueryEndpoint);
+      fetchMock.post(
+        runQueryEndpoint,
+        { async_job: { task_id: 'task-uuid-123' } },
+        { name: runQueryEndpoint },
+      );
+
+      const store = mockStore({});
+      const asyncQuery = { ...query, runAsync: true };
+      const request = actions.runQuery(asyncQuery);
+      return request(store.dispatch, () => typedInitialState, undefined).then(
+        () => {
+          const setTaskIdAction = store
+            .getActions()
+            .find(a => a.type === actions.SET_QUERY_TASK_ID);
+          expect(setTaskIdAction).toBeDefined();
+          expect(setTaskIdAction?.taskId).toBe('task-uuid-123');
+        },
+      );
+    });
+
     test('calls queryFailed on fetch error and logs the error details', () => {
       expect.assertions(2);
 

--- a/superset-frontend/src/SqlLab/actions/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/actions/sqlLab.ts
@@ -42,6 +42,7 @@ import { LOG_ACTIONS_SQLLAB_FETCH_FAILED_QUERY } from 'src/logger/LogUtils';
 import type { BootstrapData } from 'src/types/bootstrapTypes';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { logEvent } from 'src/logger/actions';
+import { getTabId } from 'src/hooks/useTabId';
 import type { QueryEditor, SqlLabRootState, Table } from '../types';
 import { newQueryTabName } from '../utils/newQueryTabName';
 import getInitialState from '../reducers/getInitialState';
@@ -80,6 +81,7 @@ export interface Query {
   inLocalStorage?: boolean;
   executedSql?: string;
   query_id?: number;
+  taskId?: string;
 }
 
 export interface Database {
@@ -114,6 +116,24 @@ export interface SqlExecuteResponse {
   expanded_columns?: QueryColumn[];
   query: SqlExecuteQueryResult;
   query_id?: number;
+}
+
+/**
+ * The GTF task an async query runs under, echoed in the execute 202 (see
+ * QueryExecutionResponseSchema.async_job). `task_id` is the uuid used to settle
+ * the query immediately on its terminal `task.status` websocket push.
+ */
+export interface AsyncJob {
+  task_id: string;
+  cursor?: string;
+  tab_id?: string;
+}
+
+/**
+ * The 202 body from POST /api/v1/sqllab/execute/ when the query runs async.
+ */
+export interface SqlExecuteAsyncResponse {
+  async_job?: AsyncJob;
 }
 
 export const RESET_STATE = 'RESET_STATE';
@@ -161,6 +181,7 @@ export const STOP_QUERY = 'STOP_QUERY';
 export const REQUEST_QUERY_RESULTS = 'REQUEST_QUERY_RESULTS';
 export const QUERY_SUCCESS = 'QUERY_SUCCESS';
 export const QUERY_FAILED = 'QUERY_FAILED';
+export const SET_QUERY_TASK_ID = 'SET_QUERY_TASK_ID';
 export const CLEAR_INACTIVE_QUERIES = 'CLEAR_INACTIVE_QUERIES';
 export const CLEAR_QUERY_RESULTS = 'CLEAR_QUERY_RESULTS';
 export const REMOVE_DATA_PREVIEW = 'REMOVE_DATA_PREVIEW';
@@ -234,6 +255,7 @@ export interface SqlLabAction {
   json?: Record<string, unknown>;
   oldQueryId?: string;
   newQuery?: { id: string };
+  taskId?: string;
 }
 
 // Use AnyAction for ThunkAction/ThunkDispatch to maintain compatibility with
@@ -412,6 +434,10 @@ export function querySuccess(query: Query, results: SqlExecuteResponse) {
   return { type: QUERY_SUCCESS, query, results } as const;
 }
 
+export function setQueryTaskId(query: Query, taskId: string) {
+  return { type: SET_QUERY_TASK_ID, query, taskId } as const;
+}
+
 export function logFailedQuery(
   query: Query,
   errors?: SupersetError[],
@@ -535,6 +561,9 @@ export function runQuery(
       templateParams: query.templateParams,
       queryLimit: query.queryLimit,
       expand_data: true,
+      // Advertise the originating tab so the backend can route this query's
+      // terminal `task.status` websocket push back to it (accelerates settling).
+      tab_id: getTabId(),
     };
 
     const search = window.location.search || '';
@@ -547,6 +576,14 @@ export function runQuery(
       .then(({ json }) => {
         if (!query.runAsync) {
           dispatch(querySuccess(query, json as SqlExecuteResponse));
+        } else {
+          // The async 202 carries the GTF task uuid; store it on the query so
+          // QueryAutoRefresh can settle immediately on its terminal
+          // `task.status` push (the 2s poll remains the backstop).
+          const taskId = (json as SqlExecuteAsyncResponse)?.async_job?.task_id;
+          if (taskId) {
+            dispatch(setQueryTaskId(query, taskId));
+          }
         }
       })
       .catch(response =>

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx
@@ -33,9 +33,30 @@ import QueryAutoRefresh, {
   shouldCheckForQueries,
   QUERY_UPDATE_FREQ,
 } from 'src/SqlLab/components/QueryAutoRefresh';
+import { subscribeRealtime } from 'src/middleware/realtime';
+import { TASK_STATUS_TOPIC } from 'src/middleware/asyncEvent';
 import { successfulQuery, runningQuery } from 'src/SqlLab/fixtures';
 import { QueryDictionary } from 'src/SqlLab/types';
 import mockDatabases from 'spec/fixtures/mockDatabases';
+
+// The realtime transport is a pure accelerator; mock it so a `task.status`
+// message can be emitted deterministically without a real socket.
+jest.mock('src/middleware/realtime', () => ({
+  subscribeRealtime: jest.fn(() => jest.fn()),
+  connectRealtime: jest.fn(),
+  subscribeRealtimeOpen: jest.fn(() => jest.fn()),
+  subscribeRealtimeState: jest.fn(() => jest.fn()),
+}));
+
+const subscribeRealtimeMock = subscribeRealtime as jest.Mock;
+
+// Return the `task.status` handler the component registered after render.
+const getTaskStatusHandler = (): ((payload: unknown) => void) => {
+  const call = subscribeRealtimeMock.mock.calls
+    .filter(([topic]) => topic === TASK_STATUS_TOPIC)
+    .pop();
+  return call?.[1] as (payload: unknown) => void;
+};
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -54,6 +75,7 @@ describe('QueryAutoRefresh', () => {
 
   beforeEach(() => {
     jest.useFakeTimers({ advanceTimers: true });
+    subscribeRealtimeMock.mockClear();
   });
 
   afterEach(() => {
@@ -275,5 +297,65 @@ describe('QueryAutoRefresh', () => {
         }),
       ),
     );
+  });
+
+  test('refreshes immediately on a terminal task.status for a tracked query', async () => {
+    const store = mockStore({ sqlLab: { ...mockState } });
+    const trackedQueries: QueryDictionary = {
+      [runningQuery.id]: { ...runningQuery, taskId: 'task-abc' },
+    };
+
+    fetchMock.get(refreshApi, {
+      result: [{ id: runningQuery.id, status: 'success' }],
+    });
+
+    render(
+      <QueryAutoRefresh
+        queries={trackedQueries}
+        queriesLastUpdate={queriesLastUpdate}
+      />,
+      { useRedux: true, store },
+    );
+
+    await act(async () => {
+      getTaskStatusHandler()({ task_id: 'task-abc', status: 'success' });
+    });
+
+    // The immediate refresh fires without advancing the 2s poll interval.
+    await waitFor(() =>
+      expect(fetchMock.callHistory.calls(refreshApi)).toHaveLength(1),
+    );
+    await waitFor(() =>
+      expect(store.getActions()).toContainEqual(
+        expect.objectContaining({ type: REFRESH_QUERIES }),
+      ),
+    );
+  });
+
+  test('ignores a task.status for an untracked task id', async () => {
+    const store = mockStore({ sqlLab: { ...mockState } });
+    const trackedQueries: QueryDictionary = {
+      [runningQuery.id]: { ...runningQuery, taskId: 'task-abc' },
+    };
+
+    fetchMock.get(refreshApi, {
+      result: [{ id: runningQuery.id, status: 'success' }],
+    });
+
+    render(
+      <QueryAutoRefresh
+        queries={trackedQueries}
+        queriesLastUpdate={queriesLastUpdate}
+      />,
+      { useRedux: true, store },
+    );
+
+    await act(async () => {
+      getTaskStatusHandler()({ task_id: 'other-task', status: 'success' });
+    });
+
+    // No accelerated refresh; the untracked message is dropped (the 2s poll
+    // remains the backstop and is not advanced here).
+    expect(fetchMock.callHistory.calls(refreshApi)).toHaveLength(0);
   });
 });

--- a/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
+++ b/superset-frontend/src/SqlLab/components/QueryAutoRefresh/index.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'src/SqlLab/hooks/useAppDispatch';
 import { isObject } from 'lodash-es';
@@ -31,6 +31,11 @@ import {
 } from '@superset-ui/core';
 import { QueryDictionary, SqlLabRootState } from 'src/SqlLab/types';
 import useInterval from 'src/SqlLab/utils/useInterval';
+import { subscribeRealtime } from 'src/middleware/realtime';
+import {
+  TASK_STATUS_TOPIC,
+  TERMINAL_STATUSES,
+} from 'src/middleware/asyncEvent';
 import {
   refreshQueries,
   clearInactiveQueries,
@@ -155,6 +160,46 @@ function QueryAutoRefresh({
   useInterval(() => {
     checkForRefresh();
   }, QUERY_UPDATE_FREQ);
+
+  // The interval poll above is the correctness backstop. When the realtime
+  // websocket is enabled, a query's GTF task publishes a terminal `task.status`
+  // push routed to this tab; reacting to it triggers an immediate refresh
+  // instead of waiting up to QUERY_UPDATE_FREQ. It is a pure accelerator: the
+  // poll still settles everything on its own if the push is missed. Refs keep
+  // the single subscription reading the latest queries / refresh closure without
+  // re-subscribing on every render.
+  const queriesRef = useRef(queries);
+  queriesRef.current = queries;
+  const checkForRefreshRef = useRef(checkForRefresh);
+  checkForRefreshRef.current = checkForRefresh;
+
+  useEffect(
+    () =>
+      subscribeRealtime(TASK_STATUS_TOPIC, payload => {
+        if (!payload || typeof payload !== 'object') {
+          return;
+        }
+        const { task_id: taskId, status } = payload as {
+          task_id?: unknown;
+          status?: unknown;
+        };
+        if (typeof taskId !== 'string' || typeof status !== 'string') {
+          return;
+        }
+        if (!TERMINAL_STATUSES.has(status)) {
+          return;
+        }
+        // Only react to task ids of currently-running SQL Lab queries, so
+        // unrelated `task.status` messages (e.g. chart-data) are ignored.
+        const isTracked = Object.values(queriesRef.current).some(
+          query => isQueryRunning(query) && query?.taskId === taskId,
+        );
+        if (isTracked) {
+          checkForRefreshRef.current();
+        }
+      }),
+    [],
+  );
 
   return null;
 }

--- a/superset-frontend/src/SqlLab/reducers/sqlLab.ts
+++ b/superset-frontend/src/SqlLab/reducers/sqlLab.ts
@@ -431,6 +431,11 @@ export default function sqlLabReducer(
         state: QueryState.Fetching,
       });
     },
+    [actions.SET_QUERY_TASK_ID]() {
+      return alterInObject(state, 'queries', action.query!, {
+        taskId: action.taskId,
+      });
+    },
     [actions.QUERY_SUCCESS]() {
       // prevent race condition where query succeeds shortly after being canceled
       // or the final result was unsuccessful

--- a/superset-frontend/src/middleware/asyncEvent.ts
+++ b/superset-frontend/src/middleware/asyncEvent.ts
@@ -56,7 +56,9 @@ const STATUS_CHANGES_URL = '/api/v1/task/status_changes';
 
 // Terminal GTF task statuses (mirror superset_core.tasks.types.TaskStatus).
 const STATUS_SUCCESS = 'success';
-const TERMINAL_STATUSES = new Set([
+// Exported so other realtime consumers (e.g. SQL Lab's QueryAutoRefresh) settle on
+// the same terminal set rather than re-declaring it.
+export const TERMINAL_STATUSES = new Set([
   STATUS_SUCCESS,
   'failure',
   'aborted',
@@ -169,8 +171,9 @@ const stopIfStale = (generation: number): boolean => {
 // GTF task-status topic emitted by superset-websocket after it fans out backend
 // task-status events (see superset/tasks/manager.py TOPIC_TASK_STATUS). Delivery
 // is scoped server-side to this principal's (or tab's) routing key, so a message
-// that reaches this browser is always its own.
-const TASK_STATUS_TOPIC = 'task.status';
+// that reaches this browser is always its own. Exported so other realtime
+// consumers (e.g. SQL Lab's QueryAutoRefresh) subscribe to the same topic.
+export const TASK_STATUS_TOPIC = 'task.status';
 
 const fetchStatusChanges = makeApi<
   { cursor?: string | null; task_type: string },

--- a/superset/commands/sql_lab/execute.py
+++ b/superset/commands/sql_lab/execute.py
@@ -256,23 +256,37 @@ class ExecuteSqlCommand(BaseCommand):
         self._pending_async = True
         return SqlJsonExecutionStatus.QUERY_IS_RUNNING
 
-    def submit_async(self) -> None:
+    def submit_async(self) -> dict[str, Any] | None:
         """Schedule the async GTF SQL task, outside this command's transaction.
 
         Called by the endpoint after ``run`` commits. Scheduling a GTF task
         acquires its own lock/transaction and refuses to run inside an outer
         ``@transaction`` (see ``SubmitTaskCommand``), so it must happen here.
+
+        Returns the ``async_job`` descriptor the endpoint surfaces in the 202
+        (``{task_id, cursor, tab_id?}``): the scheduled task's UUID, a
+        server-captured pre-task status cursor (the recovery watermark the client
+        polls/catches up ``/api/v1/task/status_changes`` from — captured *before*
+        scheduling so no completion can slip in ahead of the client's waiter), and
+        the per-tab id the subscription policy recorded (so a later cancel detaches
+        exactly this tab). ``None`` when there is nothing to schedule.
         """
         if not self._pending_async:
-            return
+            return None
         from superset_core.tasks.types import TaskOptions
 
         from superset.tasks.sql_queries import run_sql_lab_query
+        from superset.tasks.subscription import get_request_tab_id
+        from superset.tasks.utils import floored_status_cursor
 
         context = self._execution_context
         query = context.query
+        # Capture the status-poll cursor BEFORE the task is created so the client is
+        # guaranteed to observe its completion even if the task finishes before the
+        # waiter is established (floored to whole seconds; see floored_status_cursor).
+        poll_cursor = floored_status_cursor()
         try:
-            run_sql_lab_query.schedule(
+            task = run_sql_lab_query.schedule(
                 query.id,
                 self._rendered_query,
                 store_results=not context.select_as_cta,
@@ -293,6 +307,14 @@ class ExecuteSqlCommand(BaseCommand):
             )
             self._fail_query(error)
             raise SupersetErrorException(error) from ex
+
+        async_job: dict[str, Any] = {
+            "task_id": str(task.uuid),
+            "cursor": poll_cursor.isoformat(),
+        }
+        if tab_id := get_request_tab_id():
+            async_job["tab_id"] = tab_id
+        return async_job
 
     def _fail_query(self, error: SupersetError) -> None:
         """Mark the query FAILED with ``error`` (own transaction — submit_async

--- a/superset/sqllab/api.py
+++ b/superset/sqllab/api.py
@@ -584,12 +584,19 @@ class SqlLabRestApi(BaseSupersetApi):
             execution_context = SqlJsonExecutionContext(request.json)
             command = self._create_sql_json_command(execution_context, log_params)
             command_result: CommandResult = command.run()
+            payload = command_result["payload"]
 
             # Schedule the async GTF task AFTER the command's transaction commits:
             # scheduling acquires its own lock/transaction and must not run inside
-            # an outer @transaction (see ExecuteSqlCommand.submit_async).
+            # an outer @transaction (see ExecuteSqlCommand.submit_async). The task
+            # descriptor it returns (task_id/cursor/tab_id) is surfaced in the 202
+            # so the client can settle the query via the task.status push (with the
+            # /query/updated_since poll as backstop).
             if command_result["status"] == SqlJsonExecutionStatus.QUERY_IS_RUNNING:
-                command.submit_async()
+                if async_job := command.submit_async():
+                    parsed = json.loads(payload)
+                    parsed["async_job"] = async_job
+                    payload = json.dumps(parsed)
 
             response_status = (
                 202
@@ -597,7 +604,7 @@ class SqlLabRestApi(BaseSupersetApi):
                 else 200
             )
             # return the execution result without special encoding
-            return json_success(command_result["payload"], response_status)
+            return json_success(payload, response_status)
         except SqlLabException as ex:
             payload = {"errors": [ex.to_dict()]}
 

--- a/superset/sqllab/schemas.py
+++ b/superset/sqllab/schemas.py
@@ -115,6 +115,24 @@ class QueryResultSchema(Schema):
     extra = fields.Dict(keys=fields.String())
 
 
+class AsyncJobSchema(Schema):
+    task_id = fields.String(
+        metadata={"description": "UUID of the GTF task executing this query"}
+    )
+    cursor = fields.String(
+        metadata={
+            "description": (
+                "Server-captured pre-task status cursor; the recovery watermark "
+                "for polling/catching up on /api/v1/task/status_changes"
+            )
+        }
+    )
+    tab_id = fields.String(
+        required=False,
+        metadata={"description": "Per-tab id the subscription policy recorded"},
+    )
+
+
 class QueryExecutionResponseSchema(Schema):
     status = fields.String()
     data = fields.List(fields.Dict())
@@ -123,6 +141,17 @@ class QueryExecutionResponseSchema(Schema):
     expanded_columns = fields.List(fields.Dict())
     query = fields.Nested(QueryResultSchema)
     query_id = fields.Integer()
+    async_job = fields.Nested(
+        AsyncJobSchema,
+        required=False,
+        metadata={
+            "description": (
+                "Present on an asynchronous (202) response: the GTF task the "
+                "client awaits via task.status (with the status_changes poll as "
+                "backstop)"
+            )
+        },
+    )
 
 
 class TableSchema(Schema):

--- a/superset/tasks/async_queries.py
+++ b/superset/tasks/async_queries.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import Any, cast, Iterator, TYPE_CHECKING
+from typing import Any, Iterator, TYPE_CHECKING
 from uuid import UUID
 
 from flask import current_app
@@ -42,11 +42,8 @@ from superset.tasks.query_cancel import (
     capture_cancel_id,
     capture_cancel_query_id,
 )
-from superset.tasks.subscription import get_request_tab_id, TaskSubscriptionPolicy
-from superset.tasks.utils import (
-    floored_status_cursor,
-    SUBSCRIPTION_PRIVATE_NAMESPACE,
-)
+from superset.tasks.subscription import get_request_tab_id, PerTabConsumerPolicy
+from superset.tasks.utils import floored_status_cursor
 from superset.utils.core import override_user
 
 if TYPE_CHECKING:
@@ -68,12 +65,8 @@ logger = logging.getLogger(__name__)
 CHART_QUERY_TASK = "superset.query_object_v1"
 CACHE_KEY_PAYLOAD_KEY = "cache_key"
 
-# Key under ``private["task"]`` holding the chart-data consumer list (see
-# ``ChartQueryConsumerPolicy``).
-CONSUMERS_PRIVATE_KEY = "consumers"
 
-
-class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
+class ChartQueryConsumerPolicy(PerTabConsumerPolicy):
     """Ref-count the browser tabs watching a shared chart-data task.
 
     A chart-data task is ``SHARED`` and deduplicated across every request for the
@@ -81,77 +74,11 @@ class ChartQueryConsumerPolicy(TaskSubscriptionPolicy):
     single principal with a single subscriber row. Treating either tab's cancel
     (an explicit cancel, or the navigate-away teardown that cancels unwaited
     tasks) as *the* principal leaving would abort the shared task and kill the
-    other tab's still-pending query.
-
-    This policy keeps a list of ``"<principal>:<tab_id>"`` entries in the task's
-    ``private["subscription"]`` namespace (policy-owned, debug-gated). On
-    subscribe it adds the calling tab; on unsubscribe it removes the calling tab
-    and reports whether the principal has any tab left, so the framework aborts
-    the task only once the principal's last tab is gone. Both hooks run under the
-    submit/cancel lock, so the read-modify-write on the list is race-free against
-    other submits/cancels; the executor, which does not hold that lock, writes
-    the task's properties while it runs, so the list is written through
-    ``TaskDAO.merge_subscription_state`` (a row-locked merge) and the executor's
-    whole-blob writes preserve this namespace rather than replacing it with their
-    pickup-time snapshot. Otherwise a tab joining mid-execution would be dropped
-    and the other tab's detach would abort work it still awaits.
-
-    A request without a ``tab_id`` (a non-interactive or legacy caller) is a
-    no-op on subscribe and proceeds (principal-grain) on unsubscribe; in practice
-    the chart-data client always supplies a stable per-tab id.
+    other tab's still-pending query. The generic per-tab consumer ref-counting
+    that prevents this (and routes ``task.status`` to exactly the watching tabs)
+    lives in :class:`~superset.tasks.subscription.PerTabConsumerPolicy`; chart-data
+    uses it unchanged.
     """
-
-    @staticmethod
-    def _consumers(task: "CoreTask") -> list[str]:
-        private = task.properties_dict.get("private") or {}
-        subscription = private.get(SUBSCRIPTION_PRIVATE_NAMESPACE) or {}
-        consumers = subscription.get(CONSUMERS_PRIVATE_KEY) or []
-        return [entry for entry in consumers if isinstance(entry, str)]
-
-    @staticmethod
-    def _write_consumers(task: "CoreTask", consumers: list[str]) -> None:
-        from superset.daos.tasks import TaskDAO
-
-        TaskDAO.merge_subscription_state(
-            cast("Task", task), {CONSUMERS_PRIVATE_KEY: consumers}
-        )
-
-    def on_subscribe(
-        self, task: "CoreTask", *, principal: str, client_ref: str | None
-    ) -> None:
-        if client_ref is None:
-            return
-        entry = f"{principal}:{client_ref}"
-        if entry not in (consumers := self._consumers(task)):
-            self._write_consumers(task, [*consumers, entry])
-
-    def on_unsubscribe(
-        self, task: "CoreTask", *, principal: str, client_ref: str | None
-    ) -> bool:
-        consumers = self._consumers(task)
-        prefix = f"{principal}:"
-        if client_ref is None:
-            # Principal-grain unsubscribe (no tab id): the whole principal is
-            # leaving, so drop ALL of its recorded tab entries. Otherwise a later
-            # status transition would still route to this principal's tab
-            # channels (via routing_channels) after it unsubscribed.
-            remaining = [c for c in consumers if not c.startswith(prefix)]
-        else:
-            entry = f"{principal}:{client_ref}"
-            remaining = [c for c in consumers if c != entry]
-        if remaining != consumers:
-            self._write_consumers(task, remaining)
-        # Proceed to unsubscribe the principal only once it has no tab left on
-        # this task; a surviving tab of the same principal keeps it subscribed.
-        return not any(c.startswith(prefix) for c in remaining)
-
-    def routing_channels(self, task: "CoreTask") -> list[str] | None:
-        # The consumer entries are exactly the per-tab realtime routing keys
-        # (`"<principal>:<tab_id>"`), so a task-status message reaches only the
-        # tabs watching this task. Empty -> None so a chart task with no recorded
-        # tab (all detached, or a no-tab caller) falls back to principal-grain
-        # fanout instead of dropping it.
-        return self._consumers(task) or None
 
 
 def _resolve_user(user_id: int | None, guest_token: "GuestToken | None") -> User:

--- a/superset/tasks/sql_queries.py
+++ b/superset/tasks/sql_queries.py
@@ -49,6 +49,7 @@ from superset.common.db_query_status import QueryStatus
 from superset.tasks.ambient_context import get_context
 from superset.tasks.decorators import task
 from superset.tasks.query_cancel import cancel_chart_query
+from superset.tasks.subscription import PerTabConsumerPolicy
 from superset.utils.core import override_user
 from superset.utils.dates import now_as_float
 
@@ -99,7 +100,11 @@ def _mirror_terminal_status(query: "Query", ctx: "TaskContext") -> None:
     db.session.commit()
 
 
-@task(name=SQL_LAB_TASK, scope=TaskScope.PRIVATE)
+@task(
+    name=SQL_LAB_TASK,
+    scope=TaskScope.PRIVATE,
+    subscription_policy=PerTabConsumerPolicy(),
+)
 def run_sql_lab_query(
     query_id: int,
     rendered_query: str,

--- a/superset/tasks/subscription.py
+++ b/superset/tasks/subscription.py
@@ -24,14 +24,32 @@ stable routing id and the caller's opaque per-client id.
 from __future__ import annotations
 
 import re
+from typing import cast, TYPE_CHECKING
 
 from flask import has_request_context, request
 from superset_core.tasks.subscription import TaskSubscriptionPolicy
 
-__all__ = ["TaskSubscriptionPolicy", "principal_channel", "get_request_tab_id"]
+from superset.tasks.utils import SUBSCRIPTION_PRIVATE_NAMESPACE
+
+if TYPE_CHECKING:
+    from superset_core.tasks.models import Task as CoreTask
+
+    from superset.models.tasks import Task
+
+__all__ = [
+    "TaskSubscriptionPolicy",
+    "PerTabConsumerPolicy",
+    "principal_channel",
+    "get_request_tab_id",
+]
 
 # Body/query key a client uses to advertise its per-tab id on submit and cancel.
 TAB_ID_KEY = "tab_id"
+
+# Key under ``private["subscription"]`` holding the per-tab consumer list a
+# :class:`PerTabConsumerPolicy` maintains.
+CONSUMERS_PRIVATE_KEY = "consumers"
+
 
 # A client-supplied tab id is concatenated into routing keys, private task
 # properties, Redis channels, logs, and URLs. The principal prefix is
@@ -82,3 +100,84 @@ def get_request_tab_id() -> str | None:
             return tab_id
     tab_id = request.args.get(TAB_ID_KEY)
     return tab_id if _is_valid_tab_id(tab_id) else None
+
+
+class PerTabConsumerPolicy(TaskSubscriptionPolicy):
+    """Route a task's ``task.status`` fanout to exactly the browser tabs watching it.
+
+    A reusable subscription policy for any task type whose completion should be
+    delivered to the specific tabs awaiting it rather than to every tab of the
+    principal. It keeps a list of ``"<principal>:<tab_id>"`` entries in the task's
+    ``private["subscription"]`` namespace (policy-owned, debug-gated): on subscribe
+    it adds the calling tab; on unsubscribe it removes the calling tab and reports
+    whether the principal has any tab left, so the framework aborts the task only
+    once the principal's last watching tab is gone; ``routing_channels`` returns
+    those per-tab keys so a status message reaches only those tabs.
+
+    This matters for a ``SHARED`` task deduplicated across tabs/requests (one
+    principal viewing the same work in two tabs is a single subscriber row, so
+    either tab's detach must not abort work the other still awaits) and equally
+    lets a ``PRIVATE`` task deliver completion to just its originating tab. Both
+    hooks run under the submit/cancel lock, so the read-modify-write on the list is
+    race-free against other submits/cancels; the executor, which does not hold that
+    lock, writes the task's properties while it runs, so the list is written
+    through ``TaskDAO.merge_subscription_state`` (a row-locked merge) and the
+    executor's whole-blob writes preserve this namespace (see
+    ``preserve_subscription_state``) rather than replacing it with their pickup-time
+    snapshot.
+
+    A request without a ``tab_id`` (a non-interactive or legacy caller) is a no-op
+    on subscribe and proceeds (principal-grain) on unsubscribe.
+    """
+
+    @staticmethod
+    def _consumers(task: "CoreTask") -> list[str]:
+        private = task.properties_dict.get("private") or {}
+        subscription = private.get(SUBSCRIPTION_PRIVATE_NAMESPACE) or {}
+        consumers = subscription.get(CONSUMERS_PRIVATE_KEY) or []
+        return [entry for entry in consumers if isinstance(entry, str)]
+
+    @staticmethod
+    def _write_consumers(task: "CoreTask", consumers: list[str]) -> None:
+        from superset.daos.tasks import TaskDAO
+
+        TaskDAO.merge_subscription_state(
+            cast("Task", task), {CONSUMERS_PRIVATE_KEY: consumers}
+        )
+
+    def on_subscribe(
+        self, task: "CoreTask", *, principal: str, client_ref: str | None
+    ) -> None:
+        if client_ref is None:
+            return
+        entry = f"{principal}:{client_ref}"
+        if entry not in (consumers := self._consumers(task)):
+            self._write_consumers(task, [*consumers, entry])
+
+    def on_unsubscribe(
+        self, task: "CoreTask", *, principal: str, client_ref: str | None
+    ) -> bool:
+        consumers = self._consumers(task)
+        prefix = f"{principal}:"
+        if client_ref is None:
+            # Principal-grain unsubscribe (no tab id): the whole principal is
+            # leaving, so drop ALL of its recorded tab entries. Otherwise a later
+            # status transition would still route to this principal's tab channels
+            # (via routing_channels) after it unsubscribed.
+            remaining = [c for c in consumers if not c.startswith(prefix)]
+        else:
+            entry = f"{principal}:{client_ref}"
+            remaining = [c for c in consumers if c != entry]
+        if remaining != consumers:
+            self._write_consumers(task, remaining)
+        # Proceed to unsubscribe the principal only once it has no tab left on this
+        # task; a surviving tab of the same principal keeps it subscribed.
+        return not any(c.startswith(prefix) for c in remaining)
+
+    def routing_channels(self, task: "CoreTask") -> list[str] | None:
+        # The consumer entries are exactly the per-tab realtime routing keys
+        # (`"<principal>:<tab_id>"`), so a task-status message reaches only the
+        # tabs watching this task. Empty -> None so a task with no recorded tab
+        # (all detached, or a no-tab caller) falls back to principal-grain fanout
+        # instead of dropping it.
+        return self._consumers(task) or None

--- a/tests/unit_tests/commands/sql_lab/test_execute.py
+++ b/tests/unit_tests/commands/sql_lab/test_execute.py
@@ -239,7 +239,9 @@ def test_prepare_async_requires_gtf(mock_flag: MagicMock, mock_db: MagicMock) ->
 
 
 def test_submit_async_schedules_task_keyed_by_client_id() -> None:
-    """submit_async schedules the GTF task keyed by the browser client_id."""
+    """submit_async schedules the GTF task keyed by the browser client_id and
+    returns the async_job descriptor (task uuid + pre-task cursor; tab_id when the
+    request advertised one)."""
     ctx = MagicMock()
     ctx.select_as_cta = False
     ctx.expand_data = False
@@ -249,11 +251,42 @@ def test_submit_async_schedules_task_keyed_by_client_id() -> None:
     command._pending_async = True
     command._rendered_query = "SELECT 1"
     schedule = patch("superset.tasks.sql_queries.run_sql_lab_query.schedule").start()
+    schedule.return_value.uuid = "task-uuid-9"
     patch(f"{_EXEC}.get_username", return_value="admin").start()
+    # A tab id advertised on the request is echoed into the descriptor.
+    patch(
+        "superset.tasks.subscription.get_request_tab_id", return_value="tab-42"
+    ).start()
     try:
-        command.submit_async()
+        async_job = command.submit_async()
         schedule.assert_called_once()
         assert schedule.call_args.kwargs["options"].task_key == "abc123"
+        assert async_job is not None
+        assert async_job["task_id"] == "task-uuid-9"
+        assert async_job["cursor"]  # ISO-8601 pre-task poll cursor
+        assert async_job["tab_id"] == "tab-42"
+    finally:
+        patch.stopall()
+
+
+def test_submit_async_omits_tab_id_when_absent() -> None:
+    """With no tab id on the request, the async_job descriptor omits tab_id."""
+    ctx = MagicMock()
+    ctx.select_as_cta = False
+    ctx.expand_data = False
+    ctx.query.id = 7
+    ctx.query.client_id = "abc123"
+    command = _make_command(execution_context=ctx)
+    command._pending_async = True
+    command._rendered_query = "SELECT 1"
+    schedule = patch("superset.tasks.sql_queries.run_sql_lab_query.schedule").start()
+    schedule.return_value.uuid = "task-uuid-9"
+    patch(f"{_EXEC}.get_username", return_value="admin").start()
+    patch("superset.tasks.subscription.get_request_tab_id", return_value=None).start()
+    try:
+        async_job = command.submit_async()
+        assert async_job is not None
+        assert "tab_id" not in async_job
     finally:
         patch.stopall()
 
@@ -262,7 +295,7 @@ def test_submit_async_noop_when_not_pending() -> None:
     """submit_async does nothing for a sync command."""
     command = _make_command()
     command._pending_async = False
-    command.submit_async()  # must not raise / schedule
+    assert command.submit_async() is None  # must not raise / schedule
 
 
 @patch(f"{_EXEC}.app")

--- a/tests/unit_tests/tasks/test_subscription.py
+++ b/tests/unit_tests/tasks/test_subscription.py
@@ -14,55 +14,79 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Unit tests for the reusable per-tab task subscription policy."""
+
+from typing import Any, Iterator
+from unittest.mock import patch
 
 import pytest
-from flask import current_app
 
-from superset.tasks.subscription import get_request_tab_id, principal_channel
-
-
-def test_principal_channel_derivation() -> None:
-    assert principal_channel(5, None) == "user:5"
-    assert principal_channel(None, "guest:abc") == "guest:abc"
-    assert principal_channel(None, None) is None
+from superset.tasks.subscription import PerTabConsumerPolicy
 
 
-def test_get_request_tab_id_from_json_body() -> None:
-    with current_app.test_request_context(
-        "/api/v1/chart/data", json={"tab_id": "tab-7"}
+class _FakeTask:
+    """A minimal stand-in exposing ``properties_dict`` for the policy to read."""
+
+    def __init__(self, consumers: list[str] | None = None) -> None:
+        self.properties_dict: dict[str, Any] = {
+            "private": {"subscription": {"consumers": list(consumers or [])}}
+        }
+
+
+@pytest.fixture
+def policy() -> Iterator[PerTabConsumerPolicy]:
+    """A policy whose ``merge_subscription_state`` write mutates the fake in place."""
+
+    def _merge(task: _FakeTask, updates: dict[str, Any]) -> None:
+        task.properties_dict["private"]["subscription"]["consumers"] = updates[
+            "consumers"
+        ]
+
+    with patch(
+        "superset.daos.tasks.TaskDAO.merge_subscription_state", side_effect=_merge
     ):
-        assert get_request_tab_id() == "tab-7"
+        yield PerTabConsumerPolicy()
 
 
-def test_get_request_tab_id_from_query_arg() -> None:
-    with current_app.test_request_context("/api/v1/chart/data?tab_id=tab-7"):
-        assert get_request_tab_id() == "tab-7"
+def test_on_subscribe_records_tab(policy: PerTabConsumerPolicy) -> None:
+    task = _FakeTask()
+    policy.on_subscribe(task, principal="user:1", client_ref="tabA")
+    assert policy.routing_channels(task) == ["user:1:tabA"]
 
 
-def test_get_request_tab_id_none_outside_request_context() -> None:
-    assert get_request_tab_id() is None
+def test_on_subscribe_is_idempotent(policy: PerTabConsumerPolicy) -> None:
+    task = _FakeTask(["user:1:tabA"])
+    policy.on_subscribe(task, principal="user:1", client_ref="tabA")
+    assert policy.routing_channels(task) == ["user:1:tabA"]
 
 
-@pytest.mark.parametrize(
-    "value",
-    [
-        "",  # empty
-        "a" * 65,  # too long
-        "tab id",  # space
-        "tab/../etc",  # path traversal chars
-        "tab:evil",  # colon (would split a routing key)
-        "tab\nid",  # newline
-        "táb",  # non-ascii
-    ],
-)
-def test_get_request_tab_id_rejects_invalid(value: str) -> None:
-    # An out-of-bound/ill-formed tab id is dropped (falls back to principal-grain),
-    # never flowing into routing keys, private props, channels, logs, or URLs.
-    with current_app.test_request_context("/api/v1/chart/data", json={"tab_id": value}):
-        assert get_request_tab_id() is None
+def test_on_subscribe_without_tab_is_noop(policy: PerTabConsumerPolicy) -> None:
+    task = _FakeTask()
+    policy.on_subscribe(task, principal="user:1", client_ref=None)
+    assert policy.routing_channels(task) is None
 
 
-def test_get_request_tab_id_accepts_full_allowed_charset() -> None:
-    value = "Ab9_-" * 12  # 60 chars, within the 64 cap
-    with current_app.test_request_context("/api/v1/chart/data", json={"tab_id": value}):
-        assert get_request_tab_id() == value
+def test_on_unsubscribe_keeps_task_while_a_tab_remains(
+    policy: PerTabConsumerPolicy,
+) -> None:
+    task = _FakeTask(["user:1:tabA", "user:1:tabB"])
+    # tabA leaves but tabB is still watching → do not unsubscribe the principal.
+    assert policy.on_unsubscribe(task, principal="user:1", client_ref="tabA") is False
+    assert policy.routing_channels(task) == ["user:1:tabB"]
+
+
+def test_on_unsubscribe_last_tab_unsubscribes_principal(
+    policy: PerTabConsumerPolicy,
+) -> None:
+    task = _FakeTask(["user:1:tabA"])
+    assert policy.on_unsubscribe(task, principal="user:1", client_ref="tabA") is True
+    assert policy.routing_channels(task) is None
+
+
+def test_on_unsubscribe_without_tab_drops_all_principal_entries(
+    policy: PerTabConsumerPolicy,
+) -> None:
+    task = _FakeTask(["user:1:tabA", "user:1:tabB", "user:2:tabC"])
+    # Principal-grain unsubscribe drops every tab of user:1 but leaves user:2.
+    assert policy.on_unsubscribe(task, principal="user:1", client_ref=None) is True
+    assert policy.routing_channels(task) == ["user:2:tabC"]


### PR DESCRIPTION
### SUMMARY

Child PR 5 of the [SQL execution on GTF epic](https://github.com/apache/superset/pull/43928) (umbrella `villebro/sqllab-gtf`).

Adds a low-latency realtime path for async SQL Lab queries — they settle via the GTF `task.status` websocket push instead of waiting up to 2s for the next `/query/updated_since` poll. The poll is unchanged and remains the correctness backstop; the websocket is a pure accelerator. Progress still rides the poll (`task.status` is terminal-only).

**Generalized per-tab delivery.** Chart-data's per-tab consumer subscription policy (ref-count the browser tabs watching a task and route its terminal `task.status` fanout to exactly those tabs) is extracted into a reusable `PerTabConsumerPolicy` in `superset/tasks/subscription.py`. `ChartQueryConsumerPolicy` becomes a thin subclass (chart-data behavior unchanged), and the SQL Lab task `run_sql_lab_query` registers the shared policy so its completion is delivered only to the originating tab. Any future task type gets tab-isolated delivery for free.

**Task descriptor in the execute 202.** `ExecuteSqlCommand.submit_async` captures a pre-schedule status cursor (the recovery watermark) plus the scheduled task's UUID and returns an `async_job` `{task_id, cursor, tab_id?}`; the `/execute/` endpoint surfaces it in the 202 (`QueryExecutionResponseSchema` extended). The cursor is captured before the task is created so a completion can't slip in ahead of the client's waiter.

**Frontend.** `runQuery` advertises the per-tab id (`getTabId`) on execute so the backend can route the push back, and stores the 202's `async_job.task_id` on the query (new `taskId` field + `SET_QUERY_TASK_ID`). `QueryAutoRefresh` subscribes to the generic `task.status` realtime topic and triggers an immediate refresh when a currently-running query's tracked task reaches a terminal status; `task.status` messages for untracked task ids (e.g. chart-data) are ignored. The 2s poll is untouched as the backstop.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — behavior-preserving latency improvement. With `WEBSOCKET_ENABLE` on, an async query settles on its terminal `task.status` push; with it off (or a missed push), the existing poll still settles it.

### TESTING INSTRUCTIONS

Backend: `pytest tests/unit_tests/tasks/test_subscription.py tests/unit_tests/commands/sql_lab/test_execute.py tests/unit_tests/daos/test_tasks.py`. Frontend: `npm run test -- src/SqlLab/components/QueryAutoRefresh/QueryAutoRefresh.test.tsx src/SqlLab/actions/sqlLab.test.ts`. End-to-end (dev instance with `GLOBAL_TASK_FRAMEWORK` + `WEBSOCKET_ENABLE`): run an async query and confirm it settles promptly via the websocket; disable the websocket and confirm it still settles via the 2s poll.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags: `GLOBAL_TASK_FRAMEWORK` (async SQL Lab execution); `WEBSOCKET_ENABLE` + `WEBSOCKET_URL` for the realtime push (poll fallback otherwise)
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
