### PR TITLE
fix(security): suppress zizmor self-repository false positive for postgres setup step

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -111,7 +111,13 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
       - name: Setup postgres
-        uses: ./.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-postgres
       - name: Import test data


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` audit flags `uses: ./.github/actions/cached-dependencies` in the "Setup postgres" step of `superset-playwright.yml`, suggesting GitHub's dedicated `$/...` self-repository syntax instead of `./...`.

`cached-dependencies` is a git submodule (not a plain directory), and `$/` resolves action files directly from the repository without a real, submodule-aware checkout — it can't see into the submodule's gitlink. Converting this reference to `$/` breaks the step at runtime (as previously discovered and reverted for the same action elsewhere — see #43972 / 16d9ca1a337). This PR instead keeps the `./` form and adds a scoped `zizmor: ignore[self-repository]` suppression with a comment explaining why, matching the pattern already used for every other `cached-dependencies` occurrence in this workflow (and in other open PRs addressing the same rule on other steps, e.g. #44075, #44074, #44073).

Resolves code-scanning alert #2645 (https://github.com/apache/superset/security/code-scanning/2645).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-playwright.yml` passes, including the `zizmor (GHA security audit)` hook.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)