### PR TITLE
fix(security): suppress zizmor self-repository false positive for playwright test-data step

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -115,7 +115,13 @@ jobs:
         with:
           run: setup-postgres
       - name: Import test data
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: playwright_testdata
       - name: Setup Node.js


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` audit flags `uses: ./.github/actions/cached-dependencies` in the "Import test data" step of `superset-playwright.yml`, suggesting GitHub's dedicated `$/...` self-repository syntax instead of `./...`.

`cached-dependencies` is a git submodule (not a plain directory), and `$/` resolves action files directly from the repository without a real, submodule-aware checkout — it can't see into the submodule's gitlink. Converting this reference to `$/` breaks the step at runtime (as previously discovered and reverted for the same action elsewhere — see #43972 / 16d9ca1a337). This PR instead keeps the `./` form and adds a scoped `zizmor: ignore[self-repository]` suppression with a comment explaining why, matching the pattern already used for every other `cached-dependencies` occurrence.

Resolves code-scanning alert #2646 (https://github.com/apache/superset/security/code-scanning/2646).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow only)

### TESTING INSTRUCTIONS
- `zizmor .github/workflows/superset-playwright.yml` no longer flags the "Import test data" step (finding is now suppressed via the scoped ignore comment).
- `pre-commit run --files .github/workflows/superset-playwright.yml` passes, including the `zizmor (GHA security audit)` hook.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)