### PR TITLE
fix(views): error-response bodies must carry their message

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -201,7 +201,7 @@ class Superset(BaseSupersetView):
                         initial_form_data["url_params"] = dict(url_params)
                 else:
                     return json_error_response(
-                        _("Error: permalink state not found"), status=404
+                        __("Error: permalink state not found"), status=404
                     )
             except (ChartNotFoundError, ExplorePermalinkGetFailedError) as ex:
                 return json_error_response(
@@ -290,13 +290,13 @@ class Superset(BaseSupersetView):
 
         if action == "overwrite" and not slice_overwrite_perm:
             return json_error_response(
-                _("You don't have the rights to alter this chart"),
+                __("You don't have the rights to alter this chart"),
                 status=403,
             )
 
         if action == "saveas" and not slice_add_perm:
             return json_error_response(
-                _("You don't have the rights to create a chart"),
+                __("You don't have the rights to create a chart"),
                 status=403,
             )
 
@@ -432,7 +432,7 @@ class Superset(BaseSupersetView):
             dash_overwrite_perm = security_manager.is_editor(dash)
             if not dash_overwrite_perm:
                 return json_error_response(
-                    _("You don't have the rights to alter this dashboard"),
+                    __("You don't have the rights to alter this dashboard"),
                     status=403,
                 )
         elif new_dashboard_name:
@@ -441,7 +441,7 @@ class Superset(BaseSupersetView):
             dash_add_perm = security_manager.can_access("can_write", "Dashboard")
             if not dash_add_perm:
                 return json_error_response(
-                    _("You don't have the rights to create a dashboard"),
+                    __("You don't have the rights to create a dashboard"),
                     status=403,
                 )
 
@@ -633,7 +633,7 @@ class Superset(BaseSupersetView):
         except DashboardPermalinkGetFailedError as ex:
             return json_error_response(__("Error: %(msg)s", msg=ex.message), status=404)
         if not value:
-            return json_error_response(_("permalink state not found"), status=404)
+            return json_error_response(__("permalink state not found"), status=404)
 
         dashboard_id, state = value["dashboardId"], value.get("state", {})
         url = url_for(

--- a/superset/views/error_handling.py
+++ b/superset/views/error_handling.py
@@ -88,6 +88,13 @@ def json_error_response(
         ]
     elif isinstance(error_details, str):
         payload["error"] = sanitize_error_message(error_details, status)
+    elif error_details is not None:
+        # A flask-babel LazyString (or any other string-like proxy) fails the
+        # isinstance(str) check above, and the body used to silently degrade
+        # to ``{}`` — an error response whose status said "denied" but whose
+        # payload said nothing. Coerce so the message always survives; call
+        # sites should still prefer the eager gettext alias for error bodies.
+        payload["error"] = sanitize_error_message(str(error_details), status)
 
     return Response(
         json.dumps(payload, default=json.json_iso_dttm_ser, ignore_nan=True),

--- a/superset/views/error_handling.py
+++ b/superset/views/error_handling.py
@@ -31,6 +31,7 @@ from flask import (
     send_file,
 )
 from flask_babel import gettext as _
+from flask_babel.speaklater import LazyString
 from flask_wtf.csrf import CSRFError
 from sqlalchemy import exc
 from werkzeug.exceptions import HTTPException
@@ -72,7 +73,7 @@ def get_error_level_from_status(
 
 
 def json_error_response(
-    error_details: str | SupersetError | list[SupersetError] | None = None,
+    error_details: str | LazyString | SupersetError | list[SupersetError] | None = None,
     status: int = 500,
     payload: dict[str, Any] | None = None,
 ) -> FlaskResponse:
@@ -88,12 +89,14 @@ def json_error_response(
         ]
     elif isinstance(error_details, str):
         payload["error"] = sanitize_error_message(error_details, status)
-    elif error_details is not None:
-        # A flask-babel LazyString (or any other string-like proxy) fails the
-        # isinstance(str) check above, and the body used to silently degrade
-        # to ``{}`` — an error response whose status said "denied" but whose
-        # payload said nothing. Coerce so the message always survives; call
-        # sites should still prefer the eager gettext alias for error bodies.
+    elif isinstance(error_details, LazyString):
+        # A flask-babel LazyString fails the isinstance(str) check above,
+        # and the body used to silently degrade to ``{}`` — an error
+        # response whose status said "denied" but whose payload said
+        # nothing. Coerce so the message survives; call sites should still
+        # prefer the eager gettext alias for error bodies. Deliberately
+        # narrow: any OTHER out-of-contract object keeps degrading to an
+        # empty body rather than leaking ``str(obj)`` to the client.
         payload["error"] = sanitize_error_message(str(error_details), status)
 
     return Response(

--- a/tests/unit_tests/views/test_error_bodies.py
+++ b/tests/unit_tests/views/test_error_bodies.py
@@ -67,9 +67,12 @@ def test_no_lazy_gettext_reaches_json_error_response() -> None:
     convention rather than correctness — if it fires, switch the site to
     the eager ``__()`` alias.
     """
+    import superset
+
     pattern = re.compile(r"json_error_response\(\s*_\(", re.S)
     offenders: list[str] = []
-    for path in pathlib.Path("superset").rglob("*.py"):
+    package_root = pathlib.Path(superset.__file__).parent
+    for path in package_root.rglob("*.py"):
         source = path.read_text(errors="ignore")
         if "json_error_response" not in source:
             continue

--- a/tests/unit_tests/views/test_error_bodies.py
+++ b/tests/unit_tests/views/test_error_bodies.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-120052: error-response bodies must carry their message.
+
+``json_error_response`` used to set ``payload["error"]`` only for exact
+``str`` arguments; a flask-babel ``lazy_gettext`` proxy (LazyString) failed
+that isinstance check and the body silently degraded to ``{}`` while the
+status still said "denied". Five live call sites in ``superset/views``
+shipped empty 403/404 bodies that way. Pins: the helper now coerces
+string-like proxies, and a binding-aware source scan keeps lazy ``_()``
+out of error bodies at the call sites (the eager alias stays preferred —
+the coercion is the safety net, not the convention).
+"""
+
+import pathlib
+import re
+from typing import cast
+
+from flask import Response
+from flask_babel import lazy_gettext
+
+from superset.utils import json
+
+
+def test_json_error_response_carries_lazy_string_message(app_context) -> None:
+    """A LazyString body must not degrade to {} (the sc-120052 bug)."""
+    from superset.views.error_handling import json_error_response
+
+    resp = cast(
+        Response,
+        json_error_response(lazy_gettext("permalink state not found"), status=404),
+    )
+
+    body = json.loads(resp.get_data(as_text=True))
+    assert body.get("error") == "permalink state not found"
+    assert resp.status_code == 404
+
+
+def test_json_error_response_still_carries_plain_str(app_context) -> None:
+    from superset.views.error_handling import json_error_response
+
+    resp = cast(Response, json_error_response("nope", status=403))
+
+    assert json.loads(resp.get_data(as_text=True)).get("error") == "nope"
+
+
+def test_no_lazy_gettext_reaches_json_error_response() -> None:
+    """Binding-aware source tripwire for the call-site convention.
+
+    In any module that binds ``_`` to ``lazy_gettext``, an error body built
+    as ``json_error_response(_(...))`` is the sc-120052 bug shape. The
+    helper now coerces (see the tests above), so this scan guards the
+    convention rather than correctness — if it fires, switch the site to
+    the eager ``__()`` alias.
+    """
+    pattern = re.compile(r"json_error_response\(\s*_\(", re.S)
+    offenders: list[str] = []
+    for path in pathlib.Path("superset").rglob("*.py"):
+        source = path.read_text(errors="ignore")
+        if "json_error_response" not in source:
+            continue
+        if not re.search(r"lazy_gettext as _\b", source):
+            continue
+        for match in pattern.finditer(source):
+            line = source.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path}:{line}")
+    assert not offenders, f"lazy _() passed to json_error_response at: {offenders}"


### PR DESCRIPTION
### SUMMARY

`json_error_response` sets `payload["error"]` only for exact `str` arguments. A flask-babel `lazy_gettext` proxy (LazyString) fails that `isinstance` check, so the body silently degrades to `{}` while the status still says "denied" — the client gets a 403/404 with no message. Five live call sites in `superset/views/core.py` ship that today: both "permalink state not found" 404s and the create-chart / alter-dashboard / create-dashboard permission denials. (The overwrite-chart denial has the identical fix on the in-review #44025 branch; it is included here as well so the tripwire below can assert zero — identical hunks reconcile cleanly whichever lands first.)

Two-layer fix:

- **Call sites** switch to the module's eager `__()` alias (`core.py` imports `gettext as __, lazy_gettext as _`, and the neighboring sites already use `__` — these were the stragglers).
- **Root cause**: `json_error_response` now coerces `LazyString` values with `str(...)`, so any future lazy call produces a correct body instead of `{}` — deliberately narrowed to exactly that case, so any *other* out-of-contract object keeps degrading to an empty body rather than leaking `str(obj)` to the client (per committer review). The eager alias remains the convention; the coercion is the safety net.

Found via sc-120011/#44025, where a message-asserting regression test caught the same empty-body shape on a new denial — and turned out to be catching this pre-existing class. A binding-aware repo sweep (only modules binding `_` to `lazy_gettext` can have the bug; several files import `_` as eager `gettext` and are fine) confirmed `views/core.py` holds all the live sites.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API error bodies only. Before: `{}`. After: `{"error": "You don't have the rights to create a dashboard"}` etc.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/views/test_error_bodies.py` — 3 tests: a LazyString body survives into `payload["error"]` (fails pre-fix), the plain-`str` path is unchanged, and a binding-aware source scan asserts no `json_error_response(_(...))` remains in any module where `_` is `lazy_gettext` (fails pre-fix on the five sites). Reverting the production change flips the mechanism test and the tripwire.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW
