### PR TITLE
fix(security): use self-repository syntax for setup-backend in Playwright workflow

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -109,7 +109,7 @@ jobs:
           submodules: recursive
       # -------------------------------------------------------
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup postgres
         uses: ./.github/actions/cached-dependencies
         with:


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2644 (`zizmor/self-repository`, note level) on `.github/workflows/superset-playwright.yml:112`.

zizmor flags `uses: ./.github/actions/setup-backend/` because the workspace-relative `./` form is not treated as a pinned reference by GitHub, and (unlike the newer `$/` self-repository syntax) it can be affected by filesystem state from earlier steps in the same job. `setup-backend` is a plain in-repo directory (not a submodule), so it can safely use the `$/` form — this matches the fix already applied to the same action in other workflows (e.g. #44040, #44065, #44066).

Note: `cached-dependencies`, used elsewhere in this same workflow, *is* a git submodule, so the `$/` syntax can't resolve it (`$/` doesn't do a submodule-aware checkout); those occurrences are intentionally left as `./` and are being addressed separately with scoped suppression comments in other in-flight PRs, so this PR only touches the `setup-backend` line for alert #2644.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow file only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-playwright.yml` (includes the `zizmor` hook) passes.
- Confirmed with `zizmor .github/workflows/superset-playwright.yml` that the `self-repository` finding on line 112 no longer appears.
- The Playwright Experimental workflow itself will validate the change on this PR's own CI run.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)