### PR TITLE
docs(security): edit-gate version-history and change metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,6 +94,10 @@ Realtime transports, including WebSocket delivery backed by Redis or Valkey Pub/
 
 The realtime notification permission is distinct from the permission to read the underlying object. It controls whether a principal receives push notifications, not whether they may read the object once they call the protected REST API. Existing websocket connections are authorized by the JWT accepted at upgrade time; permission revocation after token minting is bounded by `WEBSOCKET_JWT_EXPIRATION_SECONDS` plus the websocket server's socket-check interval. Redis Streams are internal server-to-server coordination primitives and should not be directly exposed as an end-user subscription surface.
 
+### Version History and Change Metadata
+
+An entity's version history — its change-record activity stream, field-level before/after diffs, and the author identity and timestamps attached to each change — is not part of the base *Read data* capability. Reading it requires **object-level editorship** of the entity (owner, editor, or Admin), the same capability required to restore a version. A principal who can read an entity's current state but is not an editor of it — including an **embedded guest token** and any **view-only** (read-but-not-edit) role — is not entitled to its version history, change metadata, or author identity, and such requests are refused. Related-entity records in a cross-entity activity view remain silently filtered to the reader's own read access. A bug that discloses version history, change-record diffs, or author identity to a principal lacking object-level editorship is in scope.
+
 ### Vulnerability Scope
 
 The test for whether a finding is in scope is a single question:


### PR DESCRIPTION
### SUMMARY

Documents in `SECURITY.md` that an entity's **version history** — its change-record activity stream, field-level before/after diffs, and the author identity and timestamps attached to each change — is **not part of the base *Read data* capability** and requires **object-level editorship** (owner, editor, or Admin), the same capability required to restore a version.

An embedded guest token and any view-only (read-but-not-edit) role is explicitly **not** entitled to version history, change metadata, or author identity. Related-entity records in a cross-entity activity view remain silently filtered to the reader's own read access (AV-008, unchanged).

### Motivation

The role/capability matrix was silent on whether version-history / change metadata is inside guest and view-only entitlement, so reviewers repeatedly re-derived it. The same class surfaced three times: the versioning-UI capstone review's M10 (2026-07-31, guest tokens reading full edit history + editor identities, "the matrix doesn't answer this"), the approval-workflow review, and a QA finding where view-only roles could read full history via the API. This adds the missing row so the boundary is written down once. It documents the model that the server-side enforcement (edit-gating the version/activity endpoints) implements.

### BEFORE/AFTER

N/A — documentation only (adds one subsection to `SECURITY.md`).

### TESTING INSTRUCTIONS

N/A — no code change.

### ADDITIONAL INFORMATION

- [ ] Has associated issue
- [x] Required feature flags: N/A
- [x] Changes UI: no
- [x] Includes DB Migration: no
- [x] Introduces new feature or API: no
- [x] Removes existing feature or API: no

> **Depends on #44021 — merge after.** This paragraph documents the object-level editorship gate that #44021 (SC-120001, per the SC-103156 SIP decision) implements on `/versions/` and `/activity/`, including the explicit guest-principal refusal. At master those endpoints still take the read gate, so this docs change must land after #44021 to avoid describing a gate that is not yet enforced.
