### PR TITLE
fix(dashboard): resolve to a fixed point when un-clipping scrollable chart content

### DIFF
--- a/superset/utils/screenshot_utils.py
+++ b/superset/utils/screenshot_utils.py
@@ -641,15 +641,33 @@ async (maxWaitMs) => {{
         (el) => {{ el.style.height = 'auto'; }}
     );
 
-    document.querySelectorAll('{GENERIC_SCROLLABLE_DESCENDANT_SELECTOR}').forEach(
-        (el) => {{
-            if (el.scrollHeight > el.clientHeight) {{
-                el.style.overflow = 'visible';
-                el.style.height = 'auto';
-                el.style.maxHeight = 'none';
+    // A single pass can miss an ancestor whose own fixed height was
+    // computed as the sum of its (still-clipped) children -- e.g.
+    // plugin-chart-table's sticky wrapper (useSticky.tsx) is a
+    // `role="table"` div with a fixed height + `overflow: hidden` around
+    // its scrollable body. Before this loop runs, that wrapper's own
+    // scrollHeight already equals its clientHeight (nothing has grown yet),
+    // so the scrollHeight > clientHeight gate below skips it on the pass
+    // that also expands its child. Only after the child's height resolves
+    // to 'auto' does the wrapper's own overflow become visible to a
+    // re-check -- so repeat until a pass makes no further changes, capped
+    // to bound the cost of a pathologically deep DOM.
+    let changedInPass = true;
+    let passes = 0;
+    while (changedInPass && passes < 5) {{
+        changedInPass = false;
+        passes += 1;
+        document.querySelectorAll('{GENERIC_SCROLLABLE_DESCENDANT_SELECTOR}').forEach(
+            (el) => {{
+                if (el.scrollHeight > el.clientHeight) {{
+                    el.style.overflow = 'visible';
+                    el.style.height = 'auto';
+                    el.style.maxHeight = 'none';
+                    changedInPass = true;
+                }}
             }}
-        }}
-    );
+        );
+    }}
 }}
 """
 

--- a/tests/unit_tests/utils/test_screenshot_utils.py
+++ b/tests/unit_tests/utils/test_screenshot_utils.py
@@ -1867,3 +1867,109 @@ def test_expand_scrollable_content_js_unrolls_ag_grid_and_css_scroll() -> None:
     # bounded by a report's remaining deadline (see webdriver_test.py).
     assert "async (maxWaitMs) =>" in EXPAND_SCROLLABLE_CONTENT_JS
     assert "Date.now() + maxWaitMs" in EXPAND_SCROLLABLE_CONTENT_JS
+
+    # The generic-descendant reset repeats to a fixed point (bounded), not a
+    # single pass: an ancestor whose own height was computed as the sum of
+    # its still-clipped children (e.g. plugin-chart-table's `role="table"`
+    # sticky wrapper in useSticky.tsx) has scrollHeight == clientHeight
+    # *before* its child is expanded, so a single querySelectorAll pass
+    # skips it -- see test_expand_scrollable_content_resolves_nested_ancestor_clip
+    # below for the real-browser reproduction.
+    assert "changedInPass" in EXPAND_SCROLLABLE_CONTENT_JS
+    assert "passes < 5" in EXPAND_SCROLLABLE_CONTENT_JS
+
+
+def test_expand_scrollable_content_resolves_nested_ancestor_clip() -> None:
+    """Real-browser regression test (Playwright/Chromium) for the fixed-point
+    loop above: reproduces the exact nested clip that a single-pass reset
+    missed for `plugin-chart-table`.
+
+    `useSticky.tsx` renders a `role="table"` wrapper with a fixed pixel
+    height and `overflow: hidden`, around a `scrollBodyRef` div that has its
+    *own* fixed height + `overflow: auto`. Before any DOM mutation, the
+    wrapper's `scrollHeight` already equals its `clientHeight` (its height
+    was computed as the sum of its still-clipped children), so a single
+    querySelectorAll pass expands the inner scroll body but has already
+    evaluated -- and skipped -- the outer wrapper by the time the inner one
+    grows. This fixture reproduces that exact two-level shape and asserts
+    every row ends up inside the bounding box a locator-scoped
+    `element.screenshot()` would capture (the same clip Thread B of
+    @aminghadersohi's #43979 review flagged for the ag-Grid ancestor case).
+
+    Skips (does not fail) when Playwright's Python package or a Chromium
+    binary is unavailable -- this environment's own CI unit-test job does
+    not install either today, so this is currently a local/dev verification
+    aid rather than an enforced CI gate.
+    """
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import Error as PlaywrightError, sync_playwright
+
+    from superset.utils.screenshot_utils import EXPAND_SCROLLABLE_CONTENT_JS
+
+    n_rows = 50
+    row_height_px = 30
+    body_height_px = 250  # only ~8 rows fit before the fix
+    outer_height_px = 300  # header + visible body rows, per useSticky's realHeight
+
+    rows_html = "".join(
+        f'<tr id="row-{i}" style="height:{row_height_px}px;"><td>row {i}</td></tr>'
+        for i in range(n_rows)
+    )
+    html = f"""
+    <!doctype html><html><body style="margin:0">
+    <div class="chart-container" style="min-height: {outer_height_px}px; position: relative;">
+      <div class="slice_container" style="height: {outer_height_px}px; display:flex; flex-direction:column; justify-content:center;">
+        <div role="table" style="width: 800px; height: {outer_height_px}px; overflow: hidden;">
+          <div style="overflow: hidden; width: 780px; height: 36px;">HEADER ROW</div>
+          <div style="height: {body_height_px}px; overflow: auto; width: 780px; box-sizing: border-box;">
+            <table style="table-layout: fixed; width: 100%;">
+              <tbody>{rows_html}</tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    </body></html>
+    """  # noqa: E501
+
+    with sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.launch()
+        except PlaywrightError as ex:
+            pytest.skip(f"Chromium is not installed for Playwright: {ex}")
+            return
+
+        try:
+            page = browser.new_page(viewport={"width": 900, "height": 900})
+            page.set_content(html)
+
+            chart_container = page.locator(".chart-container")
+            last_row = page.locator(f"#row-{n_rows - 1}")
+
+            before_box = chart_container.bounding_box()
+            before_last_row_box = last_row.bounding_box()
+            assert before_box is not None
+            assert before_last_row_box is not None
+            # Confirm the fixture actually reproduces clipping before
+            # asserting the fix resolves it, so a broken fixture fails
+            # loudly instead of vacuously passing.
+            assert (
+                before_last_row_box["y"] + before_last_row_box["height"]
+                > before_box["y"] + before_box["height"]
+            )
+
+            page.evaluate(EXPAND_SCROLLABLE_CONTENT_JS, 500)
+
+            after_box = chart_container.bounding_box()
+            after_last_row_box = last_row.bounding_box()
+            assert after_box is not None
+            assert after_last_row_box is not None
+            assert (
+                after_last_row_box["y"] + after_last_row_box["height"]
+                <= after_box["y"] + after_box["height"]
+            )
+            # Every row's height, plus the header -- not just the last
+            # row's position -- actually fits inside the grown container.
+            assert after_box["height"] >= n_rows * row_height_px
+        finally:
+            browser.close()


### PR DESCRIPTION
### SUMMARY
Follow-up to #38090 / #43979. After that PR merged, testing against the **legacy (non-ag-Grid) `plugin-chart-table`** table type showed rows were still clipped in dashboard/chart PDF and PNG exports.

Root cause: `plugin-chart-table`'s sticky table (`DataTable/hooks/useSticky.tsx`) wraps its scrollable body in an **outer `role="table"` div that has its own fixed pixel height + `overflow: hidden`**, around an **inner scroll body div** that also has a fixed height + `overflow: auto`. `EXPAND_SCROLLABLE_CONTENT_JS`'s generic-descendant reset (`#43979`) is gated on `el.scrollHeight > el.clientHeight`, and does a single `querySelectorAll` pass. Before any mutation, the *outer* wrapper's height was computed as the sum of its *already-clipped* children, so its `scrollHeight` already equals its `clientHeight` — the gate skips it. Only *after* the inner scroll body gets reset (later in that same pass) does the outer wrapper's content actually overflow it. One pass is one pass too few.

### FIX
Repeat the generic-descendant reset to a fixed point (bounded to 5 passes) instead of a single `forEach`, so a wrapper that only becomes detectably clipped after its child expands still gets caught on a later pass.

### VERIFICATION
No app/browser environment available here, so I verified this directly against a **real headless Chromium via Playwright**, reproducing the exact nested shape from `useSticky.tsx` (outer fixed-height `overflow:hidden` wrapper around an inner fixed-height `overflow:auto` scroll body containing 50 rows):

- Against the pre-fix single-pass code: the fixture's last row stays outside the `.chart-container` bounding box that a locator-scoped `element.screenshot()` would capture — reproducing the report.
- Against the fixed-point loop: `.chart-container` grows from 300px to 1638px and every row is inside the captured bounding box.

Before/after screenshots (not embedded here, happy to attach on request):

| | height captured | last row visible |
|---|---|---|
| before | 300px | ❌ |
| after | 1638px | ✅ (all 50 rows) |

This browser-driven test is now `test_expand_scrollable_content_resolves_nested_ancestor_clip` in `test_screenshot_utils.py`, skipping cleanly (`pytest.importorskip`) when Playwright/Chromium aren't available — **note this repo's own `Python-Unit` CI job does not currently install either**, so today this is a strong local/dev regression aid rather than an enforced CI gate. Also added a plain string-content assertion for the loop construct, consistent with the rest of this file's existing tests.

`pytest tests/unit_tests/utils/test_screenshot_utils.py tests/unit_tests/utils/webdriver_test.py` → 130 passed. `pre-commit` clean.

### SCOPE
This addresses one of three distinct table/pivot export-completeness gaps identified while investigating the original report:
1. **Row-height clipping for the classic (non-ag-Grid) table** — this PR.
2. Column-width clipping (wide tables) — not addressed here, out of scope for a CSS-level fix.
3. Row-dropping under `server_pagination` (rows never fetched at all, not just visually clipped) — a different, larger-scope problem (would need a bounded re-fetch, not a DOM reset).

### ADDITIONAL INFORMATION
- [x] Has associated issue: follow-up to #38090, #43979
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API