### PR TITLE
fix(security): suppress zizmor self-repository false positive for hive setup-postgres step

### DIFF
--- a/.github/workflows/superset-python-presto-hive.yml
+++ b/.github/workflows/superset-python-presto-hive.yml
@@ -149,7 +149,13 @@ jobs:
       - name: Setup Python
         uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-postgres
       - name: Start Celery worker


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2679 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2679)) on `.github/workflows/superset-python-presto-hive.yml:152`.

The `Setup Postgres` step in the `test-postgres-hive` job references `.github/actions/cached-dependencies` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of the newer `uses: $/...` syntax. The mechanical rewrite doesn't apply here: `cached-dependencies` is a git submodule (see `.gitmodules`), and `$/...` resolves action files directly from the repository tree without performing a real (submodule-aware) checkout, so it can't see past the submodule's gitlink into the actual `action.yml`.

This mirrors the identical, already-suppressed false-positive pattern used for the sibling `cached-dependencies` step in the same job (`Start Celery worker`) and elsewhere in the repo (e.g. `superset-translations.yml`), using the same explanatory comment and `# zizmor: ignore[self-repository]` trailing-comment placement.

Only this one occurrence (line 152, alert #2679) is touched. The file's other `self-repository` finding (the `test-postgres-presto` job's `Start Celery worker` step, alert #2665) is already tracked and addressed by a separate open PR (#43986).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `zizmor .github/workflows/superset-python-presto-hive.yml` no longer reports a live `self-repository` finding for line 152 (now ignored instead of flagged).
- `pre-commit run --files .github/workflows/superset-python-presto-hive.yml` passes, including the `zizmor` hook.
- Workflow runtime behavior is unchanged; only a trailing comment and explanatory comment block were added.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2679

🤖 Generated with [Claude Code](https://claude.com/claude-code)