### PR TITLE
fix(select): restore oneLine height cap after antd v6 class-name drift

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/Select/Select.stories.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/Select.stories.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { t } from '@apache-superset/core/translation';
+import { Input } from '../Input';
 import { SelectOptionsType, SelectProps } from './types';
 import { Select } from '.';
 
@@ -375,6 +376,33 @@ export const ManySelectedValuesWrapping = () => (
       value={manyPermissionOptions.map(o => o.value)}
       getPopupContainer={trigger => trigger.parentElement as HTMLElement}
     />
+  </div>
+);
+
+/**
+ * Regression coverage for a `oneLine` multi-select growing taller than
+ * sibling controls (e.g. the Explore control panel, where Select-based
+ * controls sit next to plain Input controls). `oneLine` caps the tag
+ * container to a single row via CSS targeting rc-select/rc-overflow's
+ * generated class names directly -- if those selectors go stale (as
+ * happened during the antd v5->v6 upgrade), the cap silently stops
+ * applying and the Select wraps to multiple rows instead of staying at
+ * the same height as the Input beside it.
+ */
+export const OneLineHeightParity = () => (
+  <div style={{ display: 'flex', gap: 8, width: 500 }}>
+    <div style={{ flex: 1 }}>
+      <Select
+        ariaLabel="oneline-height-parity-select"
+        mode="multiple"
+        oneLine
+        options={manyPermissionOptions}
+        value={manyPermissionOptions.slice(0, 5).map(o => o.value)}
+      />
+    </div>
+    <div style={{ flex: 1 }}>
+      <Input aria-label="oneline-height-parity-input" value="Sibling input" />
+    </div>
   </div>
 );
 

--- a/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/Select/styles.tsx
@@ -54,12 +54,12 @@ export const StyledSelect = styled(Select, {
     flex: ${headerPosition === 'left' ? 1 : 0};
     line-height: ${theme.sizeXL}px;
 
-    && .ant-select-input {
+    && .ant-select-selection-search {
       left: 0px;
     }
 
     && .ant-select-selection-item,
-    && .ant-select-placeholder {
+    && .ant-select-selection-placeholder {
       max-height: ${theme.sizeXL}px;
     }
     .ant-select-selection-item::after {
@@ -69,16 +69,16 @@ export const StyledSelect = styled(Select, {
     ${
       oneLine &&
       `
-        .ant-select-content {
+        .ant-select-selection-overflow {
           flex-wrap: nowrap;
         }
 
-        .ant-select-content-item:not(.ant-select-content-item-rest):not(.ant-select-content-item-suffix) {
+        .ant-select-selection-overflow-item:not(.ant-select-selection-overflow-item-rest):not(.ant-select-selection-overflow-item-suffix) {
           flex-shrink: 1;
           min-width: ${theme.sizeUnit * 13}px;
         }
 
-        .ant-select-content-item-suffix {
+        .ant-select-selection-overflow-item-suffix {
           flex: unset;
           min-width: 0px;
         }


### PR DESCRIPTION
### SUMMARY
**Draft, stacked on #44103** — this serves double duty: it's a real fix for a visual regression Evan spotted (control-panel `Select` controls sitting taller than sibling `Input` controls), and it doubles as the first live test of #44103's new Chromatic workflow, since GitHub evaluates `pull_request`-triggered workflow files from the PR's own head ref — so Chromatic will actually run here even before #44103 merges to master. Rebase onto master once #44103 lands.

The antd v5→v6 upgrade (#41636) renamed the CSS selectors targeting rc-select/rc-overflow's multi-value tag container to class names that don't exist in the antd 6 / rc-select build actually bundled here:

| Used in code | Actually rendered |
|---|---|
| `.ant-select-content` | `.ant-select-selection-overflow` |
| `.ant-select-content-item` | `.ant-select-selection-overflow-item` |
| `.ant-select-content-item-suffix` | `.ant-select-selection-overflow-item-suffix` |
| `.ant-select-input` | `.ant-select-selection-search` |
| `.ant-select-placeholder` | `.ant-select-selection-placeholder` |

Verified against the installed `rc-select@14.16.8` / `rc-overflow` source directly (`prefixCls` string concatenation in `Selector/MultipleSelector.js`, `Selector/SingleSelector.js`, and rc-overflow's `Overflow.js`) — none of the old selectors exist anywhere in the bundled JS.

Because the `oneLine` rule's `flex-wrap: nowrap` never actually applied (it targeted a class that's never rendered), multi-value `Select` controls using `oneLine` silently stopped being capped to a single row and grew taller than sibling controls whenever their tags wrapped — visible in the Explore control panel as Select-based controls sitting noticeably taller than adjacent Input-based controls.

A follow-up fix (#42600) touched the same rule but only removed an already-dead `.ant-select-content` reference from the `max-height` selector list, without addressing the real class-name drift.

Adds a `OneLineHeightParity` story pairing an `oneLine` multi-Select with a plain Input at matching width, so this regression is visually covered going forward rather than only catchable by eye.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
The new `OneLineHeightParity` Storybook story (`Components/Select`) shows this directly; Chromatic should also pick up the height change on this PR.

### TESTING INSTRUCTIONS
- `tsc --noEmit` on `superset-ui-core` is clean (0 errors).
- `jest packages/superset-ui-core/src/components/Select` shows the identical 64-failed/148-passed baseline as unmodified master — those are pre-existing, unrelated stale-class failures in `AsyncSelect.test.tsx`'s own test helpers (querying `.ant-select-dropdown-list`, another leftover from the same antd v6 upgrade), a separate follow-up worth filing, not touched here.
- `oxlint` clean on both changed files.
- Storybook: `Components/Select` → `OneLineHeightParity` — the Select and Input should render at matching heights.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)