### PR TITLE
fix(security): use self-repository syntax for chart-testing action ref

### DIFF
--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
       # allowlist (only v8.1.0+ are, at apache/infrastructure-actions'
       # actions.yml). Needs an INFRA request before this can de-vendor too.
       - name: Set up chart-testing
-        uses: ./.github/actions/chart-testing-action
+        uses: $/.github/actions/chart-testing-action
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2642 (zizmor/self-repository, note severity).

`superset-helm-lint-test.yml` referenced the in-repo `chart-testing-action`
composite action with the legacy workspace-relative syntax
(`uses: ./.github/actions/chart-testing-action`). GitHub now supports a
dedicated ["self-repository" syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)
(`uses: $/...`) for same-repo actions/reusable workflows, which zizmor
recommends because it isn't subject to runtime filesystem state (it can't
be swapped out by an earlier step cloning something into that path) and is
treated as a pinned reference for "fully pinned" policy enforcement.

The `zizmor` pin in `.pre-commit-config.yaml` is already at `1.30.0`
(the first release that understands `$/...` refs), so no additional
tooling bump was needed here.

Only the one flagged line/instance is changed; a second `./`-style local
action ref remains in this same file (`setup-backend`, line 42) as a
separate, not-yet-filed code-scanning finding, to keep this diff scoped to
alert #2642.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-helm-lint-test.yml` passes (zizmor hook green).
- Verified with `zizmor==1.30.0` directly that the self-repository finding
  on line 52 of `superset-helm-lint-test.yml` no longer appears after the
  change.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2642: https://github.com/apache/superset/security/code-scanning/2642

🤖 Generated with [Claude Code](https://claude.com/claude-code)