### PR TITLE
fix(native-filters): clear dependent filter values when a parent filter changes (#44008)

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -24,6 +24,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'spec/helpers/testing-library';
 import { stateWithoutNativeFilters } from 'spec/fixtures/mockStore';
 import { testWithId } from 'src/utils/testUtils';
@@ -1241,4 +1242,124 @@ test('FilterBar with orientation=Vertical renders Vertical layout (sanity counte
   expect(
     screen.queryByRole('img', { name: 'setting' }),
   ).not.toBeInTheDocument();
+});
+
+describe('cascading native filter clear', () => {
+  const parentId = 'NATIVE_FILTER-cascade-country';
+  const childId = 'NATIVE_FILTER-cascade-city';
+
+  function createCascadeState() {
+    const parentFilter = createFilter({
+      id: parentId,
+      name: 'Country',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'country' } }],
+      chartsInScope: [18],
+    });
+    const childFilter = createFilter({
+      id: childId,
+      name: 'City',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'city' } }],
+      cascadeParentIds: [parentId],
+      chartsInScope: [18],
+    });
+    return {
+      ...stateWithoutNativeFilters,
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: true,
+        filterBarOrientation: FilterBarOrientation.Vertical,
+        metadata: {
+          native_filter_configuration: [parentFilter, childFilter],
+          chart_configuration: {},
+        },
+      },
+      dashboardState: {
+        ...stateWithoutNativeFilters.dashboardState,
+        activeTabs: ['ROOT_ID'],
+      },
+      dataMask: {
+        [parentId]: createDataMask(parentId, ['USA'], {
+          filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
+        }),
+        [childId]: createDataMask(childId, ['New York'], {
+          filters: [{ col: 'city', op: 'IN', val: ['New York'] }],
+        }),
+      },
+      nativeFilters: {
+        filters: {
+          [parentId]: parentFilter,
+          [childId]: childFilter,
+        },
+        filtersState: {},
+      },
+    };
+  }
+
+  beforeEach(() => {
+    // Drop any chart/data routes registered by earlier tests in this file so
+    // this suite's static response always wins for the filter queries.
+    fetchMock.removeRoutes();
+    fetchMock.post(
+      'glob:*/api/v1/chart/data',
+      {
+        result: [
+          {
+            data: [{ country: 'USA' }, { country: 'UK' }],
+            colnames: ['country'],
+            coltypes: [1],
+            applied_filters: [],
+          },
+        ],
+      },
+      { name: 'cascade-chart-data' },
+    );
+  });
+
+  test('changing a parent filter value clears the child selection', async () => {
+    // Spy must be created inside the test: earlier tests in this file restore
+    // a shared spy on the same action, which would silently detach this one.
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+
+    const state = createCascadeState();
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Locate the parent (Country) select control via its labeled form item,
+    // then change its value from USA to UK.
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole('combobox');
+    await act(async () => {
+      await userEvent.click(parentSelect);
+    });
+    const ukOption = await screen.findByText('UK');
+    await act(async () => {
+      await userEvent.click(ukOption);
+    });
+
+    // Let the parent change propagate through the filter tree.
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Apply the staged changes. The child (City) must be dispatched with a
+    // cleared value — New York is not a valid city under UK.
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
+    await act(async () => {
+      await userEvent.click(applyBtn);
+    });
+
+    const childCall = updateDataMaskSpy.mock.calls.find(
+      call => call[0] === childId,
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall![1]?.filterState?.value).toEqual(null);
+    expect(childCall![1]?.extraFormData).toEqual({});
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -25,26 +25,26 @@ import {
   userEvent,
   waitFor,
   within,
-} from "spec/helpers/testing-library";
-import { stateWithoutNativeFilters } from "spec/fixtures/mockStore";
-import { testWithId } from "src/utils/testUtils";
-import { Preset, makeApi } from "@superset-ui/core";
+} from 'spec/helpers/testing-library';
+import { stateWithoutNativeFilters } from 'spec/fixtures/mockStore';
+import { testWithId } from 'src/utils/testUtils';
+import { Preset, makeApi } from '@superset-ui/core';
 import {
   TimeFilterPlugin,
   SelectFilterPlugin,
   RangeFilterPlugin,
-} from "src/filters/components";
-import fetchMock from "fetch-mock";
-import { FilterBarOrientation } from "src/dashboard/types";
-import { FILTER_BAR_TEST_ID } from "./utils";
-import FilterBar from ".";
-import { FILTERS_CONFIG_MODAL_TEST_ID } from "../FiltersConfigModal/FiltersConfigModal";
-import * as dataMaskActions from "src/dataMask/actions";
+} from 'src/filters/components';
+import fetchMock from 'fetch-mock';
+import { FilterBarOrientation } from 'src/dashboard/types';
+import { FILTER_BAR_TEST_ID } from './utils';
+import FilterBar from '.';
+import { FILTERS_CONFIG_MODAL_TEST_ID } from '../FiltersConfigModal/FiltersConfigModal';
+import * as dataMaskActions from 'src/dataMask/actions';
 
 jest.useFakeTimers({ advanceTimers: true });
 
-jest.mock("@superset-ui/core", () => ({
-  ...jest.requireActual("@superset-ui/core"),
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
   makeApi: jest.fn(),
 }));
 
@@ -54,11 +54,11 @@ const mockedMakeApi = makeApi as jest.Mock;
 class MainPreset extends Preset {
   constructor() {
     super({
-      name: "Legacy charts",
+      name: 'Legacy charts',
       plugins: [
-        new TimeFilterPlugin().configure({ key: "filter_time" }),
-        new SelectFilterPlugin().configure({ key: "filter_select" }),
-        new RangeFilterPlugin().configure({ key: "filter_range" }),
+        new TimeFilterPlugin().configure({ key: 'filter_time' }),
+        new SelectFilterPlugin().configure({ key: 'filter_select' }),
+        new RangeFilterPlugin().configure({ key: 'filter_range' }),
       ],
     });
   }
@@ -66,17 +66,17 @@ class MainPreset extends Preset {
 
 new MainPreset().register();
 
-fetchMock.get("glob:*/api/v1/dataset/7", {
+fetchMock.get('glob:*/api/v1/dataset/7', {
   description_columns: {},
   id: 1,
-  label_columns: { columns: "Columns", table_name: "Table Name" },
+  label_columns: { columns: 'Columns', table_name: 'Table Name' },
   result: {
     metrics: [],
-    columns: [{ column_name: "Column A", id: 1 }],
-    table_name: "birth_names",
+    columns: [{ column_name: 'Column A', id: 1 }],
+    table_name: 'birth_names',
     id: 1,
   },
-  show_columns: ["id", "table_name"],
+  show_columns: ['id', 'table_name'],
 });
 
 // Cleanup between tests
@@ -95,8 +95,8 @@ function createOpenedBarProps(toggleFiltersBar = jest.fn()) {
   return { filtersOpen: true, toggleFiltersBar };
 }
 
-function createMockApi(filterName = "Time filter 1") {
-  return jest.fn(async (data) => {
+function createMockApi(filterName = 'Time filter 1') {
+  return jest.fn(async data => {
     if (!data?.modified?.length) {
       return { id: 1234, result: [] };
     }
@@ -107,12 +107,12 @@ function createMockApi(filterName = "Time filter 1") {
         {
           id: filterId,
           name: filterName,
-          filterType: "filter_time",
-          targets: [{ datasetId: 11, column: { name: "color" } }],
+          filterType: 'filter_time',
+          targets: [{ datasetId: 11, column: { name: 'color' } }],
           defaultDataMask: { filterState: { value: null } },
           controlValues: {},
           cascadeParentIds: [],
-          scope: { rootPath: ["ROOT_ID"], excluded: [] },
+          scope: { rootPath: ['ROOT_ID'], excluded: [] },
         },
       ],
     };
@@ -120,18 +120,18 @@ function createMockApi(filterName = "Time filter 1") {
 }
 
 function createFilter(overrides: Record<string, unknown> = {}) {
-  const id = (overrides.id as string) || "test-filter";
+  const id = (overrides.id as string) || 'test-filter';
   return {
     id,
-    name: "Test Filter",
-    filterType: "filter_select",
-    targets: [{ datasetId: 1, column: { name: "test_column" } }],
+    name: 'Test Filter',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 1, column: { name: 'test_column' } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     controlValues: {},
     cascadeParentIds: [],
-    scope: { rootPath: ["ROOT_ID"], excluded: [] },
-    type: "NATIVE_FILTER",
-    description: "",
+    scope: { rootPath: ['ROOT_ID'], excluded: [] },
+    type: 'NATIVE_FILTER',
+    description: '',
     chartsInScope: [],
     tabsInScope: [],
     ...overrides,
@@ -152,11 +152,11 @@ function createDataMask(
 
 function createDivider(overrides: Record<string, unknown> = {}) {
   return {
-    id: "NATIVE_FILTER_DIVIDER-1",
-    type: "DIVIDER",
-    scope: { rootPath: ["ROOT_ID"], excluded: [] },
-    title: "Select time range",
-    description: "Select year/month etc..",
+    id: 'NATIVE_FILTER_DIVIDER-1',
+    type: 'DIVIDER',
+    scope: { rootPath: ['ROOT_ID'], excluded: [] },
+    title: 'Select time range',
+    description: 'Select year/month etc..',
     chartsInScope: [],
     tabsInScope: [],
     ...overrides,
@@ -180,7 +180,7 @@ function createStateWithFilter(
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: { [filter.id]: dataMask },
     nativeFilters: {
@@ -192,15 +192,15 @@ function createStateWithFilter(
 
 function setupTimeRangeMocks() {
   const urls = {
-    noFilter: "glob:*/api/v1/time_range/?q=%27No%20filter%27",
-    lastDay: "glob:*/api/v1/time_range/?q=%27Last%20day%27",
-    lastWeek: "glob:*/api/v1/time_range/?q=%27Last%20week%27",
+    noFilter: 'glob:*/api/v1/time_range/?q=%27No%20filter%27',
+    lastDay: 'glob:*/api/v1/time_range/?q=%27Last%20day%27',
+    lastWeek: 'glob:*/api/v1/time_range/?q=%27Last%20week%27',
   };
 
   fetchMock.removeRoute(urls.noFilter);
   fetchMock.get(
     urls.noFilter,
-    { result: { since: "", until: "", timeRange: "No filter" } },
+    { result: { since: '', until: '', timeRange: 'No filter' } },
     { name: urls.noFilter },
   );
 
@@ -209,9 +209,9 @@ function setupTimeRangeMocks() {
     urls.lastDay,
     {
       result: {
-        since: "2021-04-13T00:00:00",
-        until: "2021-04-14T00:00:00",
-        timeRange: "Last day",
+        since: '2021-04-13T00:00:00',
+        until: '2021-04-14T00:00:00',
+        timeRange: 'Last day',
       },
     },
     { name: urls.lastDay },
@@ -222,9 +222,9 @@ function setupTimeRangeMocks() {
     urls.lastWeek,
     {
       result: {
-        since: "2021-04-07T00:00:00",
-        until: "2021-04-14T00:00:00",
-        timeRange: "Last week",
+        since: '2021-04-07T00:00:00',
+        until: '2021-04-14T00:00:00',
+        timeRange: 'Last week',
       },
     },
     { name: urls.lastWeek },
@@ -254,7 +254,7 @@ function renderFilterBar(
   );
 }
 
-test("FilterBar renders without crashing", () => {
+test('FilterBar renders without crashing', () => {
   const props = createClosedBarProps();
   const { container } = renderFilterBar(props);
   expect(container).toBeInTheDocument();
@@ -263,60 +263,60 @@ test("FilterBar renders without crashing", () => {
 test('FilterBar renders "Filters and controls" heading', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
 });
 
 test('FilterBar renders "Clear all" button', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText("Clear all")).toBeInTheDocument();
+  expect(screen.getByText('Clear all')).toBeInTheDocument();
 });
 
 test('FilterBar renders "Apply filters" button', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText("Apply filters")).toBeInTheDocument();
+  expect(screen.getByText('Apply filters')).toBeInTheDocument();
 });
 
-test("FilterBar renders collapse icon", () => {
+test('FilterBar renders collapse icon', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
   expect(
-    screen.getByRole("img", { name: "vertical-align" }),
+    screen.getByRole('img', { name: 'vertical-align' }),
   ).toBeInTheDocument();
 });
 
-test("FilterBar renders filter icon", () => {
+test('FilterBar renders filter icon', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByRole("img", { name: "filter" })).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'filter' })).toBeInTheDocument();
 });
 
-test("FilterBar calls toggleFiltersBar when collapse icon is clicked", () => {
+test('FilterBar calls toggleFiltersBar when collapse icon is clicked', () => {
   const toggleFiltersBar = jest.fn();
   const props = createClosedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  const collapse = screen.getByRole("img", { name: "vertical-align" });
+  const collapse = screen.getByRole('img', { name: 'vertical-align' });
   expect(toggleFiltersBar).not.toHaveBeenCalled();
 
   userEvent.click(collapse);
   expect(toggleFiltersBar).toHaveBeenCalled();
 });
 
-test("FilterBar opens when expand button is clicked", () => {
+test('FilterBar opens when expand button is clicked', () => {
   const toggleFiltersBar = jest.fn();
   const props = createClosedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
-  expect(screen.getByTestId(getTestId("expand-button"))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('expand-button'))).toBeInTheDocument();
 
-  userEvent.click(screen.getByTestId(getTestId("collapsable")));
+  userEvent.click(screen.getByTestId(getTestId('collapsable')));
   expect(toggleFiltersBar).toHaveBeenCalledWith(true);
 });
 
-test("FilterBar hides edit filter button when user lacks permissions", () => {
+test('FilterBar hides edit filter button when user lacks permissions', () => {
   const props = createOpenedBarProps();
   const stateWithoutPermissions = {
     ...stateWithoutNativeFilters,
@@ -326,31 +326,31 @@ test("FilterBar hides edit filter button when user lacks permissions", () => {
   renderFilterBar(props, stateWithoutPermissions);
 
   expect(
-    screen.queryByTestId(getTestId("create-filter")),
+    screen.queryByTestId(getTestId('create-filter')),
   ).not.toBeInTheDocument();
 });
 
-test("FilterBar closes when collapse button is clicked", () => {
+test('FilterBar closes when collapse button is clicked', () => {
   const toggleFiltersBar = jest.fn();
   const props = createOpenedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  const collapseButton = screen.getByTestId(getTestId("collapse-button"));
+  const collapseButton = screen.getByTestId(getTestId('collapse-button'));
   expect(collapseButton).toBeInTheDocument();
 
   userEvent.click(collapseButton);
   expect(toggleFiltersBar).toHaveBeenCalledWith(false);
 });
 
-test("FilterBar disables buttons when there are no filters", () => {
+test('FilterBar disables buttons when there are no filters', () => {
   const props = createOpenedBarProps();
   renderFilterBar(props, stateWithoutNativeFilters);
 
-  expect(screen.getByTestId(getTestId("clear-button"))).toBeDisabled();
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 });
 
-test("FilterBar renders dividers with title and description", async () => {
+test('FilterBar renders dividers with title and description', async () => {
   const props = createOpenedBarProps();
   const divider = createDivider();
   const stateWithDivider = {
@@ -373,64 +373,64 @@ test("FilterBar renders dividers with title and description", async () => {
     jest.advanceTimersByTime(1000);
   });
 
-  const title = await screen.findByText("Select time range");
-  const description = await screen.findByText("Select year/month etc..");
+  const title = await screen.findByText('Select time range');
+  const description = await screen.findByText('Select year/month etc..');
 
-  expect(title.tagName).toBe("H3");
-  expect(description.tagName).toBe("P");
-  expect(screen.getByTestId(getTestId("clear-button"))).toBeDisabled();
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(title.tagName).toBe('H3');
+  expect(description.tagName).toBe('P');
+  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 });
 
-test("FilterBar apply button is disabled after creating a filter", async () => {
+test('FilterBar apply button is disabled after creating a filter', async () => {
   setupTimeRangeMocks();
   mockedMakeApi.mockReturnValue(createMockApi());
 
   const props = createOpenedBarProps();
   renderFilterBar(props, stateWithoutNativeFilters);
 
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 
   // Simulate add filter flow
-  userEvent.click(screen.getByTestId(getTestId("collapsable")));
-  userEvent.click(screen.getByLabelText("setting"));
-  userEvent.click(screen.getByText("Add or edit filters and controls"));
+  userEvent.click(screen.getByTestId(getTestId('collapsable')));
+  userEvent.click(screen.getByLabelText('setting'));
+  userEvent.click(screen.getByText('Add or edit filters and controls'));
 
   // First add a filter via the dropdown (modal now shows empty state by default)
-  const dropdownButton = screen.getByTestId("new-item-dropdown-button");
+  const dropdownButton = screen.getByTestId('new-item-dropdown-button');
   fireEvent.mouseEnter(dropdownButton);
-  const addFilterMenuItem = await screen.findByRole("menuitem", {
+  const addFilterMenuItem = await screen.findByRole('menuitem', {
     name: /add filter/i,
   });
   fireEvent.click(addFilterMenuItem);
 
-  userEvent.click(screen.getByText("Value"));
-  userEvent.click(screen.getByText("Time range"));
+  userEvent.click(screen.getByText('Value'));
+  userEvent.click(screen.getByText('Time range'));
   userEvent.type(
-    screen.getByTestId(getModalTestId("name-input")),
-    "Time filter 1",
+    screen.getByTestId(getModalTestId('name-input')),
+    'Time filter 1',
   );
-  userEvent.click(screen.getByText("Save"));
+  userEvent.click(screen.getByText('Save'));
 
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 });
 
-test("FilterBar renders without errors when filter has required controlValues", () => {
+test('FilterBar renders without errors when filter has required controlValues', () => {
   const props = createOpenedBarProps();
   const filter = createFilter({
-    id: "test-filter",
+    id: 'test-filter',
     controlValues: { enableEmptyFilter: true },
   });
-  const dataMask = createDataMask("test-filter", undefined, {});
+  const dataMask = createDataMask('test-filter', undefined, {});
   const state = createStateWithFilter(filter, dataMask);
 
   const { container } = renderFilterBar(props, state);
   expect(container).toBeInTheDocument();
 });
 
-test("FilterBar does not crash when filter has value but empty extraFormData", async () => {
-  const filterId = "test-filter-auto-apply";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+test('FilterBar does not crash when filter has value but empty extraFormData', async () => {
+  const filterId = 'test-filter-auto-apply';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const props = createOpenedBarProps();
 
   const filter = createFilter({
@@ -438,12 +438,12 @@ test("FilterBar does not crash when filter has value but empty extraFormData", a
     requiredFirst: true,
     controlValues: { enableEmptyFilter: true },
     defaultDataMask: {
-      filterState: { value: ["value1"] },
+      filterState: { value: ['value1'] },
       extraFormData: {},
     },
   });
 
-  const dataMask = createDataMask(filterId, ["value1"], {});
+  const dataMask = createDataMask(filterId, ['value1'], {});
   const state = createStateWithFilter(filter, dataMask);
 
   renderFilterBar(props, state);
@@ -452,8 +452,8 @@ test("FilterBar does not crash when filter has value but empty extraFormData", a
     jest.advanceTimersByTime(300);
   });
 
-  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
-  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
 
   // The filter value should not be cleared during initialization
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
@@ -461,21 +461,21 @@ test("FilterBar does not crash when filter has value but empty extraFormData", a
   updateDataMaskSpy.mockRestore();
 });
 
-test("FilterBar renders correctly when filter has complete extraFormData", async () => {
-  const filterId = "test-filter-complete";
+test('FilterBar renders correctly when filter has complete extraFormData', async () => {
+  const filterId = 'test-filter-complete';
   const props = createOpenedBarProps();
   const filter = createFilter({
     id: filterId,
     controlValues: { enableEmptyFilter: true },
     defaultDataMask: {
-      filterState: { value: ["value1"] },
+      filterState: { value: ['value1'] },
       extraFormData: {
-        filters: [{ col: "test_column", op: "IN", val: ["value1"] }],
+        filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
       },
     },
   });
-  const dataMask = createDataMask(filterId, ["value1"], {
-    filters: [{ col: "test_column", op: "IN", val: ["value1"] }],
+  const dataMask = createDataMask(filterId, ['value1'], {
+    filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
   });
   const state = createStateWithFilter(filter, dataMask);
 
@@ -485,17 +485,17 @@ test("FilterBar renders correctly when filter has complete extraFormData", async
     jest.advanceTimersByTime(100);
   });
 
-  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
 });
 
-test("Clear All stages filter_select clear without dispatching until Apply", async () => {
-  const filterId = "NATIVE_FILTER-clear-select";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+test('Clear All stages filter_select clear without dispatching until Apply', async () => {
+  const filterId = 'NATIVE_FILTER-clear-select';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const selectFilter = createFilter({
     id: filterId,
-    name: "Region",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "region" } }],
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     chartsInScope: [18],
   });
@@ -512,11 +512,11 @@ test("Clear All stages filter_select clear without dispatching until Apply", asy
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ["East"], {
-        filters: [{ col: "region", op: "IN", val: ["East"] }],
+      [filterId]: createDataMask(filterId, ['East'], {
+        filters: [{ col: 'region', op: 'IN', val: ['East'] }],
       }),
     },
     nativeFilters: {
@@ -531,7 +531,7 @@ test("Clear All stages filter_select clear without dispatching until Apply", asy
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId("clear-button"));
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -541,7 +541,7 @@ test("Clear All stages filter_select clear without dispatching until Apply", asy
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
   // Apply commits the staged clear
-  const applyBtn = screen.getByTestId(getTestId("apply-button"));
+  const applyBtn = screen.getByTestId(getTestId('apply-button'));
   expect(applyBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(applyBtn);
@@ -554,17 +554,17 @@ test("Clear All stages filter_select clear without dispatching until Apply", asy
   updateDataMaskSpy.mockRestore();
 });
 
-test("Clear All stages filter_range clear with [null, null], dispatched on Apply", async () => {
-  fetchMock.post("glob:*/api/v1/chart/data", {
+test('Clear All stages filter_range clear with [null, null], dispatched on Apply', async () => {
+  fetchMock.post('glob:*/api/v1/chart/data', {
     result: [{ data: [{ min: 0, max: 100 }] }],
   });
-  const filterId = "NATIVE_FILTER-clear-range";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+  const filterId = 'NATIVE_FILTER-clear-range';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const rangeFilter = createFilter({
     id: filterId,
-    name: "Age",
-    filterType: "filter_range",
-    targets: [{ datasetId: 7, column: { name: "age" } }],
+    name: 'Age',
+    filterType: 'filter_range',
+    targets: [{ datasetId: 7, column: { name: 'age' } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     chartsInScope: [18],
   });
@@ -581,11 +581,11 @@ test("Clear All stages filter_range clear with [null, null], dispatched on Apply
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: {
       [filterId]: createDataMask(filterId, [10, 50], {
-        filters: [{ col: "age", op: ">=", val: 10 }],
+        filters: [{ col: 'age', op: '>=', val: 10 }],
       }),
     },
     nativeFilters: {
@@ -600,7 +600,7 @@ test("Clear All stages filter_range clear with [null, null], dispatched on Apply
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId("clear-button"));
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -608,7 +608,7 @@ test("Clear All stages filter_range clear with [null, null], dispatched on Apply
 
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
-  const applyBtn = screen.getByTestId(getTestId("apply-button"));
+  const applyBtn = screen.getByTestId(getTestId('apply-button'));
   await act(async () => {
     userEvent.click(applyBtn);
   });
@@ -620,22 +620,22 @@ test("Clear All stages filter_range clear with [null, null], dispatched on Apply
   updateDataMaskSpy.mockRestore();
 });
 
-test("Clear All + Apply only dispatches for filters present in dataMask", async () => {
-  const idInMask = "NATIVE_FILTER-has-value";
-  const idNotInMask = "NATIVE_FILTER-no-value";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+test('Clear All + Apply only dispatches for filters present in dataMask', async () => {
+  const idInMask = 'NATIVE_FILTER-has-value';
+  const idNotInMask = 'NATIVE_FILTER-no-value';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const filterInMask = createFilter({
     id: idInMask,
-    name: "A",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "x" } }],
+    name: 'A',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'x' } }],
     chartsInScope: [18],
   });
   const filterNotInMask = createFilter({
     id: idNotInMask,
-    name: "B",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "x" } }],
+    name: 'B',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'x' } }],
     chartsInScope: [18],
   });
   const stateWithTwoFilters = {
@@ -651,11 +651,11 @@ test("Clear All + Apply only dispatches for filters present in dataMask", async 
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: {
-      [idInMask]: createDataMask(idInMask, ["v"], {
-        filters: [{ col: "x", op: "IN", val: ["v"] }],
+      [idInMask]: createDataMask(idInMask, ['v'], {
+        filters: [{ col: 'x', op: 'IN', val: ['v'] }],
       }),
     },
     nativeFilters: {
@@ -673,13 +673,13 @@ test("Clear All + Apply only dispatches for filters present in dataMask", async 
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId("clear-button"));
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
   await act(async () => {
     userEvent.click(clearBtn);
   });
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
-  const applyBtn = screen.getByTestId(getTestId("apply-button"));
+  const applyBtn = screen.getByTestId(getTestId('apply-button'));
   await act(async () => {
     userEvent.click(applyBtn);
   });
@@ -692,31 +692,31 @@ test("Clear All + Apply only dispatches for filters present in dataMask", async 
   updateDataMaskSpy.mockRestore();
 });
 
-test("Clear All in horizontal bar does not re-apply default values", async () => {
+test('Clear All in horizontal bar does not re-apply default values', async () => {
   fetchMock.post(
-    "glob:*/api/v1/chart/data",
+    'glob:*/api/v1/chart/data',
     {
       result: [
         {
-          data: [{ test_column: "East" }, { test_column: "West" }],
-          colnames: ["test_column"],
+          data: [{ test_column: 'East' }, { test_column: 'West' }],
+          colnames: ['test_column'],
           coltypes: [1],
         },
       ],
     },
-    { name: "horizontal-clear-chart-data" },
+    { name: 'horizontal-clear-chart-data' },
   );
-  const filterId = "NATIVE_FILTER-horizontal-default";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+  const filterId = 'NATIVE_FILTER-horizontal-default';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const filterWithDefault = createFilter({
     id: filterId,
-    name: "Region",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "test_column" } }],
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'test_column' } }],
     defaultDataMask: {
-      filterState: { value: ["East"] },
+      filterState: { value: ['East'] },
       extraFormData: {
-        filters: [{ col: "test_column", op: "IN", val: ["East"] }],
+        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
       },
     },
     chartsInScope: [18],
@@ -734,11 +734,11 @@ test("Clear All in horizontal bar does not re-apply default values", async () =>
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ["East"], {
-        filters: [{ col: "test_column", op: "IN", val: ["East"] }],
+      [filterId]: createDataMask(filterId, ['East'], {
+        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
       }),
     },
     nativeFilters: {
@@ -757,7 +757,7 @@ test("Clear All in horizontal bar does not re-apply default values", async () =>
     jest.advanceTimersByTime(1000);
   });
 
-  const clearBtn = screen.getByTestId(getTestId("clear-button"));
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -770,78 +770,78 @@ test("Clear All in horizontal bar does not re-apply default values", async () =>
   // The staged clear must survive the trigger completing: the default value
   // must not be re-applied and Apply must stay enabled
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
-  expect(screen.queryByTitle("East")).not.toBeInTheDocument();
-  expect(screen.getByTestId(getTestId("apply-button"))).not.toBeDisabled();
+  expect(screen.queryByTitle('East')).not.toBeInTheDocument();
+  expect(screen.getByTestId(getTestId('apply-button'))).not.toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
 
-test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", async () => {
-  const inScopeFilterId = "NATIVE_FILTER-in-scope";
-  const outOfScopeRequiredFilterId = "NATIVE_FILTER-out-of-scope-required";
+test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', async () => {
+  const inScopeFilterId = 'NATIVE_FILTER-in-scope';
+  const outOfScopeRequiredFilterId = 'NATIVE_FILTER-out-of-scope-required';
   const outOfScopeNonRequiredFilterId =
-    "NATIVE_FILTER-out-of-scope-non-required";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+    'NATIVE_FILTER-out-of-scope-non-required';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
 
   const dashboardLayoutWithTabs = {
-    ROOT_ID: { id: "ROOT_ID", type: "ROOT", children: ["TABS-1"] },
-    "TABS-1": {
-      id: "TABS-1",
-      type: "TABS",
-      children: ["TAB-active", "TAB-inactive"],
+    ROOT_ID: { id: 'ROOT_ID', type: 'ROOT', children: ['TABS-1'] },
+    'TABS-1': {
+      id: 'TABS-1',
+      type: 'TABS',
+      children: ['TAB-active', 'TAB-inactive'],
     },
-    "TAB-active": {
-      id: "TAB-active",
-      type: "TAB",
-      children: ["CHART_ROW-1"],
-      meta: { text: "Active Tab" },
-      parents: ["ROOT_ID", "TABS-1"],
+    'TAB-active': {
+      id: 'TAB-active',
+      type: 'TAB',
+      children: ['CHART_ROW-1'],
+      meta: { text: 'Active Tab' },
+      parents: ['ROOT_ID', 'TABS-1'],
     },
-    "TAB-inactive": {
-      id: "TAB-inactive",
-      type: "TAB",
-      children: ["CHART_ROW-2"],
-      meta: { text: "Inactive Tab" },
-      parents: ["ROOT_ID", "TABS-1"],
+    'TAB-inactive': {
+      id: 'TAB-inactive',
+      type: 'TAB',
+      children: ['CHART_ROW-2'],
+      meta: { text: 'Inactive Tab' },
+      parents: ['ROOT_ID', 'TABS-1'],
     },
-    "CHART_ROW-1": {
-      id: "CHART_ROW-1",
-      type: "CHART",
+    'CHART_ROW-1': {
+      id: 'CHART_ROW-1',
+      type: 'CHART',
       meta: { chartId: 1 },
-      parents: ["ROOT_ID", "TABS-1", "TAB-active"],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-active'],
     },
-    "CHART_ROW-2": {
-      id: "CHART_ROW-2",
-      type: "CHART",
+    'CHART_ROW-2': {
+      id: 'CHART_ROW-2',
+      type: 'CHART',
       meta: { chartId: 2 },
-      parents: ["ROOT_ID", "TABS-1", "TAB-inactive"],
+      parents: ['ROOT_ID', 'TABS-1', 'TAB-inactive'],
     },
   };
 
   const inScopeFilter = createFilter({
     id: inScopeFilterId,
-    name: "In Scope Filter",
-    targets: [{ datasetId: 1, column: { name: "column1" } }],
+    name: 'In Scope Filter',
+    targets: [{ datasetId: 1, column: { name: 'column1' } }],
     controlValues: { enableEmptyFilter: false },
     chartsInScope: [1],
-    tabsInScope: ["TAB-active"],
+    tabsInScope: ['TAB-active'],
   });
 
   const outOfScopeRequiredFilter = createFilter({
     id: outOfScopeRequiredFilterId,
-    name: "Out of Scope Required Filter",
-    targets: [{ datasetId: 1, column: { name: "column2" } }],
+    name: 'Out of Scope Required Filter',
+    targets: [{ datasetId: 1, column: { name: 'column2' } }],
     controlValues: { enableEmptyFilter: true },
     chartsInScope: [2],
-    tabsInScope: ["TAB-inactive"],
+    tabsInScope: ['TAB-inactive'],
   });
 
   const outOfScopeNonRequiredFilter = createFilter({
     id: outOfScopeNonRequiredFilterId,
-    name: "Out of Scope Non-Required Filter",
-    targets: [{ datasetId: 1, column: { name: "column3" } }],
+    name: 'Out of Scope Non-Required Filter',
+    targets: [{ datasetId: 1, column: { name: 'column3' } }],
     controlValues: { enableEmptyFilter: false },
     chartsInScope: [2],
-    tabsInScope: ["TAB-inactive"],
+    tabsInScope: ['TAB-inactive'],
   });
 
   const stateWithTabsAndFilters = {
@@ -853,7 +853,7 @@ test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", 
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["TAB-active"],
+      activeTabs: ['TAB-active'],
     },
     dashboardInfo: {
       id: 1,
@@ -867,18 +867,18 @@ test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", 
       },
     },
     dataMask: {
-      [inScopeFilterId]: createDataMask(inScopeFilterId, ["value1"], {
-        filters: [{ col: "column1", op: "IN", val: ["value1"] }],
+      [inScopeFilterId]: createDataMask(inScopeFilterId, ['value1'], {
+        filters: [{ col: 'column1', op: 'IN', val: ['value1'] }],
       }),
       [outOfScopeRequiredFilterId]: createDataMask(
         outOfScopeRequiredFilterId,
-        ["value2"],
-        { filters: [{ col: "column2", op: "IN", val: ["value2"] }] },
+        ['value2'],
+        { filters: [{ col: 'column2', op: 'IN', val: ['value2'] }] },
       ),
       [outOfScopeNonRequiredFilterId]: createDataMask(
         outOfScopeNonRequiredFilterId,
-        ["value3"],
-        { filters: [{ col: "column3", op: "IN", val: ["value3"] }] },
+        ['value3'],
+        { filters: [{ col: 'column3', op: 'IN', val: ['value3'] }] },
       ),
     },
     nativeFilters: {
@@ -898,7 +898,7 @@ test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", 
     jest.advanceTimersByTime(300);
   });
 
-  const clearButton = screen.getByTestId(getTestId("clear-button"));
+  const clearButton = screen.getByTestId(getTestId('clear-button'));
   expect(clearButton).toBeInTheDocument();
 
   await act(async () => {
@@ -908,7 +908,7 @@ test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", 
 
   // After Apply: only the in-scope filter was cleared. Out-of-scope filters
   // retain their original values (Apply re-dispatches them unchanged).
-  const applyButton = screen.getByTestId(getTestId("apply-button"));
+  const applyButton = screen.getByTestId(getTestId('apply-button'));
   await act(async () => {
     userEvent.click(applyButton);
   });
@@ -921,27 +921,27 @@ test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", 
 
   // Out-of-scope filters keep their existing values; not cleared
   const outOfScopeRequiredCall = updateDataMaskSpy.mock.calls.find(
-    (call) => call[0] === outOfScopeRequiredFilterId,
+    call => call[0] === outOfScopeRequiredFilterId,
   );
-  expect(outOfScopeRequiredCall?.[1]?.filterState?.value).toEqual(["value2"]);
+  expect(outOfScopeRequiredCall?.[1]?.filterState?.value).toEqual(['value2']);
   const outOfScopeNonRequiredCall = updateDataMaskSpy.mock.calls.find(
-    (call) => call[0] === outOfScopeNonRequiredFilterId,
+    call => call[0] === outOfScopeNonRequiredFilterId,
   );
   expect(outOfScopeNonRequiredCall?.[1]?.filterState?.value).toEqual([
-    "value3",
+    'value3',
   ]);
 
   updateDataMaskSpy.mockRestore();
 });
 
-test("Clear All on a required filter disables Apply via validateStatus", async () => {
-  const filterId = "NATIVE_FILTER-required-clear";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+test('Clear All on a required filter disables Apply via validateStatus', async () => {
+  const filterId = 'NATIVE_FILTER-required-clear';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
   const requiredFilter = createFilter({
     id: filterId,
-    name: "Required Region",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "region" } }],
+    name: 'Required Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
     controlValues: { enableEmptyFilter: true },
     chartsInScope: [18],
   });
@@ -958,11 +958,11 @@ test("Clear All on a required filter disables Apply via validateStatus", async (
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ["East"], {
-        filters: [{ col: "region", op: "IN", val: ["East"] }],
+      [filterId]: createDataMask(filterId, ['East'], {
+        filters: [{ col: 'region', op: 'IN', val: ['East'] }],
       }),
     },
     nativeFilters: {
@@ -977,24 +977,24 @@ test("Clear All on a required filter disables Apply via validateStatus", async (
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId("clear-button"));
+  const clearBtn = screen.getByTestId(getTestId('clear-button'));
   await act(async () => {
     userEvent.click(clearBtn);
   });
 
   // No dispatch yet; Apply should be disabled because the required filter is empty
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
 
-test("FilterBar renders the configured filter name in the bar", async () => {
-  const filterId = "NATIVE_FILTER-name-render";
+test('FilterBar renders the configured filter name in the bar', async () => {
+  const filterId = 'NATIVE_FILTER-name-render';
   const filter = createFilter({
     id: filterId,
-    name: "Region",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "region" } }],
+    name: 'Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
     chartsInScope: [18],
   });
   const state = {
@@ -1010,7 +1010,7 @@ test("FilterBar renders the configured filter name in the bar", async () => {
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     dataMask: { [filterId]: createDataMask(filterId, undefined, {}) },
     nativeFilters: {
@@ -1025,7 +1025,7 @@ test("FilterBar renders the configured filter name in the bar", async () => {
     jest.advanceTimersByTime(300);
   });
 
-  expect(await screen.findByText("Region")).toBeInTheDocument();
+  expect(await screen.findByText('Region')).toBeInTheDocument();
 });
 
 test('Clicking the gear "Add or edit filters and controls" item opens the FiltersConfigModal', async () => {
@@ -1035,18 +1035,18 @@ test('Clicking the gear "Add or edit filters and controls" item opens the Filter
     jest.advanceTimersByTime(100);
   });
 
-  const gear = await screen.findByTestId("filterbar-orientation-icon");
+  const gear = await screen.findByTestId('filterbar-orientation-icon');
   userEvent.click(gear);
 
   const addEditItem = await screen.findByText(
-    "Add or edit filters and controls",
+    'Add or edit filters and controls',
   );
   userEvent.click(addEditItem);
 
-  expect(await screen.findByTestId("filter-modal")).toBeInTheDocument();
+  expect(await screen.findByTestId('filter-modal')).toBeInTheDocument();
 });
 
-test("FilterBar with orientation=Horizontal routes to Horizontal layout instead of Vertical", async () => {
+test('FilterBar with orientation=Horizontal routes to Horizontal layout instead of Vertical', async () => {
   // Migrated from the disabled Cypress spec _skip.horizontalFilterBar.test.ts:
   // proves the orientation prop selects the Horizontal subtree. The settings
   // gear (FilterBarSettings) is rendered only by Horizontal.tsx — Vertical.tsx
@@ -1055,8 +1055,8 @@ test("FilterBar with orientation=Horizontal routes to Horizontal layout instead 
   // all pending fake timers to clear useInitialization's setTimeout
   // regardless of the production timeout literal.
   const filter = createFilter({
-    id: "NATIVE_FILTER-h1",
-    name: "Horizontal filter",
+    id: 'NATIVE_FILTER-h1',
+    name: 'Horizontal filter',
   });
   const dataMask = createDataMask(filter.id);
   const state = createStateWithFilter(filter, dataMask, {
@@ -1074,10 +1074,10 @@ test("FilterBar with orientation=Horizontal routes to Horizontal layout instead 
     jest.runAllTimers();
   });
 
-  expect(screen.getByRole("img", { name: "setting" })).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
 });
 
-test("FilterBar with orientation=Horizontal and no filters shows empty state alongside default actions", async () => {
+test('FilterBar with orientation=Horizontal and no filters shows empty state alongside default actions', async () => {
   // Covers the second half of sc-107387 task #107390 ("show all default
   // actions in horizontal mode"). The original Cypress spec asserted four
   // affordances render when the bar is horizontal with no filters: the
@@ -1099,7 +1099,7 @@ test("FilterBar with orientation=Horizontal and no filters shows empty state alo
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     nativeFilters: { filters: {}, filtersState: {} },
   };
@@ -1115,53 +1115,53 @@ test("FilterBar with orientation=Horizontal and no filters shows empty state alo
     jest.runAllTimers();
   });
 
-  expect(screen.getByTestId("horizontal-filterbar-empty")).toHaveTextContent(
-    "No filters are currently added to this dashboard.",
+  expect(screen.getByTestId('horizontal-filterbar-empty')).toHaveTextContent(
+    'No filters are currently added to this dashboard.',
   );
-  expect(screen.getByRole("img", { name: "setting" })).toBeInTheDocument();
-  expect(screen.getByTestId("filterbar-action-buttons")).toBeInTheDocument();
+  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
+  expect(screen.getByTestId('filterbar-action-buttons')).toBeInTheDocument();
 });
 
-test("required filter with a default value auto-applies on load without touching other filters", async () => {
+test('required filter with a default value auto-applies on load without touching other filters', async () => {
   // Regression proof for #34617: a dashboard with a required filter that has
   // a default value used to leave the default un-applied (and Apply blocked
   // by a stale validateStatus) until the user touched every filter. Since the
   // auto-apply logic introduced by #36927, FilterBar dispatches the derived
   // dataMask itself as soon as the filter control finishes loading — the user
   // never has to touch the other filters, or the filter bar at all.
-  const requiredId = "NATIVE_FILTER-required-with-default";
-  const untouchedId = "NATIVE_FILTER-untouched";
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+  const requiredId = 'NATIVE_FILTER-required-with-default';
+  const untouchedId = 'NATIVE_FILTER-untouched';
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
 
   fetchMock.post(
-    "glob:*/api/v1/chart/data",
+    'glob:*/api/v1/chart/data',
     {
       result: [
         {
-          data: [{ region: "East" }, { region: "West" }],
-          colnames: ["region"],
+          data: [{ region: 'East' }, { region: 'West' }],
+          colnames: ['region'],
           coltypes: [1],
           applied_filters: [],
         },
       ],
     },
-    { name: "chart-data-issue-34617" },
+    { name: 'chart-data-issue-34617' },
   );
 
   const requiredFilter = createFilter({
     id: requiredId,
-    name: "Required Region",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "region" } }],
+    name: 'Required Region',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'region' } }],
     controlValues: { enableEmptyFilter: true },
-    defaultDataMask: { filterState: { value: ["East"] }, extraFormData: {} },
+    defaultDataMask: { filterState: { value: ['East'] }, extraFormData: {} },
     chartsInScope: [18],
   });
   const untouchedFilter = createFilter({
     id: untouchedId,
-    name: "Untouched Color",
-    filterType: "filter_select",
-    targets: [{ datasetId: 7, column: { name: "color" } }],
+    name: 'Untouched Color',
+    filterType: 'filter_select',
+    targets: [{ datasetId: 7, column: { name: 'color' } }],
     chartsInScope: [18],
   });
 
@@ -1178,13 +1178,13 @@ test("required filter with a default value auto-applies on load without touching
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ["ROOT_ID"],
+      activeTabs: ['ROOT_ID'],
     },
     // The default value has been hydrated into the applied dataMask, but its
     // extraFormData has not been derived yet — the state right after a
     // dashboard with default filter values loads.
     dataMask: {
-      [requiredId]: createDataMask(requiredId, ["East"], {}),
+      [requiredId]: createDataMask(requiredId, ['East'], {}),
     },
     nativeFilters: {
       filters: {
@@ -1212,9 +1212,9 @@ test("required filter with a default value auto-applies on load without touching
       requiredId,
       expect.objectContaining({
         extraFormData: {
-          filters: [{ col: "region", op: "IN", val: ["East"] }],
+          filters: [{ col: 'region', op: 'IN', val: ['East'] }],
         },
-        filterState: expect.objectContaining({ value: ["East"] }),
+        filterState: expect.objectContaining({ value: ['East'] }),
       }),
     );
   });
@@ -1226,41 +1226,41 @@ test("required filter with a default value auto-applies on load without touching
 
   // Nothing is left pending: the default value is already applied, so the
   // Apply button is not blocking on untouched filters.
-  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
 
   updateDataMaskSpy.mockRestore();
 });
 
-test("FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)", () => {
+test('FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)', () => {
   // Paired control for the routing test above: with Vertical orientation,
   // the settings gear must NOT be present (Vertical.tsx does not render
   // FilterBarSettings). Confirms the routing signal is horizontal-exclusive,
   // not a coincidence of when timers fire.
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
+  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
   expect(
-    screen.queryByRole("img", { name: "setting" }),
+    screen.queryByRole('img', { name: 'setting' }),
   ).not.toBeInTheDocument();
 });
 
-describe("cascading native filter clear", () => {
-  const parentId = "NATIVE_FILTER-cascade-country";
-  const childId = "NATIVE_FILTER-cascade-city";
+describe('cascading native filter clear', () => {
+  const parentId = 'NATIVE_FILTER-cascade-country';
+  const childId = 'NATIVE_FILTER-cascade-city';
 
   function createCascadeState() {
     const parentFilter = createFilter({
       id: parentId,
-      name: "Country",
-      filterType: "filter_select",
-      targets: [{ datasetId: 7, column: { name: "country" } }],
+      name: 'Country',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'country' } }],
       chartsInScope: [18],
     });
     const childFilter = createFilter({
       id: childId,
-      name: "City",
-      filterType: "filter_select",
-      targets: [{ datasetId: 7, column: { name: "city" } }],
+      name: 'City',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'city' } }],
       cascadeParentIds: [parentId],
       chartsInScope: [18],
     });
@@ -1277,14 +1277,14 @@ describe("cascading native filter clear", () => {
       },
       dashboardState: {
         ...stateWithoutNativeFilters.dashboardState,
-        activeTabs: ["ROOT_ID"],
+        activeTabs: ['ROOT_ID'],
       },
       dataMask: {
-        [parentId]: createDataMask(parentId, ["USA"], {
-          filters: [{ col: "country", op: "IN", val: ["USA"] }],
+        [parentId]: createDataMask(parentId, ['USA'], {
+          filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
         }),
-        [childId]: createDataMask(childId, ["New York"], {
-          filters: [{ col: "city", op: "IN", val: ["New York"] }],
+        [childId]: createDataMask(childId, ['New York'], {
+          filters: [{ col: 'city', op: 'IN', val: ['New York'] }],
         }),
       },
       nativeFilters: {
@@ -1302,25 +1302,25 @@ describe("cascading native filter clear", () => {
     // this suite's static response always wins for the filter queries.
     fetchMock.removeRoutes();
     fetchMock.post(
-      "glob:*/api/v1/chart/data",
+      'glob:*/api/v1/chart/data',
       {
         result: [
           {
-            data: [{ country: "USA" }, { country: "UK" }],
-            colnames: ["country"],
+            data: [{ country: 'USA' }, { country: 'UK' }],
+            colnames: ['country'],
             coltypes: [1],
             applied_filters: [],
           },
         ],
       },
-      { name: "cascade-chart-data" },
+      { name: 'cascade-chart-data' },
     );
   });
 
-  test("changing a parent filter value clears the child selection", async () => {
+  test('changing a parent filter value clears the child selection', async () => {
     // Spy must be created inside the test: earlier tests in this file restore
     // a shared spy on the same action, which would silently detach this one.
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
 
     const state = createCascadeState();
     const props = createOpenedBarProps();
@@ -1332,13 +1332,13 @@ describe("cascading native filter clear", () => {
 
     // Locate the parent (Country) select control via its labeled form item,
     // then change its value from USA to UK.
-    const parentLabel = await screen.findByText("Country");
-    const parentFormItem = parentLabel.closest(".ant-form-item") as HTMLElement;
-    const parentSelect = within(parentFormItem).getByRole("combobox");
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole('combobox');
     await act(async () => {
       await userEvent.click(parentSelect);
     });
-    const ukOption = await screen.findByText("UK");
+    const ukOption = await screen.findByText('UK');
     await act(async () => {
       await userEvent.click(ukOption);
     });
@@ -1350,26 +1350,26 @@ describe("cascading native filter clear", () => {
 
     // Apply the staged changes. The child (City) must be dispatched with a
     // cleared value — New York is not a valid city under UK.
-    const applyBtn = screen.getByTestId(getTestId("apply-button"));
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
     await act(async () => {
       await userEvent.click(applyBtn);
     });
 
     const childCall = updateDataMaskSpy.mock.calls.find(
-      (call) => call[0] === childId,
+      call => call[0] === childId,
     );
     expect(childCall).toBeDefined();
     expect(childCall![1]?.filterState?.value).toEqual(null);
     expect(childCall![1]?.extraFormData).toEqual({});
   });
 
-  test("changing a parent filter value clears a dependent Range child with [null, null]", async () => {
-    const rangeChildId = "NATIVE_FILTER-cascade-age";
+  test('changing a parent filter value clears a dependent Range child with [null, null]', async () => {
+    const rangeChildId = 'NATIVE_FILTER-cascade-age';
     const rangeChildFilter = createFilter({
       id: rangeChildId,
-      name: "Age",
-      filterType: "filter_range",
-      targets: [{ datasetId: 7, column: { name: "age" } }],
+      name: 'Age',
+      filterType: 'filter_range',
+      targets: [{ datasetId: 7, column: { name: 'age' } }],
       cascadeParentIds: [parentId],
       chartsInScope: [18],
     });
@@ -1383,9 +1383,9 @@ describe("cascading native filter clear", () => {
           native_filter_configuration: [
             createFilter({
               id: parentId,
-              name: "Country",
-              filterType: "filter_select",
-              targets: [{ datasetId: 7, column: { name: "country" } }],
+              name: 'Country',
+              filterType: 'filter_select',
+              targets: [{ datasetId: 7, column: { name: 'country' } }],
               chartsInScope: [18],
             }),
             rangeChildFilter,
@@ -1395,16 +1395,16 @@ describe("cascading native filter clear", () => {
       },
       dashboardState: {
         ...stateWithoutNativeFilters.dashboardState,
-        activeTabs: ["ROOT_ID"],
+        activeTabs: ['ROOT_ID'],
       },
       dataMask: {
-        [parentId]: createDataMask(parentId, ["USA"], {
-          filters: [{ col: "country", op: "IN", val: ["USA"] }],
+        [parentId]: createDataMask(parentId, ['USA'], {
+          filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
         }),
         [rangeChildId]: createDataMask(rangeChildId, [10, 70], {
           filters: [
-            { col: "age", op: ">=", val: 10 },
-            { col: "age", op: "<=", val: 70 },
+            { col: 'age', op: '>=', val: 10 },
+            { col: 'age', op: '<=', val: 70 },
           ],
         }),
       },
@@ -1412,9 +1412,9 @@ describe("cascading native filter clear", () => {
         filters: {
           [parentId]: createFilter({
             id: parentId,
-            name: "Country",
-            filterType: "filter_select",
-            targets: [{ datasetId: 7, column: { name: "country" } }],
+            name: 'Country',
+            filterType: 'filter_select',
+            targets: [{ datasetId: 7, column: { name: 'country' } }],
             chartsInScope: [18],
           }),
           [rangeChildId]: rangeChildFilter,
@@ -1427,27 +1427,27 @@ describe("cascading native filter clear", () => {
     // for the child (loaded after the parent dependency resolves).
     fetchMock.removeRoutes();
     fetchMock.post(
-      "glob:*/api/v1/chart/data",
+      'glob:*/api/v1/chart/data',
       {
         result: [
           {
-            data: [{ country: "USA" }, { country: "UK" }],
-            colnames: ["country"],
+            data: [{ country: 'USA' }, { country: 'UK' }],
+            colnames: ['country'],
             coltypes: [1],
             applied_filters: [],
           },
           {
             data: [{ min: 0, max: 100 }],
-            colnames: ["min", "max"],
+            colnames: ['min', 'max'],
             coltypes: [0, 0],
             applied_filters: [],
           },
         ],
       },
-      { name: "cascade-range-chart-data" },
+      { name: 'cascade-range-chart-data' },
     );
 
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
     const props = createOpenedBarProps();
     renderFilterBar(props, state);
 
@@ -1455,13 +1455,13 @@ describe("cascading native filter clear", () => {
       jest.advanceTimersByTime(1000);
     });
 
-    const parentLabel = await screen.findByText("Country");
-    const parentFormItem = parentLabel.closest(".ant-form-item") as HTMLElement;
-    const parentSelect = within(parentFormItem).getByRole("combobox");
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole('combobox');
     await act(async () => {
       await userEvent.click(parentSelect);
     });
-    const ukOption = await screen.findByText("UK");
+    const ukOption = await screen.findByText('UK');
     await act(async () => {
       await userEvent.click(ukOption);
     });
@@ -1470,7 +1470,7 @@ describe("cascading native filter clear", () => {
       jest.advanceTimersByTime(1000);
     });
 
-    const applyBtn = screen.getByTestId(getTestId("apply-button"));
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
     await act(async () => {
       await userEvent.click(applyBtn);
     });
@@ -1479,7 +1479,7 @@ describe("cascading native filter clear", () => {
     // Bare null is ignored by RangeFilterPlugin's sync effect and would
     // leave stale UI (the original reviewer concern).
     const rangeChildCall = updateDataMaskSpy.mock.calls.find(
-      (call) => call[0] === rangeChildId,
+      call => call[0] === rangeChildId,
     );
     expect(rangeChildCall).toBeDefined();
     expect(rangeChildCall![1]?.filterState?.value).toEqual([null, null]);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -25,26 +25,26 @@ import {
   userEvent,
   waitFor,
   within,
-} from 'spec/helpers/testing-library';
-import { stateWithoutNativeFilters } from 'spec/fixtures/mockStore';
-import { testWithId } from 'src/utils/testUtils';
-import { Preset, makeApi } from '@superset-ui/core';
+} from "spec/helpers/testing-library";
+import { stateWithoutNativeFilters } from "spec/fixtures/mockStore";
+import { testWithId } from "src/utils/testUtils";
+import { Preset, makeApi } from "@superset-ui/core";
 import {
   TimeFilterPlugin,
   SelectFilterPlugin,
   RangeFilterPlugin,
-} from 'src/filters/components';
-import fetchMock from 'fetch-mock';
-import { FilterBarOrientation } from 'src/dashboard/types';
-import { FILTER_BAR_TEST_ID } from './utils';
-import FilterBar from '.';
-import { FILTERS_CONFIG_MODAL_TEST_ID } from '../FiltersConfigModal/FiltersConfigModal';
-import * as dataMaskActions from 'src/dataMask/actions';
+} from "src/filters/components";
+import fetchMock from "fetch-mock";
+import { FilterBarOrientation } from "src/dashboard/types";
+import { FILTER_BAR_TEST_ID } from "./utils";
+import FilterBar from ".";
+import { FILTERS_CONFIG_MODAL_TEST_ID } from "../FiltersConfigModal/FiltersConfigModal";
+import * as dataMaskActions from "src/dataMask/actions";
 
 jest.useFakeTimers({ advanceTimers: true });
 
-jest.mock('@superset-ui/core', () => ({
-  ...jest.requireActual('@superset-ui/core'),
+jest.mock("@superset-ui/core", () => ({
+  ...jest.requireActual("@superset-ui/core"),
   makeApi: jest.fn(),
 }));
 
@@ -54,11 +54,11 @@ const mockedMakeApi = makeApi as jest.Mock;
 class MainPreset extends Preset {
   constructor() {
     super({
-      name: 'Legacy charts',
+      name: "Legacy charts",
       plugins: [
-        new TimeFilterPlugin().configure({ key: 'filter_time' }),
-        new SelectFilterPlugin().configure({ key: 'filter_select' }),
-        new RangeFilterPlugin().configure({ key: 'filter_range' }),
+        new TimeFilterPlugin().configure({ key: "filter_time" }),
+        new SelectFilterPlugin().configure({ key: "filter_select" }),
+        new RangeFilterPlugin().configure({ key: "filter_range" }),
       ],
     });
   }
@@ -66,17 +66,17 @@ class MainPreset extends Preset {
 
 new MainPreset().register();
 
-fetchMock.get('glob:*/api/v1/dataset/7', {
+fetchMock.get("glob:*/api/v1/dataset/7", {
   description_columns: {},
   id: 1,
-  label_columns: { columns: 'Columns', table_name: 'Table Name' },
+  label_columns: { columns: "Columns", table_name: "Table Name" },
   result: {
     metrics: [],
-    columns: [{ column_name: 'Column A', id: 1 }],
-    table_name: 'birth_names',
+    columns: [{ column_name: "Column A", id: 1 }],
+    table_name: "birth_names",
     id: 1,
   },
-  show_columns: ['id', 'table_name'],
+  show_columns: ["id", "table_name"],
 });
 
 // Cleanup between tests
@@ -95,8 +95,8 @@ function createOpenedBarProps(toggleFiltersBar = jest.fn()) {
   return { filtersOpen: true, toggleFiltersBar };
 }
 
-function createMockApi(filterName = 'Time filter 1') {
-  return jest.fn(async data => {
+function createMockApi(filterName = "Time filter 1") {
+  return jest.fn(async (data) => {
     if (!data?.modified?.length) {
       return { id: 1234, result: [] };
     }
@@ -107,12 +107,12 @@ function createMockApi(filterName = 'Time filter 1') {
         {
           id: filterId,
           name: filterName,
-          filterType: 'filter_time',
-          targets: [{ datasetId: 11, column: { name: 'color' } }],
+          filterType: "filter_time",
+          targets: [{ datasetId: 11, column: { name: "color" } }],
           defaultDataMask: { filterState: { value: null } },
           controlValues: {},
           cascadeParentIds: [],
-          scope: { rootPath: ['ROOT_ID'], excluded: [] },
+          scope: { rootPath: ["ROOT_ID"], excluded: [] },
         },
       ],
     };
@@ -120,18 +120,18 @@ function createMockApi(filterName = 'Time filter 1') {
 }
 
 function createFilter(overrides: Record<string, unknown> = {}) {
-  const id = (overrides.id as string) || 'test-filter';
+  const id = (overrides.id as string) || "test-filter";
   return {
     id,
-    name: 'Test Filter',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 1, column: { name: 'test_column' } }],
+    name: "Test Filter",
+    filterType: "filter_select",
+    targets: [{ datasetId: 1, column: { name: "test_column" } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     controlValues: {},
     cascadeParentIds: [],
-    scope: { rootPath: ['ROOT_ID'], excluded: [] },
-    type: 'NATIVE_FILTER',
-    description: '',
+    scope: { rootPath: ["ROOT_ID"], excluded: [] },
+    type: "NATIVE_FILTER",
+    description: "",
     chartsInScope: [],
     tabsInScope: [],
     ...overrides,
@@ -152,11 +152,11 @@ function createDataMask(
 
 function createDivider(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'NATIVE_FILTER_DIVIDER-1',
-    type: 'DIVIDER',
-    scope: { rootPath: ['ROOT_ID'], excluded: [] },
-    title: 'Select time range',
-    description: 'Select year/month etc..',
+    id: "NATIVE_FILTER_DIVIDER-1",
+    type: "DIVIDER",
+    scope: { rootPath: ["ROOT_ID"], excluded: [] },
+    title: "Select time range",
+    description: "Select year/month etc..",
     chartsInScope: [],
     tabsInScope: [],
     ...overrides,
@@ -180,7 +180,7 @@ function createStateWithFilter(
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: { [filter.id]: dataMask },
     nativeFilters: {
@@ -192,15 +192,15 @@ function createStateWithFilter(
 
 function setupTimeRangeMocks() {
   const urls = {
-    noFilter: 'glob:*/api/v1/time_range/?q=%27No%20filter%27',
-    lastDay: 'glob:*/api/v1/time_range/?q=%27Last%20day%27',
-    lastWeek: 'glob:*/api/v1/time_range/?q=%27Last%20week%27',
+    noFilter: "glob:*/api/v1/time_range/?q=%27No%20filter%27",
+    lastDay: "glob:*/api/v1/time_range/?q=%27Last%20day%27",
+    lastWeek: "glob:*/api/v1/time_range/?q=%27Last%20week%27",
   };
 
   fetchMock.removeRoute(urls.noFilter);
   fetchMock.get(
     urls.noFilter,
-    { result: { since: '', until: '', timeRange: 'No filter' } },
+    { result: { since: "", until: "", timeRange: "No filter" } },
     { name: urls.noFilter },
   );
 
@@ -209,9 +209,9 @@ function setupTimeRangeMocks() {
     urls.lastDay,
     {
       result: {
-        since: '2021-04-13T00:00:00',
-        until: '2021-04-14T00:00:00',
-        timeRange: 'Last day',
+        since: "2021-04-13T00:00:00",
+        until: "2021-04-14T00:00:00",
+        timeRange: "Last day",
       },
     },
     { name: urls.lastDay },
@@ -222,9 +222,9 @@ function setupTimeRangeMocks() {
     urls.lastWeek,
     {
       result: {
-        since: '2021-04-07T00:00:00',
-        until: '2021-04-14T00:00:00',
-        timeRange: 'Last week',
+        since: "2021-04-07T00:00:00",
+        until: "2021-04-14T00:00:00",
+        timeRange: "Last week",
       },
     },
     { name: urls.lastWeek },
@@ -254,7 +254,7 @@ function renderFilterBar(
   );
 }
 
-test('FilterBar renders without crashing', () => {
+test("FilterBar renders without crashing", () => {
   const props = createClosedBarProps();
   const { container } = renderFilterBar(props);
   expect(container).toBeInTheDocument();
@@ -263,60 +263,60 @@ test('FilterBar renders without crashing', () => {
 test('FilterBar renders "Filters and controls" heading', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
 });
 
 test('FilterBar renders "Clear all" button', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText('Clear all')).toBeInTheDocument();
+  expect(screen.getByText("Clear all")).toBeInTheDocument();
 });
 
 test('FilterBar renders "Apply filters" button', () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText('Apply filters')).toBeInTheDocument();
+  expect(screen.getByText("Apply filters")).toBeInTheDocument();
 });
 
-test('FilterBar renders collapse icon', () => {
+test("FilterBar renders collapse icon", () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
   expect(
-    screen.getByRole('img', { name: 'vertical-align' }),
+    screen.getByRole("img", { name: "vertical-align" }),
   ).toBeInTheDocument();
 });
 
-test('FilterBar renders filter icon', () => {
+test("FilterBar renders filter icon", () => {
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByRole('img', { name: 'filter' })).toBeInTheDocument();
+  expect(screen.getByRole("img", { name: "filter" })).toBeInTheDocument();
 });
 
-test('FilterBar calls toggleFiltersBar when collapse icon is clicked', () => {
+test("FilterBar calls toggleFiltersBar when collapse icon is clicked", () => {
   const toggleFiltersBar = jest.fn();
   const props = createClosedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  const collapse = screen.getByRole('img', { name: 'vertical-align' });
+  const collapse = screen.getByRole("img", { name: "vertical-align" });
   expect(toggleFiltersBar).not.toHaveBeenCalled();
 
   userEvent.click(collapse);
   expect(toggleFiltersBar).toHaveBeenCalled();
 });
 
-test('FilterBar opens when expand button is clicked', () => {
+test("FilterBar opens when expand button is clicked", () => {
   const toggleFiltersBar = jest.fn();
   const props = createClosedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
-  expect(screen.getByTestId(getTestId('expand-button'))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId("expand-button"))).toBeInTheDocument();
 
-  userEvent.click(screen.getByTestId(getTestId('collapsable')));
+  userEvent.click(screen.getByTestId(getTestId("collapsable")));
   expect(toggleFiltersBar).toHaveBeenCalledWith(true);
 });
 
-test('FilterBar hides edit filter button when user lacks permissions', () => {
+test("FilterBar hides edit filter button when user lacks permissions", () => {
   const props = createOpenedBarProps();
   const stateWithoutPermissions = {
     ...stateWithoutNativeFilters,
@@ -326,31 +326,31 @@ test('FilterBar hides edit filter button when user lacks permissions', () => {
   renderFilterBar(props, stateWithoutPermissions);
 
   expect(
-    screen.queryByTestId(getTestId('create-filter')),
+    screen.queryByTestId(getTestId("create-filter")),
   ).not.toBeInTheDocument();
 });
 
-test('FilterBar closes when collapse button is clicked', () => {
+test("FilterBar closes when collapse button is clicked", () => {
   const toggleFiltersBar = jest.fn();
   const props = createOpenedBarProps(toggleFiltersBar);
   renderFilterBar(props);
 
-  const collapseButton = screen.getByTestId(getTestId('collapse-button'));
+  const collapseButton = screen.getByTestId(getTestId("collapse-button"));
   expect(collapseButton).toBeInTheDocument();
 
   userEvent.click(collapseButton);
   expect(toggleFiltersBar).toHaveBeenCalledWith(false);
 });
 
-test('FilterBar disables buttons when there are no filters', () => {
+test("FilterBar disables buttons when there are no filters", () => {
   const props = createOpenedBarProps();
   renderFilterBar(props, stateWithoutNativeFilters);
 
-  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("clear-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
 });
 
-test('FilterBar renders dividers with title and description', async () => {
+test("FilterBar renders dividers with title and description", async () => {
   const props = createOpenedBarProps();
   const divider = createDivider();
   const stateWithDivider = {
@@ -373,64 +373,64 @@ test('FilterBar renders dividers with title and description', async () => {
     jest.advanceTimersByTime(1000);
   });
 
-  const title = await screen.findByText('Select time range');
-  const description = await screen.findByText('Select year/month etc..');
+  const title = await screen.findByText("Select time range");
+  const description = await screen.findByText("Select year/month etc..");
 
-  expect(title.tagName).toBe('H3');
-  expect(description.tagName).toBe('P');
-  expect(screen.getByTestId(getTestId('clear-button'))).toBeDisabled();
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(title.tagName).toBe("H3");
+  expect(description.tagName).toBe("P");
+  expect(screen.getByTestId(getTestId("clear-button"))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
 });
 
-test('FilterBar apply button is disabled after creating a filter', async () => {
+test("FilterBar apply button is disabled after creating a filter", async () => {
   setupTimeRangeMocks();
   mockedMakeApi.mockReturnValue(createMockApi());
 
   const props = createOpenedBarProps();
   renderFilterBar(props, stateWithoutNativeFilters);
 
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
 
   // Simulate add filter flow
-  userEvent.click(screen.getByTestId(getTestId('collapsable')));
-  userEvent.click(screen.getByLabelText('setting'));
-  userEvent.click(screen.getByText('Add or edit filters and controls'));
+  userEvent.click(screen.getByTestId(getTestId("collapsable")));
+  userEvent.click(screen.getByLabelText("setting"));
+  userEvent.click(screen.getByText("Add or edit filters and controls"));
 
   // First add a filter via the dropdown (modal now shows empty state by default)
-  const dropdownButton = screen.getByTestId('new-item-dropdown-button');
+  const dropdownButton = screen.getByTestId("new-item-dropdown-button");
   fireEvent.mouseEnter(dropdownButton);
-  const addFilterMenuItem = await screen.findByRole('menuitem', {
+  const addFilterMenuItem = await screen.findByRole("menuitem", {
     name: /add filter/i,
   });
   fireEvent.click(addFilterMenuItem);
 
-  userEvent.click(screen.getByText('Value'));
-  userEvent.click(screen.getByText('Time range'));
+  userEvent.click(screen.getByText("Value"));
+  userEvent.click(screen.getByText("Time range"));
   userEvent.type(
-    screen.getByTestId(getModalTestId('name-input')),
-    'Time filter 1',
+    screen.getByTestId(getModalTestId("name-input")),
+    "Time filter 1",
   );
-  userEvent.click(screen.getByText('Save'));
+  userEvent.click(screen.getByText("Save"));
 
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
 });
 
-test('FilterBar renders without errors when filter has required controlValues', () => {
+test("FilterBar renders without errors when filter has required controlValues", () => {
   const props = createOpenedBarProps();
   const filter = createFilter({
-    id: 'test-filter',
+    id: "test-filter",
     controlValues: { enableEmptyFilter: true },
   });
-  const dataMask = createDataMask('test-filter', undefined, {});
+  const dataMask = createDataMask("test-filter", undefined, {});
   const state = createStateWithFilter(filter, dataMask);
 
   const { container } = renderFilterBar(props, state);
   expect(container).toBeInTheDocument();
 });
 
-test('FilterBar does not crash when filter has value but empty extraFormData', async () => {
-  const filterId = 'test-filter-auto-apply';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+test("FilterBar does not crash when filter has value but empty extraFormData", async () => {
+  const filterId = "test-filter-auto-apply";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const props = createOpenedBarProps();
 
   const filter = createFilter({
@@ -438,12 +438,12 @@ test('FilterBar does not crash when filter has value but empty extraFormData', a
     requiredFirst: true,
     controlValues: { enableEmptyFilter: true },
     defaultDataMask: {
-      filterState: { value: ['value1'] },
+      filterState: { value: ["value1"] },
       extraFormData: {},
     },
   });
 
-  const dataMask = createDataMask(filterId, ['value1'], {});
+  const dataMask = createDataMask(filterId, ["value1"], {});
   const state = createStateWithFilter(filter, dataMask);
 
   renderFilterBar(props, state);
@@ -452,8 +452,8 @@ test('FilterBar does not crash when filter has value but empty extraFormData', a
     jest.advanceTimersByTime(300);
   });
 
-  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
-  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
+  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
 
   // The filter value should not be cleared during initialization
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
@@ -461,21 +461,21 @@ test('FilterBar does not crash when filter has value but empty extraFormData', a
   updateDataMaskSpy.mockRestore();
 });
 
-test('FilterBar renders correctly when filter has complete extraFormData', async () => {
-  const filterId = 'test-filter-complete';
+test("FilterBar renders correctly when filter has complete extraFormData", async () => {
+  const filterId = "test-filter-complete";
   const props = createOpenedBarProps();
   const filter = createFilter({
     id: filterId,
     controlValues: { enableEmptyFilter: true },
     defaultDataMask: {
-      filterState: { value: ['value1'] },
+      filterState: { value: ["value1"] },
       extraFormData: {
-        filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
+        filters: [{ col: "test_column", op: "IN", val: ["value1"] }],
       },
     },
   });
-  const dataMask = createDataMask(filterId, ['value1'], {
-    filters: [{ col: 'test_column', op: 'IN', val: ['value1'] }],
+  const dataMask = createDataMask(filterId, ["value1"], {
+    filters: [{ col: "test_column", op: "IN", val: ["value1"] }],
   });
   const state = createStateWithFilter(filter, dataMask);
 
@@ -485,17 +485,17 @@ test('FilterBar renders correctly when filter has complete extraFormData', async
     jest.advanceTimersByTime(100);
   });
 
-  expect(screen.getByTestId(getTestId('filter-icon'))).toBeInTheDocument();
+  expect(screen.getByTestId(getTestId("filter-icon"))).toBeInTheDocument();
 });
 
-test('Clear All stages filter_select clear without dispatching until Apply', async () => {
-  const filterId = 'NATIVE_FILTER-clear-select';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+test("Clear All stages filter_select clear without dispatching until Apply", async () => {
+  const filterId = "NATIVE_FILTER-clear-select";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const selectFilter = createFilter({
     id: filterId,
-    name: 'Region',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    name: "Region",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "region" } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     chartsInScope: [18],
   });
@@ -512,11 +512,11 @@ test('Clear All stages filter_select clear without dispatching until Apply', asy
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ['East'], {
-        filters: [{ col: 'region', op: 'IN', val: ['East'] }],
+      [filterId]: createDataMask(filterId, ["East"], {
+        filters: [{ col: "region", op: "IN", val: ["East"] }],
       }),
     },
     nativeFilters: {
@@ -531,7 +531,7 @@ test('Clear All stages filter_select clear without dispatching until Apply', asy
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  const clearBtn = screen.getByTestId(getTestId("clear-button"));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -541,7 +541,7 @@ test('Clear All stages filter_select clear without dispatching until Apply', asy
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
   // Apply commits the staged clear
-  const applyBtn = screen.getByTestId(getTestId('apply-button'));
+  const applyBtn = screen.getByTestId(getTestId("apply-button"));
   expect(applyBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(applyBtn);
@@ -554,17 +554,17 @@ test('Clear All stages filter_select clear without dispatching until Apply', asy
   updateDataMaskSpy.mockRestore();
 });
 
-test('Clear All stages filter_range clear with [null, null], dispatched on Apply', async () => {
-  fetchMock.post('glob:*/api/v1/chart/data', {
+test("Clear All stages filter_range clear with [null, null], dispatched on Apply", async () => {
+  fetchMock.post("glob:*/api/v1/chart/data", {
     result: [{ data: [{ min: 0, max: 100 }] }],
   });
-  const filterId = 'NATIVE_FILTER-clear-range';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const filterId = "NATIVE_FILTER-clear-range";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const rangeFilter = createFilter({
     id: filterId,
-    name: 'Age',
-    filterType: 'filter_range',
-    targets: [{ datasetId: 7, column: { name: 'age' } }],
+    name: "Age",
+    filterType: "filter_range",
+    targets: [{ datasetId: 7, column: { name: "age" } }],
     defaultDataMask: { filterState: { value: null }, extraFormData: {} },
     chartsInScope: [18],
   });
@@ -581,11 +581,11 @@ test('Clear All stages filter_range clear with [null, null], dispatched on Apply
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: {
       [filterId]: createDataMask(filterId, [10, 50], {
-        filters: [{ col: 'age', op: '>=', val: 10 }],
+        filters: [{ col: "age", op: ">=", val: 10 }],
       }),
     },
     nativeFilters: {
@@ -600,7 +600,7 @@ test('Clear All stages filter_range clear with [null, null], dispatched on Apply
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  const clearBtn = screen.getByTestId(getTestId("clear-button"));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -608,7 +608,7 @@ test('Clear All stages filter_range clear with [null, null], dispatched on Apply
 
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
-  const applyBtn = screen.getByTestId(getTestId('apply-button'));
+  const applyBtn = screen.getByTestId(getTestId("apply-button"));
   await act(async () => {
     userEvent.click(applyBtn);
   });
@@ -620,22 +620,22 @@ test('Clear All stages filter_range clear with [null, null], dispatched on Apply
   updateDataMaskSpy.mockRestore();
 });
 
-test('Clear All + Apply only dispatches for filters present in dataMask', async () => {
-  const idInMask = 'NATIVE_FILTER-has-value';
-  const idNotInMask = 'NATIVE_FILTER-no-value';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+test("Clear All + Apply only dispatches for filters present in dataMask", async () => {
+  const idInMask = "NATIVE_FILTER-has-value";
+  const idNotInMask = "NATIVE_FILTER-no-value";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const filterInMask = createFilter({
     id: idInMask,
-    name: 'A',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'x' } }],
+    name: "A",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "x" } }],
     chartsInScope: [18],
   });
   const filterNotInMask = createFilter({
     id: idNotInMask,
-    name: 'B',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'x' } }],
+    name: "B",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "x" } }],
     chartsInScope: [18],
   });
   const stateWithTwoFilters = {
@@ -651,11 +651,11 @@ test('Clear All + Apply only dispatches for filters present in dataMask', async 
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: {
-      [idInMask]: createDataMask(idInMask, ['v'], {
-        filters: [{ col: 'x', op: 'IN', val: ['v'] }],
+      [idInMask]: createDataMask(idInMask, ["v"], {
+        filters: [{ col: "x", op: "IN", val: ["v"] }],
       }),
     },
     nativeFilters: {
@@ -673,13 +673,13 @@ test('Clear All + Apply only dispatches for filters present in dataMask', async 
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  const clearBtn = screen.getByTestId(getTestId("clear-button"));
   await act(async () => {
     userEvent.click(clearBtn);
   });
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
 
-  const applyBtn = screen.getByTestId(getTestId('apply-button'));
+  const applyBtn = screen.getByTestId(getTestId("apply-button"));
   await act(async () => {
     userEvent.click(applyBtn);
   });
@@ -692,31 +692,31 @@ test('Clear All + Apply only dispatches for filters present in dataMask', async 
   updateDataMaskSpy.mockRestore();
 });
 
-test('Clear All in horizontal bar does not re-apply default values', async () => {
+test("Clear All in horizontal bar does not re-apply default values", async () => {
   fetchMock.post(
-    'glob:*/api/v1/chart/data',
+    "glob:*/api/v1/chart/data",
     {
       result: [
         {
-          data: [{ test_column: 'East' }, { test_column: 'West' }],
-          colnames: ['test_column'],
+          data: [{ test_column: "East" }, { test_column: "West" }],
+          colnames: ["test_column"],
           coltypes: [1],
         },
       ],
     },
-    { name: 'horizontal-clear-chart-data' },
+    { name: "horizontal-clear-chart-data" },
   );
-  const filterId = 'NATIVE_FILTER-horizontal-default';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const filterId = "NATIVE_FILTER-horizontal-default";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const filterWithDefault = createFilter({
     id: filterId,
-    name: 'Region',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'test_column' } }],
+    name: "Region",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "test_column" } }],
     defaultDataMask: {
-      filterState: { value: ['East'] },
+      filterState: { value: ["East"] },
       extraFormData: {
-        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
+        filters: [{ col: "test_column", op: "IN", val: ["East"] }],
       },
     },
     chartsInScope: [18],
@@ -734,11 +734,11 @@ test('Clear All in horizontal bar does not re-apply default values', async () =>
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ['East'], {
-        filters: [{ col: 'test_column', op: 'IN', val: ['East'] }],
+      [filterId]: createDataMask(filterId, ["East"], {
+        filters: [{ col: "test_column", op: "IN", val: ["East"] }],
       }),
     },
     nativeFilters: {
@@ -757,7 +757,7 @@ test('Clear All in horizontal bar does not re-apply default values', async () =>
     jest.advanceTimersByTime(1000);
   });
 
-  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  const clearBtn = screen.getByTestId(getTestId("clear-button"));
   expect(clearBtn).not.toBeDisabled();
   await act(async () => {
     userEvent.click(clearBtn);
@@ -770,78 +770,78 @@ test('Clear All in horizontal bar does not re-apply default values', async () =>
   // The staged clear must survive the trigger completing: the default value
   // must not be re-applied and Apply must stay enabled
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
-  expect(screen.queryByTitle('East')).not.toBeInTheDocument();
-  expect(screen.getByTestId(getTestId('apply-button'))).not.toBeDisabled();
+  expect(screen.queryByTitle("East")).not.toBeInTheDocument();
+  expect(screen.getByTestId(getTestId("apply-button"))).not.toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
 
-test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', async () => {
-  const inScopeFilterId = 'NATIVE_FILTER-in-scope';
-  const outOfScopeRequiredFilterId = 'NATIVE_FILTER-out-of-scope-required';
+test("FilterBar Clear All only clears in-scope filters, not out-of-scope ones", async () => {
+  const inScopeFilterId = "NATIVE_FILTER-in-scope";
+  const outOfScopeRequiredFilterId = "NATIVE_FILTER-out-of-scope-required";
   const outOfScopeNonRequiredFilterId =
-    'NATIVE_FILTER-out-of-scope-non-required';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+    "NATIVE_FILTER-out-of-scope-non-required";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
 
   const dashboardLayoutWithTabs = {
-    ROOT_ID: { id: 'ROOT_ID', type: 'ROOT', children: ['TABS-1'] },
-    'TABS-1': {
-      id: 'TABS-1',
-      type: 'TABS',
-      children: ['TAB-active', 'TAB-inactive'],
+    ROOT_ID: { id: "ROOT_ID", type: "ROOT", children: ["TABS-1"] },
+    "TABS-1": {
+      id: "TABS-1",
+      type: "TABS",
+      children: ["TAB-active", "TAB-inactive"],
     },
-    'TAB-active': {
-      id: 'TAB-active',
-      type: 'TAB',
-      children: ['CHART_ROW-1'],
-      meta: { text: 'Active Tab' },
-      parents: ['ROOT_ID', 'TABS-1'],
+    "TAB-active": {
+      id: "TAB-active",
+      type: "TAB",
+      children: ["CHART_ROW-1"],
+      meta: { text: "Active Tab" },
+      parents: ["ROOT_ID", "TABS-1"],
     },
-    'TAB-inactive': {
-      id: 'TAB-inactive',
-      type: 'TAB',
-      children: ['CHART_ROW-2'],
-      meta: { text: 'Inactive Tab' },
-      parents: ['ROOT_ID', 'TABS-1'],
+    "TAB-inactive": {
+      id: "TAB-inactive",
+      type: "TAB",
+      children: ["CHART_ROW-2"],
+      meta: { text: "Inactive Tab" },
+      parents: ["ROOT_ID", "TABS-1"],
     },
-    'CHART_ROW-1': {
-      id: 'CHART_ROW-1',
-      type: 'CHART',
+    "CHART_ROW-1": {
+      id: "CHART_ROW-1",
+      type: "CHART",
       meta: { chartId: 1 },
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-active'],
+      parents: ["ROOT_ID", "TABS-1", "TAB-active"],
     },
-    'CHART_ROW-2': {
-      id: 'CHART_ROW-2',
-      type: 'CHART',
+    "CHART_ROW-2": {
+      id: "CHART_ROW-2",
+      type: "CHART",
       meta: { chartId: 2 },
-      parents: ['ROOT_ID', 'TABS-1', 'TAB-inactive'],
+      parents: ["ROOT_ID", "TABS-1", "TAB-inactive"],
     },
   };
 
   const inScopeFilter = createFilter({
     id: inScopeFilterId,
-    name: 'In Scope Filter',
-    targets: [{ datasetId: 1, column: { name: 'column1' } }],
+    name: "In Scope Filter",
+    targets: [{ datasetId: 1, column: { name: "column1" } }],
     controlValues: { enableEmptyFilter: false },
     chartsInScope: [1],
-    tabsInScope: ['TAB-active'],
+    tabsInScope: ["TAB-active"],
   });
 
   const outOfScopeRequiredFilter = createFilter({
     id: outOfScopeRequiredFilterId,
-    name: 'Out of Scope Required Filter',
-    targets: [{ datasetId: 1, column: { name: 'column2' } }],
+    name: "Out of Scope Required Filter",
+    targets: [{ datasetId: 1, column: { name: "column2" } }],
     controlValues: { enableEmptyFilter: true },
     chartsInScope: [2],
-    tabsInScope: ['TAB-inactive'],
+    tabsInScope: ["TAB-inactive"],
   });
 
   const outOfScopeNonRequiredFilter = createFilter({
     id: outOfScopeNonRequiredFilterId,
-    name: 'Out of Scope Non-Required Filter',
-    targets: [{ datasetId: 1, column: { name: 'column3' } }],
+    name: "Out of Scope Non-Required Filter",
+    targets: [{ datasetId: 1, column: { name: "column3" } }],
     controlValues: { enableEmptyFilter: false },
     chartsInScope: [2],
-    tabsInScope: ['TAB-inactive'],
+    tabsInScope: ["TAB-inactive"],
   });
 
   const stateWithTabsAndFilters = {
@@ -853,7 +853,7 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['TAB-active'],
+      activeTabs: ["TAB-active"],
     },
     dashboardInfo: {
       id: 1,
@@ -867,18 +867,18 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
       },
     },
     dataMask: {
-      [inScopeFilterId]: createDataMask(inScopeFilterId, ['value1'], {
-        filters: [{ col: 'column1', op: 'IN', val: ['value1'] }],
+      [inScopeFilterId]: createDataMask(inScopeFilterId, ["value1"], {
+        filters: [{ col: "column1", op: "IN", val: ["value1"] }],
       }),
       [outOfScopeRequiredFilterId]: createDataMask(
         outOfScopeRequiredFilterId,
-        ['value2'],
-        { filters: [{ col: 'column2', op: 'IN', val: ['value2'] }] },
+        ["value2"],
+        { filters: [{ col: "column2", op: "IN", val: ["value2"] }] },
       ),
       [outOfScopeNonRequiredFilterId]: createDataMask(
         outOfScopeNonRequiredFilterId,
-        ['value3'],
-        { filters: [{ col: 'column3', op: 'IN', val: ['value3'] }] },
+        ["value3"],
+        { filters: [{ col: "column3", op: "IN", val: ["value3"] }] },
       ),
     },
     nativeFilters: {
@@ -898,7 +898,7 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
     jest.advanceTimersByTime(300);
   });
 
-  const clearButton = screen.getByTestId(getTestId('clear-button'));
+  const clearButton = screen.getByTestId(getTestId("clear-button"));
   expect(clearButton).toBeInTheDocument();
 
   await act(async () => {
@@ -908,7 +908,7 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
 
   // After Apply: only the in-scope filter was cleared. Out-of-scope filters
   // retain their original values (Apply re-dispatches them unchanged).
-  const applyButton = screen.getByTestId(getTestId('apply-button'));
+  const applyButton = screen.getByTestId(getTestId("apply-button"));
   await act(async () => {
     userEvent.click(applyButton);
   });
@@ -921,27 +921,27 @@ test('FilterBar Clear All only clears in-scope filters, not out-of-scope ones', 
 
   // Out-of-scope filters keep their existing values; not cleared
   const outOfScopeRequiredCall = updateDataMaskSpy.mock.calls.find(
-    call => call[0] === outOfScopeRequiredFilterId,
+    (call) => call[0] === outOfScopeRequiredFilterId,
   );
-  expect(outOfScopeRequiredCall?.[1]?.filterState?.value).toEqual(['value2']);
+  expect(outOfScopeRequiredCall?.[1]?.filterState?.value).toEqual(["value2"]);
   const outOfScopeNonRequiredCall = updateDataMaskSpy.mock.calls.find(
-    call => call[0] === outOfScopeNonRequiredFilterId,
+    (call) => call[0] === outOfScopeNonRequiredFilterId,
   );
   expect(outOfScopeNonRequiredCall?.[1]?.filterState?.value).toEqual([
-    'value3',
+    "value3",
   ]);
 
   updateDataMaskSpy.mockRestore();
 });
 
-test('Clear All on a required filter disables Apply via validateStatus', async () => {
-  const filterId = 'NATIVE_FILTER-required-clear';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+test("Clear All on a required filter disables Apply via validateStatus", async () => {
+  const filterId = "NATIVE_FILTER-required-clear";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
   const requiredFilter = createFilter({
     id: filterId,
-    name: 'Required Region',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    name: "Required Region",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "region" } }],
     controlValues: { enableEmptyFilter: true },
     chartsInScope: [18],
   });
@@ -958,11 +958,11 @@ test('Clear All on a required filter disables Apply via validateStatus', async (
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: {
-      [filterId]: createDataMask(filterId, ['East'], {
-        filters: [{ col: 'region', op: 'IN', val: ['East'] }],
+      [filterId]: createDataMask(filterId, ["East"], {
+        filters: [{ col: "region", op: "IN", val: ["East"] }],
       }),
     },
     nativeFilters: {
@@ -977,24 +977,24 @@ test('Clear All on a required filter disables Apply via validateStatus', async (
     jest.advanceTimersByTime(300);
   });
 
-  const clearBtn = screen.getByTestId(getTestId('clear-button'));
+  const clearBtn = screen.getByTestId(getTestId("clear-button"));
   await act(async () => {
     userEvent.click(clearBtn);
   });
 
   // No dispatch yet; Apply should be disabled because the required filter is empty
   expect(updateDataMaskSpy).not.toHaveBeenCalled();
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
   updateDataMaskSpy.mockRestore();
 });
 
-test('FilterBar renders the configured filter name in the bar', async () => {
-  const filterId = 'NATIVE_FILTER-name-render';
+test("FilterBar renders the configured filter name in the bar", async () => {
+  const filterId = "NATIVE_FILTER-name-render";
   const filter = createFilter({
     id: filterId,
-    name: 'Region',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    name: "Region",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "region" } }],
     chartsInScope: [18],
   });
   const state = {
@@ -1010,7 +1010,7 @@ test('FilterBar renders the configured filter name in the bar', async () => {
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     dataMask: { [filterId]: createDataMask(filterId, undefined, {}) },
     nativeFilters: {
@@ -1025,7 +1025,7 @@ test('FilterBar renders the configured filter name in the bar', async () => {
     jest.advanceTimersByTime(300);
   });
 
-  expect(await screen.findByText('Region')).toBeInTheDocument();
+  expect(await screen.findByText("Region")).toBeInTheDocument();
 });
 
 test('Clicking the gear "Add or edit filters and controls" item opens the FiltersConfigModal', async () => {
@@ -1035,18 +1035,18 @@ test('Clicking the gear "Add or edit filters and controls" item opens the Filter
     jest.advanceTimersByTime(100);
   });
 
-  const gear = await screen.findByTestId('filterbar-orientation-icon');
+  const gear = await screen.findByTestId("filterbar-orientation-icon");
   userEvent.click(gear);
 
   const addEditItem = await screen.findByText(
-    'Add or edit filters and controls',
+    "Add or edit filters and controls",
   );
   userEvent.click(addEditItem);
 
-  expect(await screen.findByTestId('filter-modal')).toBeInTheDocument();
+  expect(await screen.findByTestId("filter-modal")).toBeInTheDocument();
 });
 
-test('FilterBar with orientation=Horizontal routes to Horizontal layout instead of Vertical', async () => {
+test("FilterBar with orientation=Horizontal routes to Horizontal layout instead of Vertical", async () => {
   // Migrated from the disabled Cypress spec _skip.horizontalFilterBar.test.ts:
   // proves the orientation prop selects the Horizontal subtree. The settings
   // gear (FilterBarSettings) is rendered only by Horizontal.tsx — Vertical.tsx
@@ -1055,8 +1055,8 @@ test('FilterBar with orientation=Horizontal routes to Horizontal layout instead 
   // all pending fake timers to clear useInitialization's setTimeout
   // regardless of the production timeout literal.
   const filter = createFilter({
-    id: 'NATIVE_FILTER-h1',
-    name: 'Horizontal filter',
+    id: "NATIVE_FILTER-h1",
+    name: "Horizontal filter",
   });
   const dataMask = createDataMask(filter.id);
   const state = createStateWithFilter(filter, dataMask, {
@@ -1074,10 +1074,10 @@ test('FilterBar with orientation=Horizontal routes to Horizontal layout instead 
     jest.runAllTimers();
   });
 
-  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
+  expect(screen.getByRole("img", { name: "setting" })).toBeInTheDocument();
 });
 
-test('FilterBar with orientation=Horizontal and no filters shows empty state alongside default actions', async () => {
+test("FilterBar with orientation=Horizontal and no filters shows empty state alongside default actions", async () => {
   // Covers the second half of sc-107387 task #107390 ("show all default
   // actions in horizontal mode"). The original Cypress spec asserted four
   // affordances render when the bar is horizontal with no filters: the
@@ -1099,7 +1099,7 @@ test('FilterBar with orientation=Horizontal and no filters shows empty state alo
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     nativeFilters: { filters: {}, filtersState: {} },
   };
@@ -1115,53 +1115,53 @@ test('FilterBar with orientation=Horizontal and no filters shows empty state alo
     jest.runAllTimers();
   });
 
-  expect(screen.getByTestId('horizontal-filterbar-empty')).toHaveTextContent(
-    'No filters are currently added to this dashboard.',
+  expect(screen.getByTestId("horizontal-filterbar-empty")).toHaveTextContent(
+    "No filters are currently added to this dashboard.",
   );
-  expect(screen.getByRole('img', { name: 'setting' })).toBeInTheDocument();
-  expect(screen.getByTestId('filterbar-action-buttons')).toBeInTheDocument();
+  expect(screen.getByRole("img", { name: "setting" })).toBeInTheDocument();
+  expect(screen.getByTestId("filterbar-action-buttons")).toBeInTheDocument();
 });
 
-test('required filter with a default value auto-applies on load without touching other filters', async () => {
+test("required filter with a default value auto-applies on load without touching other filters", async () => {
   // Regression proof for #34617: a dashboard with a required filter that has
   // a default value used to leave the default un-applied (and Apply blocked
   // by a stale validateStatus) until the user touched every filter. Since the
   // auto-apply logic introduced by #36927, FilterBar dispatches the derived
   // dataMask itself as soon as the filter control finishes loading — the user
   // never has to touch the other filters, or the filter bar at all.
-  const requiredId = 'NATIVE_FILTER-required-with-default';
-  const untouchedId = 'NATIVE_FILTER-untouched';
-  const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+  const requiredId = "NATIVE_FILTER-required-with-default";
+  const untouchedId = "NATIVE_FILTER-untouched";
+  const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
 
   fetchMock.post(
-    'glob:*/api/v1/chart/data',
+    "glob:*/api/v1/chart/data",
     {
       result: [
         {
-          data: [{ region: 'East' }, { region: 'West' }],
-          colnames: ['region'],
+          data: [{ region: "East" }, { region: "West" }],
+          colnames: ["region"],
           coltypes: [1],
           applied_filters: [],
         },
       ],
     },
-    { name: 'chart-data-issue-34617' },
+    { name: "chart-data-issue-34617" },
   );
 
   const requiredFilter = createFilter({
     id: requiredId,
-    name: 'Required Region',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'region' } }],
+    name: "Required Region",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "region" } }],
     controlValues: { enableEmptyFilter: true },
-    defaultDataMask: { filterState: { value: ['East'] }, extraFormData: {} },
+    defaultDataMask: { filterState: { value: ["East"] }, extraFormData: {} },
     chartsInScope: [18],
   });
   const untouchedFilter = createFilter({
     id: untouchedId,
-    name: 'Untouched Color',
-    filterType: 'filter_select',
-    targets: [{ datasetId: 7, column: { name: 'color' } }],
+    name: "Untouched Color",
+    filterType: "filter_select",
+    targets: [{ datasetId: 7, column: { name: "color" } }],
     chartsInScope: [18],
   });
 
@@ -1178,13 +1178,13 @@ test('required filter with a default value auto-applies on load without touching
     },
     dashboardState: {
       ...stateWithoutNativeFilters.dashboardState,
-      activeTabs: ['ROOT_ID'],
+      activeTabs: ["ROOT_ID"],
     },
     // The default value has been hydrated into the applied dataMask, but its
     // extraFormData has not been derived yet — the state right after a
     // dashboard with default filter values loads.
     dataMask: {
-      [requiredId]: createDataMask(requiredId, ['East'], {}),
+      [requiredId]: createDataMask(requiredId, ["East"], {}),
     },
     nativeFilters: {
       filters: {
@@ -1212,9 +1212,9 @@ test('required filter with a default value auto-applies on load without touching
       requiredId,
       expect.objectContaining({
         extraFormData: {
-          filters: [{ col: 'region', op: 'IN', val: ['East'] }],
+          filters: [{ col: "region", op: "IN", val: ["East"] }],
         },
-        filterState: expect.objectContaining({ value: ['East'] }),
+        filterState: expect.objectContaining({ value: ["East"] }),
       }),
     );
   });
@@ -1226,41 +1226,41 @@ test('required filter with a default value auto-applies on load without touching
 
   // Nothing is left pending: the default value is already applied, so the
   // Apply button is not blocking on untouched filters.
-  expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+  expect(screen.getByTestId(getTestId("apply-button"))).toBeDisabled();
 
   updateDataMaskSpy.mockRestore();
 });
 
-test('FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)', () => {
+test("FilterBar with orientation=Vertical renders Vertical layout (sanity counterpart to the horizontal routing test)", () => {
   // Paired control for the routing test above: with Vertical orientation,
   // the settings gear must NOT be present (Vertical.tsx does not render
   // FilterBarSettings). Confirms the routing signal is horizontal-exclusive,
   // not a coincidence of when timers fire.
   const props = createClosedBarProps();
   renderFilterBar(props);
-  expect(screen.getByText('Filters and controls')).toBeInTheDocument();
+  expect(screen.getByText("Filters and controls")).toBeInTheDocument();
   expect(
-    screen.queryByRole('img', { name: 'setting' }),
+    screen.queryByRole("img", { name: "setting" }),
   ).not.toBeInTheDocument();
 });
 
-describe('cascading native filter clear', () => {
-  const parentId = 'NATIVE_FILTER-cascade-country';
-  const childId = 'NATIVE_FILTER-cascade-city';
+describe("cascading native filter clear", () => {
+  const parentId = "NATIVE_FILTER-cascade-country";
+  const childId = "NATIVE_FILTER-cascade-city";
 
   function createCascadeState() {
     const parentFilter = createFilter({
       id: parentId,
-      name: 'Country',
-      filterType: 'filter_select',
-      targets: [{ datasetId: 7, column: { name: 'country' } }],
+      name: "Country",
+      filterType: "filter_select",
+      targets: [{ datasetId: 7, column: { name: "country" } }],
       chartsInScope: [18],
     });
     const childFilter = createFilter({
       id: childId,
-      name: 'City',
-      filterType: 'filter_select',
-      targets: [{ datasetId: 7, column: { name: 'city' } }],
+      name: "City",
+      filterType: "filter_select",
+      targets: [{ datasetId: 7, column: { name: "city" } }],
       cascadeParentIds: [parentId],
       chartsInScope: [18],
     });
@@ -1277,14 +1277,14 @@ describe('cascading native filter clear', () => {
       },
       dashboardState: {
         ...stateWithoutNativeFilters.dashboardState,
-        activeTabs: ['ROOT_ID'],
+        activeTabs: ["ROOT_ID"],
       },
       dataMask: {
-        [parentId]: createDataMask(parentId, ['USA'], {
-          filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
+        [parentId]: createDataMask(parentId, ["USA"], {
+          filters: [{ col: "country", op: "IN", val: ["USA"] }],
         }),
-        [childId]: createDataMask(childId, ['New York'], {
-          filters: [{ col: 'city', op: 'IN', val: ['New York'] }],
+        [childId]: createDataMask(childId, ["New York"], {
+          filters: [{ col: "city", op: "IN", val: ["New York"] }],
         }),
       },
       nativeFilters: {
@@ -1302,25 +1302,25 @@ describe('cascading native filter clear', () => {
     // this suite's static response always wins for the filter queries.
     fetchMock.removeRoutes();
     fetchMock.post(
-      'glob:*/api/v1/chart/data',
+      "glob:*/api/v1/chart/data",
       {
         result: [
           {
-            data: [{ country: 'USA' }, { country: 'UK' }],
-            colnames: ['country'],
+            data: [{ country: "USA" }, { country: "UK" }],
+            colnames: ["country"],
             coltypes: [1],
             applied_filters: [],
           },
         ],
       },
-      { name: 'cascade-chart-data' },
+      { name: "cascade-chart-data" },
     );
   });
 
-  test('changing a parent filter value clears the child selection', async () => {
+  test("changing a parent filter value clears the child selection", async () => {
     // Spy must be created inside the test: earlier tests in this file restore
     // a shared spy on the same action, which would silently detach this one.
-    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
 
     const state = createCascadeState();
     const props = createOpenedBarProps();
@@ -1332,13 +1332,13 @@ describe('cascading native filter clear', () => {
 
     // Locate the parent (Country) select control via its labeled form item,
     // then change its value from USA to UK.
-    const parentLabel = await screen.findByText('Country');
-    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
-    const parentSelect = within(parentFormItem).getByRole('combobox');
+    const parentLabel = await screen.findByText("Country");
+    const parentFormItem = parentLabel.closest(".ant-form-item") as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole("combobox");
     await act(async () => {
       await userEvent.click(parentSelect);
     });
-    const ukOption = await screen.findByText('UK');
+    const ukOption = await screen.findByText("UK");
     await act(async () => {
       await userEvent.click(ukOption);
     });
@@ -1350,16 +1350,139 @@ describe('cascading native filter clear', () => {
 
     // Apply the staged changes. The child (City) must be dispatched with a
     // cleared value — New York is not a valid city under UK.
-    const applyBtn = screen.getByTestId(getTestId('apply-button'));
+    const applyBtn = screen.getByTestId(getTestId("apply-button"));
     await act(async () => {
       await userEvent.click(applyBtn);
     });
 
     const childCall = updateDataMaskSpy.mock.calls.find(
-      call => call[0] === childId,
+      (call) => call[0] === childId,
     );
     expect(childCall).toBeDefined();
     expect(childCall![1]?.filterState?.value).toEqual(null);
     expect(childCall![1]?.extraFormData).toEqual({});
+  });
+
+  test("changing a parent filter value clears a dependent Range child with [null, null]", async () => {
+    const rangeChildId = "NATIVE_FILTER-cascade-age";
+    const rangeChildFilter = createFilter({
+      id: rangeChildId,
+      name: "Age",
+      filterType: "filter_range",
+      targets: [{ datasetId: 7, column: { name: "age" } }],
+      cascadeParentIds: [parentId],
+      chartsInScope: [18],
+    });
+    const state = {
+      ...stateWithoutNativeFilters,
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: true,
+        filterBarOrientation: FilterBarOrientation.Vertical,
+        metadata: {
+          native_filter_configuration: [
+            createFilter({
+              id: parentId,
+              name: "Country",
+              filterType: "filter_select",
+              targets: [{ datasetId: 7, column: { name: "country" } }],
+              chartsInScope: [18],
+            }),
+            rangeChildFilter,
+          ],
+          chart_configuration: {},
+        },
+      },
+      dashboardState: {
+        ...stateWithoutNativeFilters.dashboardState,
+        activeTabs: ["ROOT_ID"],
+      },
+      dataMask: {
+        [parentId]: createDataMask(parentId, ["USA"], {
+          filters: [{ col: "country", op: "IN", val: ["USA"] }],
+        }),
+        [rangeChildId]: createDataMask(rangeChildId, [10, 70], {
+          filters: [
+            { col: "age", op: ">=", val: 10 },
+            { col: "age", op: "<=", val: 70 },
+          ],
+        }),
+      },
+      nativeFilters: {
+        filters: {
+          [parentId]: createFilter({
+            id: parentId,
+            name: "Country",
+            filterType: "filter_select",
+            targets: [{ datasetId: 7, column: { name: "country" } }],
+            chartsInScope: [18],
+          }),
+          [rangeChildId]: rangeChildFilter,
+        },
+        filtersState: {},
+      },
+    };
+
+    // First call returns parent options; second call returns range data
+    // for the child (loaded after the parent dependency resolves).
+    fetchMock.removeRoutes();
+    fetchMock.post(
+      "glob:*/api/v1/chart/data",
+      {
+        result: [
+          {
+            data: [{ country: "USA" }, { country: "UK" }],
+            colnames: ["country"],
+            coltypes: [1],
+            applied_filters: [],
+          },
+          {
+            data: [{ min: 0, max: 100 }],
+            colnames: ["min", "max"],
+            coltypes: [0, 0],
+            applied_filters: [],
+          },
+        ],
+      },
+      { name: "cascade-range-chart-data" },
+    );
+
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, "updateDataMask");
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const parentLabel = await screen.findByText("Country");
+    const parentFormItem = parentLabel.closest(".ant-form-item") as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole("combobox");
+    await act(async () => {
+      await userEvent.click(parentSelect);
+    });
+    const ukOption = await screen.findByText("UK");
+    await act(async () => {
+      await userEvent.click(ukOption);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const applyBtn = screen.getByTestId(getTestId("apply-button"));
+    await act(async () => {
+      await userEvent.click(applyBtn);
+    });
+
+    // The Range child must be cleared with [null, null], not bare null.
+    // Bare null is ignored by RangeFilterPlugin's sync effect and would
+    // leave stale UI (the original reviewer concern).
+    const rangeChildCall = updateDataMaskSpy.mock.calls.find(
+      (call) => call[0] === rangeChildId,
+    );
+    expect(rangeChildCall).toBeDefined();
+    expect(rangeChildCall![1]?.filterState?.value).toEqual([null, null]);
+    expect(rangeChildCall![1]?.extraFormData).toEqual({});
   });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -1485,4 +1485,291 @@ describe('cascading native filter clear', () => {
     expect(rangeChildCall![1]?.filterState?.value).toEqual([null, null]);
     expect(rangeChildCall![1]?.extraFormData).toEqual({});
   });
+
+  test('an optional parent first real selection clears the child', async () => {
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+
+    const state = createCascadeState();
+    // The parent starts with no value (no default, nothing persisted) while
+    // the child still holds a persisted value from a prior combination.
+    state.dataMask[parentId] = createDataMask(parentId, undefined, {});
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Locate the parent (Country) select control via its labeled form item,
+    // then pick the parent's first value.
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole('combobox');
+    await act(async () => {
+      await userEvent.click(parentSelect);
+    });
+    const ukOption = await screen.findByText('UK');
+    await act(async () => {
+      await userEvent.click(ukOption);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // The first user-selected parent value is a dependency change, so the
+    // child's stale persisted selection must be cleared.
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
+    await act(async () => {
+      await userEvent.click(applyBtn);
+    });
+
+    const childCall = updateDataMaskSpy.mock.calls.find(
+      call => call[0] === childId,
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall![1]?.filterState?.value).toEqual(null);
+    expect(childCall![1]?.extraFormData).toEqual({});
+
+    updateDataMaskSpy.mockRestore();
+  });
+
+  test('defaultToFirstItem auto-seed does not clear the child', async () => {
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+
+    const state = createCascadeState();
+    // The parent auto-selects its first option on load; that initialization
+    // must not be treated as a dependency change.
+    state.dataMask[parentId] = createDataMask(parentId, undefined, {});
+    state.nativeFilters.filters[parentId] = createFilter({
+      id: parentId,
+      name: 'Country',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'country' } }],
+      controlValues: { defaultToFirstItem: true },
+      chartsInScope: [18],
+    });
+    state.dashboardInfo.metadata.native_filter_configuration = [
+      state.nativeFilters.filters[parentId],
+      state.nativeFilters.filters[childId],
+    ];
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // The child keeps its persisted value once the parent auto-seeds.
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
+    await act(async () => {
+      await userEvent.click(applyBtn);
+    });
+
+    const childCall = updateDataMaskSpy.mock.calls.find(
+      call => call[0] === childId,
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall![1]?.filterState?.value).toEqual(['New York']);
+
+    updateDataMaskSpy.mockRestore();
+  });
+
+  test('inverse-selection toggle clears the child even though the selected value is unchanged', async () => {
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+
+    const state = createCascadeState();
+    // Configure the parent as an inverse-selection filter so the IN / NOT IN
+    // (exclude) control is available.
+    const inverseParentFilter = createFilter({
+      id: parentId,
+      name: 'Country',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'country' } }],
+      controlValues: { inverseSelection: true },
+      chartsInScope: [18],
+    });
+    state.nativeFilters.filters[parentId] = inverseParentFilter;
+    state.dashboardInfo.metadata.native_filter_configuration = [
+      inverseParentFilter,
+      state.nativeFilters.filters[childId],
+    ];
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+
+    // Flip the clause from 'is' (IN) to 'is not' (NOT IN) while the selected
+    // value stays ['USA'].
+    const excludeSelect = parentFormItem.querySelector(
+      '.exclude-select',
+    ) as HTMLElement;
+    await act(async () => {
+      await userEvent.click(excludeSelect);
+    });
+    const isNotOption = await screen.findByText('is not');
+    await act(async () => {
+      await userEvent.click(isNotOption);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // IN -> NOT IN changes the dependency clause, so the child must clear.
+    const applyBtn = screen.getByTestId(getTestId('apply-button'));
+    await act(async () => {
+      await userEvent.click(applyBtn);
+    });
+
+    const childCall = updateDataMaskSpy.mock.calls.find(
+      call => call[0] === childId,
+    );
+    expect(childCall).toBeDefined();
+    expect(childCall![1]?.filterState?.value).toEqual(null);
+    expect(childCall![1]?.extraFormData).toEqual({});
+
+    updateDataMaskSpy.mockRestore();
+  });
+
+  test('cascading clear of a required Range child keeps Apply disabled', async () => {
+    const requiredRangeChildId = 'NATIVE_FILTER-cascade-required-age';
+    const requiredRangeChildFilter = createFilter({
+      id: requiredRangeChildId,
+      name: 'Age',
+      filterType: 'filter_range',
+      targets: [{ datasetId: 7, column: { name: 'age' } }],
+      controlValues: { enableEmptyFilter: true },
+      cascadeParentIds: [parentId],
+      chartsInScope: [18],
+    });
+    const countryFilter = createFilter({
+      id: parentId,
+      name: 'Country',
+      filterType: 'filter_select',
+      targets: [{ datasetId: 7, column: { name: 'country' } }],
+      chartsInScope: [18],
+    });
+    const state = {
+      ...stateWithoutNativeFilters,
+      dashboardInfo: {
+        id: 1,
+        dash_edit_perm: true,
+        filterBarOrientation: FilterBarOrientation.Vertical,
+        metadata: {
+          native_filter_configuration: [
+            countryFilter,
+            requiredRangeChildFilter,
+          ],
+          chart_configuration: {},
+        },
+      },
+      dashboardState: {
+        ...stateWithoutNativeFilters.dashboardState,
+        activeTabs: ['ROOT_ID'],
+      },
+      dataMask: {
+        [parentId]: createDataMask(parentId, ['USA'], {
+          filters: [{ col: 'country', op: 'IN', val: ['USA'] }],
+        }),
+        [requiredRangeChildId]: createDataMask(requiredRangeChildId, [10, 70], {
+          filters: [
+            { col: 'age', op: '>=', val: 10 },
+            { col: 'age', op: '<=', val: 70 },
+          ],
+        }),
+      },
+      nativeFilters: {
+        filters: {
+          [parentId]: countryFilter,
+          [requiredRangeChildId]: requiredRangeChildFilter,
+        },
+        filtersState: {},
+      },
+    };
+
+    fetchMock.removeRoutes();
+    // The Range child requests MIN/MAX aggregates, which lets us tell its
+    // query apart from the parent select's options query and give it numeric data.
+    fetchMock.post(
+      request => {
+        const [url, opts] = (request as { args: [string, { body?: string }] })
+          .args;
+        return (
+          url.includes('/api/v1/chart/data') &&
+          typeof opts.body === 'string' &&
+          opts.body.includes('"aggregate":"MIN"')
+        );
+      },
+      {
+        result: [
+          {
+            data: [{ min: 0, max: 100 }],
+            colnames: ['min', 'max'],
+            coltypes: [0, 0],
+            applied_filters: [],
+          },
+        ],
+      },
+      { name: 'cascade-required-range-minmax' },
+    );
+    fetchMock.post(
+      // Fallback: serve the parent select's country options
+      'glob:*/api/v1/chart/data',
+      {
+        result: [
+          {
+            data: [{ country: 'USA' }, { country: 'UK' }],
+            colnames: ['country'],
+            coltypes: [1],
+            applied_filters: [],
+          },
+        ],
+      },
+      { name: 'cascade-required-range-values' },
+    );
+
+    const updateDataMaskSpy = jest.spyOn(dataMaskActions, 'updateDataMask');
+    const props = createOpenedBarProps();
+    renderFilterBar(props, state);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const parentLabel = await screen.findByText('Country');
+    const parentFormItem = parentLabel.closest('.ant-form-item') as HTMLElement;
+    const parentSelect = within(parentFormItem).getByRole('combobox');
+    await act(async () => {
+      await userEvent.click(parentSelect);
+    });
+    const ukOption = await screen.findByText('UK');
+    await act(async () => {
+      await userEvent.click(ukOption);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // The required Range child must not be applied empty: Apply stays
+    // disabled and the stale [10, 70] value is never re-dispatched.
+    expect(screen.getByTestId(getTestId('apply-button'))).toBeDisabled();
+    expect(
+      updateDataMaskSpy.mock.calls.find(
+        call => call[0] === requiredRangeChildId,
+      ),
+    ).toBeUndefined();
+
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs[0]).toHaveValue('');
+    expect(inputs[1]).toHaveValue('');
+
+    updateDataMaskSpy.mockRestore();
+  });
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx
@@ -1698,8 +1698,9 @@ describe('cascading native filter clear', () => {
     // query apart from the parent select's options query and give it numeric data.
     fetchMock.post(
       request => {
-        const [url, opts] = (request as { args: [string, { body?: string }] })
-          .args;
+        const [url, opts] = (
+          request as unknown as { args: [string, { body?: string }] }
+        ).args;
         return (
           url.includes('/api/v1/chart/data') &&
           typeof opts.body === 'string' &&

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControl.tsx
@@ -54,6 +54,8 @@ const FilterControl = ({
   overflow = false,
   clearAllTrigger,
   onClearAllComplete,
+  cascadeClearTrigger,
+  onCascadeClearComplete,
 }: FilterControlProps) => {
   const portalNode = useMemo(() => createHtmlPortalNode(), []);
   const [isFilterActive, setIsFilterActive] = useState(false);
@@ -160,6 +162,8 @@ const FilterControl = ({
           validateStatus={validateStatus}
           clearAllTrigger={clearAllTrigger}
           onClearAllComplete={onClearAllComplete}
+          cascadeClearTrigger={cascadeClearTrigger}
+          onCascadeClearComplete={onCascadeClearComplete}
         />
       </InPortal>
       <FilterControlContainer

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterControls.tsx
@@ -97,6 +97,8 @@ type FilterControlsProps = {
   chartCustomizationValues: (ChartCustomization | ChartCustomizationDivider)[];
   clearAllTriggers?: Record<string, boolean>;
   onClearAllComplete?: (filterId: string) => void;
+  cascadeClearTriggers?: Record<string, boolean>;
+  onCascadeClearComplete?: (filterId: string) => void;
   hideHeader?: boolean;
 };
 
@@ -157,6 +159,8 @@ const FilterControls: FC<FilterControlsProps> = ({
   chartCustomizationValues,
   clearAllTriggers,
   onClearAllComplete,
+  cascadeClearTriggers,
+  onCascadeClearComplete,
   hideHeader = false,
 }) => {
   const theme = useTheme();
@@ -192,6 +196,8 @@ const FilterControls: FC<FilterControlsProps> = ({
     onFilterSelectionChange,
     clearAllTriggers,
     onClearAllComplete,
+    cascadeClearTriggers,
+    onCascadeClearComplete,
   );
   const portalNodes = useMemo(
     () =>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -111,6 +111,8 @@ const FilterValue: FC<FilterValueProps> = ({
   validateStatus,
   clearAllTrigger,
   onClearAllComplete,
+  cascadeClearTrigger,
+  onCascadeClearComplete,
 }) => {
   const theme = useTheme() as SupersetTheme;
   const { id, targets, filterType } = filter;
@@ -375,6 +377,8 @@ const FilterValue: FC<FilterValueProps> = ({
       setFilterActive,
       clearAllTrigger,
       onClearAllComplete,
+      cascadeClearTrigger,
+      onCascadeClearComplete,
     }),
     [
       setDataMask,
@@ -385,6 +389,8 @@ const FilterValue: FC<FilterValueProps> = ({
       unsetFocusedFilter,
       clearAllTrigger,
       onClearAllComplete,
+      cascadeClearTrigger,
+      onCascadeClearComplete,
     ],
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
@@ -29,8 +29,11 @@ import {
   FilterConfigMap,
   resolveTransitiveParentIds,
 } from '../../dependencyGraph';
-import { useFilterDependencies, useTransitiveParentIds } from './state';
-
+import {
+  useFilterDependencies,
+  useTransitiveChildIds,
+  useTransitiveParentIds,
+} from './state';
 const mockStore = configureStore([]);
 
 const buildWrapper = (filters: FilterConfigMap) => {
@@ -179,4 +182,24 @@ test('useFilterDependencies returns empty object when parent state is missing', 
     wrapper,
   });
   expect(result.current).toEqual({});
+});
+
+test('useTransitiveChildIds reads descendant filter config from redux', () => {
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+    D: { cascadeParentIds: ['B'] },
+  });
+  const { result } = renderHook(() => useTransitiveChildIds('A'), { wrapper });
+  expect(result.current).toEqual(['B', 'C', 'D']);
+});
+
+test('useTransitiveChildIds returns empty for a leaf filter', () => {
+  const wrapper = buildWrapper({
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+  });
+  const { result } = renderHook(() => useTransitiveChildIds('B'), { wrapper });
+  expect(result.current).toEqual([]);
 });

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts
@@ -34,6 +34,7 @@ import {
   useTransitiveChildIds,
   useTransitiveParentIds,
 } from './state';
+
 const mockStore = configureStore([]);
 
 const buildWrapper = (filters: FilterConfigMap) => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.ts
@@ -23,6 +23,7 @@ import { RootState } from 'src/dashboard/types';
 import { mergeExtraFormData } from '../../utils';
 import {
   FilterConfigMap,
+  resolveTransitiveChildIds,
   resolveTransitiveParentIds,
 } from '../../dependencyGraph';
 
@@ -61,4 +62,21 @@ export function useFilterDependencies(
     });
     return dependencies;
   }, [dataMaskSelected, dependencyIds]);
+}
+
+/**
+ * Resolve the transitive descendant (child) filter ids for a given filter
+ * from the live native-filter configuration in Redux. Used to determine which
+ * dependent filters must be cleared when a parent filter's value changes.
+ */
+export function useTransitiveChildIds(id: string): string[] {
+  const filterConfig = useSelector<RootState, FilterConfigMap | undefined>(
+    state => state.nativeFilters?.filters,
+    shallowEqual,
+  );
+
+  return useMemo(
+    () => resolveTransitiveChildIds(id, filterConfig ?? {}),
+    [id, filterConfig],
+  );
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
@@ -56,4 +56,5 @@ export interface FilterControlProps extends BaseFilterProps {
   clearAllTrigger?: boolean;
   cascadeClearTrigger?: boolean;
   onClearAllComplete?: () => void;
+  onCascadeClearComplete?: () => void;
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/types.ts
@@ -54,5 +54,6 @@ export interface FilterControlProps extends BaseFilterProps {
   setFilterActive?: (isActive: boolean) => void;
   validateStatus?: string;
   clearAllTrigger?: boolean;
+  cascadeClearTrigger?: boolean;
   onClearAllComplete?: () => void;
 }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -116,6 +116,8 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
   onPendingCustomizationDataMaskChange,
   clearAllTriggers,
   onClearAllComplete,
+  cascadeClearTriggers,
+  onCascadeClearComplete,
 }) => {
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
     state => state.dataMask,
@@ -230,6 +232,8 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
                   chartCustomizationValues={chartCustomizationValues}
                   clearAllTriggers={clearAllTriggers}
                   onClearAllComplete={onClearAllComplete}
+                  cascadeClearTriggers={cascadeClearTriggers}
+                  onCascadeClearComplete={onCascadeClearComplete}
                 />
               </>
             )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Vertical.tsx
@@ -146,6 +146,10 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
   toggleFiltersBar,
   width,
   mobileMode,
+  clearAllTriggers,
+  onClearAllComplete,
+  cascadeClearTriggers,
+  onCascadeClearComplete,
 }) => {
   const theme = useTheme();
   const [isScrolling, setIsScrolling] = useState(false);
@@ -232,6 +236,10 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
           }
           chartCustomizationValues={chartCustomizationValues}
           hideHeader={hasOnlyOneSectionType}
+          clearAllTriggers={clearAllTriggers}
+          onClearAllComplete={onClearAllComplete}
+          cascadeClearTriggers={cascadeClearTriggers}
+          onCascadeClearComplete={onCascadeClearComplete}
         />
       </FilterControlsWrapper>
     ) : (
@@ -257,6 +265,10 @@ const VerticalFilterBar: FC<VerticalBarProps> = ({
     onPendingCustomizationDataMaskChange,
     chartCustomizationValues,
     hasOnlyOneSectionType,
+    clearAllTriggers,
+    onClearAllComplete,
+    cascadeClearTriggers,
+    onCascadeClearComplete,
   ]);
 
   return (

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -26,9 +26,9 @@ import {
   useCallback,
   useRef,
   useMemo,
-} from 'react';
+} from "react";
 
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from "react-redux";
 import {
   DataMaskStateWithId,
   DataMaskWithId,
@@ -40,47 +40,47 @@ import {
   NativeFilterTarget,
   ChartCustomization,
   ChartCustomizationDivider,
-} from '@superset-ui/core';
-import { styled } from '@apache-superset/core/theme';
-import { Constants } from '@superset-ui/core/components';
-import { useHistory } from 'react-router-dom';
-import { updateDataMask, removeDataMask } from 'src/dataMask/actions';
+} from "@superset-ui/core";
+import { styled } from "@apache-superset/core/theme";
+import { Constants } from "@superset-ui/core/components";
+import { useHistory } from "react-router-dom";
+import { updateDataMask, removeDataMask } from "src/dataMask/actions";
 import {
   saveChartCustomization,
   clearAllPendingChartCustomizations,
   clearAllChartCustomizationsFromMetadata,
-} from 'src/dashboard/actions/chartCustomizationActions';
+} from "src/dashboard/actions/chartCustomizationActions";
 
-import { useImmer } from 'use-immer';
-import { isEmpty, isEqual, debounce } from 'lodash-es';
-import { getInitialDataMask } from 'src/dataMask/reducer';
-import { URL_PARAMS } from 'src/constants';
-import { applicationRoot } from 'src/utils/getBootstrapData';
-import { getUrlParam } from 'src/utils/urlUtils';
-import { useTabId } from 'src/hooks/useTabId';
-import { logEvent } from 'src/logger/actions';
-import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from 'src/logger/LogUtils';
-import { FilterBarOrientation, RootState } from 'src/dashboard/types';
-import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
-import { isChartCustomization } from '../FiltersConfigModal/utils';
-import { checkIsApplyDisabled, getFiltersToApply } from './utils';
-import { extractLabel } from '../selectors';
-import { FiltersBarProps } from './types';
-import { resolveTransitiveChildIds } from '../dependencyGraph';
+import { useImmer } from "use-immer";
+import { isEmpty, isEqual, debounce } from "lodash-es";
+import { getInitialDataMask } from "src/dataMask/reducer";
+import { URL_PARAMS } from "src/constants";
+import { applicationRoot } from "src/utils/getBootstrapData";
+import { getUrlParam } from "src/utils/urlUtils";
+import { useTabId } from "src/hooks/useTabId";
+import { logEvent } from "src/logger/actions";
+import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from "src/logger/LogUtils";
+import { FilterBarOrientation, RootState } from "src/dashboard/types";
+import { UserWithPermissionsAndRoles } from "src/types/bootstrapTypes";
+import { isChartCustomization } from "../FiltersConfigModal/utils";
+import { checkIsApplyDisabled, getFiltersToApply } from "./utils";
+import { extractLabel } from "../selectors";
+import { FiltersBarProps } from "./types";
+import { resolveTransitiveChildIds } from "../dependencyGraph";
 import {
   useAllAppliedDataMask,
   useFilters,
   useFilterUpdates,
   useInitialization,
-} from './state';
-import { createFilterKey, updateFilterKey } from './keyValue';
-import ActionButtons from './ActionButtons';
-import Horizontal from './Horizontal';
-import Vertical from './Vertical';
+} from "./state";
+import { createFilterKey, updateFilterKey } from "./keyValue";
+import ActionButtons from "./ActionButtons";
+import Horizontal from "./Horizontal";
+import Vertical from "./Vertical";
 import {
   useSelectFiltersInScope,
   useChartCustomizationConfiguration,
-} from '../state';
+} from "../state";
 
 // FilterBar is just being hidden as it must still
 // render fully due to encapsulated logics
@@ -115,7 +115,7 @@ const publishDataMask = debounce(
     const rawRisonFilterValue = rawRisonMatch ? rawRisonMatch[1] : null;
 
     previousParams.forEach((value, key) => {
-      if (!EXCLUDED_URL_PARAMS.includes(key) && key !== 'f') {
+      if (!EXCLUDED_URL_PARAMS.includes(key) && key !== "f") {
         newParams.append(key, value);
       }
     });
@@ -154,13 +154,13 @@ const publishDataMask = debounce(
       // double it up.
       const appRoot = applicationRoot();
       let replacementPathname = window.location.pathname;
-      if (appRoot !== '/' && replacementPathname.startsWith(appRoot)) {
+      if (appRoot !== "/" && replacementPathname.startsWith(appRoot)) {
         replacementPathname = replacementPathname.substring(appRoot.length);
       }
       // Manually reconstruct the search string to preserve Rison filter encoding
       let searchString = newParams.toString();
       if (rawRisonFilterValue) {
-        const separator = searchString ? '&' : '';
+        const separator = searchString ? "&" : "";
         searchString = `${searchString}${separator}f=${rawRisonFilterValue}`;
       }
 
@@ -209,18 +209,18 @@ const FilterBar: FC<FiltersBarProps> = ({
   const user: UserWithPermissionsAndRoles = useSelector<
     RootState,
     UserWithPermissionsAndRoles
-  >(state => state.user);
+  >((state) => state.user);
 
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
   const inScopeFilterIds = useMemo(
-    () => new Set(filtersInScope.map(f => f.id)),
+    () => new Set(filtersInScope.map((f) => f.id)),
     [filtersInScope],
   );
 
   const hasOutOfScopeRequiredFilters = useMemo(
     () =>
       nativeFilterValues.some(
-        filter =>
+        (filter) =>
           !inScopeFilterIds.has(filter.id) &&
           !!filter.controlValues?.enableEmptyFilter,
       ),
@@ -243,10 +243,10 @@ const FilterBar: FC<FiltersBarProps> = ({
   dataMaskSelectedRef.current = dataMaskSelected;
   const handleFilterSelectionChange = useCallback(
     (
-      filter: Pick<Filter, 'id'> & Partial<Filter>,
+      filter: Pick<Filter, "id"> & Partial<Filter>,
       dataMask: Partial<DataMask>,
     ) => {
-      setDataMaskSelected(draft => {
+      setDataMaskSelected((draft) => {
         const appliedDataMask = dataMaskApplied[filter.id];
         const isFirstTimeInitialization = !initializedFilters.has(filter.id);
 
@@ -296,7 +296,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           Object.keys(dataMask.extraFormData).length > 0 &&
           !initializedFilters.has(filter.id)
         ) {
-          setInitializedFilters(prev => new Set(prev).add(filter.id));
+          setInitializedFilters((prev) => new Set(prev).add(filter.id));
         }
 
         const baseDataMask = {
@@ -311,7 +311,7 @@ const FilterBar: FC<FiltersBarProps> = ({
         const isEmptyValue =
           value == null ||
           (Array.isArray(value) && value.length === 0) ||
-          (typeof value === 'string' && value.trim() === '');
+          (typeof value === "string" && value.trim() === "");
 
         const hasRequiredValue = isRequired && isEmptyValue;
 
@@ -327,7 +327,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           prevValue !== undefined && !isEqual(prevValue, nextValue);
         if (parentValueChanged) {
           const childIds = resolveTransitiveChildIds(filter.id, filters);
-          childIds.forEach(childId => {
+          childIds.forEach((childId) => {
             const childMask = draft[childId];
             if (!childMask) return;
             childMask.extraFormData = {};
@@ -335,14 +335,20 @@ const FilterBar: FC<FiltersBarProps> = ({
             if (filterState) {
               const childIsRequired =
                 !!filters[childId]?.controlValues?.enableEmptyFilter;
-              filterState.value = null;
+              // Mirror handleClearAll: range filters use [null, null] as the
+              // canonical cleared value.  Bare null would be ignored by
+              // RangeFilterPlugin's sync effect, leaving stale UI.
+              filterState.value =
+                filters[childId]?.filterType === "filter_range"
+                  ? [null, null]
+                  : null;
               filterState.validateStatus = childIsRequired
-                ? 'error'
+                ? "error"
                 : undefined;
             }
             // Signal the child's filter plugin to clear its visual selection
             // and avoid re-applying defaults.
-            setCascadeClearTriggers(prev => ({
+            setCascadeClearTriggers((prev) => ({
               ...prev,
               [childId]: true,
             }));
@@ -353,7 +359,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           ...baseDataMask,
           filterState: {
             ...baseDataMask.filterState,
-            validateStatus: hasRequiredValue ? 'error' : undefined,
+            validateStatus: hasRequiredValue ? "error" : undefined,
           },
         };
       });
@@ -371,7 +377,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   useEffect(() => {
     if (previousFilters && dashboardId === previousDashboardId) {
       const updates: Record<string, DataMaskWithId> = {};
-      Object.values(filters).forEach(currentFilter => {
+      Object.values(filters).forEach((currentFilter) => {
         const previousFilter = previousFilters?.[currentFilter.id];
         if (!previousFilter) {
           return;
@@ -394,7 +400,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       });
 
       if (!isEmpty(updates)) {
-        setDataMaskSelected(draft => ({ ...draft, ...updates }));
+        setDataMaskSelected((draft) => ({ ...draft, ...updates }));
       }
     }
   }, [dashboardId, filters, previousDashboardId, setDataMaskSelected]);
@@ -411,7 +417,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       const prevApplied = prevDataMaskAppliedRef.current;
 
       // Only sync filters whose applied state actually changed
-      setDataMaskSelected(prev => {
+      setDataMaskSelected((prev) => {
         let hasChanges = false;
         const updated = { ...prev };
 
@@ -427,7 +433,7 @@ const FilterBar: FC<FiltersBarProps> = ({
         });
 
         // Remove stale entries that no longer exist in dataMaskApplied
-        Object.keys(updated).forEach(filterId => {
+        Object.keys(updated).forEach((filterId) => {
           if (
             !isChartCustomization(filterId) &&
             !(filterId in dataMaskApplied)
@@ -455,11 +461,11 @@ const FilterBar: FC<FiltersBarProps> = ({
   const pendingChartCustomizations = useSelector<
     RootState,
     Record<string, ChartCustomization> | undefined
-  >(state => state.dashboardInfo.pendingChartCustomizations);
+  >((state) => state.dashboardInfo.pendingChartCustomizations);
 
   const handlePendingCustomizationDataMaskChange = useCallback(
     (customizationId: string, dataMask: DataMask) => {
-      setPendingCustomizationDataMasks(prev => ({
+      setPendingCustomizationDataMasks((prev) => ({
         ...prev,
         [customizationId]: dataMask,
       }));
@@ -476,7 +482,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       inScopeFilterIds,
     );
 
-    filtersToApply.forEach(filterId => {
+    filtersToApply.forEach((filterId) => {
       const dataMask = dataMaskSelected[filterId];
       if (dataMask) {
         dispatch(updateDataMask(filterId, dataMask));
@@ -504,14 +510,13 @@ const FilterBar: FC<FiltersBarProps> = ({
       // Skip pending items no longer in the config; re-saving a deleted one
       // makes the backend append it back, resurrecting the control.
       const existingCustomizationIds = new Set(
-        chartCustomizationValues.map(item => item.id),
+        chartCustomizationValues.map((item) => item.id),
       );
       const pendingItems = (
         Object.values(pendingChartCustomizations).filter(Boolean) as (
-          | ChartCustomization
-          | ChartCustomizationDivider
+          ChartCustomization | ChartCustomizationDivider
         )[]
-      ).filter(item => existingCustomizationIds.has(item.id));
+      ).filter((item) => existingCustomizationIds.has(item.id));
 
       if (pendingItems.length > 0) {
         dispatch(saveChartCustomization(pendingItems, []));
@@ -519,16 +524,18 @@ const FilterBar: FC<FiltersBarProps> = ({
       dispatch(clearAllPendingChartCustomizations());
       setPendingCustomizationDataMasks({});
     } else if (hasClearedChartCustomizations) {
-      const clearedChartCustomizations = chartCustomizationValues.map(item => ({
-        ...item,
-        targets: [
-          {
-            datasetId: item.targets?.[0]?.datasetId,
-          },
-        ] as [Partial<NativeFilterTarget>],
-      }));
+      const clearedChartCustomizations = chartCustomizationValues.map(
+        (item) => ({
+          ...item,
+          targets: [
+            {
+              datasetId: item.targets?.[0]?.datasetId,
+            },
+          ] as [Partial<NativeFilterTarget>],
+        }),
+      );
 
-      chartCustomizationValues.forEach(item => {
+      chartCustomizationValues.forEach((item) => {
         dispatch(removeDataMask(item.id));
       });
 
@@ -551,7 +558,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   const handleClearAll = useCallback(() => {
     const newClearAllTriggers = { ...clearAllTriggers };
 
-    nativeFilterValues.forEach(filter => {
+    nativeFilterValues.forEach((filter) => {
       const { id, filterType } = filter;
 
       // Only clear in-scope filters
@@ -561,17 +568,17 @@ const FilterBar: FC<FiltersBarProps> = ({
       // undefined: the select plugin's init effect treats undefined as
       // "uninitialized" and would re-apply default values once the clear-all
       // trigger completes.
-      const clearedValue = filterType === 'filter_range' ? [null, null] : null;
+      const clearedValue = filterType === "filter_range" ? [null, null] : null;
       const isRequired = !!filter.controlValues?.enableEmptyFilter;
       if (dataMaskSelected[id]) {
         // Stage the cleared value locally; do NOT dispatch to Redux here.
         // Persistence happens when the user clicks Apply.
-        setDataMaskSelected(draft => {
+        setDataMaskSelected((draft) => {
           draft[id].extraFormData = {};
           const { filterState } = draft[id];
           if (filterState) {
             filterState.value = clearedValue;
-            filterState.validateStatus = isRequired ? 'error' : undefined;
+            filterState.validateStatus = isRequired ? "error" : undefined;
           }
         });
         newClearAllTriggers[id] = true;
@@ -579,18 +586,18 @@ const FilterBar: FC<FiltersBarProps> = ({
     });
 
     const allDataMasks = { ...dataMaskSelected, ...dataMaskApplied };
-    const hasCustomizationDataMasks = Object.keys(allDataMasks).some(key =>
+    const hasCustomizationDataMasks = Object.keys(allDataMasks).some((key) =>
       isChartCustomization(key),
     );
-    const hasSavedCustomizations = chartCustomizationValues.some(item => {
+    const hasSavedCustomizations = chartCustomizationValues.some((item) => {
       if (item.removed) return false;
       const mask = dataMaskApplied[item.id] || dataMaskSelected[item.id];
       return extractLabel(mask?.filterState) !== null;
     });
 
     if (hasCustomizationDataMasks || hasSavedCustomizations) {
-      chartCustomizationValues.forEach(item => {
-        setDataMaskSelected(draft => {
+      chartCustomizationValues.forEach((item) => {
+        setDataMaskSelected((draft) => {
           draft[item.id] = {
             id: item.id,
             filterState: { value: null },
@@ -618,7 +625,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   ]);
 
   const handleClearAllComplete = useCallback((filterId: string) => {
-    setClearAllTriggers(prev => {
+    setClearAllTriggers((prev) => {
       const newTriggers = { ...prev };
       delete newTriggers[filterId];
       return newTriggers;
@@ -626,7 +633,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   }, []);
 
   const handleCascadeClearComplete = useCallback((filterId: string) => {
-    setCascadeClearTriggers(prev => {
+    setCascadeClearTriggers((prev) => {
       const newTriggers = { ...prev };
       delete newTriggers[filterId];
       return newTriggers;
@@ -640,7 +647,7 @@ const FilterBar: FC<FiltersBarProps> = ({
     Object.keys(pendingChartCustomizations).length > 0;
 
   const hasMissingRequiredChartCustomization =
-    chartCustomizationValues?.some(item => {
+    chartCustomizationValues?.some((item) => {
       if (item.removed) return false;
 
       const required = !!item.controlValues?.enableEmptyFilter;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -328,13 +328,15 @@ const FilterBar: FC<FiltersBarProps> = ({
         if (parentValueChanged) {
           const childIds = resolveTransitiveChildIds(filter.id, filters);
           childIds.forEach(childId => {
-            if (!draft[childId]) return;
-            draft[childId].extraFormData = {};
-            if (draft[childId].filterState) {
+            const childMask = draft[childId];
+            if (!childMask) return;
+            childMask.extraFormData = {};
+            const { filterState } = childMask;
+            if (filterState) {
               const childIsRequired =
                 !!filters[childId]?.controlValues?.enableEmptyFilter;
-              draft[childId].filterState.value = null;
-              draft[childId].filterState.validateStatus = childIsRequired
+              filterState.value = null;
+              filterState.validateStatus = childIsRequired
                 ? 'error'
                 : undefined;
             }

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -321,10 +321,23 @@ const FilterBar: FC<FiltersBarProps> = ({
         // longer belongs to the parent's option set (e.g. Country=UK with a
         // City value only valid under USA), producing impossible filter
         // combinations that blank charts.
-        const prevValue = draft[filter.id]?.filterState?.value;
-        const nextValue = baseDataMask.filterState?.value;
+        const prevMask = draft[filter.id];
+        const prevValue = prevMask?.filterState?.value;
+        const prevExtra = prevMask?.extraFormData;
+        const nextExtra = baseDataMask.extraFormData;
+        // Filters configured with defaultToFirstItem auto-select their first
+        // option on load. That seed is initialization, not a dependency
+        // change, and must not clear descendants. Persisted values reach the
+        // applied state through the sync effect rather than this callback, so
+        // any other first emission is a genuine user selection.
+        const isAutoSeedInit =
+          prevValue === undefined && !!filter.controlValues?.defaultToFirstItem;
+        // The effective dependency state is the parent's extraFormData (the
+        // clauses and time_range merged into descendants), not the raw
+        // selected value: inverse-selection toggles change the clause while
+        // the selected value stays identical.
         const parentValueChanged =
-          prevValue !== undefined && !isEqual(prevValue, nextValue);
+          !!prevMask && !isAutoSeedInit && !isEqual(prevExtra, nextExtra);
         if (parentValueChanged) {
           const childIds = resolveTransitiveChildIds(filter.id, filters);
           childIds.forEach(childId => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -26,9 +26,9 @@ import {
   useCallback,
   useRef,
   useMemo,
-} from "react";
+} from 'react';
 
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from 'react-redux';
 import {
   DataMaskStateWithId,
   DataMaskWithId,
@@ -40,47 +40,47 @@ import {
   NativeFilterTarget,
   ChartCustomization,
   ChartCustomizationDivider,
-} from "@superset-ui/core";
-import { styled } from "@apache-superset/core/theme";
-import { Constants } from "@superset-ui/core/components";
-import { useHistory } from "react-router-dom";
-import { updateDataMask, removeDataMask } from "src/dataMask/actions";
+} from '@superset-ui/core';
+import { styled } from '@apache-superset/core/theme';
+import { Constants } from '@superset-ui/core/components';
+import { useHistory } from 'react-router-dom';
+import { updateDataMask, removeDataMask } from 'src/dataMask/actions';
 import {
   saveChartCustomization,
   clearAllPendingChartCustomizations,
   clearAllChartCustomizationsFromMetadata,
-} from "src/dashboard/actions/chartCustomizationActions";
+} from 'src/dashboard/actions/chartCustomizationActions';
 
-import { useImmer } from "use-immer";
-import { isEmpty, isEqual, debounce } from "lodash-es";
-import { getInitialDataMask } from "src/dataMask/reducer";
-import { URL_PARAMS } from "src/constants";
-import { applicationRoot } from "src/utils/getBootstrapData";
-import { getUrlParam } from "src/utils/urlUtils";
-import { useTabId } from "src/hooks/useTabId";
-import { logEvent } from "src/logger/actions";
-import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from "src/logger/LogUtils";
-import { FilterBarOrientation, RootState } from "src/dashboard/types";
-import { UserWithPermissionsAndRoles } from "src/types/bootstrapTypes";
-import { isChartCustomization } from "../FiltersConfigModal/utils";
-import { checkIsApplyDisabled, getFiltersToApply } from "./utils";
-import { extractLabel } from "../selectors";
-import { FiltersBarProps } from "./types";
-import { resolveTransitiveChildIds } from "../dependencyGraph";
+import { useImmer } from 'use-immer';
+import { isEmpty, isEqual, debounce } from 'lodash-es';
+import { getInitialDataMask } from 'src/dataMask/reducer';
+import { URL_PARAMS } from 'src/constants';
+import { applicationRoot } from 'src/utils/getBootstrapData';
+import { getUrlParam } from 'src/utils/urlUtils';
+import { useTabId } from 'src/hooks/useTabId';
+import { logEvent } from 'src/logger/actions';
+import { LOG_ACTIONS_CHANGE_DASHBOARD_FILTER } from 'src/logger/LogUtils';
+import { FilterBarOrientation, RootState } from 'src/dashboard/types';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { isChartCustomization } from '../FiltersConfigModal/utils';
+import { checkIsApplyDisabled, getFiltersToApply } from './utils';
+import { extractLabel } from '../selectors';
+import { FiltersBarProps } from './types';
+import { resolveTransitiveChildIds } from '../dependencyGraph';
 import {
   useAllAppliedDataMask,
   useFilters,
   useFilterUpdates,
   useInitialization,
-} from "./state";
-import { createFilterKey, updateFilterKey } from "./keyValue";
-import ActionButtons from "./ActionButtons";
-import Horizontal from "./Horizontal";
-import Vertical from "./Vertical";
+} from './state';
+import { createFilterKey, updateFilterKey } from './keyValue';
+import ActionButtons from './ActionButtons';
+import Horizontal from './Horizontal';
+import Vertical from './Vertical';
 import {
   useSelectFiltersInScope,
   useChartCustomizationConfiguration,
-} from "../state";
+} from '../state';
 
 // FilterBar is just being hidden as it must still
 // render fully due to encapsulated logics
@@ -115,7 +115,7 @@ const publishDataMask = debounce(
     const rawRisonFilterValue = rawRisonMatch ? rawRisonMatch[1] : null;
 
     previousParams.forEach((value, key) => {
-      if (!EXCLUDED_URL_PARAMS.includes(key) && key !== "f") {
+      if (!EXCLUDED_URL_PARAMS.includes(key) && key !== 'f') {
         newParams.append(key, value);
       }
     });
@@ -154,13 +154,13 @@ const publishDataMask = debounce(
       // double it up.
       const appRoot = applicationRoot();
       let replacementPathname = window.location.pathname;
-      if (appRoot !== "/" && replacementPathname.startsWith(appRoot)) {
+      if (appRoot !== '/' && replacementPathname.startsWith(appRoot)) {
         replacementPathname = replacementPathname.substring(appRoot.length);
       }
       // Manually reconstruct the search string to preserve Rison filter encoding
       let searchString = newParams.toString();
       if (rawRisonFilterValue) {
-        const separator = searchString ? "&" : "";
+        const separator = searchString ? '&' : '';
         searchString = `${searchString}${separator}f=${rawRisonFilterValue}`;
       }
 
@@ -209,18 +209,18 @@ const FilterBar: FC<FiltersBarProps> = ({
   const user: UserWithPermissionsAndRoles = useSelector<
     RootState,
     UserWithPermissionsAndRoles
-  >((state) => state.user);
+  >(state => state.user);
 
   const [filtersInScope] = useSelectFiltersInScope(nativeFilterValues);
   const inScopeFilterIds = useMemo(
-    () => new Set(filtersInScope.map((f) => f.id)),
+    () => new Set(filtersInScope.map(f => f.id)),
     [filtersInScope],
   );
 
   const hasOutOfScopeRequiredFilters = useMemo(
     () =>
       nativeFilterValues.some(
-        (filter) =>
+        filter =>
           !inScopeFilterIds.has(filter.id) &&
           !!filter.controlValues?.enableEmptyFilter,
       ),
@@ -243,10 +243,10 @@ const FilterBar: FC<FiltersBarProps> = ({
   dataMaskSelectedRef.current = dataMaskSelected;
   const handleFilterSelectionChange = useCallback(
     (
-      filter: Pick<Filter, "id"> & Partial<Filter>,
+      filter: Pick<Filter, 'id'> & Partial<Filter>,
       dataMask: Partial<DataMask>,
     ) => {
-      setDataMaskSelected((draft) => {
+      setDataMaskSelected(draft => {
         const appliedDataMask = dataMaskApplied[filter.id];
         const isFirstTimeInitialization = !initializedFilters.has(filter.id);
 
@@ -296,7 +296,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           Object.keys(dataMask.extraFormData).length > 0 &&
           !initializedFilters.has(filter.id)
         ) {
-          setInitializedFilters((prev) => new Set(prev).add(filter.id));
+          setInitializedFilters(prev => new Set(prev).add(filter.id));
         }
 
         const baseDataMask = {
@@ -311,7 +311,7 @@ const FilterBar: FC<FiltersBarProps> = ({
         const isEmptyValue =
           value == null ||
           (Array.isArray(value) && value.length === 0) ||
-          (typeof value === "string" && value.trim() === "");
+          (typeof value === 'string' && value.trim() === '');
 
         const hasRequiredValue = isRequired && isEmptyValue;
 
@@ -327,7 +327,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           prevValue !== undefined && !isEqual(prevValue, nextValue);
         if (parentValueChanged) {
           const childIds = resolveTransitiveChildIds(filter.id, filters);
-          childIds.forEach((childId) => {
+          childIds.forEach(childId => {
             const childMask = draft[childId];
             if (!childMask) return;
             childMask.extraFormData = {};
@@ -339,16 +339,16 @@ const FilterBar: FC<FiltersBarProps> = ({
               // canonical cleared value.  Bare null would be ignored by
               // RangeFilterPlugin's sync effect, leaving stale UI.
               filterState.value =
-                filters[childId]?.filterType === "filter_range"
+                filters[childId]?.filterType === 'filter_range'
                   ? [null, null]
                   : null;
               filterState.validateStatus = childIsRequired
-                ? "error"
+                ? 'error'
                 : undefined;
             }
             // Signal the child's filter plugin to clear its visual selection
             // and avoid re-applying defaults.
-            setCascadeClearTriggers((prev) => ({
+            setCascadeClearTriggers(prev => ({
               ...prev,
               [childId]: true,
             }));
@@ -359,7 +359,7 @@ const FilterBar: FC<FiltersBarProps> = ({
           ...baseDataMask,
           filterState: {
             ...baseDataMask.filterState,
-            validateStatus: hasRequiredValue ? "error" : undefined,
+            validateStatus: hasRequiredValue ? 'error' : undefined,
           },
         };
       });
@@ -377,7 +377,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   useEffect(() => {
     if (previousFilters && dashboardId === previousDashboardId) {
       const updates: Record<string, DataMaskWithId> = {};
-      Object.values(filters).forEach((currentFilter) => {
+      Object.values(filters).forEach(currentFilter => {
         const previousFilter = previousFilters?.[currentFilter.id];
         if (!previousFilter) {
           return;
@@ -400,7 +400,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       });
 
       if (!isEmpty(updates)) {
-        setDataMaskSelected((draft) => ({ ...draft, ...updates }));
+        setDataMaskSelected(draft => ({ ...draft, ...updates }));
       }
     }
   }, [dashboardId, filters, previousDashboardId, setDataMaskSelected]);
@@ -417,7 +417,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       const prevApplied = prevDataMaskAppliedRef.current;
 
       // Only sync filters whose applied state actually changed
-      setDataMaskSelected((prev) => {
+      setDataMaskSelected(prev => {
         let hasChanges = false;
         const updated = { ...prev };
 
@@ -433,7 +433,7 @@ const FilterBar: FC<FiltersBarProps> = ({
         });
 
         // Remove stale entries that no longer exist in dataMaskApplied
-        Object.keys(updated).forEach((filterId) => {
+        Object.keys(updated).forEach(filterId => {
           if (
             !isChartCustomization(filterId) &&
             !(filterId in dataMaskApplied)
@@ -461,11 +461,11 @@ const FilterBar: FC<FiltersBarProps> = ({
   const pendingChartCustomizations = useSelector<
     RootState,
     Record<string, ChartCustomization> | undefined
-  >((state) => state.dashboardInfo.pendingChartCustomizations);
+  >(state => state.dashboardInfo.pendingChartCustomizations);
 
   const handlePendingCustomizationDataMaskChange = useCallback(
     (customizationId: string, dataMask: DataMask) => {
-      setPendingCustomizationDataMasks((prev) => ({
+      setPendingCustomizationDataMasks(prev => ({
         ...prev,
         [customizationId]: dataMask,
       }));
@@ -482,7 +482,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       inScopeFilterIds,
     );
 
-    filtersToApply.forEach((filterId) => {
+    filtersToApply.forEach(filterId => {
       const dataMask = dataMaskSelected[filterId];
       if (dataMask) {
         dispatch(updateDataMask(filterId, dataMask));
@@ -510,13 +510,14 @@ const FilterBar: FC<FiltersBarProps> = ({
       // Skip pending items no longer in the config; re-saving a deleted one
       // makes the backend append it back, resurrecting the control.
       const existingCustomizationIds = new Set(
-        chartCustomizationValues.map((item) => item.id),
+        chartCustomizationValues.map(item => item.id),
       );
       const pendingItems = (
         Object.values(pendingChartCustomizations).filter(Boolean) as (
-          ChartCustomization | ChartCustomizationDivider
+          | ChartCustomization
+          | ChartCustomizationDivider
         )[]
-      ).filter((item) => existingCustomizationIds.has(item.id));
+      ).filter(item => existingCustomizationIds.has(item.id));
 
       if (pendingItems.length > 0) {
         dispatch(saveChartCustomization(pendingItems, []));
@@ -524,18 +525,16 @@ const FilterBar: FC<FiltersBarProps> = ({
       dispatch(clearAllPendingChartCustomizations());
       setPendingCustomizationDataMasks({});
     } else if (hasClearedChartCustomizations) {
-      const clearedChartCustomizations = chartCustomizationValues.map(
-        (item) => ({
-          ...item,
-          targets: [
-            {
-              datasetId: item.targets?.[0]?.datasetId,
-            },
-          ] as [Partial<NativeFilterTarget>],
-        }),
-      );
+      const clearedChartCustomizations = chartCustomizationValues.map(item => ({
+        ...item,
+        targets: [
+          {
+            datasetId: item.targets?.[0]?.datasetId,
+          },
+        ] as [Partial<NativeFilterTarget>],
+      }));
 
-      chartCustomizationValues.forEach((item) => {
+      chartCustomizationValues.forEach(item => {
         dispatch(removeDataMask(item.id));
       });
 
@@ -558,7 +557,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   const handleClearAll = useCallback(() => {
     const newClearAllTriggers = { ...clearAllTriggers };
 
-    nativeFilterValues.forEach((filter) => {
+    nativeFilterValues.forEach(filter => {
       const { id, filterType } = filter;
 
       // Only clear in-scope filters
@@ -568,17 +567,17 @@ const FilterBar: FC<FiltersBarProps> = ({
       // undefined: the select plugin's init effect treats undefined as
       // "uninitialized" and would re-apply default values once the clear-all
       // trigger completes.
-      const clearedValue = filterType === "filter_range" ? [null, null] : null;
+      const clearedValue = filterType === 'filter_range' ? [null, null] : null;
       const isRequired = !!filter.controlValues?.enableEmptyFilter;
       if (dataMaskSelected[id]) {
         // Stage the cleared value locally; do NOT dispatch to Redux here.
         // Persistence happens when the user clicks Apply.
-        setDataMaskSelected((draft) => {
+        setDataMaskSelected(draft => {
           draft[id].extraFormData = {};
           const { filterState } = draft[id];
           if (filterState) {
             filterState.value = clearedValue;
-            filterState.validateStatus = isRequired ? "error" : undefined;
+            filterState.validateStatus = isRequired ? 'error' : undefined;
           }
         });
         newClearAllTriggers[id] = true;
@@ -586,18 +585,18 @@ const FilterBar: FC<FiltersBarProps> = ({
     });
 
     const allDataMasks = { ...dataMaskSelected, ...dataMaskApplied };
-    const hasCustomizationDataMasks = Object.keys(allDataMasks).some((key) =>
+    const hasCustomizationDataMasks = Object.keys(allDataMasks).some(key =>
       isChartCustomization(key),
     );
-    const hasSavedCustomizations = chartCustomizationValues.some((item) => {
+    const hasSavedCustomizations = chartCustomizationValues.some(item => {
       if (item.removed) return false;
       const mask = dataMaskApplied[item.id] || dataMaskSelected[item.id];
       return extractLabel(mask?.filterState) !== null;
     });
 
     if (hasCustomizationDataMasks || hasSavedCustomizations) {
-      chartCustomizationValues.forEach((item) => {
-        setDataMaskSelected((draft) => {
+      chartCustomizationValues.forEach(item => {
+        setDataMaskSelected(draft => {
           draft[item.id] = {
             id: item.id,
             filterState: { value: null },
@@ -625,7 +624,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   ]);
 
   const handleClearAllComplete = useCallback((filterId: string) => {
-    setClearAllTriggers((prev) => {
+    setClearAllTriggers(prev => {
       const newTriggers = { ...prev };
       delete newTriggers[filterId];
       return newTriggers;
@@ -633,7 +632,7 @@ const FilterBar: FC<FiltersBarProps> = ({
   }, []);
 
   const handleCascadeClearComplete = useCallback((filterId: string) => {
-    setCascadeClearTriggers((prev) => {
+    setCascadeClearTriggers(prev => {
       const newTriggers = { ...prev };
       delete newTriggers[filterId];
       return newTriggers;
@@ -647,7 +646,7 @@ const FilterBar: FC<FiltersBarProps> = ({
     Object.keys(pendingChartCustomizations).length > 0;
 
   const hasMissingRequiredChartCustomization =
-    chartCustomizationValues?.some((item) => {
+    chartCustomizationValues?.some(item => {
       if (item.removed) return false;
 
       const required = !!item.controlValues?.enableEmptyFilter;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/index.tsx
@@ -66,6 +66,7 @@ import { isChartCustomization } from '../FiltersConfigModal/utils';
 import { checkIsApplyDisabled, getFiltersToApply } from './utils';
 import { extractLabel } from '../selectors';
 import { FiltersBarProps } from './types';
+import { resolveTransitiveChildIds } from '../dependencyGraph';
 import {
   useAllAppliedDataMask,
   useFilters,
@@ -229,6 +230,9 @@ const FilterBar: FC<FiltersBarProps> = ({
   const [clearAllTriggers, setClearAllTriggers] = useState<
     Record<string, boolean>
   >({});
+  const [cascadeClearTriggers, setCascadeClearTriggers] = useState<
+    Record<string, boolean>
+  >({});
   const [initializedFilters, setInitializedFilters] = useState<Set<string>>(
     new Set(),
   );
@@ -311,6 +315,38 @@ const FilterBar: FC<FiltersBarProps> = ({
 
         const hasRequiredValue = isRequired && isEmptyValue;
 
+        // Cascade clearing: when a parent filter's value changes, every
+        // transitive descendant (child) dependent filter must have its
+        // selection reset. Otherwise the child keeps a stale value that no
+        // longer belongs to the parent's option set (e.g. Country=UK with a
+        // City value only valid under USA), producing impossible filter
+        // combinations that blank charts.
+        const prevValue = draft[filter.id]?.filterState?.value;
+        const nextValue = baseDataMask.filterState?.value;
+        const parentValueChanged =
+          prevValue !== undefined && !isEqual(prevValue, nextValue);
+        if (parentValueChanged) {
+          const childIds = resolveTransitiveChildIds(filter.id, filters);
+          childIds.forEach(childId => {
+            if (!draft[childId]) return;
+            draft[childId].extraFormData = {};
+            if (draft[childId].filterState) {
+              const childIsRequired =
+                !!filters[childId]?.controlValues?.enableEmptyFilter;
+              draft[childId].filterState.value = null;
+              draft[childId].filterState.validateStatus = childIsRequired
+                ? 'error'
+                : undefined;
+            }
+            // Signal the child's filter plugin to clear its visual selection
+            // and avoid re-applying defaults.
+            setCascadeClearTriggers(prev => ({
+              ...prev,
+              [childId]: true,
+            }));
+          });
+        }
+
         draft[filter.id] = {
           ...baseDataMask,
           filterState: {
@@ -326,6 +362,7 @@ const FilterBar: FC<FiltersBarProps> = ({
       initializedFilters,
       setInitializedFilters,
       dataMaskApplied,
+      filters,
     ],
   );
 
@@ -586,6 +623,14 @@ const FilterBar: FC<FiltersBarProps> = ({
     });
   }, []);
 
+  const handleCascadeClearComplete = useCallback((filterId: string) => {
+    setCascadeClearTriggers(prev => {
+      const newTriggers = { ...prev };
+      delete newTriggers[filterId];
+      return newTriggers;
+    });
+  }, []);
+
   useFilterUpdates(dataMaskSelected, setDataMaskSelected);
 
   const hasPendingChartCustomizations =
@@ -662,6 +707,8 @@ const FilterBar: FC<FiltersBarProps> = ({
         }
         clearAllTriggers={clearAllTriggers}
         onClearAllComplete={handleClearAllComplete}
+        cascadeClearTriggers={cascadeClearTriggers}
+        onCascadeClearComplete={handleCascadeClearComplete}
       />
     ) : verticalConfig ? (
       <Vertical
@@ -683,6 +730,8 @@ const FilterBar: FC<FiltersBarProps> = ({
         mobileMode={verticalConfig.mobileMode}
         clearAllTriggers={clearAllTriggers}
         onClearAllComplete={handleClearAllComplete}
+        cascadeClearTriggers={cascadeClearTriggers}
+        onCascadeClearComplete={handleCascadeClearComplete}
       />
     ) : null;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
@@ -45,6 +45,8 @@ interface CommonFiltersBarProps {
   ) => void;
   clearAllTriggers?: Record<string, boolean>;
   onClearAllComplete?: (filterId: string) => void;
+  cascadeClearTriggers?: Record<string, boolean>;
+  onCascadeClearComplete?: (filterId: string) => void;
 }
 
 interface VerticalBarConfig {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/useFilterControlFactory.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/useFilterControlFactory.tsx
@@ -35,6 +35,8 @@ export const useFilterControlFactory = (
   onFilterSelectionChange: (filter: Filter, dataMask: DataMask) => void,
   clearAllTriggers?: Record<string, boolean>,
   onClearAllComplete?: (filterId: string) => void,
+  cascadeClearTriggers?: Record<string, boolean>,
+  onCascadeClearComplete?: (filterId: string) => void,
 ) => {
   const filters = useFilters();
   const filterValues = useMemo(
@@ -77,6 +79,8 @@ export const useFilterControlFactory = (
           overflow={overflow}
           clearAllTrigger={clearAllTriggers?.[filter.id]}
           onClearAllComplete={() => onClearAllComplete?.(filter.id)}
+          cascadeClearTrigger={cascadeClearTriggers?.[filter.id]}
+          onCascadeClearComplete={() => onCascadeClearComplete?.(filter.id)}
         />
       );
     },
@@ -86,6 +90,8 @@ export const useFilterControlFactory = (
       onFilterSelectionChange,
       clearAllTriggers,
       onClearAllComplete,
+      cascadeClearTriggers,
+      onCascadeClearComplete,
     ],
   );
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.test.ts
@@ -197,6 +197,27 @@ test('checkIsMissingRequiredValue returns true for required filter with null val
   expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
 });
 
+test('checkIsMissingRequiredValue returns true for required filter with [null, null] value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: [null, null] };
+
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+});
+
+test('checkIsMissingRequiredValue returns true for required filter with empty array value', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: [] };
+
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(true);
+});
+
+test('checkIsMissingRequiredValue returns false for a partially filled range', () => {
+  const filter = createFilter('test-filter', { enableEmptyFilter: true });
+  const filterState: FilterState = { value: [null, 70] };
+
+  expect(checkIsMissingRequiredValue(filter, filterState)).toBe(false);
+});
+
 test('checkIsMissingRequiredValue returns false for required filter with valid value', () => {
   const filter = createFilter('test-filter', { enableEmptyFilter: true });
   const filterState: FilterState = { value: ['CA'] };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -56,9 +56,14 @@ export const checkIsMissingRequiredValue = (
   if (!isRequired) return false;
 
   const value = filterState?.value;
+  const isMissing =
+    value === null ||
+    value === undefined ||
+    (Array.isArray(value) &&
+      (value.length === 0 || value.every(item => item === null)));
 
   // TODO: this property should be unhardcoded
-  return value === null || value === undefined;
+  return isMissing;
 };
 
 export const checkIsValidateError = (dataMask: DataMaskStateWithId) => {

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/utils.ts
@@ -59,8 +59,7 @@ export const checkIsMissingRequiredValue = (
   const isMissing =
     value === null ||
     value === undefined ||
-    (Array.isArray(value) &&
-      (value.length === 0 || value.every(item => item === null)));
+    (Array.isArray(value) && value.every(item => item === null));
 
   // TODO: this property should be unhardcoded
   return isMissing;

--- a/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { resolveTransitiveChildIds } from './dependencyGraph';
+
+test('resolveTransitiveChildIds returns empty for a filter with no children', () => {
+  expect(
+    resolveTransitiveChildIds('A', {
+      A: { cascadeParentIds: [] },
+    }),
+  ).toEqual([]);
+});
+
+test('resolveTransitiveChildIds returns direct children', () => {
+  const result = resolveTransitiveChildIds('A', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['A'] },
+  });
+  // Breadth-first: direct children before grandchildren.
+  expect(result).toEqual(['B', 'C']);
+});
+
+test('resolveTransitiveChildIds walks a linear chain A -> B -> C -> D', () => {
+  // D depends on C, C on B, B on A.
+  const result = resolveTransitiveChildIds('A', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['B'] },
+    D: { cascadeParentIds: ['C'] },
+  });
+  // Breadth-first: B (direct child) before C, then D.
+  expect(result).toEqual(['B', 'C', 'D']);
+});
+
+test('resolveTransitiveChildIds deduplicates shared descendants in a diamond', () => {
+  //      A
+  //    /  \
+  //   B    C
+  //    \  /
+  //     D
+  const result = resolveTransitiveChildIds('A', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['A'] },
+    D: { cascadeParentIds: ['B', 'C'] },
+  });
+  expect(result).toEqual(['B', 'C', 'D']);
+});
+
+test('resolveTransitiveChildIds collects descendants for a mid-chain filter', () => {
+  // Given B below, descendants of B are D (and any deeper nodes).
+  const result = resolveTransitiveChildIds('B', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: ['A'] },
+    D: { cascadeParentIds: ['B'] },
+  });
+  expect(result).toEqual(['D']);
+});
+
+test('resolveTransitiveChildIds defends against cyclic configuration', () => {
+  const result = resolveTransitiveChildIds('A', {
+    A: { cascadeParentIds: ['B'] },
+    B: { cascadeParentIds: ['A'] },
+  });
+  expect(result).toEqual(['B']);
+});
+
+test('resolveTransitiveChildIds only includes filters that list the parent', () => {
+  // Filters that do not declare a dependency should not be considered
+  // descendants even though they reference the same columns.
+  const result = resolveTransitiveChildIds('A', {
+    A: { cascadeParentIds: [] },
+    B: { cascadeParentIds: ['A'] },
+    C: { cascadeParentIds: [] },
+  });
+  expect(result).toEqual(['B']);
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.ts
@@ -73,3 +73,50 @@ export function resolveTransitiveParentIds(
   visit(id);
   return ordered;
 }
+
+/**
+ * Resolve the set of transitive *descendant* filter ids for the given filter.
+ *
+ * This is the inverse of `resolveTransitiveParentIds`: instead of walking the
+ * `cascadeParentIds` edges upward to find ancestors, it builds a reverse
+ * adjacency map (parent -> children) and walks that downward to collect every
+ * filter that transitively depends on `id`.
+ *
+ * It is used to know which dependent filters must be cleared/reset when a
+ * parent filter's value changes (a cascading native-filter behavior). The
+ * returned array is ordered breadth-first so direct children come before
+ * grandchildren, which is the natural order in which they should be cleared.
+ *
+ * Cycles are silently skipped to defend against malformed saved configs,
+ * mirroring the `resolveTransitiveParentIds` behavior.
+ */
+export function resolveTransitiveChildIds(
+  id: string,
+  filterConfig: FilterConfigMap,
+): string[] {
+  const childrenByParent = new Map<string, string[]>();
+  Object.entries(filterConfig).forEach(([childId, filter]) => {
+    ensureIsArray(filter?.cascadeParentIds).forEach((parentId: string) => {
+      const siblings = childrenByParent.get(parentId) ?? [];
+      siblings.push(childId);
+      childrenByParent.set(parentId, siblings);
+    });
+  });
+
+  const ordered: string[] = [];
+  const visited = new Set<string>([id]);
+  const queue = [id];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()!;
+    const children = childrenByParent.get(currentId) ?? [];
+    children.forEach(childId => {
+      if (visited.has(childId)) return;
+      visited.add(childId);
+      ordered.push(childId);
+      queue.push(childId);
+    });
+  }
+
+  return ordered;
+}

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.test.tsx
@@ -19,7 +19,7 @@
 import { AppSection, type ChartProps } from '@superset-ui/core';
 import { GenericDataType } from '@apache-superset/core/common';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 import RangeFilterPlugin, { calculateStep } from './RangeFilterPlugin';
 import { RangeDisplayMode, type PluginFilterRangeProps } from './types';
 import { SingleValueType } from './SingleValueType';
@@ -470,6 +470,51 @@ describe('RangeFilterPlugin', () => {
         validateStatus: undefined,
         validateMessage: '',
       },
+    });
+  });
+
+  test('required range cascade clear keeps the validation error instead of re-applying the stale value', async () => {
+    const setDataMaskMock = jest.fn();
+    const renderWith = (filterState: PluginFilterRangeProps['filterState']) => (
+      <RangeFilterPlugin
+        {...(transformProps({
+          ...rangeProps,
+          formData: { ...rangeProps.formData, enableEmptyFilter: true },
+          filterState,
+        } as unknown as ChartProps) as PluginFilterRangeProps)}
+        setDataMask={setDataMaskMock}
+      />
+    );
+
+    // Required range sitting at its selected value.
+    const { rerender } = render(renderWith({ value: [10, 70] }));
+    setDataMaskMock.mockClear();
+
+    // A parent filter change stages the canonical [null, null] clear with an
+    // 'error' status for required filters.
+    rerender(renderWith({ value: [null, null], validateStatus: 'error' }));
+
+    // The stale [10, 70] value must never be re-applied.
+    await waitFor(() => {
+      expect(setDataMaskMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          filterState: expect.objectContaining({ value: [10, 70] }),
+        }),
+      );
+    });
+
+    // The required error mask is emitted with no clauses.
+    await waitFor(() => {
+      expect(setDataMaskMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extraFormData: {},
+          filterState: expect.objectContaining({
+            value: null,
+            validateStatus: 'error',
+            validateMessage: 'Please provide a valid min or max value',
+          }),
+        }),
+      );
     });
   });
 });

--- a/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Range/RangeFilterPlugin.tsx
@@ -339,6 +339,34 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
       return;
     }
 
+    // Clear sentinel takes priority over the error revalidation below. The
+    // filter bar stages [null, null] (plus a validateStatus of 'error' for
+    // required filters) when a parent filter changes or Clear All is
+    // triggered. Re-validating the stale local inputValue in that case would
+    // re-emit the previously selected range, defeating the clear.
+    if (
+      filterState.value === undefined ||
+      isEqualArray(filterState.value, [null, null])
+    ) {
+      setInputValue([null, null]);
+      if (enableEmptyFilter) {
+        // A required range must not be applied empty: keep the validation
+        // error active and emit no clauses instead of the stale value.
+        const { errorMessage } = validateRange(
+          [null, null],
+          min,
+          max,
+          enableEmptyFilter,
+          enableSingleValue,
+        );
+        setError(errorMessage);
+        updateDataMaskError(errorMessage);
+      } else {
+        updateDataMaskValue([null, null]);
+      }
+      return;
+    }
+
     if (filterState.validateStatus === 'error') {
       setError(filterState.validateMessage);
 
@@ -360,19 +388,6 @@ export default function RangeFilterPlugin(props: PluginFilterRangeProps) {
           updateDataMaskValue(inputValue);
         }
       }
-      return;
-    }
-
-    // Clear all case. The filter bar stages [null, null] for range filters, so
-    // matching only undefined let a filter still sitting at its default fall
-    // through to the default-restoring branch below.
-    if (
-      (filterState.value === undefined ||
-        isEqualArray(filterState.value, [null, null])) &&
-      !filterState.validateStatus
-    ) {
-      setInputValue([null, null]);
-      updateDataMaskValue([null, null]);
       return;
     }
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.test.tsx
@@ -1953,6 +1953,81 @@ test('clear-all resets LIKE input value and calls setDataMask with empty state',
   expect(setDataMaskMock).toHaveBeenCalledTimes(callsBeforeDebounceFlush);
 });
 
+test('cascade clear cancels a pending LIKE debounce so stale text is not re-applied', async () => {
+  jest.useFakeTimers({ advanceTimers: true });
+  const setDataMaskMock = jest.fn();
+  const likeProps = buildSelectFilterProps({
+    formData: { operatorType: SelectFilterOperatorType.Contains },
+    filterState: { value: ['Jen'] },
+    setDataMask: setDataMaskMock,
+  });
+
+  const reduxState = {
+    useRedux: true,
+    initialState: {
+      nativeFilters: {
+        filters: { 'test-filter': { name: 'Test Filter' } },
+      },
+      dataMask: {
+        'test-filter': {
+          extraFormData: {
+            filters: [{ col: 'gender', op: 'ILIKE', val: '%Jen%' }],
+          },
+          filterState: { value: ['Jen'] },
+        },
+      },
+    },
+  };
+
+  const { rerender } = render(
+    <SelectFilterPlugin {...likeProps} />,
+    reduxState,
+  );
+
+  const input = screen.getByPlaceholderText('Type to search (contains)...');
+
+  // Type new text; the LIKE debounce is scheduled but not flushed yet.
+  fireEvent.change(input, {
+    target: { value: 'Mar' },
+  });
+  expect(input).toHaveValue('Mar');
+
+  setDataMaskMock.mockClear();
+
+  // A parent filter change cascades a clear into this dependent filter while
+  // the LIKE debounce is still pending.
+  rerender(
+    <SelectFilterPlugin
+      {...likeProps}
+      cascadeClearTrigger={{ 'test-filter': true }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(input).toHaveValue('');
+  });
+
+  await waitFor(() => {
+    expect(setDataMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filterState: expect.objectContaining({
+          value: null,
+        }),
+      }),
+    );
+  });
+
+  const callsBeforeDebounceFlush = setDataMaskMock.mock.calls.length;
+
+  // Without the cancellation fix the pending 'Mar' debounce fires now and
+  // re-applies the stale ILIKE %Mar% clause.
+  act(() => {
+    jest.advanceTimersByTime(500);
+  });
+
+  expect(setDataMaskMock).toHaveBeenCalledTimes(callsBeforeDebounceFlush);
+});
+
 test('pending LIKE debounce still applies after rerender recreates updateDataMask', async () => {
   jest.useFakeTimers({ advanceTimers: true });
   const setDataMaskMock = jest.fn();

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -582,10 +582,15 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
   );
 
   useEffect(() => {
-    if (!isLikeOperator || clearAllTrigger) {
+    if (!isLikeOperator || clearAllTrigger || cascadeClearTrigger) {
       debouncedLikeChange.cancel();
     }
-  }, [clearAllTrigger, debouncedLikeChange, isLikeOperator]);
+  }, [
+    cascadeClearTrigger,
+    clearAllTrigger,
+    debouncedLikeChange,
+    isLikeOperator,
+  ]);
 
   useEffect(() => () => debouncedLikeChange.cancel(), [debouncedLikeChange]);
 

--- a/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
+++ b/superset-frontend/src/filters/components/Select/SelectFilterPlugin.tsx
@@ -138,6 +138,8 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
     filterBarOrientation,
     clearAllTrigger,
     onClearAllComplete,
+    cascadeClearTrigger,
+    onCascadeClearComplete,
   } = props;
   const {
     enableEmptyFilter,
@@ -512,6 +514,27 @@ export default function PluginFilterSelect(props: PluginFilterSelectProps) {
       onClearAllComplete?.(formData.nativeFilterId);
     }
   }, [clearAllTrigger, onClearAllComplete, updateDataMask]);
+
+  useEffect(() => {
+    // When a parent filter's value changes, a cascading clear signals this
+    // dependent filter to reset its visual selection. Same behavior as a
+    // global clear-all but scoped to one descendant.
+    if (cascadeClearTrigger) {
+      dispatchDataMask({
+        type: 'filterState',
+        extraFormData: {},
+        filterState: {
+          value: undefined,
+          label: undefined,
+        },
+      });
+
+      updateDataMask(null);
+      setSearch('');
+      setLikeInputValue('');
+      onCascadeClearComplete?.(formData.nativeFilterId);
+    }
+  }, [cascadeClearTrigger, onCascadeClearComplete, updateDataMask]);
 
   useEffect(() => {
     if (prevExcludeFilterValues.current !== excludeFilterValues) {

--- a/superset-frontend/src/filters/components/Select/transformProps.ts
+++ b/superset-frontend/src/filters/components/Select/transformProps.ts
@@ -53,6 +53,8 @@ export default function transformProps(
     setFilterActive = noOp,
     clearAllTrigger,
     onClearAllComplete,
+    cascadeClearTrigger,
+    onCascadeClearComplete,
   } = hooks;
   const [queryData] = queriesData;
   const { colnames = [], coltypes = [], data = [] } = queryData || {};
@@ -82,5 +84,7 @@ export default function transformProps(
     isOverflowingFilterBar: displaySettings?.isOverflowingFilterBar,
     clearAllTrigger,
     onClearAllComplete,
+    cascadeClearTrigger,
+    onCascadeClearComplete,
   };
 }

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -74,6 +74,7 @@ export type PluginFilterSelectProps = PluginFilterStylesProps & {
   filterBarOrientation?: FilterBarOrientation;
   isOverflowingFilterBar?: boolean;
   clearAllTrigger?: Record<string, boolean>;
+  cascadeClearTrigger?: Record<string, boolean>;
   onClearAllComplete?: (filterId: string) => void;
 } & PluginFilterHooks;
 

--- a/superset-frontend/src/filters/components/Select/types.ts
+++ b/superset-frontend/src/filters/components/Select/types.ts
@@ -76,6 +76,7 @@ export type PluginFilterSelectProps = PluginFilterStylesProps & {
   clearAllTrigger?: Record<string, boolean>;
   cascadeClearTrigger?: Record<string, boolean>;
   onClearAllComplete?: (filterId: string) => void;
+  onCascadeClearComplete?: (filterId: string) => void;
 } & PluginFilterHooks;
 
 export const DEFAULT_FORM_DATA: PluginFilterSelectCustomizeProps = {


### PR DESCRIPTION
### SUMMARY

Fixes #44008. When a parent (cascading) native filter's value changes, dependent child filter selections are now cleared/reset so they cannot retain stale values from the old parent combination (e.g. `Country=UK` with a `City` that is only valid under `USA`), which previously produced impossible filter combinations that blank charts.

**Root cause:** the dashboard filter tree only resolved *ancestors* (`resolveTransitiveParentIds`); nothing tracked *descendants*, so no code cleared a dependent filter's selection when its parent changed.

**Fix:**
- Add `resolveTransitiveChildIds()` to `dependencyGraph.ts` — the inverse walk over `cascadeParentIds` (builds a parent→children reverse adjacency map and BFS-walks it downward; cycle-safe, breadth-first order).
- In `FilterBar.handleFilterSelectionChange`, detect a parent value change (`prevValue !== undefined && !isEqual(prevValue, nextValue)`) and, in the staged `dataMaskSelected` draft, reset every transitive descendant's `filterState.value` to `null` and clear its `extraFormData` (marking required children with `validateStatus: 'error'`).
- Signal each descendant's filter plugin via a new `cascadeClearTrigger` prop (threaded through `Horizontal`/`Vertical` → `FilterControls` → `useFilterControlFactory` → `FilterControl` → `FilterValue` → SuperChart hooks → `SelectFilterPlugin`), so the plugin clears its visual selection and does **not** re-apply `defaultToFirstItem` defaults (the same pattern already used for `clearAllTrigger`). `onCascadeClearComplete` removes the trigger once the child acknowledges the clear.
- Set the cleared value to `null` (not `undefined`) to match the existing Clear All semantics: `undefined` is treated as "uninitialized" and would re-apply defaults.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS

**Manual:**
1. Create a dashboard with a cascading native filter pair, e.g. `Country` (select) with `City` (select, dependency: `Country`), both on the same dataset.
2. Select a `Country` (e.g. `USA`) and a `City` (e.g. `New York`), click **Apply**.
3. Change **Country** to a different value (e.g. `UK`).
4. Verify the **City** selection is cleared (no stale `New York`) before/after clicking **Apply**.

**Automated:**
- `superset-frontend/src/dashboard/components/nativeFilters/dependencyGraph.test.ts` (new): unit tests for `resolveTransitiveChildIds` (direct children, chained, diamond dedup, mid-chain, cycles, filters that don't declare the parent).
- `FilterBar/FilterControls/state.test.ts`: tests for `useTransitiveChildIds`.
- `FilterBar.test.tsx`: integration test rendering `Country → City` and asserting that changing `Country` to `UK` clears `City` (value `null`, empty `extraFormData`) when applied.

Verification command:
```bash
npx jest src/dashboard/components/nativeFilters/FilterBar/FilterBar.test.tsx \
  src/dashboard/components/nativeFilters/dependencyGraph.test.ts \
  src/dashboard/components/nativeFilters/FilterBar/FilterControls/state.test.ts \
  src/filters/components/Select/
```
All 114 tests pass across the 6 suites.

### ADDITIONAL INFORMATION
- [x] Has associated issue: #44008
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
