### PR TITLE
fix(mcp): expose resolved query time boundaries

### DIFF
--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1018,6 +1018,10 @@ For example, `previous calendar month` evaluated on July 17, 2026 resolves to
 `2026-06-01T00:00:00` through, but not including, `2026-07-01T00:00:00`.
 `Last month` is a rolling month, not the previous calendar month.
 
+On a cache hit, these bounds reflect the current request, not necessarily the
+original cached execution. A cached result can outlive a relative-range rollover;
+check `cache_status.cache_hit` before describing the bounds as execution dates.
+
 Relative expressions use Superset's server clock and configured
 `DEFAULT_RELATIVE_START_TIME` / `DEFAULT_RELATIVE_END_TIME` (both default to
 `today`, meaning midnight). Valid explicit dates are used as supplied; the server

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1007,3 +1007,28 @@ The callable must be cheap and in-process (consult already-loaded feature flags 
 - **[MCP Integration](/developer-docs/extensions/mcp)** -- Build custom MCP tools and prompts via Superset extensions
 - **[Security](/developer-docs/extensions/security)** -- Security best practices for extensions
 - **[Deployment](/developer-docs/extensions/deployment)** -- Package and deploy Superset extensions
+
+### Reporting query dates
+
+`query_dataset` and `get_table` return `from_dttm` (inclusive) and `to_dttm`
+(exclusive): the primary time boundaries from the query engine's result payload,
+including cached and empty results. Callers should quote these ISO 8601 values
+when explaining the numbers, rather than calculate dates from the request again.
+For example, `previous calendar month` evaluated on July 17, 2026 resolves to
+`2026-06-01T00:00:00` through, but not including, `2026-07-01T00:00:00`.
+`Last month` is a rolling month, not the previous calendar month.
+
+Relative expressions use Superset's server clock and configured
+`DEFAULT_RELATIVE_START_TIME` / `DEFAULT_RELATIVE_END_TIME` (both default to
+`today`, meaning midnight). Valid explicit dates are used as supplied; the server
+cannot determine whether a model intended a different year.
+
+These fields describe the engine's **primary logical range**, not the observed
+minimum/maximum dates in the rows or every SQL predicate. A null boundary means
+no primary bound is available; it does not prove the absence of other filters.
+Additional column filters, virtual dataset SQL, and semantic-view one-sided
+ranges rewritten as comparison filters can further constrain the data. Naive
+boundaries are not labeled UTC: dataset timezone or legacy hour-offset settings
+can adjust the SQL comparisons. Use the applied filters and datasource settings
+as well when explaining such queries. `query_dataset.applied_filters` retains the
+original expressions so callers can compare the requested and resolved ranges.

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1030,8 +1030,10 @@ cannot determine whether a model intended a different year.
 These fields describe the engine's **primary logical range**, not the observed
 minimum/maximum dates in the rows or every SQL predicate. A null boundary means
 no primary bound is available; it does not prove the absence of other filters.
-Additional column filters, virtual dataset SQL, and semantic-view one-sided
-ranges rewritten as comparison filters can further constrain the data. Naive
+Additional column filters and virtual dataset SQL can further constrain the
+data. MCP validation rejects open-ended `time_range` strings such as
+`"2025-01-01 : "` or `" : 2025-02-01"` before execution; use explicit comparison
+filters for one-sided constraints. Those comparisons are not primary bounds. Naive
 boundaries are not labeled UTC: dataset timezone or legacy hour-offset settings
 can adjust the SQL comparisons. Use the applied filters and datasource settings
 as well when explaining such queries. `query_dataset.applied_filters` retains the

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -873,7 +873,7 @@ class QueryDatasetResponse(BaseModel):
             "Null means no primary lower bound is available. ISO 8601; naive "
             "values are in Superset's logical time coordinates, not necessarily UTC. "
             "On cache hits, these are current-request bounds; cached rows can reflect "
-            "an earlier relative range. Check performance.cache_status."
+            "an earlier relative range. Check cache_status.cache_hit."
         ),
     )
     to_dttm: datetime | None = Field(
@@ -884,7 +884,7 @@ class QueryDatasetResponse(BaseModel):
             "describing results; do not infer dates from relative expressions. "
             "Additional filters and datasource timezone adjustments still apply. "
             "On cache hits, these are current-request bounds; cached rows can reflect "
-            "an earlier relative range. Check performance.cache_status."
+            "an earlier relative range. Check cache_status.cache_hit."
         ),
     )
     summary: str = Field("", description="Human-readable summary of the results")

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -866,6 +866,23 @@ class QueryDatasetResponse(BaseModel):
     total_rows: int | None = Field(
         None, description="Total row count from the query engine"
     )
+    from_dttm: datetime | None = Field(
+        None,
+        description=(
+            "Resolved inclusive start of the query engine's primary time range. "
+            "Null means no primary lower bound is available. ISO 8601; naive "
+            "values are in Superset's logical time coordinates, not necessarily UTC."
+        ),
+    )
+    to_dttm: datetime | None = Field(
+        None,
+        description=(
+            "Resolved exclusive end of the query engine's primary time range. "
+            "Null means no primary upper bound is available. Report these bounds when "
+            "describing results; do not infer dates from relative expressions. "
+            "Additional filters and datasource timezone adjustments still apply."
+        ),
+    )
     summary: str = Field("", description="Human-readable summary of the results")
     performance: PerformanceMetadata | None = Field(
         None, description="Query performance metadata"

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -880,7 +880,9 @@ class QueryDatasetResponse(BaseModel):
             "Resolved exclusive end of the query engine's primary time range. "
             "Null means no primary upper bound is available. Report these bounds when "
             "describing results; do not infer dates from relative expressions. "
-            "Additional filters and datasource timezone adjustments still apply."
+            "Additional filters and datasource timezone adjustments still apply. "
+            "On a cache hit these bounds reflect the current request, not necessarily "
+            "the cached execution; check cache_status.cache_hit."
         ),
     )
     summary: str = Field("", description="Human-readable summary of the results")

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -871,7 +871,9 @@ class QueryDatasetResponse(BaseModel):
         description=(
             "Resolved inclusive start of the query engine's primary time range. "
             "Null means no primary lower bound is available. ISO 8601; naive "
-            "values are in Superset's logical time coordinates, not necessarily UTC."
+            "values are in Superset's logical time coordinates, not necessarily UTC. "
+            "On cache hits, these are current-request bounds; cached rows can reflect "
+            "an earlier relative range. Check performance.cache_status."
         ),
     )
     to_dttm: datetime | None = Field(
@@ -881,8 +883,8 @@ class QueryDatasetResponse(BaseModel):
             "Null means no primary upper bound is available. Report these bounds when "
             "describing results; do not infer dates from relative expressions. "
             "Additional filters and datasource timezone adjustments still apply. "
-            "On a cache hit these bounds reflect the current request, not necessarily "
-            "the cached execution; check cache_status.cache_hit."
+            "On cache hits, these are current-request bounds; cached rows can reflect "
+            "an earlier relative range. Check performance.cache_status."
         ),
     )
     summary: str = Field("", description="Human-readable summary of the results")

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -90,6 +90,10 @@ async def query_dataset(  # noqa: C901
     expressions such as "SUM(col)" are not accepted. When the dataset has no
     saved metric for the aggregate you need, use execute_sql instead.
 
+    When reporting results, state the returned from_dttm (inclusive) and
+    to_dttm (exclusive) primary bounds rather than guessing dates from the
+    relative expression. Additional filters can further constrain the range.
+
     Workflow:
     1. list_datasets -> find a dataset
     2. get_dataset_info -> discover available columns and metrics
@@ -310,6 +314,8 @@ async def query_dataset(  # noqa: C901
 
         if not data:
             return QueryDatasetResponse(
+                from_dttm=query_result.get("from_dttm"),
+                to_dttm=query_result.get("to_dttm"),
                 dataset_id=dataset.id,
                 dataset_name=dataset_name,
                 columns=[],
@@ -346,6 +352,8 @@ async def query_dataset(  # noqa: C901
         )
 
         return QueryDatasetResponse(
+            from_dttm=query_result.get("from_dttm"),
+            to_dttm=query_result.get("to_dttm"),
             dataset_id=dataset.id,
             dataset_name=dataset_name,
             columns=columns_meta,

--- a/superset/mcp_service/semantic_layer/schemas.py
+++ b/superset/mcp_service/semantic_layer/schemas.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -244,6 +245,23 @@ class GetTableResponse(BaseModel):
     data: list[dict[str, Any]]
     row_count: int
     total_rows: int | None = None
+    from_dttm: datetime | None = Field(
+        None,
+        description=(
+            "Resolved inclusive start of the query engine's primary time range. "
+            "Null means no primary lower bound is available. ISO 8601; naive "
+            "values are in Superset's logical time coordinates, not necessarily UTC."
+        ),
+    )
+    to_dttm: datetime | None = Field(
+        None,
+        description=(
+            "Resolved exclusive end of the query engine's primary time range. "
+            "Null means no primary upper bound is available. Report these bounds when "
+            "describing results; do not infer dates from relative expressions. "
+            "Additional filters and datasource timezone adjustments still apply."
+        ),
+    )
     summary: str
     source: Literal["builtin", "external"]
     dataset_id: int | None = None

--- a/superset/mcp_service/semantic_layer/schemas.py
+++ b/superset/mcp_service/semantic_layer/schemas.py
@@ -259,7 +259,9 @@ class GetTableResponse(BaseModel):
             "Resolved exclusive end of the query engine's primary time range. "
             "Null means no primary upper bound is available. Report these bounds when "
             "describing results; do not infer dates from relative expressions. "
-            "Additional filters and datasource timezone adjustments still apply."
+            "Additional filters and datasource timezone adjustments still apply. "
+            "On a cache hit these bounds reflect the current request, not necessarily "
+            "the cached execution; check cache_status.cache_hit."
         ),
     )
     summary: str

--- a/superset/mcp_service/semantic_layer/schemas.py
+++ b/superset/mcp_service/semantic_layer/schemas.py
@@ -250,7 +250,9 @@ class GetTableResponse(BaseModel):
         description=(
             "Resolved inclusive start of the query engine's primary time range. "
             "Null means no primary lower bound is available. ISO 8601; naive "
-            "values are in Superset's logical time coordinates, not necessarily UTC."
+            "values are in Superset's logical time coordinates, not necessarily UTC. "
+            "On cache hits, these are current-request bounds; cached rows can reflect "
+            "an earlier relative range. Check performance.cache_status."
         ),
     )
     to_dttm: datetime | None = Field(
@@ -260,8 +262,8 @@ class GetTableResponse(BaseModel):
             "Null means no primary upper bound is available. Report these bounds when "
             "describing results; do not infer dates from relative expressions. "
             "Additional filters and datasource timezone adjustments still apply. "
-            "On a cache hit these bounds reflect the current request, not necessarily "
-            "the cached execution; check cache_status.cache_hit."
+            "On cache hits, these are current-request bounds; cached rows can reflect "
+            "an earlier relative range. Check performance.cache_status."
         ),
     )
     summary: str

--- a/superset/mcp_service/semantic_layer/schemas.py
+++ b/superset/mcp_service/semantic_layer/schemas.py
@@ -252,7 +252,7 @@ class GetTableResponse(BaseModel):
             "Null means no primary lower bound is available. ISO 8601; naive "
             "values are in Superset's logical time coordinates, not necessarily UTC. "
             "On cache hits, these are current-request bounds; cached rows can reflect "
-            "an earlier relative range. Check performance.cache_status."
+            "an earlier relative range. Check cache_status.cache_hit."
         ),
     )
     to_dttm: datetime | None = Field(
@@ -263,7 +263,7 @@ class GetTableResponse(BaseModel):
             "describing results; do not infer dates from relative expressions. "
             "Additional filters and datasource timezone adjustments still apply. "
             "On cache hits, these are current-request bounds; cached rows can reflect "
-            "an earlier relative range. Check performance.cache_status."
+            "an earlier relative range. Check cache_status.cache_hit."
         ),
     )
     summary: str

--- a/superset/mcp_service/semantic_layer/tool/get_table.py
+++ b/superset/mcp_service/semantic_layer/tool/get_table.py
@@ -244,6 +244,8 @@ def _build_response(
 
     if not data:
         return GetTableResponse(
+            from_dttm=query_result.get("from_dttm"),
+            to_dttm=query_result.get("to_dttm"),
             columns=[],
             data=[],
             row_count=0,
@@ -270,6 +272,8 @@ def _build_response(
     )
 
     return GetTableResponse(
+        from_dttm=query_result.get("from_dttm"),
+        to_dttm=query_result.get("to_dttm"),
         columns=columns_meta,
         data=data,
         row_count=len(data),
@@ -403,6 +407,10 @@ async def get_table(
 
     Works with both built-in datasets and external semantic views. The
     ``dataset_id`` or ``view_id`` comes from the ``list_metrics`` response.
+
+    When reporting results, state the returned from_dttm (inclusive) and
+    to_dttm (exclusive) primary bounds rather than guessing dates from the
+    relative expression. Additional filters can further constrain the range.
 
     Workflow:
     1. list_metrics -> discover metrics and their compatible_dimensions

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -1480,3 +1480,101 @@ async def test_query_dataset_returns_engine_time_bounds(
     assert data["from_dttm"] == expected_start
     assert data["to_dttm"] == expected_end
     assert data["applied_filters"][0]["val"] == expression.strip()
+
+
+@pytest.mark.parametrize("empty", [False, True])
+@pytest.mark.asyncio
+async def test_query_dataset_cached_bounds_across_rollover(
+    mcp_server: FastMCP, empty: bool
+) -> None:
+    """Round-trip cached rows while resolving bounds for each MCP request."""
+    from datetime import timedelta
+
+    from flask import current_app
+    from flask_caching import Cache
+    from freezegun import freeze_time
+    from pandas import DataFrame
+
+    from superset.common.chart_data import ChartDataResultType
+    from superset.common.query_context_processor import QueryContextProcessor
+    from superset.common.query_object import QueryObject
+    from superset.common.query_object_factory import QueryObjectFactory
+    from superset.constants import CacheRegion
+    from superset.models.helpers import QueryResult
+
+    dataset = _make_dataset(main_dttm_col="order_date")
+    dataset.column_names = ["count"]
+    context = MagicMock(datasource=dataset, force=False)
+    processor = QueryContextProcessor(context)
+    cache = Cache(current_app, config={"CACHE_TYPE": "SimpleCache"})
+    rows = [] if empty else [{"count": 3}]
+    source_result = QueryResult(
+        df=DataFrame(rows, columns=["count"]),
+        query="SELECT COUNT(*) AS count FROM orders",
+        duration=timedelta(0),
+        applied_filter_columns=["order_date"],
+    )
+    keys: list[str] = []
+
+    def execute(
+        datasource_id: int, datasource_type: str, query_dict: dict[str, Any], **_: Any
+    ) -> dict[str, Any]:
+        """Acquire through production cache handling; adapt its dataframe payload."""
+        query = QueryObjectFactory(current_app.config, MagicMock()).create(
+            parent_result_type=ChartDataResultType.FULL, **query_dict
+        )
+        keys.append(query.cache_key())
+        payload = processor.get_df_payload(query)
+        frame = payload.pop("df")
+        payload.update(
+            data=frame.to_dict(orient="records"), colnames=list(frame.columns)
+        )
+        return {"queries": [payload]}
+
+    with (
+        patch.object(query_dataset_module, "resolve_dataset", return_value=dataset),
+        patch.object(
+            query_dataset_module, "execute_tabular_query", side_effect=execute
+        ),
+        patch.dict(
+            "superset.common.utils.query_cache_manager._cache",
+            {CacheRegion.DATA: cache},
+        ),
+        patch.object(processor, "query_cache_key", side_effect=QueryObject.cache_key),
+        patch.object(processor, "get_cache_timeout", return_value=300),
+        patch.object(processor, "get_annotation_data", return_value={}),
+        patch.object(
+            processor, "get_query_result", return_value=source_result
+        ) as get_query_result,
+    ):
+        async with Client(mcp_server) as client:
+            request = {
+                "request": {
+                    "dataset_id": 1,
+                    "metrics": ["count"],
+                    "time_range": "Last month",
+                }
+            }
+            with freeze_time("2026-07-17 23:59:59"):
+                fresh = await client.call_tool("query_dataset", request)
+            with freeze_time("2026-07-18 00:00:01"):
+                cached = await client.call_tool("query_dataset", request)
+                stored = cache.get(keys[0])
+                assert stored is not None
+                assert "from_dttm" not in stored
+                assert "to_dttm" not in stored
+
+    get_query_result.assert_called_once()
+    assert keys[0] == keys[1]
+    fresh_data = json.loads(fresh.content[0].text)
+    cached_data = json.loads(cached.content[0].text)
+    assert fresh_data["data"] == cached_data["data"] == rows
+    assert fresh_data["cache_status"]["cache_hit"] is False
+    assert cached_data["cache_status"]["cache_hit"] is True
+    assert fresh_data["from_dttm"] == "2026-06-17T00:00:00"
+    assert fresh_data["to_dttm"] == "2026-07-17T00:00:00"
+    assert cached_data["from_dttm"] == "2026-06-18T00:00:00"
+    assert cached_data["to_dttm"] == "2026-07-18T00:00:00"
+    assert cached_data["performance"]["cache_status"] == (
+        "no_data" if empty else "cached"
+    )

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -177,6 +177,8 @@ async def test_query_dataset_success(mcp_server: FastMCP) -> None:
     data = json.loads(result.content[0].text)
     assert data["dataset_id"] == 1
     assert data["dataset_name"] == "orders"
+    assert data["from_dttm"] is None
+    assert data["to_dttm"] is None
     assert data["row_count"] == 2
     assert len(data["data"]) == 2
     assert data["data"][0]["category"] == "Electronics"
@@ -1406,3 +1408,75 @@ async def test_query_dataset_bracket_hour_resolves_without_parse_error(
     assert since is not None
     assert until is not None
     assert since < until
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected_start", "expected_end"),
+    [
+        ("Last month", "2026-06-17T00:00:00", "2026-07-17T00:00:00"),
+        ("Last year", "2025-07-17T00:00:00", "2026-07-17T00:00:00"),
+        ("previous calendar month", "2026-06-01T00:00:00", "2026-07-01T00:00:00"),
+        ("Current year", "2026-01-01T00:00:00", "2027-01-01T00:00:00"),
+        ("2025-06-01 : 2025-07-01", "2025-06-01T00:00:00", "2025-07-01T00:00:00"),
+        ("No filter", None, None),
+    ],
+)
+@pytest.mark.parametrize("use_filter", [False, True])
+@pytest.mark.parametrize("result_kind", ["fresh", "cached", "empty"])
+@pytest.mark.asyncio
+async def test_query_dataset_returns_engine_time_bounds(
+    mcp_server: FastMCP,
+    expression: str,
+    expected_start: str | None,
+    expected_end: str | None,
+    use_filter: bool,
+    result_kind: str,
+) -> None:
+    """Resolve MCP inputs with the real factory and serialize execution bounds."""
+    from flask import current_app
+    from freezegun import freeze_time
+
+    from superset.common.chart_data import ChartDataResultType
+    from superset.common.query_object_factory import QueryObjectFactory
+
+    dataset = _make_dataset(main_dttm_col="order_date")
+
+    def execute(
+        datasource_id: int, datasource_type: str, query_dict: dict[str, Any], **_: Any
+    ) -> dict[str, Any]:
+        """Use production date resolution in place of database execution."""
+        factory = QueryObjectFactory(current_app.config, MagicMock())
+        with freeze_time("2026-07-17 12:34:56"):
+            query = factory.create(
+                parent_result_type=ChartDataResultType.FULL,
+                **query_dict,
+            )
+        payload = _mock_command_result()
+        result = payload["queries"][0]
+        result.update(from_dttm=query.from_dttm, to_dttm=query.to_dttm)
+        result["is_cached"] = result_kind == "cached"
+        if result_kind == "empty":
+            result.update(data=[], colnames=[], rowcount=0)
+        return payload
+
+    request: dict[str, Any] = {"dataset_id": 1, "metrics": ["count"]}
+    if use_filter:
+        request["filters"] = [
+            {"col": "order_date", "op": "TEMPORAL_RANGE", "val": expression}
+        ]
+    else:
+        request["time_range"] = expression
+
+    with (
+        patch.object(query_dataset_module, "resolve_dataset", return_value=dataset),
+        patch.object(
+            query_dataset_module, "execute_tabular_query", side_effect=execute
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool("query_dataset", {"request": request})
+
+    data = json.loads(result.content[0].text)
+    assert data["from_dttm"] == expected_start
+    assert data["to_dttm"] == expected_end
+    assert data["applied_filters"][0]["val"] == expression.strip()

--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
@@ -638,3 +638,38 @@ class TestGetTableTemporalRangeFilterValidation:
             }
         )
         assert req.filters[0].val == "banana"
+
+
+@pytest.mark.parametrize("is_builtin", [False, True])
+@pytest.mark.parametrize("empty", [False, True])
+def test_response_preserves_execution_time_bounds(
+    is_builtin: bool, empty: bool
+) -> None:
+    """Use execution metadata, including for empty results, rather than reparse."""
+    from datetime import datetime
+
+    from superset.mcp_service.semantic_layer.schemas import GetTableRequest
+
+    request = GetTableRequest(
+        dataset_id=42 if is_builtin else None,
+        view_id=None if is_builtin else 1,
+        metrics=["count"],
+        time_range="Last month",
+    )
+    response = get_table_module._build_response(
+        request,
+        is_builtin,
+        "orders",
+        {
+            "data": [] if empty else [{"count": 3}],
+            "colnames": ["count"],
+            "from_dttm": datetime(2026, 6, 1),
+            "to_dttm": datetime(2026, 7, 1),
+            "is_cached": True,
+        },
+        10,
+        [],
+    )
+    data = response.model_dump(mode="json")
+    assert data["from_dttm"] == "2026-06-01T00:00:00"
+    assert data["to_dttm"] == "2026-07-01T00:00:00"

--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
@@ -673,3 +673,28 @@ def test_response_preserves_execution_time_bounds(
     data = response.model_dump(mode="json")
     assert data["from_dttm"] == "2026-06-01T00:00:00"
     assert data["to_dttm"] == "2026-07-01T00:00:00"
+
+
+@pytest.mark.parametrize("source_field", ["dataset_id", "view_id"])
+@pytest.mark.parametrize("expression", ["2025-01-01 : ", " : 2025-02-01"])
+@pytest.mark.asyncio
+async def test_get_table_rejects_open_ended_range_before_execution(
+    mcp_server: FastMCP, source_field: str, expression: str
+) -> None:
+    """Open-ended MCP input cannot reach the shared comparison-filter rewrite."""
+    from fastmcp.exceptions import ToolError
+
+    with patch.object(get_table_module, "execute_tabular_query") as execute:
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="Unrecognized time_range"):
+                await client.call_tool(
+                    "get_table",
+                    {
+                        "request": {
+                            source_field: 1,
+                            "metrics": ["count"],
+                            "time_range": expression,
+                        }
+                    },
+                )
+    execute.assert_not_called()


### PR DESCRIPTION
### SUMMARY

The query engine resolves a relative time range to concrete bounds, but MCP discarded them. Callers could not tell which range produced the numbers: a model can narrate one range while the query used another.

Verified on `master`: `from_dttm`/`to_dttm` appear nowhere in `superset/mcp_service/`, while `superset/common/query_context_processor.py` computes the result payload containing those resolved bounds.

Both `query_dataset` and `get_table` return `from_dttm` (inclusive) and `to_dttm` (exclusive), including on cached and empty results. The response schemas and tool documentation explain how to report these ISO 8601 values. Missing primary bounds remain null.

**What this does not do:** no parser change; no year-offset bug was found. Callers can identify the engine's primary logical range, not every additional SQL filter or timezone-adjusted boundary. These fields are not observed row minima/maxima, and naive timestamps are not asserted to be UTC. Additional column filters, virtual dataset SQL, and semantic-view one-sided ranges rewritten as comparison filters can still constrain results.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (MCP response metadata only).

Before: the request's relative expression was available, but the resolved primary bounds were omitted.

After: for example, `previous calendar month` evaluated on July 17, 2026 returns `from_dttm: "2026-06-01T00:00:00"` and `to_dttm: "2026-07-01T00:00:00"` (exclusive).

### TESTING INSTRUCTIONS

- Run `pytest -q tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py`.
- With MCP configured, query a temporal dataset using `query_dataset` and a relative `time_range`; compare the returned bounds with the engine result and generated primary time predicate.
- Repeat using `get_table` for a built-in dataset and an external semantic view.
- Repeat with a cache hit and with a query returning zero rows. Both fields should remain present and reflect the engine payload.
- Check an unbounded query: missing primary bounds should serialize as null. Verify that descriptions distinguish an inclusive start from an exclusive end.

Validation: all changed-file `uvx pre-commit run --files ...` hooks passed, including mypy and pylint. Targeted unit tests: **128 passed** (`PYTHONPATH=.:superset-core/src /tmp/ssvenv/bin/pytest -q` with the two files above). A live-server check was unavailable because no service was listening on localhost:8088.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

Additive response fields only; no database migration or date-parser changes.

#### Deferred follow-ups (outside this PR)

- **Cached execution provenance:** The engine excludes concrete `from_dttm`/`to_dttm` values from its cache key and assembles these response fields from the requesting query object. A cache hit spanning a relative-range rollover can therefore report the requesting range rather than the original cached execution's bounds. This PR forwards the engine's metadata unchanged; it does not establish historical execution provenance. Investigating cache identity/provenance belongs in a separate change.
- **Optional test coverage:** Real cache storage/retrieval across a rollover, direct `get_table` null assertions, and timezone-aware serialization cases could strengthen coverage separately. The added cached-result cases use mocked execution payloads.

Review: one adversarial review round found no substantive in-scope defects in cached/empty forwarding, boundary semantics, or serialization. That round required no changes. The subsequent maintainer review requested a model-facing cache caveat: both `to_dttm` field descriptions and the query-date documentation explain that cache-hit bounds reflect the requesting range, not necessarily the original cached execution, and point to `cache_status.cache_hit`. No query or parser behavior changed. Changed-file pre-commit and all 128 targeted unit tests passed again after this update.

