### PR TITLE
fix(security): suppress zizmor self-repository false positive for mysql setup step

### DIFF
--- a/.github/workflows/superset-python-integrationtest.yml
+++ b/.github/workflows/superset-python-integrationtest.yml
@@ -77,7 +77,13 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
       - name: Setup MySQL
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a git submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's gitlink. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-mysql
       - name: Start Celery worker


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2654 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2654)) flagged on the `Setup MySQL` step in `.github/workflows/superset-python-integrationtest.yml`.

zizmor recommends switching workspace-relative `uses: ./...` action references to GitHub's newer self-repository `uses: $/...` syntax. That's already the repo's default for plain-directory local actions (e.g. `setup-backend`, `change-detector`). However, `.github/actions/cached-dependencies` is a git submodule, and the `$/` syntax resolves action files directly from the repository content without a real, submodule-aware checkout, so it can't see into a submodule's gitlink. Because of that, this codebase has been keeping `./` for `cached-dependencies` specifically, with a scoped `zizmor: ignore[self-repository]` suppression comment explaining why (see the already-merged precedent for the sqlite job in this same file, and other jobs across the repo).

This PR applies that same, already-established pattern to the one remaining unaddressed instance for the MySQL job's `Setup MySQL` step.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow YAML only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-python-integrationtest.yml` passes, including the `zizmor (GHA security audit)` hook.
- Verified locally with `zizmor .github/workflows/superset-python-integrationtest.yml` that the alert for this line is now suppressed (ignored) rather than reported.
- CI for this workflow (`Python-Integration` / MySQL job) should behave identically since the runtime `uses:` value is unchanged.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)