### PR TITLE
fix(datasource): apply target-table access check on same-database repoint

### DIFF
--- a/superset/views/datasource/views.py
+++ b/superset/views/datasource/views.py
@@ -121,25 +121,45 @@ class Datasource(BaseSupersetView):
         except SupersetSecurityException as ex:
             raise DatasetForbiddenError() from ex
 
-        if database_id != orm_datasource.database_id:
+        # The request may repoint the dataset to a different database and/or a
+        # different table/schema/catalog; update_from_object (below) applies
+        # whatever the request supplies. Resolve the target of both dimensions
+        # up front so the access check is evaluated against what the dataset
+        # will actually point at, not its current (stale) values.
+        database_changed = database_id != orm_datasource.database_id
+        requested_table = Table(
+            datasource_dict.get("table_name", orm_datasource.table_name),
+            datasource_dict.get("schema", orm_datasource.schema),
+            datasource_dict.get("catalog", orm_datasource.catalog),
+        )
+        table_changed = (
+            requested_table.table != orm_datasource.table_name
+            or requested_table.schema != orm_datasource.schema
+            or requested_table.catalog != orm_datasource.catalog
+        )
+
+        if database_changed:
             new_database = DatasetDAO.get_database_by_id(database_id)
             if new_database is None:
                 return json_error_response(_("Database not found."), status=422)
+            target_database = new_database
+        else:
+            target_database = orm_datasource.database
+
+        # Whenever the dataset is repointed -- to a new database or, within the
+        # same database, to a different table -- the caller must be authorised
+        # for the target table, mirroring the create path. Editorship of the
+        # dataset alone is not sufficient.
+        if database_changed or table_changed:
             try:
                 security_manager.raise_for_access(
-                    database=new_database,
-                    # Check access against the table/schema/catalog the
-                    # request is repointing to, not the dataset's current
-                    # values -- update_from_object (below) applies whatever
-                    # table_name/schema/catalog the request supplies.
-                    table=Table(
-                        datasource_dict.get("table_name", orm_datasource.table_name),
-                        datasource_dict.get("schema", orm_datasource.schema),
-                        datasource_dict.get("catalog", orm_datasource.catalog),
-                    ),
+                    database=target_database,
+                    table=requested_table,
                 )
             except SupersetSecurityException as ex:
                 raise DatasetForbiddenError() from ex
+
+        if database_changed:
             orm_datasource.database_id = database_id
 
         duplicates = [

--- a/tests/unit_tests/views/datasource/views_test.py
+++ b/tests/unit_tests/views/datasource/views_test.py
@@ -501,6 +501,118 @@ def test_save_checks_access_against_requested_table_not_stale_one(
     assert call_kwargs["table"].schema == "finance"
 
 
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_rejects_same_database_repoint_to_table_without_access(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    A request that keeps the same ``database.id`` but changes
+    ``table_name``/``schema``/``catalog`` also repoints the dataset via
+    ``update_from_object``. The target-table access check must run in this
+    case too -- editorship of the dataset alone must not let a caller point
+    it at a table they are not authorised for within the same database.
+    """
+    mock_orm = MagicMock()
+    mock_orm.database_id = 1
+    mock_orm.table_name = "authorised_table"
+    mock_orm.schema = "public"
+    mock_orm.catalog = None
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+    # Same database, so no lookup happens; access to the requested table is denied.
+    mock_security_manager.raise_for_access.side_effect = _security_exception()
+
+    from flask import Flask
+
+    from superset.commands.dataset.exceptions import DatasetForbiddenError
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 1},  # unchanged
+                    "table_name": "secret_table",  # but repointed to another table
+                    "schema": "finance",
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        with pytest.raises(DatasetForbiddenError):
+            raw_save(_view_self())
+
+    mock_security_manager.raise_for_access.assert_called_once()
+    call_kwargs = mock_security_manager.raise_for_access.call_args.kwargs
+    assert call_kwargs["database"] is mock_orm.database
+    assert call_kwargs["table"].table == "secret_table"
+    assert call_kwargs["table"].schema == "finance"
+    # No cross-database lookup for a same-database repoint.
+    mock_get_database_by_id.assert_not_called()
+
+
+@patch("superset.views.datasource.views.db")
+@patch("superset.views.datasource.views.DatasetDAO.get_database_by_id")
+@patch("superset.views.datasource.views.security_manager", new_callable=MagicMock)
+@patch("superset.views.datasource.views.DatasourceDAO.get_datasource")
+def test_save_allows_unchanged_datasource_without_access_recheck(
+    mock_get_datasource: MagicMock,
+    mock_security_manager: MagicMock,
+    mock_get_database_by_id: MagicMock,
+    mock_db: MagicMock,
+) -> None:
+    """
+    A plain save that changes neither the database nor the table (e.g. a
+    column/metric edit) must not require a fresh datasource-access check --
+    editorship already gates it, and re-checking would be a behavior change.
+    """
+    mock_orm = MagicMock()
+    mock_orm.database_id = 1
+    mock_orm.table_name = "my_table"
+    mock_orm.schema = "public"
+    mock_orm.catalog = None
+    mock_orm.data = {"id": 1}
+    mock_get_datasource.return_value = mock_orm
+    mock_security_manager.raise_for_editorship.return_value = None
+
+    from flask import Flask
+
+    raw_save = _get_view_func("save")
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/datasource/save/",
+        method="POST",
+        data={
+            "data": superset_json.dumps(
+                {
+                    "id": 1,
+                    "type": "table",
+                    "database": {"id": 1},
+                    "table_name": "my_table",
+                    "schema": "public",
+                    "columns": [],
+                }
+            )
+        },
+    ):
+        raw_save(_view_self())
+
+    mock_security_manager.raise_for_access.assert_not_called()
+    mock_get_database_by_id.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Datasource.samples
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### SUMMARY

The legacy `Datasource.save` view (`POST /superset/datasource/save/`) ran `security_manager.raise_for_access(table=...)` only inside the `if database_id != orm_datasource.database_id:` branch. A request that keeps the same `database.id` but changes `table_name`/`schema`/`catalog` also repoints the dataset (`update_from_object` applies whatever the request supplies), but skipped the target-table check, so it ran only for cross-database repoints.

This aligns the legacy view with the create/update paths: resolve the target database and table up front, and run the access check whenever either changes. A plain save that changes neither the database nor the table (a column/metric edit) still needs no recheck, since editorship already gates it.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/views/datasource/views_test.py`

Adds `test_save_rejects_same_database_repoint_to_table_without_access` (same-DB repoint is now checked) and `test_save_allows_unchanged_datasource_without_access_recheck` (no behavior change for plain edits). Existing cross-database repoint tests still pass.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API