### PR TITLE
fix(security): use self-repository syntax for setup-backend in postgres job

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -160,7 +160,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Postgres


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2656 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2656)) on `.github/workflows/superset-python-integrationtest.yml:163`.

The `Setup Python` step in the `test-postgres` job references `.github/actions/setup-backend/` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of GitHub's dedicated `uses: $/...` syntax. `setup-backend` is a plain in-repo directory (not a git submodule), so the mechanical rewrite applies cleanly here — same as the already-merged fix for the analogous references in `superset-python-presto-hive.yml` (#43975) and for the `test-sqlite` job's `setup-backend` step in this same workflow (#44018).

The ASF allowlist check (`apache/infrastructure-actions/allowlist-check`) was bumped to `v1.0.1` in #44014, which added `$/` to its recognized local-action prefixes, so this rewrite no longer breaks that required check.

Only this one occurrence (line 163, alert #2656) is touched; the file's other `self-repository` findings on `cached-dependencies` (a submodule, which needs a different, suppression-based fix) are tracked under separate, already-open PRs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `zizmor .github/workflows/superset-python-integrationtest.yml` no longer reports a `self-repository` finding for line 163.
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes, including the `zizmor` hook.
- Workflow runtime behavior is unchanged; `$/...` and `./...` resolve to the same in-repo action content.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2656

🤖 Generated with [Claude Code](https://claude.com/claude-code)