### PR TITLE
fix(db): honor connect_args returned by adjust_engine_params

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -653,6 +653,7 @@ class Database(CoreDatabase, AuditMixinNullable, ImportExportMixin):  # pylint: 
             catalog=catalog,
             schema=schema,
         )
+        engine_kwargs["connect_args"] = connect_args
 
         effective_username = self.get_effective_user(sqlalchemy_url)
         if effective_username and is_feature_enabled("IMPERSONATE_WITH_EMAIL_PREFIX"):

--- a/tests/unit_tests/models/core_test.py
+++ b/tests/unit_tests/models/core_test.py
@@ -595,6 +595,29 @@ def test_get_sqla_engine(mocker: MockerFixture) -> None:
     )
 
 
+def test_get_sqla_engine_honors_adjusted_connect_args(mocker: MockerFixture) -> None:
+    """
+    ``adjust_engine_params`` returns a *new* ``connect_args`` dict (the base
+    impl merges ``enforce_uri_query_params`` into a fresh copy). The result must
+    be written back into ``engine_kwargs`` so those enforced params actually
+    reach ``create_engine``. Exercised via MySQL, which enforces
+    ``local_infile=0`` this way; before the write-back the enforcement was
+    silently dropped.
+    """
+    from superset.models.core import Database
+
+    create_engine_mock = mocker.patch(
+        "superset.models.core.create_engine",
+        return_value=create_engine("sqlite://"),
+    )
+
+    database = Database(database_name="my_db", sqlalchemy_uri="mysql://u:p@h/db")
+    database._get_sqla_engine(nullpool=False)
+
+    _, kwargs = create_engine_mock.call_args
+    assert kwargs["connect_args"].get("local_infile") == 0
+
+
 def test_get_sqla_engine_caches_engine_per_url(mocker: MockerFixture) -> None:
     """
     Regression for #27897: a single SQLAlchemy ``Engine`` should be created per


### PR DESCRIPTION
### SUMMARY

`Database._get_sqla_engine` calls `db_engine_spec.adjust_engine_params(...)`, which **returns a new `connect_args` dict** — the base implementation builds `{**connect_args, **enforce_uri_query_params}` — but the return value was discarded and the original `connect_args` was passed to `create_engine`.

As a result, any `connect_args` entry that a spec contributes through `adjust_engine_params` was silently dropped. The clearest case is the MySQL specs, whose `enforce_uri_query_params` (`{"local_infile": 0}` for mysqldb, `{"allow_local_infile": 0}` for mysqlconnector) never actually reached the driver.

The fix writes the returned dict back into `engine_kwargs["connect_args"]`. Specs that mutate `connect_args` in place (e.g. trino's `source`) are unaffected, since the base merge preserves existing keys.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/models/core_test.py -k get_sqla_engine`

Adds `test_get_sqla_engine_honors_adjusted_connect_args`, which asserts the enforced MySQL param reaches `create_engine`. Existing `test_get_sqla_engine` (trino `source` path) still passes.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
