### PR TITLE
fix(security): suppress zizmor self-repository false positive for playwright install step

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -133,7 +133,12 @@ jobs:
         with:
           run: build-instrumented-assets
       - name: Install Playwright
-        uses: ./.github/actions/cached-dependencies
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's gitlink. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: playwright-install
       - name: Run Playwright (Experimental Tests)


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2649 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2649)) on `.github/workflows/superset-playwright.yml:136`.

The `Install Playwright` step references `.github/actions/cached-dependencies` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of the newer `uses: $/...` syntax. The mechanical rewrite doesn't apply here: `cached-dependencies` is a git submodule (see `.gitmodules`), and `$/...` resolves action files directly from the repository tree without performing a real, submodule-aware checkout, so it can't see past the submodule's gitlink into the actual `action.yml`.

This mirrors the same documented false-positive pattern already used for sibling `cached-dependencies` steps elsewhere in the repo (e.g. `superset-python-integrationtest.yml`, `superset-python-presto-hive.yml`, `superset-translations.yml`, and open PRs #44064/#44045 for the neighboring steps in this same file), using the same explanatory comment and `# zizmor: ignore[self-repository]` trailing-comment placement.

Only this one occurrence (line 136, alert #2649) is touched, to keep the diff scoped. The other `cached-dependencies` steps in this same file are covered by their own separate alerts/PRs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-playwright.yml` passes, including the local `zizmor` hook.
- Workflow runtime behavior is unchanged; only a trailing comment and explanatory comment block were added.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2649

🤖 Generated with [Claude Code](https://claude.com/claude-code)