### PR TITLE
fix(mcp): bound chart_ids length in the generate-dashboard request

### DIFF
--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -645,7 +645,10 @@ class GenerateDashboardRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     chart_ids: List[int] = Field(
-        ..., description="List of chart IDs to include in the dashboard", min_length=1
+        ...,
+        description="List of chart IDs to include in the dashboard",
+        min_length=1,
+        max_length=250,
     )
     dashboard_title: str | None = Field(
         None,

--- a/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
+++ b/tests/unit_tests/mcp_service/dashboard/test_dashboard_schemas.py
@@ -1053,3 +1053,14 @@ class TestRequestSchemaAliasChoices:
     def test_add_chart_to_dashboard_chart_alias(self) -> None:
         req = AddChartToDashboardRequest.model_validate({"dashboard_id": 1, "chart": 2})
         assert req.chart_id == 2
+
+
+def test_generate_dashboard_request_chart_ids_is_bounded() -> None:
+    """chart_ids is bounded (min 1, max 250) to prevent an unbounded array,
+    matching the length caps on sibling MCP request schemas."""
+    GenerateDashboardRequest(chart_ids=[1])
+    GenerateDashboardRequest(chart_ids=list(range(250)))
+    with pytest.raises(ValidationError):
+        GenerateDashboardRequest(chart_ids=[])
+    with pytest.raises(ValidationError):
+        GenerateDashboardRequest(chart_ids=list(range(251)))


### PR DESCRIPTION
`GenerateDashboardRequest.chart_ids` declares `min_length=1` but no `max_length`, whereas the sibling MCP request schemas cap their list and string fields (e.g. dataset schemas use `max_length=250`). An unbounded list lets a caller submit an arbitrarily large `chart_ids` array.

This adds `max_length=250`, so an oversized array is rejected at validation, consistent with the other request schemas in the service. Adds a unit test covering the min/max bounds.
