### PR TITLE
docs(extensions): point the quick-start closing example at real references

### DIFF
--- a/docs/developer_docs/extensions/quick-start.md
+++ b/docs/developer_docs/extensions/quick-start.md
@@ -513,4 +513,4 @@ Now that you have a working extension, explore:
 - **[Deployment](./deployment.md)** - Packaging and deploying your extension
 - **[Security](./security.md)** - Security best practices for extensions
 
-No complete real-world extension is bundled in this repository yet. For working examples, browse the [community extension registry](./registry.md). The scaffold built in this guide mirrors the templates shipped in [`superset-extensions-cli/templates`](https://github.com/apache/superset/tree/master/superset-extensions-cli/templates), the closest in-repo reference for the expected project layout.
+No complete real-world extension is bundled in this repository yet. For working examples, browse the [community extension registry](./registry.md). The scaffold built in this guide mirrors the templates shipped in [`superset-extensions-cli/src/superset_extensions_cli/templates`](https://github.com/apache/superset/tree/master/superset-extensions-cli/src/superset_extensions_cli/templates), the closest in-repo reference for the expected project layout.

--- a/docs/developer_docs/extensions/quick-start.md
+++ b/docs/developer_docs/extensions/quick-start.md
@@ -513,4 +513,4 @@ Now that you have a working extension, explore:
 - **[Deployment](./deployment.md)** - Packaging and deploying your extension
 - **[Security](./security.md)** - Security best practices for extensions
 
-For a complete real-world example, examine the query insights extension in the Superset codebase.
+No complete real-world extension is bundled in this repository yet. For working examples, browse the [community extension registry](./registry.md). The scaffold built in this guide mirrors the templates shipped in [`superset-extensions-cli/templates`](https://github.com/apache/superset/tree/master/superset-extensions-cli/templates), the closest in-repo reference for the expected project layout.


### PR DESCRIPTION
### Summary

Fixes #44095

The closing line of the extensions quick start told readers to "examine the query insights extension in the Superset codebase" as a complete real-world example. No such extension exists anywhere in the repository — the only other matches are the frozen `version-6.1.0` doc snapshot and a fictional fixture name in `tests/unit_tests/extensions/test_types.py`.

The line now:

- states explicitly that no end-to-end extension is bundled in this repository yet,
- points to the community extension registry (real, working extensions),
- points to `superset-extensions-cli/templates` — the scaffold this very guide builds with `superset-extensions init` — as the closest in-repo reference for the expected project layout.

### Testing

Docs-only change in `docs/developer_docs/extensions/quick-start.md`:

- verified `./registry.md` resolves (sibling file, same link style as the neighboring `./development.md` etc.),
- verified the `superset-extensions-cli/src/superset_extensions_cli/templates` path exists on `master`,
- the versioned `version-6.1.0` snapshot is intentionally left untouched (release cut, not live docs).
