### PR TITLE
fix(sql): classify ATTACH/DETACH and MySQL REPLACE/RENAME/SET PASSWORD as mutating

### DIFF
--- a/superset/sql/parse.py
+++ b/superset/sql/parse.py
@@ -824,6 +824,11 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             # MySQL LOAD DATA INFILE ingests server files into a table;
             # PostgreSQL LOAD '/path/lib.so' dlopens a shared library.
             "LOAD",
+            # MySQL REPLACE INTO is destructive DML and RENAME TABLE is DDL;
+            # both fall back to an opaque exp.Command with these heads (no
+            # structured node), and neither has a read-only form.
+            "REPLACE",
+            "RENAME",
             # NOTE: `SHOW` is intentionally NOT included. It is a read (mutates
             # nothing), so classifying it as mutating would be wrong for every
             # is_mutating()/has_mutation() consumer (the commit decision, the
@@ -854,6 +859,10 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
         {
             Dialects.POSTGRES,
             Dialects.STARROCKS,
+            # MySQL shares StarRocks' parser: ordinary `SET var = value` parses
+            # as exp.Set, so the opaque-Command fallback is reached only by the
+            # dangerous forms (SET PASSWORD FOR .../SET ROLE).
+            Dialects.MYSQL,
         }
     )
 
@@ -1035,6 +1044,11 @@ class SQLStatement(BaseSQLStatement[exp.Expression]):
             # fires for dialects where this instead falls back to
             # exp.Command.
             exp.Refresh,
+            # ATTACH/DETACH (SQLite) connect or disconnect a database file;
+            # ATTACH can bring a writable database into scope. Structured
+            # nodes on SQLite, so the exp.Command fallback never sees them.
+            exp.Attach,
+            exp.Detach,
         )
 
         if self._parsed.find(*mutating_nodes):

--- a/tests/unit_tests/sql/parse_tests.py
+++ b/tests/unit_tests/sql/parse_tests.py
@@ -1979,6 +1979,14 @@ def test_is_mutating(sql: str, engine: str, expected: bool) -> None:
         ("EXPLAIN ANALYZE VERBOSE UPDATE t SET x = 1", "postgresql"),
         ("EXPLAIN (ANALYZE)", "postgresql"),
         ("EXPLAIN ANALYZE )))", "postgresql"),
+        # SQLite ATTACH/DETACH and MySQL REPLACE INTO / RENAME TABLE /
+        # SET PASSWORD FOR fall past node-type matching (opaque command or
+        # dialect-specific structured nodes) and must be gated as mutating.
+        ("ATTACH DATABASE 'x.db' AS y", "sqlite"),
+        ("DETACH DATABASE y", "sqlite"),
+        ("REPLACE INTO t VALUES (1)", "mysql"),
+        ("RENAME TABLE a TO b", "mysql"),
+        ("SET PASSWORD FOR 'u'@'h' = 'p'", "mysql"),
     ],
 )
 def test_is_mutating_fails_closed_on_gate_blind_spots(sql: str, engine: str) -> None:
@@ -1988,6 +1996,15 @@ def test_is_mutating_fails_closed_on_gate_blind_spots(sql: str, engine: str) -> 
     variants, and structured `COMMIT`.
     """
     assert SQLStatement(sql, engine).is_mutating()
+
+
+@pytest.mark.parametrize("engine", ["mysql", "sqlite"])
+def test_is_mutating_replace_function_is_read(engine: str) -> None:
+    """The REPLACE() string function inside a SELECT is a read; only the
+    REPLACE INTO statement form is mutating."""
+    assert not SQLStatement(
+        "SELECT REPLACE(name, 'a', 'b') FROM t", engine
+    ).is_mutating()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`SQLStatement.is_mutating()` (and therefore `has_mutation()` and the read-only consumers built on it) did not classify a few statement forms as mutating:

- SQLite `ATTACH` / `DETACH` — parsed as structured `exp.Attach` / `exp.Detach` nodes, which were absent from the mutating node set.
- MySQL `REPLACE INTO ...` and `RENAME TABLE ...` — fall back to an opaque `exp.Command` whose head (`REPLACE` / `RENAME`) was not in the mutating command names.
- MySQL `SET PASSWORD FOR ... = ...` — reaches the opaque-command SET/RESET path, but MySQL was not in the set of dialects for which that path is treated as mutating (only PostgreSQL and StarRocks were).

This adds `exp.Attach`/`exp.Detach` to the mutating node set, `REPLACE`/`RENAME` to the mutating command names, and `MySQL` to the SET/RESET mutating dialects. All three additions are consistent with the existing, documented reasoning in the file (structured nodes with no read-only form; opaque-command heads with no read form; dialects where ordinary `SET var = value` parses as `exp.Set` so only the dangerous forms reach the command fallback).

Behavior-preserving: the `REPLACE()` string function inside a `SELECT` remains a read (guarded by an added test); ordinary `SET var = value` and `PRAGMA table_info(...)` are unaffected. Adds unit coverage for each new mutating form.
