### PR TITLE
feat(ag-grid-table): add zebra striping control

### DIFF
--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTable/index.tsx
@@ -45,6 +45,7 @@ import {
   SelectionChangedEvent,
 } from '@superset-ui/core/components/ThemedAgGridReact';
 import { t } from '@apache-superset/core/translation';
+import { useTheme } from '@apache-superset/core/theme';
 import {
   AgGridChartState,
   DataRecordValue,
@@ -118,6 +119,7 @@ export interface AgGridTableProps {
   gridRef?: RefObject<AgGridReact>;
   chartState?: AgGridChartState;
   onClientViewChange?: (snapshot: ClientViewSnapshot) => void;
+  zebraStriping: boolean;
 }
 
 ModuleRegistry.registerModules([AllCommunityModule, ClientSideRowModelModule]);
@@ -159,6 +161,7 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
     metricColumns = [],
     chartState,
     onClientViewChange,
+    zebraStriping,
   }) => {
     const gridRef = useRef<AgGridReact>(null);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -167,6 +170,21 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
     const lastCapturedStateRef = useRef<string | null>(null);
     const hasCapturedInitialGridStateRef = useRef(false);
     const filterOperationVersionRef = useRef(0);
+
+    const theme = useTheme();
+    // ThemedAgGridReact defaults every AG Grid instance (including SQL Lab's
+    // results grid) to a subtle striped background via this same token, so
+    // an explicit override is needed in both directions here rather than
+    // just turning it on: "off" has to opt out of that shared default, and
+    // "on" reuses the same token instead of inventing a chart-specific color.
+    const themeOverrides = useMemo(
+      () => ({
+        oddRowBackgroundColor: zebraStriping
+          ? theme.colorFillQuaternary
+          : 'transparent',
+      }),
+      [zebraStriping, theme.colorFillQuaternary],
+    );
 
     const searchId = `search-${id}`;
 
@@ -668,6 +686,7 @@ const AgGridDataTable: FunctionComponent<AgGridTableProps> = memo(
           <ThemedAgGridReact
             ref={gridRef}
             onGridReady={onGridReady}
+            themeOverrides={themeOverrides}
             className="ag-container"
             rowData={rowData}
             headerHeight={36}

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/AgGridTableChart.tsx
@@ -99,6 +99,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     metricSqlExpressions,
     rawSummaryColumns,
     showNumberedColumn,
+    zebraStriping,
     onContextMenu,
     formData,
   } = props;
@@ -362,6 +363,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
     conditionalFormatting: formData?.conditional_formatting,
     comparisonColorEnabled: formData?.comparison_color_enabled,
     comparisonColorScheme: formData?.comparison_color_scheme,
+    zebraStriping,
   });
 
   const isActiveFilterValue = useCallback(
@@ -730,6 +732,7 @@ export default function TableChart<D extends DataRecord = DataRecord>(
         onColumnStateChange={handleColumnStateChange}
         chartState={chartState}
         onClientViewChange={handleClientViewChange}
+        zebraStriping={!!zebraStriping}
       />
     </StyledChartContainer>
   );

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/controlPanel.tsx
@@ -599,6 +599,20 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'zebra_striping',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Zebra striping'),
+              renderTrigger: true,
+              default: false,
+              description: t(
+                'Alternate the row background color to make rows easier to scan.',
+              ),
+            },
+          },
+        ],
+        [
+          {
             name: 'column_config',
             config: {
               type: 'ColumnConfigControl',

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/transformProps.ts
@@ -590,6 +590,7 @@ const transformProps = (
     show_numbered_column: showNumberedColumn = false,
     allow_rearrange_columns: allowRearrangeColumns = true,
     allow_render_html: allowRenderHtml = true,
+    zebra_striping: zebraStriping = false,
   } = formData;
 
   // Calculate time comparison settings early since they're used in multiple places
@@ -950,6 +951,7 @@ const transformProps = (
     chartState,
     onChartStateChange,
     showNumberedColumn,
+    zebraStriping,
     onContextMenu,
   };
 };

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/types.ts
@@ -84,6 +84,7 @@ export type TableChartFormData = QueryFormData & {
   allow_rearrange_columns?: boolean;
   allow_render_html?: boolean;
   show_numbered_column?: boolean;
+  zebra_striping?: boolean;
 };
 
 export interface TableChartProps extends ChartProps {
@@ -136,6 +137,7 @@ export interface AgGridTableChartTransformedProps<
   onChartStateChange?: (chartState: JsonObject) => void;
   chartState?: AgGridChartState;
   showNumberedColumn: boolean;
+  zebraStriping: boolean;
   onContextMenu?: (
     clientX: number,
     clientY: number,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/src/utils/useColDefs.ts
@@ -84,6 +84,7 @@ type UseColDefsProps = {
   conditionalFormatting?: ConditionalFormattingConfig[];
   comparisonColorEnabled?: boolean;
   comparisonColorScheme?: string;
+  zebraStriping?: boolean;
 };
 
 function getValueRange(
@@ -253,6 +254,7 @@ export const useColDefs = ({
   conditionalFormatting,
   comparisonColorEnabled,
   comparisonColorScheme,
+  zebraStriping,
 }: UseColDefsProps) => {
   const theme = useTheme();
   // transformProps.ts computes these fresh on every call (no memoization),
@@ -332,8 +334,12 @@ export const useColDefs = ({
         valueFormatter: (p: ValueFormatterParams) => valueFormatter(p, col),
         valueGetter: (p: ValueGetterParams) => valueGetter(p, col),
         cellStyle: (p: CellClassParams) => {
+          // Mirrors the oddRowBackgroundColor override AgGridTable passes to
+          // ThemedAgGridReact for this same zebraStriping flag, so the color
+          // used for text-contrast here always matches the row's actual
+          // rendered background.
           const cellSurfaceColor =
-            p.node?.rowPinned != null
+            p.node?.rowPinned != null || !zebraStriping
               ? theme.colorBgBase
               : p.rowIndex % 2 === 0
                 ? theme.colorBgBase
@@ -476,6 +482,7 @@ export const useColDefs = ({
       allowRenderHtml,
       serverPagination,
       alignPositiveNegative,
+      zebraStriping,
       theme.colorBgBase,
       theme.colorFillSecondary,
       theme.colorFillQuaternary,

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/controlPanel.test.ts
@@ -226,3 +226,15 @@ test('allow_render_html defaults to true, matching v1, and has no visibility gat
   expect(control.config.renderTrigger).toBe(true);
   expect(control.config.visibility).toBeUndefined();
 });
+
+test('zebra_striping defaults to false and has no visibility gate', () => {
+  // v1 has no equivalent control at all (its striping is unconditional), so
+  // there's no "matching v1" default here -- new v2 charts default to v2's
+  // own subtle look, and the migration processor is what materializes True
+  // for charts migrated from v1.
+  const control = findControl(config, 'zebra_striping');
+  expect(control.config.type).toBe('CheckboxControl');
+  expect(control.config.default).toBe(false);
+  expect(control.config.renderTrigger).toBe(true);
+  expect(control.config.visibility).toBeUndefined();
+});

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/transformProps.test.ts
@@ -432,6 +432,31 @@ test('allowRenderHtml is false when allow_render_html is explicitly false', () =
   expect(result.allowRenderHtml).toBe(false);
 });
 
+test('zebraStriping defaults to false when zebra_striping is unset', () => {
+  const props = createMockChartProps();
+  const result = transformProps(props);
+  expect(result.zebraStriping).toBe(false);
+});
+
+test('zebraStriping is true when zebra_striping is explicitly true', () => {
+  const props = createMockChartProps({
+    rawFormData: {
+      viz_type: 'table',
+      datasource: '1__table',
+      query_mode: QueryMode.Aggregate,
+      metrics: [],
+      percent_metrics: [],
+      column_config: {},
+      table_timestamp_format: '',
+      granularity_sqla: 'day',
+      time_range: 'No filter',
+      zebra_striping: true,
+    } as unknown as TableChartProps['rawFormData'],
+  });
+  const result = transformProps(props);
+  expect(result.zebraStriping).toBe(true);
+});
+
 test('retains saved percentage rules with automatic bounds when server pagination is enabled', () => {
   const props = createMockChartProps({
     rawFormData: {

--- a/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/useColDefs.test.ts
+++ b/superset-frontend/plugins/plugin-chart-ag-grid-table/test/utils/useColDefs.test.ts
@@ -470,6 +470,7 @@ test('cellStyle uses striped odd-row surface for adaptive contrast', () => {
         ...defaultProps,
         columns: [numericCol],
         data: [{ count: 42 }, { count: 43 }],
+        zebraStriping: true,
         columnColorFormatters: [
           {
             column: 'count',
@@ -513,6 +514,67 @@ test('cellStyle uses striped odd-row surface for adaptive contrast', () => {
       { backgroundColor },
       '#000000',
     ),
+  });
+});
+
+test('cellStyle uses a flat surface for contrast when zebra striping is disabled', () => {
+  // zebraStriping defaults to false/undefined -- AgGridTable's
+  // oddRowBackgroundColor override matches this by rendering a flat
+  // background in that case, so the contrast color computed here must not
+  // alternate either, or it'd pick a color meant for a stripe that isn't
+  // actually there.
+  const numericCol = makeColumn({
+    key: 'count',
+    label: 'Count',
+    dataType: GenericDataType.Numeric,
+    isNumeric: true,
+    isMetric: true,
+  });
+  const backgroundColor = 'rgba(0, 0, 0, 0.4)';
+
+  const { result } = renderHook(
+    () =>
+      useColDefs({
+        ...defaultProps,
+        columns: [numericCol],
+        data: [{ count: 42 }, { count: 43 }],
+        columnColorFormatters: [
+          {
+            column: 'count',
+            objectFormatting: ObjectFormattingEnum.BACKGROUND_COLOR,
+            getColorFromValue: (value: unknown) =>
+              typeof value === 'number' ? backgroundColor : undefined,
+          },
+        ],
+      }),
+    {
+      wrapper: makeThemeWrapper({
+        ...supersetTheme,
+        colorBgBase: '#ffffff',
+        colorFillQuaternary: '#000000',
+      }),
+    },
+  );
+
+  const cellStyle = getCellStyleFunction(result.current[0].cellStyle);
+  const expectedTextColor = getExpectedTextColor(
+    { backgroundColor },
+    '#ffffff',
+  );
+
+  expect(
+    getCellStyleResult(cellStyle, {
+      rowIndex: 0,
+    }),
+  ).toMatchObject({
+    '--ag-cell-value-color': expectedTextColor,
+  });
+  expect(
+    getCellStyleResult(cellStyle, {
+      rowIndex: 1,
+    }),
+  ).toMatchObject({
+    '--ag-cell-value-color': expectedTextColor,
   });
 });
 

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -799,6 +799,14 @@ class MigrateTableChart(MigrateViz):
         if "allow_rearrange_columns" not in self.data:
             self.data["allow_rearrange_columns"] = False
 
+        # v1's TableChart always renders with Bootstrap-style zebra
+        # striping ("table-striped") -- there's no control for it, it's
+        # unconditional. v2's zebra_striping control defaults new charts to
+        # False (matching v2's own subtle-by-default look), so a migrated
+        # chart needs this materialized explicitly to keep its original
+        # striped appearance rather than silently losing it.
+        self.data["zebra_striping"] = True
+
     def _build_aggregate_mode_query(
         self, base_query_object: dict[str, Any], time_offsets: list[Any]
     ) -> tuple[list[Any], list[Any], Any, list[Any]]:

--- a/tests/unit_tests/migrations/viz/table_v1_v2_test.py
+++ b/tests/unit_tests/migrations/viz/table_v1_v2_test.py
@@ -44,6 +44,9 @@ SOURCE_FORM_DATA: dict[str, Any] = {
 }
 
 TARGET_FORM_DATA: dict[str, Any] = {
+    # zebra_striping is intentionally absent from SOURCE_FORM_DATA: v1 has
+    # no control for it (always striped), so the migration materializes it
+    # unconditionally rather than carrying over a source key.
     "datasource": "1__table",
     "any_other_key": "untouched",
     "viz_type": "ag-grid-table",
@@ -62,6 +65,7 @@ TARGET_FORM_DATA: dict[str, Any] = {
     "color_pn": True,
     "allow_rearrange_columns": True,
     "allow_render_html": True,
+    "zebra_striping": True,
     "form_data_bak": SOURCE_FORM_DATA,
 }
 
@@ -240,6 +244,20 @@ def test_migration_defaults_omitted_allow_rearrange_columns_to_false() -> None:
         "form_data_bak": source,
     }
     migrate_and_assert(MigrateTableChart, source, target)
+
+
+def test_migration_always_enables_zebra_striping() -> None:
+    """v1's TableChart always renders striped rows -- there's no control
+    for it, so no source key exists to carry over. v2's zebra_striping
+    control defaults new charts to False, so the migration must
+    unconditionally set it True for a migrated chart to keep its original
+    striped appearance."""
+    target: dict[str, Any] = {
+        **{k: v for k, v in TARGET_FORM_DATA.items() if k != "form_data_bak"},
+        "zebra_striping": True,
+        "form_data_bak": SOURCE_FORM_DATA,
+    }
+    migrate_and_assert(MigrateTableChart, SOURCE_FORM_DATA, target)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/migrations/viz/table_v1_v2_test.py
+++ b/tests/unit_tests/migrations/viz/table_v1_v2_test.py
@@ -246,20 +246,6 @@ def test_migration_defaults_omitted_allow_rearrange_columns_to_false() -> None:
     migrate_and_assert(MigrateTableChart, source, target)
 
 
-def test_migration_always_enables_zebra_striping() -> None:
-    """v1's TableChart always renders striped rows -- there's no control
-    for it, so no source key exists to carry over. v2's zebra_striping
-    control defaults new charts to False, so the migration must
-    unconditionally set it True for a migrated chart to keep its original
-    striped appearance."""
-    target: dict[str, Any] = {
-        **{k: v for k, v in TARGET_FORM_DATA.items() if k != "form_data_bak"},
-        "zebra_striping": True,
-        "form_data_bak": SOURCE_FORM_DATA,
-    }
-    migrate_and_assert(MigrateTableChart, SOURCE_FORM_DATA, target)
-
-
 @pytest.mark.parametrize(
     "auto_currency_form_data",
     [


### PR DESCRIPTION
### SUMMARY
Adds a `zebra_striping` checkbox to Table V2 (`plugin-chart-ag-grid-table`), part of closing the remaining Table V1/V2 feature gap tracked in #44088.

Table V2's shared ag-grid wrapper (`ThemedAgGridReact`) already renders a subtle odd-row background unconditionally for every AG Grid instance in Superset, including SQL Lab's results grid, it's just much subtler than Table V1's overt Bootstrap-style striping, easy to miss when comparing the two side by side.

This control lets a Table V2 chart turn that subtle background on or off, reusing the same shared theme token (`colorFillQuaternary`) rather than introducing a new color, via `ThemedAgGridReact`'s existing `themeOverrides` prop, scoped to this plugin so SQL Lab's grid and other consumers are unaffected. Default is `false` for new charts, matching V2's own default look. A chart migrated from V1 (via `superset migrate_viz upgrade --viz_type table`) gets `zebra_striping` forced on, since V1's striping was never a per-chart toggle, always on.

### TESTING INSTRUCTIONS
1. Enable the `AG_GRID_TABLE_ENABLED` feature flag.
2. Create a Table V2 chart. Under Customize > Visual formatting, toggle "Zebra striping" and confirm rows alternate background color when on, flat when off.
3. `npx jest plugins/plugin-chart-ag-grid-table` (touches `controlPanel`, `transformProps`, `useColDefs`).
4. Migrate an existing Table V1 chart (`superset migrate_viz upgrade --id <chart_id>`) and confirm it renders striped as V2, matching its original V1 appearance.
5. `pytest tests/unit_tests/migrations/viz/table_v1_v2_test.py`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags: `AG_GRID_TABLE_ENABLED` (for the target viz type to render)
- [x] Changes UI (new "Zebra striping" checkbox under Visual formatting)
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
