### PR TITLE
fix(jinja): escape current_username/current_user_email like sibling macros

### DIFF
--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -236,29 +236,43 @@ class ExtraCache:
             return user_id
         return None
 
-    def current_username(self, add_to_cache_keys: bool = True) -> str | None:
+    def current_username(
+        self, add_to_cache_keys: bool = True, escape_result: bool = True
+    ) -> str | None:
         """
         Return the username of the user who is currently logged in.
 
         :param add_to_cache_keys: Whether the value should be included in the cache key
+        :param escape_result: Should special characters in the result be escaped
         :returns: The username
         """
 
         if username := get_username():
+            # The documented templating pattern interpolates this value into a
+            # SQL literal, so apply the same dialect-specific escaping the other
+            # viewer-controlled macros (url_param, get_guest_user_attribute) use,
+            # keeping the identity macros consistent with their siblings.
+            if escape_result:
+                username = self._escape_value(username)
             if add_to_cache_keys:
                 self.cache_key_wrapper(username)
             return username
         return None
 
-    def current_user_email(self, add_to_cache_keys: bool = True) -> str | None:
+    def current_user_email(
+        self, add_to_cache_keys: bool = True, escape_result: bool = True
+    ) -> str | None:
         """
         Return the email address of the user who is currently logged in.
 
         :param add_to_cache_keys: Whether the value should be included in the cache key
+        :param escape_result: Should special characters in the result be escaped
         :returns: The user email address
         """
 
         if email_address := get_user_email():
+            if escape_result:
+                email_address = self._escape_value(email_address)
             if add_to_cache_keys:
                 self.cache_key_wrapper(email_address)
             return email_address

--- a/tests/unit_tests/jinja_context_test.py
+++ b/tests/unit_tests/jinja_context_test.py
@@ -782,6 +782,47 @@ def test_user_macros_without_user_info(mocker: MockerFixture):
     assert cache.current_user_rls_rules() is None
 
 
+def test_current_username_email_escaped(mocker: MockerFixture) -> None:
+    """
+    ``current_username`` / ``current_user_email`` apply the same dialect
+    escaping as the other viewer-controlled macros, so a quote in the value
+    cannot break out of a SQL literal it is interpolated into.
+    """
+    mock_g = mocker.patch("superset.utils.core.g")
+    mock_g.user.username = "O'Brien"
+    mock_g.user.email = "o'brien@test.com"
+    cache = ExtraCache(dialect=dialect(), table=mocker.MagicMock())
+    assert cache.current_username() == "O''Brien"
+    assert cache.current_user_email() == "o''brien@test.com"
+
+
+def test_current_username_email_unescaped_opt_out(mocker: MockerFixture) -> None:
+    """
+    ``escape_result=False`` opts out of escaping, mirroring ``url_param``.
+    """
+    mock_g = mocker.patch("superset.utils.core.g")
+    mock_g.user.username = "O'Brien"
+    mock_g.user.email = "o'brien@test.com"
+    cache = ExtraCache(dialect=dialect(), table=mocker.MagicMock())
+    assert cache.current_username(escape_result=False) == "O'Brien"
+    assert cache.current_user_email(escape_result=False) == "o'brien@test.com"
+
+
+def test_current_username_email_unchanged_without_dialect(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Without a configured dialect the value is returned unchanged, preserving
+    the prior behavior.
+    """
+    mock_g = mocker.patch("superset.utils.core.g")
+    mock_g.user.username = "O'Brien"
+    mock_g.user.email = "o'brien@test.com"
+    cache = ExtraCache(table=mocker.MagicMock())
+    assert cache.current_username() == "O'Brien"
+    assert cache.current_user_email() == "o'brien@test.com"
+
+
 def _user_metadata_cache_keys(
     mocker: MockerFixture,
     *,


### PR DESCRIPTION
### SUMMARY

The identity template macros `current_username()` and `current_user_email()` returned their value verbatim, while the other viewer-controlled macros run theirs through `_escape_value` for dialect-specific literal rendering: `url_param` ([jinja_context.py](https://github.com/apache/superset/blob/master/superset/jinja_context.py)), `get_guest_user_attribute`, and `get_filters`' `escaped_val`. The documented templating pattern interpolates these identity values into a single-quoted SQL literal, so leaving them unescaped was inconsistent with their siblings.

This applies `_escape_value` to both identity macros, keeping them consistent with the rest of the family. An `escape_result=True` parameter mirrors `url_param` so callers can opt out, and when no dialect is configured the value is returned unchanged, preserving prior behavior (ordinary values without special characters are unaffected).

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/jinja_context_test.py -k current_username`

Adds `test_current_username_email_escaped`, `test_current_username_email_unescaped_opt_out`, and `test_current_username_email_unchanged_without_dialect`.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API