### PR TITLE
fix(security): use self-repository syntax for setup-backend in mysql job

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup MySQL
         uses: ./.github/actions/cached-dependencies
         with:


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert [#2653](https://github.com/apache/superset/security/code-scanning/2653) (`zizmor/self-repository`).

The mysql job's "Setup Python" step in `superset-python-integrationtest.yml` referenced the local `setup-backend` action via the workspace-relative `./` form. zizmor flags this because `./`-style `uses:` references aren't eligible for GitHub's "fully pinned" policy enforcement and can, in principle, resolve against files checked out earlier in the run rather than a trusted, pinned reference.

`setup-backend` is a plain directory in this repo (not a submodule), so it can safely switch to GitHub's newer `$/` self-repository syntax, which resolves the action directly from the repository. This matches the fix already applied to the equivalent "Setup Python" step in the postgres (#44040) and sqlite (#44018) jobs of the same workflow.

The neighboring `cached-dependencies` steps are intentionally left on `./`, since that action lives in a git submodule that `$/` cannot resolve into (see the existing suppression comment a few lines below in the same file) — those are tracked by separate, still-open alerts.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (workflow YAML only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes, including the `zizmor` hook.
- CI on this PR will exercise the `test-mysql` job itself, confirming the `$/` reference resolves the action correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)