### PR TITLE
feat(ci): restore container image vulnerability scanning with Grype

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,6 +107,12 @@ jobs:
       needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-26.04
     timeout-minutes: 60
+    permissions:
+      contents: read
+      # Required for the vulnerability scan below to upload its SARIF
+      # results to GitHub code scanning (advanced-security is enabled by
+      # default), matching the same grant in github-action-validator.yml.
+      security-events: write
     strategy:
       matrix:
         build_preset: ${{fromJson(needs.setup_matrix.outputs.matrix_config)}}
@@ -212,6 +218,31 @@ jobs:
           echo "IMAGE: $IMAGE_TAG"
           docker images $IMAGE_TAG
           docker history $IMAGE_TAG
+
+      # Scan the built image for known vulnerabilities and publish results
+      # to the Security tab. Trivy did this until #38780 removed it: both
+      # aquasecurity/trivy-action and the trivy binary itself were
+      # compromised (twice) to steal GitHub Secrets from CI runs. Grype is a
+      # different tool from a different maintainer with no shared supply
+      # chain, and is already on the ASF Infra GitHub Actions allowlist.
+      - name: Scan built image for vulnerabilities
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_preset == 'lean'
+        id: grype-scan
+        uses: anchore/scan-action@27805bf3b4e84b4a5c980df22ed233c00390a439 # v7.4.2
+        with:
+          image: ${{ env.IMAGE_TAG }}
+          output-format: sarif
+          severity-cutoff: high
+          only-fixed: true
+          # Informational only, matching the prior Trivy setup: this
+          # workflow does not gate merges on scan findings.
+          fail-build: false
+
+      - name: Upload vulnerability scan results to GitHub Security tab
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_preset == 'lean'
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: ${{ steps.grype-scan.outputs.sarif }}
 
       - name: WebSocket server smoke test
         if: contains(fromJson('["lean", "dev"]'), matrix.build_preset)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -228,6 +228,11 @@ jobs:
       - name: Scan built image for vulnerabilities
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_preset == 'lean'
         id: grype-scan
+        # This step's own failure (e.g. a transient issue pulling the Grype
+        # vulnerability DB) must not fail docker-build, matching the
+        # informational fail-build: false below -- one is findings, the
+        # other is the scan itself not completing.
+        continue-on-error: true
         uses: anchore/scan-action@27805bf3b4e84b4a5c980df22ed233c00390a439 # v7.4.2
         with:
           image: ${{ env.IMAGE_TAG }}
@@ -239,7 +244,10 @@ jobs:
           fail-build: false
 
       - name: Upload vulnerability scan results to GitHub Security tab
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_preset == 'lean'
+        if: >-
+          github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+          matrix.build_preset == 'lean' && steps.grype-scan.outputs.sarif != ''
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}

--- a/scripts/change_detector.py
+++ b/scripts/change_detector.py
@@ -61,6 +61,7 @@ PATTERNS = {
     "docker": [
         r"^Dockerfile$",
         r"^docker.*",
+        r"^\.github/workflows/docker\.yml$",
     ],
     "docs": [
         r"^docs/",

--- a/tests/unit_tests/scripts/change_detector_test.py
+++ b/tests/unit_tests/scripts/change_detector_test.py
@@ -164,3 +164,15 @@ def test_image_tag_compose_changes_trigger_python_tests() -> None:
         ["docker-compose-image-tag.yml"],
         change_detector.PATTERNS["python"],
     )
+
+
+def test_docker_workflow_changes_trigger_docker_build() -> None:
+    """A change to only the docker-build workflow file itself (no
+    Dockerfile/docker-compose/app-code changes) must still be classified as
+    "docker", or docker-build's job-level `if:` skips the job entirely and a
+    broken workflow edit -- including to the vulnerability scan step it
+    runs -- is never actually exercised on merge."""
+    assert change_detector.detect_changes(
+        [".github/workflows/docker.yml"],
+        change_detector.PATTERNS["docker"],
+    )


### PR DESCRIPTION
### SUMMARY
Container image vulnerability scanning has been dark since [#38780](https://github.com/apache/superset/pull/38780) removed `aquasecurity/trivy-action` from `docker.yml`. That removal was the right call: both the Action and the `trivy` binary itself were compromised (twice), per [ASF's incident report](https://news.apache.org/foundation/entry/initial-report-on-trivy-security-incident) and a follow-up [StepSecurity writeup](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release) — the injected code harvested `/proc/*/environ` and process memory for secrets, SSH keys, and cloud credentials, and exfiltrated them. No replacement was put in place, so the `docker.yml:docker-build` code-scanning configuration has been showing as stale/failing in the Security tab ever since (nothing has uploaded results for it in ~6 months).

This PR restores scanning with **Grype** (`anchore/scan-action`) instead of going back to Trivy: a different tool, different maintainer, no shared supply chain with the compromised project. It's already on the [ASF Infra GitHub Actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/actions.yml) (`anchore/scan-action@27805bf3...` / `v7.4.2`), so no new allowlist request is needed — `asf-allowlist-check` should pass as-is.

### CHANGES
- Added a `Scan built image for vulnerabilities` step (Grype, SARIF output) and an `Upload vulnerability scan results to GitHub Security tab` step (`github/codeql-action/upload-sarif`, same pin already used in `codeql-analysis.yml`), gated on the same condition the old Trivy step used (`push` to `master`, `lean` preset only).
- Added `security-events: write`, scoped to just the `docker-build` job, for the SARIF upload — the same grant pattern already used in `github-action-validator.yml` for zizmor's scan.
- `fail-build: false`, matching the prior Trivy config: this stays informational and doesn't gate merges on findings.

### TESTING INSTRUCTIONS
- `action-validator .github/workflows/docker.yml` passes.
- `zizmor .github/workflows/docker.yml` reports no new findings (only 5 pre-existing, unrelated `self-repository` nits on other steps).
- Since this only runs on `push` to `master` with `build_preset == 'lean'`, it won't fire on this PR itself — the way to confirm it after merge is checking that a new Grype-produced analysis shows up under Security → Code scanning for the `docker.yml:docker-build` category.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API