### PR TITLE
fix(couchbase): remove debug prints that emit the connection URI to stdout

### DIFF
--- a/superset/db_engine_specs/couchbase.py
+++ b/superset/db_engine_specs/couchbase.py
@@ -175,7 +175,6 @@ class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
                 port=parameters.get("port"),
                 query=query_params,
             )
-        print(uri)
         # SQLAlchemy 2.0 made URL.__str__() hide the password by default
         # (it rendered in full under 1.4); render_as_string(hide_password=
         # False) is required here since this URI is stored/used to actually
@@ -186,7 +185,6 @@ class CouchbaseEngineSpec(BasicParametersMixin, BaseEngineSpec):
     def get_parameters_from_uri(
         cls, uri: str, encrypted_extra: Optional[dict[str, Any]] = None
     ) -> BaseBasicParametersType:
-        print("get_parameters is called : ", uri)
         url = make_url_safe(uri)
         query = {
             key: value


### PR DESCRIPTION
`CouchbaseEngineSpec.get_parameters()` and `get_parameters_from_uri()` each contain a leftover debug `print()` that writes the connection URI to stdout on every call. These are development leftovers with no functional purpose (the return values are unaffected), and emitting connection strings to stdout is undesirable in production where stdout is typically shipped to log aggregation.

This removes the two `print()` statements. No behavior change.
