### PR TITLE
fix(drillby): use rowcount in drill-by results table

### DIFF
--- a/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
+++ b/superset-frontend/src/components/Chart/DrillBy/useResultsTableView.tsx
@@ -48,7 +48,7 @@ export const useResultsTableView = (
         <SingleQueryResultPane
           colnames={chartDataResult[0].colnames}
           coltypes={chartDataResult[0].coltypes}
-          rowcount={chartDataResult[0].sql_rowcount}
+          rowcount={chartDataResult[0].rowcount}
           data={chartDataResult[0].data}
           datasourceId={datasourceId}
           isVisible
@@ -72,7 +72,7 @@ export const useResultsTableView = (
               colnames={res.colnames}
               coltypes={res.coltypes}
               data={res.data}
-              rowcount={res.sql_rowcount}
+              rowcount={res.rowcount}
               datasourceId={datasourceId}
               isVisible
               canDownload={canDownload}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fixes row count handling in Drill By results by passing rowcount to SingleQueryResultPane instead of sql_rowcount.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
Before:

https://github.com/user-attachments/assets/5666ffc2-51a4-4cb4-9a1d-d6cf022994ca


After:

https://github.com/user-attachments/assets/08ccfbe4-036a-4a26-ac15-8891d5013011

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
