### PR TITLE
fix(deps): cap mcp to <2.0 to match fastmcp 3.x's own constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,11 @@ excel = ["xlrd>=2.0.2, <2.1"]
 excel-export = ["boto3"]
 fastmcp = [
     "fastmcp>=3.4.7,<4.0",
-    "mcp>=1.29.1,<3.0",
+    # fastmcp 3.x itself requires mcp<2.0; the upper bound here was looser
+    # than that until Dependabot proposed mcp 2.1.1 and the resolver caught
+    # the conflict (#43876). Capped to match what fastmcp 3.x actually
+    # supports until this extra moves to fastmcp 4.x, which accepts mcp 2.x.
+    "mcp>=1.29.1,<2.0",
     # tiktoken backs the response-size-guard token estimator. Without
     # it, the middleware falls back to a coarser character-based
     # heuristic that under-counts JSON-heavy MCP responses.


### PR DESCRIPTION
### SUMMARY
`fastmcp` 3.4.7 requires `mcp<2.0`, but this extra's own declared upper bound on `mcp` was looser (`<3.0`), so Dependabot proposed bumping `mcp` to 2.1.1 (#43876), which `uv`'s resolver then rejected as unsatisfiable against `fastmcp`'s own pin. This tightens the bound to match reality so Dependabot stops re-proposing an incompatible bump.

Moving past `mcp` 2.x needs a `fastmcp` 3→4 migration of `superset/mcp_service` first (81 files reference `fastmcp`, likely breaking API changes) — that's tracked as a separate, deliberate effort, not folded into this.

### TESTING INSTRUCTIONS
No behavior change — `requirements/development.txt` already pins `mcp==1.29.1`, well within the new cap, so no lockfile regeneration was needed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API