### PR TITLE
fix(security): use self-repository syntax for change-detector in integration tests

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### SUMMARY
`.github/workflows/superset-python-integrationtest.yml`'s `changes` job referenced the local `change-detector` composite action with the workspace-relative `uses: ./...` form. zizmor's `self-repository` audit flags this because the `./` form resolves against runtime filesystem state rather than a pinned ref. GitHub's dedicated `$/` self-repository syntax always resolves the action to the exact commit the workflow itself is running at, with no checkout required, and is treated by GitHub as a pinned reference.

This swaps the one flagged `uses: ./.github/actions/change-detector/` to `uses: $/.github/actions/change-detector/`, matching the fix already applied to the equivalent job in other workflows (e.g. #43971, #43961, #43968, #43969).

Resolves code-scanning alert #2652 (https://github.com/apache/superset/security/code-scanning/2652).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow file only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes (zizmor no longer flags the line)
- CI on this PR exercises the `changes` job itself, confirming `$/.github/actions/change-detector/` resolves correctly

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)