### PR TITLE
fix(database): reject non-dict extra field in extra_validator

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -261,7 +261,7 @@ def masked_encrypted_extra_validator(value: str) -> None:
     encrypted_extra_validator(value)
 
 
-def extra_validator(value: str) -> str:
+def extra_validator(value: str) -> str:  # noqa: C901
     """
     Validate that extra is a valid JSON string, and that metadata_params
     keys are on the call signature for SQLAlchemy Metadata
@@ -273,6 +273,11 @@ def extra_validator(value: str) -> str:
             raise ValidationError(
                 [_("Field cannot be decoded by JSON. %(msg)s", msg=str(ex))]
             ) from ex
+
+        if not isinstance(extra_, dict):
+            raise ValidationError(
+                [_("Extra field must be a mapping from string keys to values.")]
+            )
 
         metadata_signature = inspect.signature(MetaData)
         for key in extra_.get("metadata_params", {}):

--- a/tests/unit_tests/databases/schema_tests.py
+++ b/tests/unit_tests/databases/schema_tests.py
@@ -595,6 +595,25 @@ def test_extra_validator_interpolates_json_decode_error() -> None:
     assert "%(" not in message
 
 
+@pytest.mark.parametrize("value", [123, None, [1, 2], True, "abc"])
+def test_extra_validator_rejects_non_dict_top_level_value(value: Any) -> None:
+    """
+    Test that extra_validator rejects a top-level extra value that is valid
+    JSON but not a mapping (int, null, list, bool, string), instead of
+    letting AttributeError propagate from extra_.get("metadata_params").
+    """
+    from superset.databases.schemas import DatabasePostSchema
+
+    schema = DatabasePostSchema()
+    payload = {
+        "database_name": "test_db",
+        "extra": json.dumps(value),
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        schema.load(payload)
+    assert "must be a mapping" in str(exc_info.value)
+
+
 def test_cache_timeout_rejects_values_below_minus_one() -> None:
     """
     Test that cache_timeout rejects values less than -1.


### PR DESCRIPTION
### SUMMARY

`superset/databases/schemas.py::extra_validator` — the shared marshmallow `validate=`
callable for the `extra` field on `DatabasePostSchema`, `DatabasePutSchema`,
`DatabaseTestConnectionSchema` and friends — could let a raw `AttributeError` escape as
an opaque HTTP 500 instead of returning a validation error.

**Problem**

```python
extra_ = json.loads(value)          # accepts ANY valid JSON, not just objects
...
for key in extra_.get("metadata_params", {}):   # <-- assumes a mapping
```

`json.loads()` happily returns non-mapping values: `json.loads("123")` → `int`,
`"null"` → `None`, `"[1,2]"` → `list`, `"true"` → `bool`, `'"abc"'` → `str`. None of
those have `.get()`, so the next line raises
`AttributeError: 'int' object has no attribute 'get'`.

Nothing along the path turns that into a validation error:

- marshmallow only translates `ValidationError` raised by a field validator; anything
  else propagates straight out of `schema.load()`;
- `superset/databases/api.py` `post()` / `put()` wrap `self.add_model_schema.load(...)` /
  `self.edit_model_schema.load(...)` in `except ValidationError` only — nothing broader
  (`statsd_metrics` catches `Exception` purely to emit a metric and re-raises);
- it is ultimately swallowed by the catch-all `@app.errorhandler(Exception)` in
  `superset/views/error_handling.py`, which renders it as a SIP-40
  `GENERIC_BACKEND_ERROR` **500** whose message is the raw
  `'int' object has no attribute 'get'`.

So any authenticated user with database create/edit permission sending
`POST /api/v1/database/` or `PUT /api/v1/database/<pk>/` with `{"extra": "123"}` (or any
other non-object JSON string) gets a 500 leaking an internal type error, where a 4xx
validation error is the correct response. This is a robustness/error-handling
bug, not a privilege issue: the request already requires the database write capability,
so no principal gains anything they were not entitled to.

**Fix**

Guard the decoded value with the same `isinstance` + `ValidationError` pattern that
already exists a few lines below in the very same function for `metadata_cache_timeout`:

```python
if not isinstance(extra_, dict):
    raise ValidationError(
        [_("Extra field must be a mapping from string keys to values.")]
    )
```

The check is placed after the `json.JSONDecodeError` handler and before any `.get()` /
`in` use of `extra_`, so malformed JSON still reports the existing decode message and
dict-valued `extra` behaves exactly as before.

This follows the same "raw exception → proper Superset exception" cleanup as
apache/superset#42366 and apache/superset#42401.

**Behavior change:** a request that previously returned an unhandled 500 now returns a
proper 4xx validation error. Strict improvement — no tradeoff to disclose. Valid
`extra` payloads are unaffected.

One incidental note: adding the branch pushed `extra_validator` from McCabe complexity
10 to 11, so the function carries a `# noqa: C901`. Its complexity is a flat sequence of
independent field validations rather than nesting, and this matches ~144 existing
`# noqa: C901` usages under `superset/`. Extracting the neighboring
`metadata_cache_timeout` block into a helper would also work if reviewers prefer that,
but it would enlarge an otherwise 5-line diff.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — API error-handling change, no UI surface.

### TESTING INSTRUCTIONS

Automated: `pytest tests/unit_tests/databases/schema_tests.py`

A new parametrized regression test,
`test_extra_validator_rejects_non_dict_top_level_value`, drives the real code path
through `DatabasePostSchema().load(...)` (not a direct call to the validator, so
marshmallow's error handling is exercised) for all five non-mapping JSON shapes
(`123`, `null`, `[1, 2]`, `true`, `"abc"`).

Verified both ways:
- against unfixed code: all 5 parametrizations fail with
  `AttributeError: 'str' object has no attribute 'get'` at `schemas.py:278`
- with the fix: 5 passed
- whole file after the fix: **44 passed**, including the pre-existing
  `metadata_params`, `metadata_cache_timeout` and JSON-decode-message tests — the new
  check does not fire ahead of the `JSONDecodeError` handler and does not change
  behavior for dict-valued `extra`.

Manual:
```bash
curl -X POST "$SUPERSET/api/v1/database/" -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"database_name": "test_db", "sqlalchemy_uri": "sqlite://", "extra": "123"}'
```
Before: 500 (`GENERIC_BACKEND_ERROR`, message `'int' object has no attribute 'get'`).
After: a 422 validation error naming the `extra` field.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
