### PR TITLE
fix(mcp): make unknown dataset dimension errors actionable

### DIFF
--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1038,3 +1038,24 @@ boundaries are not labeled UTC: dataset timezone or legacy hour-offset settings
 can adjust the SQL comparisons. Use the applied filters and datasource settings
 as well when explaining such queries. `query_dataset.applied_filters` retains the
 original expressions so callers can compare the requested and resolved ranges.
+
+## Dataset query dimensions and nested fields
+
+The `query_dataset` tool accepts exact column names registered on the selected
+Superset dataset. Use `get_dataset_info` with the same `dataset_id` to discover
+those names; a column available on one dataset may not exist on another.
+
+A dotted name such as `address.city.name` can be used as a GROUP BY
+column when that exact name is registered. Registering only the parent
+`address` column does not register its nested fields. If a field is missing,
+refresh the dataset columns when the database exposes nested-field metadata,
+or add a calculated column with the warehouse-appropriate field-access
+expression and query its registered name. For ad-hoc expressions, use
+`execute_sql` instead.
+
+Unknown dimensions return the selected dataset's name and ID, up to ten
+available column names, and a pointer to `get_dataset_info` for the full list.
+Unregistered dotted dimensions also include nested-field setup guidance.
+The tool does not rewrite dots into SQL path separators: quoting and nested-field
+support depend on the dataset's database dialect, and dots can also be literal
+characters in column names.

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1055,7 +1055,8 @@ expression and query its registered name. For ad-hoc expressions, use
 
 Unknown dimensions return the selected dataset's name and ID, up to ten
 available column names, and a pointer to `get_dataset_info` for the full list.
-Unregistered dotted dimensions also include nested-field setup guidance.
+Unregistered dotted dimensions also include shared nested-field setup guidance
+once, even when multiple dimensions are missing.
 The tool does not rewrite dots into SQL path separators: quoting and nested-field
 support depend on the dataset's database dialect, and dots can also be literal
 characters in column names.

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -204,19 +204,25 @@ async def query_dataset(  # noqa: C901
                 f"Available columns: {available}. "
                 "Use get_dataset_info with this dataset_id for the full column list."
             )
-            for name in missing_dimensions:
-                if "." in name:
-                    validation_errors.append(
-                        f"'{name}' is not registered as a column on this dataset. "
-                        "query_dataset requires exact registered column names; "
-                        "registering a parent struct does not expose its "
-                        "nested fields. "
-                        "Refresh the dataset columns if the database exposes "
-                        "this field, "
-                        "or add a calculated column using the warehouse's field-access "
-                        "expression and query its registered name. "
-                        "Use execute_sql if you need an ad-hoc nested-field expression."
-                    )
+            dotted_missing = [name for name in missing_dimensions if "." in name]
+            if dotted_missing:
+                names = ", ".join(f"'{name}'" for name in dotted_missing)
+                registration = (
+                    "is not registered as a column"
+                    if len(dotted_missing) == 1
+                    else "are not registered as columns"
+                )
+                validation_errors.append(
+                    f"{names} {registration} on this dataset. "
+                    "query_dataset requires exact registered column names; "
+                    "registering a parent struct does not expose its "
+                    "nested fields. "
+                    "Refresh the dataset columns if the database exposes "
+                    "this field, "
+                    "or add a calculated column using the warehouse's field-access "
+                    "expression and query its registered name. "
+                    "Use execute_sql if you need an ad-hoc nested-field expression."
+                )
 
         if validation_errors:
             error_msg = "; ".join(validation_errors)

--- a/superset/mcp_service/dataset/tool/query_dataset.py
+++ b/superset/mcp_service/dataset/tool/query_dataset.py
@@ -191,6 +191,33 @@ async def query_dataset(  # noqa: C901
             metrics_empty_hint=_NO_SAVED_METRICS_HINT,
         )
 
+        missing_dimensions = [
+            name for name in request.columns if name not in valid_columns
+        ]
+        if missing_dimensions:
+            available = ", ".join(sorted(valid_columns)[:10]) or "(none)"
+            remaining = max(0, len(valid_columns) - 10)
+            if remaining:
+                available += f" (and {remaining} more)"
+            validation_errors.append(
+                f"Dataset '{dataset_name}' (id={dataset.id}). "
+                f"Available columns: {available}. "
+                "Use get_dataset_info with this dataset_id for the full column list."
+            )
+            for name in missing_dimensions:
+                if "." in name:
+                    validation_errors.append(
+                        f"'{name}' is not registered as a column on this dataset. "
+                        "query_dataset requires exact registered column names; "
+                        "registering a parent struct does not expose its "
+                        "nested fields. "
+                        "Refresh the dataset columns if the database exposes "
+                        "this field, "
+                        "or add a calculated column using the warehouse's field-access "
+                        "expression and query its registered name. "
+                        "Use execute_sql if you need an ad-hoc nested-field expression."
+                    )
+
         if validation_errors:
             error_msg = "; ".join(validation_errors)
             await ctx.error("Validation failed: %s" % (error_msg,))

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -1581,9 +1581,17 @@ async def test_query_dataset_cached_bounds_across_rollover(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("dimension", ["address.city.name", "event_name"])
+@pytest.mark.parametrize(
+    "dimensions",
+    [
+        ["address.city.name"],
+        ["event_name"],
+        ["address.city.name", "address.postal_code"],
+        ["address.city.name", "event_name", "address.postal_code"],
+    ],
+)
 async def test_query_dataset_unregistered_dimension_is_actionable(
-    mcp_server: FastMCP, dimension: str
+    mcp_server: FastMCP, dimensions: list[str]
 ) -> None:
     """Unregistered struct paths and wrong-dataset names explain how to recover."""
     dataset = _make_dataset(
@@ -1601,19 +1609,30 @@ async def test_query_dataset_unregistered_dimension_is_actionable(
                     "request": {
                         "dataset_id": 1,
                         "metrics": ["count"],
-                        "columns": [dimension],
+                        "columns": dimensions,
                     }
                 },
             )
     data = json.loads(result.content[0].text)
     assert data["error_type"] == "ValidationError"
-    assert dimension in data["error"]
+    for dimension in dimensions:
+        assert dimension in data["error"]
     assert "example_events" in data["error"]
     assert "Available columns: address, channel" in data["error"]
     assert "get_dataset_info" in data["error"]
-    if "." in dimension:
+    dotted_dimensions = [name for name in dimensions if "." in name]
+    if dotted_dimensions:
         assert "not registered" in data["error"]
-        assert "calculated column" in data["error"]
+        for guidance in (
+            "query_dataset requires exact registered column names",
+            "registering a parent struct does not expose its nested fields",
+            "Refresh the dataset columns",
+            "add a calculated column",
+            "Use execute_sql",
+        ):
+            assert data["error"].count(guidance) == 1
+    else:
+        assert "nested fields" not in data["error"]
     execute.assert_not_called()
 
 

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -1578,3 +1578,148 @@ async def test_query_dataset_cached_bounds_across_rollover(
     assert cached_data["performance"]["cache_status"] == (
         "no_data" if empty else "cached"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dimension", ["address.city.name", "event_name"])
+async def test_query_dataset_unregistered_dimension_is_actionable(
+    mcp_server: FastMCP, dimension: str
+) -> None:
+    """Unregistered struct paths and wrong-dataset names explain how to recover."""
+    dataset = _make_dataset(
+        table_name="example_events",
+        columns=[_make_column("address"), _make_column("channel")],
+    )
+    with (
+        patch.object(query_dataset_module, "resolve_dataset", return_value=dataset),
+        patch.object(query_dataset_module, "execute_tabular_query") as execute,
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "query_dataset",
+                {
+                    "request": {
+                        "dataset_id": 1,
+                        "metrics": ["count"],
+                        "columns": [dimension],
+                    }
+                },
+            )
+    data = json.loads(result.content[0].text)
+    assert data["error_type"] == "ValidationError"
+    assert dimension in data["error"]
+    assert "example_events" in data["error"]
+    assert "Available columns: address, channel" in data["error"]
+    assert "get_dataset_info" in data["error"]
+    if "." in dimension:
+        assert "not registered" in data["error"]
+        assert "calculated column" in data["error"]
+    execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["sqlite", "bigquery"])
+async def test_query_dataset_registered_dotted_groupby(
+    mcp_server: FastMCP, engine: str
+) -> None:
+    """Registered dotted names reach SQL generation without MCP sanitization.
+
+    SQLite treats the dot as part of a literal identifier, not a struct path.
+    Splitting every dotted dimension into SQL identifiers would break this case.
+    """
+    from sqlalchemy.dialects.sqlite import dialect
+
+    from superset.connectors.sqla.models import SqlaTable, SqlMetric, TableColumn
+    from superset.models.core import Database
+
+    sql_dialect = (
+        pytest.importorskip("sqlalchemy_bigquery").BigQueryDialect()
+        if engine == "bigquery"
+        else dialect()
+    )
+    database = Database(
+        database_name="test",
+        sqlalchemy_uri="bigquery://test-project"
+        if engine == "bigquery"
+        else "sqlite://",
+    )
+    mock_engine = MagicMock()
+    mock_engine.dialect = sql_dialect
+    engine_context = MagicMock()
+    engine_context.__enter__.return_value = mock_engine
+    dimension = "address.city.name"
+    dataset = SqlaTable(
+        id=1,
+        table_name="example_locations",
+        database=database,
+        columns=[TableColumn(column_name=dimension, type="TEXT")],
+        metrics=[SqlMetric(metric_name="count", expression="COUNT(*)")],
+    )
+    compiled: list[str] = []
+
+    def compile_query(
+        dataset_id: int, datasource_type: str, query: dict[str, Any], **kwargs: Any
+    ) -> dict[str, Any]:
+        """Exercise the real dataset SQL builder without a warehouse connection."""
+        assert query["columns"] == [dimension]
+        sqla_query = dataset.get_sqla_query(
+            groupby=query["columns"], metrics=query["metrics"], is_timeseries=False
+        )
+        compiled.append(str(sqla_query.sqla_query.compile(dialect=sql_dialect)))
+        return _mock_command_result(
+            data=[{dimension: "Sports", "count": 2}], colnames=[dimension, "count"]
+        )
+
+    with (
+        patch.object(query_dataset_module, "resolve_dataset", return_value=dataset),
+        patch.object(database, "get_sqla_engine", return_value=engine_context),
+        patch.object(dataset, "get_sqla_row_level_filters", return_value=[]),
+        patch.object(
+            query_dataset_module, "execute_tabular_query", side_effect=compile_query
+        ),
+    ):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "query_dataset",
+                {
+                    "request": {
+                        "dataset_id": 1,
+                        "metrics": ["count"],
+                        "columns": [dimension],
+                    }
+                },
+            )
+    data = json.loads(result.content[0].text)
+    assert data["data"] == [{dimension: "Sports", "count": 2}]
+    assert len(compiled) == 1
+    if engine == "bigquery":
+        assert "`address`.`city`.`name`" in compiled[0]
+        assert "GROUP BY" in compiled[0]
+    else:
+        assert 'GROUP BY "address.city.name"' in compiled[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("column_count", [0, 12])
+async def test_query_dataset_available_columns_preview(
+    mcp_server: FastMCP, column_count: int
+) -> None:
+    """Dimension errors bound the preview and handle datasets without columns."""
+    dataset = _make_dataset()
+    dataset.columns = [_make_column(f"col_{i:02}") for i in range(column_count)]
+    with patch.object(query_dataset_module, "resolve_dataset", return_value=dataset):
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "query_dataset",
+                {"request": {"dataset_id": 1, "columns": ["missing"]}},
+            )
+    data = json.loads(result.content[0].text)
+    assert data["error_type"] == "ValidationError"
+    if column_count:
+        assert "col_00" in data["error"]
+        assert "col_09" in data["error"]
+        assert "col_10" not in data["error"]
+        assert "(and 2 more)" in data["error"]
+    else:
+        assert "Available columns: (none)" in data["error"]
+    assert "get_dataset_info with this dataset_id" in data["error"]


### PR DESCRIPTION
### SUMMARY

`query_dataset` rejected unregistered nested (dotted) column names during exact-name metadata validation with a bare `Unknown dimension: 'x'`, giving the caller nothing to act on.

Errors identify the selected dataset, list up to ten available columns (with a remaining count), and point to `get_dataset_info` for the full list. Dotted names additionally explain refreshing dataset metadata, adding a calculated column, or using `execute_sql` for an ad-hoc expression. When several dotted names are missing, they are named together and the shared recovery guidance is emitted once rather than repeated per name.

**Scope:** This is a diagnosability fix, not a SQL-generation or dialect fix. Registered dotted names already worked: tests cover BigQuery nested paths and SQLite literal dotted identifiers. The validation guidance is dialect-independent; there are no quoting changes and no new nested-column support.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No UI changes. Example error strings for dataset `example_events` (ID 1), with registered columns `address` and `channel`:

Before:
```text
Unknown dimension: 'address.city.name'
```

After:
```text
Unknown dimension: 'address.city.name'; Dataset 'example_events' (id=1). Available columns: address, channel. Use get_dataset_info with this dataset_id for the full column list.; 'address.city.name' is not registered as a column on this dataset. query_dataset requires exact registered column names; registering a parent struct does not expose its nested fields. Refresh the dataset columns if the database exposes this field, or add a calculated column using the warehouse's field-access expression and query its registered name. Use execute_sql if you need an ad-hoc nested-field expression.
```

Non-dotted unknown dimensions receive the dataset, column preview, and discovery guidance without the nested-field paragraph. With multiple missing dotted dimensions, every name is reported (`'a.b', 'c.d' are not registered as columns on this dataset.`) and the guidance paragraph appears once.

### TESTING INSTRUCTIONS

- Run `pytest tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py -q`: 102 passed, 1 skipped locally, including BigQuery and SQLite registered dotted-name cases, unregistered dimensions, multiple and mixed dotted/non-dotted missing dimensions, empty metadata, and capped previews.
- All applicable hooks passed with `uvx pre-commit run --files docs/admin_docs/configuration/mcp-server.mdx superset/mcp_service/dataset/tool/query_dataset.py tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py` (including mypy, Ruff, and pylint).
- With an accessible dataset, call `query_dataset` with an unknown plain column, then an unregistered dotted column. Verify the error identifies the dataset and offers recovery guidance without executing a query.
- Pass two unregistered dotted columns and confirm both names appear while the recovery guidance appears once.
- Repeat with more than ten registered columns; verify ten names and a remaining count, then use `get_dataset_info` with the dataset identifier to retrieve the full list.
- Query an exact registered dotted name and confirm existing dialect-specific SQL behavior is unchanged.
- Live-app verification was not run: the local health endpoint was unavailable.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
