### PR TITLE
fix(versioning): resolve change-record dashboard membership via attachment windows

### DIFF
--- a/superset/versioning/changes/shadow_queries.py
+++ b/superset/versioning/changes/shadow_queries.py
@@ -32,10 +32,13 @@ mapper-resolution side effects.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
+
+if TYPE_CHECKING:
+    from superset.versioning.activity.kinds import Window
 
 from superset.versioning.baseline import (
     CONTINUUM_BOOKKEEPING_COLUMNS,
@@ -233,54 +236,73 @@ def _affected_dashboard_ids_at_tx(session: Session, tx: int) -> set[int]:
 
 
 def _dashboard_slice_uuids_at_tx(
-    session: Session, dashboard_id: int, tx: int
+    session: Session, attached: list[tuple[int, Window]], tx: int
 ) -> list[str]:
-    """Slice UUIDs attached to *dashboard_id* as of *tx*, read by joining
-    ``dashboard_slices_version`` (M2M membership) against
-    ``slices_version`` (slice content).
+    """Return the uuids of charts attached to a dashboard at *tx*.
 
-    Joining through both is necessary — and matches the same query
-    Continuum's M2M ``Reverter`` uses — because a slice that's
-    referenced by the M2M but has no slice-version row at this tx is
-    treated as "not yet versioned" and excluded.
+    *attached* is :func:`~superset.versioning.membership.charts_attached_to_dashboard`'s
+    output — ``(slice_id, window)`` pairs where each window is the chart's
+    INSERT/DELETE-paired ``[attach, detach)`` interval — so membership at *tx*
+    is simply the charts whose window contains *tx*. The raw association-shadow
+    validity predicate (``end_transaction_id IS NULL OR > tx`` +
+    ``operation_type != DELETE``) must NOT be used: Continuum never closes
+    ``end_transaction_id`` on the M2M association shadow, so a chart attached at
+    tx 1 and removed at tx 5 would still read as a member at tx 10 —
+    over-reporting membership in the change-record diff (sc-120007, the third
+    consumer of this pattern; restore and impact were fixed the same way in
+    #44010 / #43837).
+
+    The ``slices_version`` (content) shadow, by contrast, *does* close
+    ``end_transaction_id`` correctly, so its validity predicate is trustworthy
+    and is kept: a chart attached at *tx* but with no slice-version row at *tx*
+    is "not yet versioned" and excluded, matching Continuum's M2M ``Reverter``.
+    The read runs on the passed *session* — the committing connection whose
+    flushed-but-uncommitted current-tx rows are visible only there.
 
     Returns UUIDs (strings) so the result can be diffed by the existing
     :func:`diff_dashboard_slices` helper, which keys on uuid.
     """
+    attached_ids = {slice_id for slice_id, window in attached if window.contains(tx)}
+    if not attached_ids:
+        return []
+
     # pylint: disable=import-outside-toplevel
+    # Deferred imports: ``version_class`` / ``Slice`` because this module loads
+    # from ``init_versioning()`` before all mappers are configured (see the
+    # module docstring); ``activity.kinds`` because it imports
+    # ``ENTITY_KIND_BY_CLASS_NAME`` from ``superset.versioning.changes``, so a
+    # module-top import would cycle back into this package during the
+    # changes-listener bootstrap (activity.kinds → changes → listener →
+    # shadow_queries).
     from sqlalchemy_continuum import version_class
 
     from superset.models.slice import Slice
+    from superset.versioning.activity.kinds import chunked_ids, ENTITY_ID_CHUNK_SIZE
 
-    metadata = version_class(Slice).__table__.metadata
-    m2m_tbl = metadata.tables.get("dashboard_slices_version")
+    # Resolve each attached chart's uuid from the content shadow at tx. The id
+    # set is a dashboard's simultaneous membership at one tx (realistically
+    # dozens), but chunk the IN anyway to stay under SQLite's bind-variable
+    # floor, mirroring the sibling impact rollup (#44010).
     slices_tbl = version_class(Slice).__table__
-    if m2m_tbl is None:
-        return []
-
-    rows = (
-        session.connection()
-        .execute(
-            sa.select(slices_tbl.c.uuid).where(
-                slices_tbl.c.id == m2m_tbl.c.slice_id,
-                m2m_tbl.c.dashboard_id == dashboard_id,
-                m2m_tbl.c.transaction_id <= tx,
-                sa.or_(
-                    m2m_tbl.c.end_transaction_id.is_(None),
-                    m2m_tbl.c.end_transaction_id > tx,
-                ),
-                m2m_tbl.c.operation_type != OPERATION_DELETE,
-                slices_tbl.c.transaction_id <= tx,
-                sa.or_(
-                    slices_tbl.c.end_transaction_id.is_(None),
-                    slices_tbl.c.end_transaction_id > tx,
-                ),
-                slices_tbl.c.operation_type != OPERATION_DELETE,
+    uuids: list[str] = []
+    for chunk in chunked_ids(attached_ids, ENTITY_ID_CHUNK_SIZE):
+        rows = (
+            session.connection()
+            .execute(
+                sa.select(slices_tbl.c.uuid).where(
+                    slices_tbl.c.id.in_(chunk),
+                    slices_tbl.c.transaction_id <= tx,
+                    sa.or_(
+                        slices_tbl.c.end_transaction_id.is_(None),
+                        slices_tbl.c.end_transaction_id > tx,
+                    ),
+                    slices_tbl.c.operation_type != OPERATION_DELETE,
+                )
             )
+            .all()
         )
-        .all()
-    )
-    return [str(r[0]) for r in rows if r[0] is not None]
+        uuids.extend(str(r[0]) for r in rows if r[0] is not None)
+    return uuids
 
 
 def _dashboard_child_records_for_tx_from_shadows(
@@ -296,6 +318,7 @@ def _dashboard_child_records_for_tx_from_shadows(
     from sqlalchemy_continuum import version_class
 
     from superset.models.dashboard import Dashboard
+    from superset.versioning.membership import charts_attached_to_dashboard
 
     metadata = version_class(Dashboard).__table__.metadata
     m2m_tbl = metadata.tables.get("dashboard_slices_version")
@@ -317,8 +340,14 @@ def _dashboard_child_records_for_tx_from_shadows(
         if prior_tx is None:
             continue
 
-        post_uuids = _dashboard_slice_uuids_at_tx(session, dashboard_id, transaction_id)
-        pre_uuids = _dashboard_slice_uuids_at_tx(session, dashboard_id, prior_tx)
+        # Resolve the attachment windows once (threading the committing
+        # *session* so the flushed-but-uncommitted current-tx association rows
+        # are visible), then take the pre/post membership by which windows
+        # contain each tx — the windows are tx-independent, so no need to
+        # re-scan the association history for both reads.
+        attached = charts_attached_to_dashboard(dashboard_id, session=session)
+        post_uuids = _dashboard_slice_uuids_at_tx(session, attached, transaction_id)
+        pre_uuids = _dashboard_slice_uuids_at_tx(session, attached, prior_tx)
 
         records = diff_dashboard_slices(pre_uuids, post_uuids)
         if records:

--- a/superset/versioning/membership.py
+++ b/superset/versioning/membership.py
@@ -37,10 +37,14 @@ import sqlalchemy as sa
 from superset.extensions import db
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from superset.versioning.activity.kinds import Window
 
 
-def charts_attached_to_dashboard(dashboard_id: int) -> list[tuple[int, Window]]:
+def charts_attached_to_dashboard(
+    dashboard_id: int, session: Session | None = None
+) -> list[tuple[int, Window]]:
     """Return ``(slice_id, window)`` for every chart that has ever been on
     *dashboard_id*, with each attachment episode's validity window in
     transaction-id space.
@@ -69,8 +73,15 @@ def charts_attached_to_dashboard(dashboard_id: int) -> list[tuple[int, Window]]:
     if m2m_tbl is None:
         return []
 
+    # *session* lets a caller thread the committing session so the read hits
+    # the same connection as its other reads — required on the commit-
+    # finalization path (changes/shadow_queries.py), where the current
+    # transaction's association-shadow rows are flushed-but-not-committed and
+    # visible only on that session's connection. Defaults to the Flask-scoped
+    # ``db.session``, which the read/restore-path callers already run on.
     rows = (
-        db.session.connection()
+        (session or db.session)
+        .connection()
         .execute(
             sa.select(
                 m2m_tbl.c.slice_id,

--- a/tests/unit_tests/versioning/test_shadow_queries.py
+++ b/tests/unit_tests/versioning/test_shadow_queries.py
@@ -1,0 +1,250 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for the change-record shadow queries (sc-120007).
+
+``_dashboard_slice_uuids_at_tx`` takes a dashboard's precomputed attachment
+windows (from :func:`charts_attached_to_dashboard`, which pairs the
+``dashboard_slices_version`` INSERT/DELETE rows into ``[attach, detach)``
+intervals) and keeps only the charts whose window contains the target tx. The
+raw association-shadow validity predicate must NOT be used: Continuum never
+closes ``end_transaction_id`` on the M2M association shadow, so it over-reports
+a removed chart as still a member. Third consumer of the pattern fixed for
+restore/impact in #44010.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.dialects import sqlite
+
+from superset.versioning.activity.kinds import ENTITY_ID_CHUNK_SIZE, Window
+from superset.versioning.changes.shadow_queries import (
+    _dashboard_child_records_for_tx_from_shadows,
+    _dashboard_slice_uuids_at_tx,
+)
+
+# Chart ids in the small fixtures; distinguishes them from the other binds
+# (tx, operation_type) so the fake result can echo only the queried chart ids
+# back as uuids — the returned rows then reflect the real filter rather than a
+# constant, so a broken membership filter changes the result.
+_CHART_IDS = {101, 202, 303}
+
+
+class _EchoResult:
+    def __init__(self, ids: set[int]) -> None:
+        self._ids = ids
+
+    def all(self) -> list[tuple[str]]:
+        return [(f"uuid-{i}",) for i in sorted(self._ids)]
+
+
+def _session_echoing_queried_ids(
+    captured: list[Any], id_predicate: Any = None
+) -> MagicMock:
+    """Build a session whose execute() echoes back one uuid row per queried id.
+
+    Each returned row is ``uuid-<id>`` for every chart id actually bound into
+    the statement's ``IN`` clause, so the result reflects the real filter.
+    """
+    predicate = id_predicate or (lambda v: v in _CHART_IDS)
+
+    def _execute(stmt: Any) -> _EchoResult:
+        captured.append(stmt)
+        compiled = stmt.compile(
+            dialect=sqlite.dialect(), compile_kwargs={"render_postcompile": True}
+        )
+        queried = {v for v in compiled.params.values() if predicate(v)}
+        return _EchoResult(queried)
+
+    session = MagicMock()
+    session.connection.return_value.execute.side_effect = _execute
+    return session
+
+
+def test_dashboard_slice_uuids_excludes_chart_detached_before_tx(
+    app_context: None,
+) -> None:
+    """A chart removed before the target tx is not resolved as a member.
+
+    sc-120007: a chart attached@1 and removed@5 (window ``[1, 5)``) is NOT a
+    member at tx=10, while a still-attached chart (open-ended window) is — so
+    only the live chart is resolved. The never-closed association-shadow row
+    would pass a naive validity filter; the ``window.contains(tx)`` resolution
+    is what excludes it.
+    """
+    attached = [(101, Window(1, 5)), (202, Window(1, None))]  # 101 detached, 202 live
+    captured: list[Any] = []
+    session = _session_echoing_queried_ids(captured)
+
+    result = _dashboard_slice_uuids_at_tx(session, attached, tx=10)
+
+    assert result == ["uuid-202"]
+    assert captured, "expected a slices_version uuid query"
+    compiled = captured[0].compile(
+        dialect=sqlite.dialect(), compile_kwargs={"render_postcompile": True}
+    )
+    bind_values = set(compiled.params.values())
+    assert 202 in bind_values, "still-attached chart must be resolved"
+    assert 101 not in bind_values, (
+        "a chart removed before the target tx must not be resolved as a member "
+        "(sc-120007: never-closed association shadow must not over-report)"
+    )
+
+
+def test_dashboard_slice_uuids_empty_when_nothing_attached_at_tx(
+    app_context: None,
+) -> None:
+    """No uuid query is issued when every window excludes the target tx.
+
+    The caller's diff then sees zero members, not a stale set.
+    """
+    attached = [(101, Window(1, 5)), (202, Window(2, 6))]  # both closed before 10
+    session = MagicMock()
+
+    result = _dashboard_slice_uuids_at_tx(session, attached, tx=10)
+
+    assert result == []
+    session.connection.return_value.execute.assert_not_called()
+
+
+def test_dashboard_slice_uuids_includes_chart_reattached_before_tx(
+    app_context: None,
+) -> None:
+    """A re-attached chart is a member if any of its windows contains tx.
+
+    The two windows collapse to one id in the resolved set (resolved once).
+    """
+    attached = [(101, Window(1, 5)), (101, Window(8, None))]  # re-attached at 8
+    captured: list[Any] = []
+    session = _session_echoing_queried_ids(captured)
+
+    result = _dashboard_slice_uuids_at_tx(session, attached, tx=10)
+
+    assert result == ["uuid-101"]
+
+
+def test_dashboard_slice_uuids_drops_null_uuid_rows(app_context: None) -> None:
+    """A content-shadow row with a NULL uuid is filtered out, not emitted."""
+    attached = [(202, Window(1, None))]
+
+    class _NullThenReal:
+        def all(self) -> list[tuple[Any]]:
+            return [(None,), ("uuid-202",)]
+
+    session = MagicMock()
+    session.connection.return_value.execute.return_value = _NullThenReal()
+
+    result = _dashboard_slice_uuids_at_tx(session, attached, tx=10)
+
+    assert result == ["uuid-202"]
+
+
+def test_dashboard_slice_uuids_chunks_wide_membership_under_bind_floor(
+    app_context: None,
+) -> None:
+    """A wide dashboard's membership IN is chunked to stay under the bind floor.
+
+    sc-120007 MEDIUM: with more than ``ENTITY_ID_CHUNK_SIZE`` attached charts a
+    single IN would exceed SQLite's ~999 bind-variable floor. The read chunks
+    the id set; assert multiple statements are issued, each compiles to well
+    under 999 binds, and every id is resolved across the chunks. Dropping the
+    chunking would emit one statement whose bind count exceeds the floor.
+    """
+    count = 2 * ENTITY_ID_CHUNK_SIZE + 50  # spans three chunks
+    ids = list(range(1000, 1000 + count))  # >= 1000 so tx/op binds never collide
+    attached = [(i, Window(1, None)) for i in ids]  # all attached at tx=10
+    captured: list[Any] = []
+    session = _session_echoing_queried_ids(captured, id_predicate=lambda v: v >= 1000)
+
+    result = _dashboard_slice_uuids_at_tx(session, attached, tx=10)
+
+    assert sorted(result) == sorted(f"uuid-{i}" for i in ids)
+    assert len(captured) >= 2, "wide membership must be split across statements"
+    for stmt in captured:
+        compiled = stmt.compile(
+            dialect=sqlite.dialect(), compile_kwargs={"render_postcompile": True}
+        )
+        assert len(compiled.params) < 999, "each statement must stay under the floor"
+
+
+def test_child_records_threads_committing_session_into_membership(
+    app_context: None,
+) -> None:
+    """The membership read runs on the committing session, not global db.session.
+
+    sc-120007 HIGH regression guard: ``_dashboard_child_records_for_tx_from_shadows``
+    runs during commit finalization, when the current transaction's association
+    rows are flushed-but-not-committed and visible only on the committing
+    connection. It must pass that session to ``charts_attached_to_dashboard``;
+    reading via ``db.session`` would miss those rows on a non-scoped committing
+    session and silently drop the change record. Asserted at the call site so
+    dropping ``session=session`` fails here even though the direct-window tests
+    above stay green.
+    """
+    committing_session = MagicMock(name="committing_session")
+    # The prior-tx lookup runs on the same session; give it a value.
+    prior_tx_result = committing_session.connection.return_value.execute.return_value
+    prior_tx_result.scalar.return_value = 5
+    spy = MagicMock(return_value=[])  # no attached members -> no uuid query
+
+    with (
+        patch(
+            "superset.versioning.changes.shadow_queries._affected_dashboard_ids_at_tx",
+            return_value={7},
+        ),
+        patch(
+            "superset.versioning.membership.charts_attached_to_dashboard",
+            spy,
+        ),
+    ):
+        _dashboard_child_records_for_tx_from_shadows(
+            committing_session, transaction_id=10
+        )
+
+    spy.assert_called_once_with(7, session=committing_session)
+
+
+def test_charts_attached_to_dashboard_uses_the_passed_session(
+    app_context: None,
+) -> None:
+    """The membership helper reads on the passed session, never db.session."""
+    from superset.versioning.membership import charts_attached_to_dashboard
+
+    passed = MagicMock(name="passed_session")
+    passed.connection.return_value.execute.return_value.all.return_value = []
+
+    with patch("superset.versioning.membership.db") as mock_db:
+        charts_attached_to_dashboard(1, session=passed)
+
+    passed.connection.assert_called_once_with()
+    mock_db.session.connection.assert_not_called()
+
+
+def test_charts_attached_to_dashboard_defaults_to_db_session(
+    app_context: None,
+) -> None:
+    """With no session, the helper falls back to the Flask-scoped db.session."""
+    from superset.versioning.membership import charts_attached_to_dashboard
+
+    with patch("superset.versioning.membership.db") as mock_db:
+        db_result = mock_db.session.connection.return_value.execute.return_value
+        db_result.all.return_value = []
+        charts_attached_to_dashboard(1)
+
+    mock_db.session.connection.assert_called_once_with()


### PR DESCRIPTION
### SUMMARY

`_dashboard_slice_uuids_at_tx` — the change-record diff's "which charts were on
this dashboard at transaction *tx*" read — used the raw `dashboard_slices_version`
validity predicate (`end_transaction_id IS NULL OR > tx` + `operation_type != DELETE`).
SQLAlchemy-Continuum **never closes `end_transaction_id` on an M2M association
shadow**, so a chart attached at tx 1 and removed at tx 5 still read as a member
at tx 10 — over-reporting membership in the dashboard's change-record diff (and
emitting phantom slice records for charts that were already gone).

This is the **third consumer** of that broken pattern; the version-restore
membership read (`restore.py`) and the impact rollup (`impact.py`) were fixed the
same way in #44010 (sc-119907), and Amin flagged this change-record diff site as
the known remaining one.

The fix resolves membership through `charts_attached_to_dashboard`, which pairs
the association shadow's INSERT/DELETE rows into half-open `[attach, detach)`
windows (via `attachment_windows`), and keeps only charts whose window contains
*tx*. The `slices_version` (content) shadow **does** close `end_transaction_id`
correctly, so its validity predicate is kept for uuid resolution and the "not yet
versioned at tx" exclusion (matching Continuum's M2M `Reverter`).

Threading + performance details (from the local 4-lens review):
- The committing `session` is threaded into `charts_attached_to_dashboard` (new
  optional param, defaulting to `db.session`). This read runs during commit
  finalization, when the current transaction's association-shadow rows are
  flushed-but-not-committed and visible only on the committing connection —
  reading via the global `db.session` would miss them whenever the committing
  session isn't the Flask-scoped one. Read/restore-path callers keep the default.
- The attachment windows are computed once per dashboard and reused for the
  pre/post-tx membership (they're tx-independent), instead of re-scanning the
  association history twice.
- The `slices_version` id IN is chunked via `chunked_ids`, mirroring the sibling
  impact rollup, so a pathologically wide dashboard can't exceed the SQLite bind
  floor.

Refs: sc-120007. Follow-up to #44010 / sc-119907.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No UI change — backend versioning correctness. Behaviorally: a dashboard's
version-history/change-record diff no longer lists a chart that had already been
removed before the transaction being described.

### TESTING INSTRUCTIONS

Unit: `pytest tests/unit_tests/versioning/test_shadow_queries.py` — a chart
detached before the target tx is excluded from resolved membership while a
still-attached (or re-attached) chart is included; empty-membership short-circuit
and NULL-uuid filtering covered; includes a reverted-fix control. The read path
is also exercised end-to-end by `tests/integration_tests/versioning/change_records_tests.py`.

Manual: attach a chart to a dashboard, save; remove it, save; edit the dashboard
again, save. The change record for the last save must not report the removed
chart as a member.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
