### PR TITLE
fix(security): use self-repository syntax for setup-backend in testcontainers workflow

### DIFF
--- a/.github/workflows/testcontainers.yml
+++ b/.github/workflows/testcontainers.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: current
       - name: Install db2 driver (ibm-db-sa)


### PR DESCRIPTION
### SUMMARY
Resolves code-scanning alert #2685 ([zizmor/self-repository](https://github.com/apache/superset/security/code-scanning/2685)) on `.github/workflows/testcontainers.yml:122`.

The `Setup Python` step in the `testcontainers` job references `.github/actions/setup-backend/` via the workspace-relative `uses: ./...` syntax, which zizmor's `self-repository` audit flags in favor of GitHub's dedicated `uses: $/...` syntax. `setup-backend` is a plain in-repo directory (not a git submodule), so the mechanical rewrite applies cleanly here — same pattern as the already-merged fixes for the analogous `setup-backend` references in `superset-python-integrationtest.yml` (#44040) and `superset-python-presto-hive.yml` (#44037).

The ASF allowlist check (`apache/infrastructure-actions/allowlist-check`) was bumped to `v1.0.1` in #44014 (merged), which added `$/` to its recognized local-action prefixes, so this rewrite doesn't break that required check.

Only this one occurrence (line 122, alert #2685) is touched.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — CI workflow YAML only, no UI change.

### TESTING INSTRUCTIONS
- `zizmor .github/workflows/testcontainers.yml` no longer reports a `self-repository` finding.
- `pre-commit run --files .github/workflows/testcontainers.yml` passes, including the `zizmor` hook.
- Workflow runtime behavior is unchanged; `$/...` and `./...` resolve to the same in-repo action content.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Resolves code-scanning alert #2685

🤖 Generated with [Claude Code](https://claude.com/claude-code)