### PR TITLE
fix(security): use self-repository syntax for change-detector in Playwright workflow

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert [#2643](https://github.com/apache/superset/security/code-scanning/2643) (zizmor `self-repository` rule) on `.github/workflows/superset-playwright.yml`.

The `changes` job referenced the in-repo `change-detector` action using the older workspace-relative `uses: ./...` syntax. GitHub Actions now supports a dedicated `$/...` self-repository syntax for referencing same-repo actions, which:
- resolves the action at the exact commit currently running, without depending on runtime filesystem/checkout state
- is treated by GitHub as a pinning mechanism (unlike `./`), enabling stricter "fully pinned" policy enforcement

`change-detector` is a plain in-repo directory (not a git submodule), so it's safe to switch to `$/`. This matches the same fix already applied to this exact action in `superset-python-integrationtest.yml` (#44065). Other `./` references in this workflow point at `cached-dependencies`, which *is* a submodule and can't use `$/`, so those are intentionally left untouched (see #44064, #44045, #44073, #44074, #44075).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow config only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-playwright.yml` passes, including the `zizmor` hook.
- CI on this PR will exercise the `changes` job in the Playwright workflow directly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)