### PR TITLE
fix(mcp): refuse certification changes on externally managed dashboards

### DIFF
--- a/superset/mcp_service/dashboard/schemas.py
+++ b/superset/mcp_service/dashboard/schemas.py
@@ -1070,7 +1070,11 @@ class DashboardMutationErrorFields(BaseModel):
     error: str | None = Field(None, description="Error message, if operation failed")
     permission_denied: bool = Field(
         default=False,
-        description=("True when the user lacks edit rights on the target dashboard."),
+        description=(
+            "True when the user lacks edit rights on the target dashboard, "
+            "or the dashboard refuses the mutation (e.g. it is managed "
+            "externally)."
+        ),
     )
 
 

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -83,15 +83,25 @@ def manage_dashboard_certification(
         return auth_error
     assert dashboard is not None  # narrows for mypy
 
-    # Externally managed dashboards refuse certification changes: their
+    if request.certified_by is None and request.certification_details is None:
+        return ManageDashboardCertificationResponse(
+            certified_by=dashboard.certified_by,
+            certification_details=dashboard.certification_details,
+            dashboard_url=dashboard_url(dashboard),
+            changed_fields=[],
+            warnings=["No fields provided; dashboard unchanged."],
+        )
+
+    # Externally managed dashboards refuse certification CHANGES (the
+    # no-field inspect path above still returns current values): their
     # source of truth lives outside Superset, so a badge set here would be
     # overwritten (or drift from the certifying system) on the next
-    # external sync. This tool writes by direct attribute assignment +
-    # commit, bypassing UpdateDashboardCommand's shared
-    # raise_if_managed_externally gate, so the refusal must live here.
-    # Placed after the editorship check, mirroring the command-layer
-    # ordering: a caller with no edit rights keeps getting the plain
-    # editorship denial.
+    # external sync. The dashboard command layer does not yet enforce
+    # is_managed_externally (apache/superset#44025 proposes that gate for
+    # the ordinary update paths), and this tool writes by direct attribute
+    # assignment + commit in any case — so the refusal lives here, after
+    # the editorship check, where a caller with no edit rights keeps
+    # getting the plain editorship denial.
     if dashboard.is_managed_externally:
         return ManageDashboardCertificationResponse(
             permission_denied=True,
@@ -100,15 +110,6 @@ def manage_dashboard_certification(
                 "is managed externally; its certification is owned by the "
                 "external system and cannot be changed here."
             ),
-        )
-
-    if request.certified_by is None and request.certification_details is None:
-        return ManageDashboardCertificationResponse(
-            certified_by=dashboard.certified_by,
-            certification_details=dashboard.certification_details,
-            dashboard_url=dashboard_url(dashboard),
-            changed_fields=[],
-            warnings=["No fields provided; dashboard unchanged."],
         )
 
     changed_fields: list[str] = []

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -96,12 +96,11 @@ def manage_dashboard_certification(
     # no-field inspect path above still returns current values): their
     # source of truth lives outside Superset, so a badge set here would be
     # overwritten (or drift from the certifying system) on the next
-    # external sync. The dashboard command layer does not yet enforce
-    # is_managed_externally (apache/superset#44025 proposes that gate for
-    # the ordinary update paths), and this tool writes by direct attribute
-    # assignment + commit in any case — so the refusal lives here, after
-    # the editorship check, where a caller with no edit rights keeps
-    # getting the plain editorship denial.
+    # external sync. This tool writes by direct attribute assignment +
+    # commit rather than through a command, so no command-layer check can
+    # protect it — the refusal must live in the tool itself, after the
+    # editorship check, where a caller with no edit rights keeps getting
+    # the plain editorship denial.
     if dashboard.is_managed_externally:
         return ManageDashboardCertificationResponse(
             permission_denied=True,

--- a/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
+++ b/superset/mcp_service/dashboard/tool/manage_dashboard_certification.py
@@ -83,6 +83,25 @@ def manage_dashboard_certification(
         return auth_error
     assert dashboard is not None  # narrows for mypy
 
+    # Externally managed dashboards refuse certification changes: their
+    # source of truth lives outside Superset, so a badge set here would be
+    # overwritten (or drift from the certifying system) on the next
+    # external sync. This tool writes by direct attribute assignment +
+    # commit, bypassing UpdateDashboardCommand's shared
+    # raise_if_managed_externally gate, so the refusal must live here.
+    # Placed after the editorship check, mirroring the command-layer
+    # ordering: a caller with no edit rights keeps getting the plain
+    # editorship denial.
+    if dashboard.is_managed_externally:
+        return ManageDashboardCertificationResponse(
+            permission_denied=True,
+            error=(
+                f"Dashboard '{dashboard.dashboard_title}' (ID: {dashboard.id}) "
+                "is managed externally; its certification is owned by the "
+                "external system and cannot be changed here."
+            ),
+        )
+
     if request.certified_by is None and request.certification_details is None:
         return ManageDashboardCertificationResponse(
             certified_by=dashboard.certified_by,

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -34,6 +34,7 @@ def _mock_dashboard(
     slug: str | None = "test-slug",
     certified_by: str | None = None,
     certification_details: str | None = None,
+    is_managed_externally: bool = False,
 ) -> Mock:
     dashboard: Mock = Mock()
     dashboard.id = id
@@ -41,10 +42,46 @@ def _mock_dashboard(
     dashboard.slug = slug
     dashboard.certified_by = certified_by
     dashboard.certification_details = certification_details
+    # Declared explicitly: a bare Mock attribute is truthy, which would
+    # trip the managed-externally refusal in every test (real dashboards
+    # default the flag to False).
+    dashboard.is_managed_externally = is_managed_externally
     return dashboard
 
 
 class TestManageDashboardCertification:
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_refuses_externally_managed_dashboard(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """sc-120051: certification of a managed dashboard is refused.
+
+        This tool writes by direct attribute assignment + commit,
+        bypassing UpdateDashboardCommand's raise_if_managed_externally
+        gate — so the refusal lives in the tool, and nothing may be
+        assigned or committed on the refused path."""
+        dash: Mock = _mock_dashboard(is_managed_externally=True)
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {
+                    "request": {
+                        "identifier": 42,
+                        "certified_by": "Data Platform Team",
+                    }
+                },
+            )
+
+        payload: dict[str, Any] = json.loads(result.content[0].text)
+        assert payload["permission_denied"] is True
+        assert "managed externally" in payload["error"]
+        assert dash.certified_by is None
+        mock_session.commit.assert_not_called()
+
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from fastmcp import Client
+from fastmcp.client.client import CallToolResult
 
 from superset.utils import json
 
@@ -50,37 +51,41 @@ def _mock_dashboard(
 
 
 class TestManageDashboardCertification:
+    @pytest.mark.parametrize("field", ["certified_by", "certification_details"])
+    @pytest.mark.parametrize("value", ["Data Platform Team", ""])
     @patch(DAO_GET)
     @patch("superset.extensions.db.session")
     @pytest.mark.asyncio
     async def test_refuses_externally_managed_dashboard(
-        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+        self,
+        mock_session: Mock,
+        mock_get: Mock,
+        mcp_server: object,
+        field: str,
+        value: str,
     ) -> None:
-        """sc-120051: certification of a managed dashboard is refused.
+        """sc-120051: certification changes on a managed dashboard are refused.
 
-        The dashboard command layer does not yet enforce
-        is_managed_externally (apache/superset#44025 proposes that gate),
-        and this tool writes by direct attribute assignment + commit in
-        any case — so the refusal lives in the tool, and nothing may be
-        assigned or committed on the refused path."""
+        This tool writes by direct attribute assignment + commit rather
+        than through a command, so no command-layer check can protect it —
+        the refusal lives in the tool, and nothing may be assigned or
+        committed on the refused path. Parametrized across BOTH badge
+        fields and both set and clear, so gating one field but not the
+        other cannot pass."""
         dash: Mock = _mock_dashboard(is_managed_externally=True)
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool(
+            result: CallToolResult = await client.call_tool(
                 "manage_dashboard_certification",
-                {
-                    "request": {
-                        "identifier": 42,
-                        "certified_by": "Data Platform Team",
-                    }
-                },
+                {"request": {"identifier": 42, field: value}},
             )
 
         payload: dict[str, Any] = json.loads(result.content[0].text)
         assert payload["permission_denied"] is True
         assert "managed externally" in payload["error"]
         assert dash.certified_by is None
+        assert dash.certification_details is None
         mock_session.commit.assert_not_called()
 
     @patch(DAO_GET)
@@ -95,12 +100,14 @@ class TestManageDashboardCertification:
         dashboard returns current values (which the caller can read via
         get_dashboard_info anyway) instead of a misleading denial."""
         dash: Mock = _mock_dashboard(
-            certified_by="External Certifier", is_managed_externally=True
+            certified_by="External Certifier",
+            certification_details="Synced from the source of truth",
+            is_managed_externally=True,
         )
         mock_get.return_value = dash
 
         async with Client(mcp_server) as client:
-            result = await client.call_tool(
+            result: CallToolResult = await client.call_tool(
                 "manage_dashboard_certification",
                 {"request": {"identifier": 42}},
             )
@@ -108,6 +115,8 @@ class TestManageDashboardCertification:
         payload: dict[str, Any] = json.loads(result.content[0].text)
         assert payload.get("permission_denied") is not True
         assert payload["certified_by"] == "External Certifier"
+        assert payload["certification_details"] == "Synced from the source of truth"
+        assert payload["changed_fields"] == []
         mock_session.commit.assert_not_called()
 
     @patch(DAO_GET)

--- a/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
+++ b/tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py
@@ -58,9 +58,10 @@ class TestManageDashboardCertification:
     ) -> None:
         """sc-120051: certification of a managed dashboard is refused.
 
-        This tool writes by direct attribute assignment + commit,
-        bypassing UpdateDashboardCommand's raise_if_managed_externally
-        gate — so the refusal lives in the tool, and nothing may be
+        The dashboard command layer does not yet enforce
+        is_managed_externally (apache/superset#44025 proposes that gate),
+        and this tool writes by direct attribute assignment + commit in
+        any case — so the refusal lives in the tool, and nothing may be
         assigned or committed on the refused path."""
         dash: Mock = _mock_dashboard(is_managed_externally=True)
         mock_get.return_value = dash
@@ -80,6 +81,33 @@ class TestManageDashboardCertification:
         assert payload["permission_denied"] is True
         assert "managed externally" in payload["error"]
         assert dash.certified_by is None
+        mock_session.commit.assert_not_called()
+
+    @patch(DAO_GET)
+    @patch("superset.extensions.db.session")
+    @pytest.mark.asyncio
+    async def test_no_fields_on_managed_dashboard_still_inspects(
+        self, mock_session: Mock, mock_get: Mock, mcp_server: object
+    ) -> None:
+        """The no-field inspect path is not gated: reading changes nothing.
+
+        The refusal covers CHANGES only; a no-field call on a managed
+        dashboard returns current values (which the caller can read via
+        get_dashboard_info anyway) instead of a misleading denial."""
+        dash: Mock = _mock_dashboard(
+            certified_by="External Certifier", is_managed_externally=True
+        )
+        mock_get.return_value = dash
+
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "manage_dashboard_certification",
+                {"request": {"identifier": 42}},
+            )
+
+        payload: dict[str, Any] = json.loads(result.content[0].text)
+        assert payload.get("permission_denied") is not True
+        assert payload["certified_by"] == "External Certifier"
         mock_session.commit.assert_not_called()
 
     @patch(DAO_GET)


### PR DESCRIPTION
### SUMMARY

The sc-120051 write-surface inventory (which walked every path that mutates chart/dashboard/dataset content outside the gated `UpdateCommand`s) found exactly one live command-layer bypass: the `manage_dashboard_certification` MCP tool writes `certified_by` / `certification_details` — exported governance fields — by direct model-attribute assignment + `db.session.commit()`. It therefore never inherits the server-side `is_managed_externally` gate the ordinary update paths carry, so an MCP caller could badge or un-badge an **externally managed** dashboard, for the next external sync to overwrite (or worse, leave the badge drifting from the certifying system of record).

**Fix**: after the tool's editorship check (a caller with no edit rights keeps getting the plain editorship denial) and below the no-field inspect branch (reading current values changes nothing and stays available — they're served by `get_dashboard_info` anyway), an externally managed dashboard's certification *change* is refused through the tool's structured `permission_denied` response, naming the reason. The `permission_denied` schema description is widened to cover object-state refusals. Note the in-tree dashboard command layer has no managed-externally check at all today (#44025 proposes the gate for the ordinary update paths) — which makes the tool-local refusal more necessary, not less.

Sibling context: the ordinary update/refresh/restore surfaces are gated in #44025/#44013; other MCP writers (`update_chart`, `update_dashboard`, `update_dataset_metric`) route through the gated commands and inherit the refusal; the DeleteCommands' exemption is an explicitly ratified policy (soft delete changes visibility, not content) documented separately. The sibling governance tools (`manage_dashboard_owners`, `manage_dashboard_roles`) share this direct-commit shape and remain ungated — recorded as a deliberate follow-up (hoisting the check into the shared `find_and_authorize_dashboard` helper needs a per-tool policy decision, since owners/roles are arguably Superset-side ACLs rather than synced content).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — MCP tool behavior. Before: badge applied + committed on a managed dashboard. After: structured `permission_denied` response, nothing assigned, nothing committed.

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/mcp_service/dashboard/tool/test_manage_dashboard_certification.py` — 17 tests. The new `test_refuses_externally_managed_dashboard` pins the refusal (permission_denied + reason), that no attribute is assigned, and that `commit` is never called; reverting the production change flips exactly that test (stash-verified), and `test_no_fields_on_managed_dashboard_still_inspects` pins that the no-field inspect path is not gated. The fixture change declares `is_managed_externally=False` explicitly — a bare `Mock` attribute is truthy and would otherwise trip the gate across the suite (real dashboards default the flag to `False`).

Manual: flip `is_managed_externally` on a dashboard, call the `manage_dashboard_certification` MCP tool → `permission_denied: true` with the externally-managed reason; flip it back → badge applies.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW
