### PR TITLE
fix(security): suppress zizmor self-repository false positive for mysql celery worker step

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -81,7 +81,13 @@ jobs:
         with:
           run: setup-mysql
       - name: Start Celery worker
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a git submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's gitlink. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: celery-worker
       - name: Python integration tests (MySQL)


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert [#2655](https://github.com/apache/superset/security/code-scanning/2655) (zizmor `self-repository`) at `.github/workflows/superset-python-integrationtest.yml:84`.

zizmor's `self-repository` audit suggests replacing local action references like `./.github/actions/foo` with GitHub's `$/.github/actions/foo` self-repository syntax. That works for actions that live as plain directories in this repo, but `.github/actions/cached-dependencies` is a git submodule (see `.gitmodules`) — `$/` resolves action files directly from the repository content without a real, submodule-aware checkout, so it can't see into the submodule's gitlink and the step would fail to resolve the action.

This keeps the workspace-relative `./` form for the "Start Celery worker" step in the `test-mysql` job, with a scoped `zizmor: ignore[self-repository]` suppression and an explanatory comment, matching the pattern already applied and merged for the other `cached-dependencies` references in this same workflow (e.g. #44018, #44038).

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes, including the `zizmor` hook.
- `zizmor .github/workflows/superset-python-integrationtest.yml` no longer flags line 84.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)