### PR TITLE
docs(contributing): update legacy rst reference

### DIFF
--- a/docs/developer_docs/contributing/overview.md
+++ b/docs/developer_docs/contributing/overview.md
@@ -93,7 +93,7 @@ Look through the GitHub issues. Issues tagged with
 
 Superset could always use better documentation,
 whether as part of the official Superset docs,
-in docstrings, `docs/*.rst` or even on the web as blog posts or
+in docstrings, Markdown files in `docs/`, or even on the web as blog posts or
 articles. See [Documentation](./howtos.md#contributing-to-documentation) for more details.
 
 ### Add Translations


### PR DESCRIPTION
## Summary

- Update the contributor documentation to remove the outdated `docs/*.rst` reference.
- Clarify that documentation in the `docs/` directory is written in Markdown.

## Why

The contributor overview referenced `docs/*.rst`, but the current documentation is maintained using Markdown files in the `docs/` directory.

This update keeps the contributor guidance consistent with the current documentation structure.

## Testing

Documentation-only change. No application code was modified.