### PR TITLE
fix(tests): narrow semantic view mock before inspecting calls

### DIFF
--- a/tests/unit_tests/semantic_layers/values_endpoint_test.py
+++ b/tests/unit_tests/semantic_layers/values_endpoint_test.py
@@ -106,6 +106,7 @@ def test_semantic_view_values_endpoint_passes_search_to_the_provider(
 
     assert response.status_code == 200
     implementation = semantic_view_datasource.implementation
+    assert isinstance(implementation, MagicMock)
     _, filters = implementation.get_values.call_args.args
     (narrowing,) = filters
     assert narrowing.value == "%oo%"


### PR DESCRIPTION
### SUMMARY
The scheduled full-repository pre-commit run fails because the semantic-view search test reads `call_args` from a method typed as a regular callable. Assert that the implementation is the `MagicMock` supplied by the fixture before inspecting its recorded arguments.

Failure: https://github.com/apache/superset/actions/runs/34091125458

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable; test typing only.

### TESTING INSTRUCTIONS
- Reproduced the error before the fix with `pre-commit run mypy --files superset-core/src/superset_core/semantic_layers/view.py tests/unit_tests/semantic_layers/values_endpoint_test.py`; the same command passes after the fix.
- `pre-commit run` passes for the staged change.
- Full-tree mypy no longer reports this error; local full-tree validation reports a separate unused type-ignore in `superset/db_engine_specs/mysql.py:476`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
