### PR TITLE
fix(security): suppress zizmor self-repository false positive for postgres setup step

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -164,7 +164,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Postgres
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a git submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's gitlink. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: |
             setup-postgres


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` audit flags the `Setup Postgres` step in `superset-python-integrationtest.yml` for using `uses: ./.github/actions/cached-dependencies` instead of the dedicated `$/...` self-repository syntax.

`cached-dependencies` is a git submodule (see `.gitmodules`), not a plain in-repo directory. GitHub's `$/` self-repository syntax resolves action files directly from the repository tree without a submodule-aware checkout, so it cannot see into a submodule's gitlink — only the workspace-relative `./` form works here. This is a known false positive, and the codebase already suppresses it with the same justification everywhere else this action is referenced (e.g. `superset-python-presto-hive.yml`, `superset-translations.yml`, and sibling steps in this same workflow file).

This PR adds the matching scoped suppression comment for this one occurrence, resolving the alert without changing behavior.

Resolves code-scanning alert #2657: https://github.com/apache/superset/security/code-scanning/2657

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow comment-only change)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes (including the local `zizmor` hook)
- No functional change to the workflow; `test-postgres` CI job continues to run as before

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)