### PR TITLE
feat(ci): add Chromatic visual regression testing for Storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -97,6 +97,12 @@ jobs:
             --target superset-node-ci \
             .
 
+      # --webpack-stats-json writes preview-stats.json into storybook-static.
+      # TurboSnap (onlyChanged below) needs it to trace which stories a
+      # changed file affects; without it, chromaui/action fails with "Could
+      # not retrieve dependent story files" since storybookBuildDir points
+      # at an already-built Storybook it can't inject its own stats
+      # collection into.
       - name: Build Storybook
         if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
         run: |
@@ -104,7 +110,7 @@ jobs:
           docker run \
           -v ${{ github.workspace }}/superset-frontend/storybook-static:/app/superset-frontend/storybook-static \
           --rm $TAG \
-          bash -c "npm i && npm run build-storybook"
+          bash -c "npm i && npm run build-storybook -- --webpack-stats-json"
 
       - name: Publish to Chromatic
         if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,6 +30,11 @@
 # A prior Chromatic setup here (#21095) was removed in #27232 for being
 # unmaintained and overlapping with Applitools (since also discontinued).
 # Keep this one simple and watch it before considering a required check.
+#
+# The master (push) run auto-accepts its own changes so the baseline stays
+# current; otherwise every subsequent PR would keep reporting the same
+# already-merged diff against a stale baseline. PR runs are left alone so a
+# human still reviews what changed.
 name: Chromatic
 
 on:
@@ -124,4 +129,5 @@ jobs:
           # since the baseline build.
           onlyChanged: true
           exitZeroOnChanges: true
+          autoAcceptChanges: ${{ github.event_name == 'push' }}
           zip: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Publishes superset-frontend's Storybook to Chromatic for visual
+# regression testing. See https://www.chromatic.com/docs/github-actions
+#
+# Runs on pushes to master (keeps the Chromatic baseline in sync with
+# mainline) and on pull requests that touch superset-frontend. Fork PRs
+# don't receive CHROMATIC_PROJECT_TOKEN -- GitHub withholds repository
+# secrets from pull_request runs triggered by a fork -- so the publish
+# steps below no-op for them (via the CHROMATIC_PROJECT_TOKEN != '' guard)
+# rather than failing.
+#
+# Non-blocking for now (exitZeroOnChanges: true): visual changes are
+# surfaced as a PR check/comment for review, not enforced as a merge gate.
+# A prior Chromatic setup here (#21095) was removed in #27232 for being
+# unmaintained and overlapping with Applitools (since also discontinued).
+# Keep this one simple and watch it before considering a required check.
+name: Chromatic
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "superset-frontend/**"
+  pull_request:
+    types: [synchronize, opened, reopened, ready_for_review]
+    paths:
+      - "superset-frontend/**"
+
+# cancel previous workflow jobs for PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  TAG: apache/superset:chromatic-${{ github.run_id }}
+  CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    # pull-requests: write lets chromaui/action post its check and PR
+    # comment. Withheld automatically by GitHub for fork-triggered
+    # pull_request runs, same as CHROMATIC_PROJECT_TOKEN above.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # TurboSnap (onlyChanged below) needs full history to diff
+          # against the baseline commit.
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Build Docker Image
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
+        run: |
+          docker buildx build \
+            -t $TAG \
+            --cache-from=type=registry,ref=apache/superset-cache:3.11-slim-trixie \
+            --target superset-node-ci \
+            .
+
+      - name: Build Storybook
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
+        run: |
+          mkdir -p ${{ github.workspace }}/superset-frontend/storybook-static
+          docker run \
+          -v ${{ github.workspace }}/superset-frontend/storybook-static:/app/superset-frontend/storybook-static \
+          --rm $TAG \
+          bash -c "npm i && npm run build-storybook"
+
+      - name: Publish to Chromatic
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
+        uses: chromaui/action@6b31c4307e3f5a150ab5345b051bb40a62923a5f # v18.7.3
+        with:
+          projectToken: ${{ env.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workingDir: superset-frontend
+          storybookBuildDir: storybook-static
+          # TurboSnap: only re-snapshot stories affected by files changed
+          # since the baseline build.
+          onlyChanged: true
+          exitZeroOnChanges: true
+          zip: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,6 +42,7 @@ on:
     types: [synchronize, opened, reopened, ready_for_review]
     paths:
       - "superset-frontend/**"
+  workflow_dispatch: {}
 
 # cancel previous workflow jobs for PRs
 concurrency:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -71,9 +71,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # TurboSnap (onlyChanged below) needs full history to diff
-          # against the baseline commit.
-          fetch-depth: 0
+          # TurboSnap (onlyChanged below) needs history to diff against the
+          # baseline commit, but NOT fetch-depth: 0. This Chromatic project
+          # was dormant for ~2 years (Chromatic here shipped in #21095,
+          # removed in #27232) before this workflow, so its last known
+          # baseline predates thousands of commits on a very active repo.
+          # With full history, Chromatic's CLI tries to `git log` every
+          # commit back to that ancient baseline as individual CLI args and
+          # hits the OS ARG_MAX limit (E2BIG) -- see
+          # https://github.com/chromaui/chromatic-cli/issues/432, where the
+          # Chromatic team's own recommended workaround is exactly this: a
+          # bounded depth, since a multi-year-old baseline isn't useful
+          # anyway. 500 is far more than any realistic PR needs once a
+          # recent baseline exists (i.e. after this workflow's own first
+          # successful run on master).
+          fetch-depth: 500
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Build Docker Image


### PR DESCRIPTION
### SUMMARY
Publishes `superset-frontend`'s Storybook to [Chromatic](https://www.chromatic.com/) for visual regression testing, using the existing `CHROMATIC_PROJECT_TOKEN` repo secret.

**History check before implementing:** Chromatic was actually set up here once before (#21095, 2021) and later removed in #27232 (Feb 2024). The stated reasons were that the workflow was "not maintained anymore" and that it "overlaps with Applitools which is used for visual testing." I checked — Applitools has since also been discontinued (no live references anywhere in the repo, only historical CHANGELOG mentions), so that overlap concern no longer applies. The original setup also went through several `fix:`/"remove chromatic job, it has errors" PRs during its life, which this design tries to avoid repeating:

- **Fork-safe by construction, not by extra logic**: GitHub withholds repository secrets from `pull_request` runs triggered by a fork, so `CHROMATIC_PROJECT_TOKEN` is simply empty for those runs. The publish steps guard on `CHROMATIC_PROJECT_TOKEN != ''` and no-op cleanly instead of failing — same pattern `frontend-bundle-size-nightly.yml` already uses for its optional Netlify secret.
- **Non-blocking for now** (`exitZeroOnChanges: true`): visual changes surface as a PR check + comment for review, without gating merges. Straightforward to flip to a required check later once the signal is trusted.
- **TurboSnap enabled** (`onlyChanged: true`) to keep runs fast given this monorepo's large chart-plugin story set; checkout uses `fetch-depth: 0` so it has the git history TurboSnap needs.
- Reuses the existing `superset-node-ci` Docker target and the build-then-mount-output pattern `frontend-bundle-size-nightly.yml` already established, instead of installing Node directly on the runner.
- `chromaui/action` is already wildcard-allowlisted in the ASF allowlist (`chromaui/action@*`), so this doesn't interact with #44014 at all.

**Manual follow-up needed (can't be done from a PR):** the rich PR-comment experience with inline screenshots comes from the Chromatic GitHub App, which is a separate one-time org-level installation via Chromatic's dashboard (Project → Manage → GitHub), not something `chromaui/action`'s `token` input alone provides. The `token: ${{ secrets.GITHUB_TOKEN }}` input in this workflow already gets a status check + basic PR comment; worth confirming whether the GitHub App is still installed (the project token dates to 2022) for the full experience.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow only.

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/chromatic.yml` passes (zizmor clean).
- `actionlint` passes, aside from a stale-label false positive on `ubuntu-26.04` (actionlint's bundled runner list hasn't caught up; this label is already used throughout the repo's other workflows) and `$TAG`-quoting notices that are already pervasive in this repo's existing workflows (e.g. `frontend-bundle-size-nightly.yml`, `superset-frontend.yml`).
- Fetched the real `apache/infrastructure-actions` `check_asf_allowlist.py` + `approved_patterns.yml`/`actions.yml` and ran it locally against this branch: `chromaui/action@6b31c43... — matches allowlist`, `All 38 unique action refs are on the ASF allowlist`.
- Live CI on this PR will exercise the actual publish (same-repo branch, so `CHROMATIC_PROJECT_TOKEN` is available).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)