### PR TITLE
fix(security): suppress zizmor self-repository false positive for npm install step

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -125,7 +125,13 @@ jobs:
           cache: "npm"
           cache-dependency-path: "superset-frontend/package-lock.json"
       - name: Install npm dependencies
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: npm-install
       - name: Build javascript packages


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2647 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2647)) on `.github/workflows/superset-playwright.yml:128`.

The `Install npm dependencies` step references `.github/actions/cached-dependencies` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of the newer `uses: $/...` syntax. The mechanical rewrite doesn't apply here: `cached-dependencies` is a git submodule (see `.gitmodules`), and `$/...` resolves action files directly from the repository tree without performing a real, submodule-aware checkout, so it can't see past the submodule's gitlink into the actual `action.yml`.

This mirrors the same documented false-positive pattern already used (in other open PRs) for sibling `cached-dependencies` steps in this same file, e.g. #44045 (alert #2651) and #44064 (alert #2650), using the same explanatory comment and `# zizmor: ignore[self-repository]` trailing-comment placement (required because zizmor's comment-placement rule for this audit needs the suppression to fall within the flagged `uses:` value's span).

Only this one occurrence (line 128, alert #2647) is touched, to keep the diff scoped.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-playwright.yml` passes, including the local `zizmor` hook.
- Workflow runtime behavior is unchanged; only a trailing comment and explanatory comment block were added.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2647

🤖 Generated with [Claude Code](https://claude.com/claude-code)