### PR TITLE
fix(security): use self-repository syntax for setup-backend in helm workflow

### DIFF
--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -39,7 +39,7 @@ jobs:
           version: v3.21.3
 
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           install-superset: "false"
 


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` check flags the relative `./` action reference in
`.github/workflows/superset-helm-lint-test.yml`'s "Setup Python" step: GitHub
has a dedicated `$/...` syntax for referencing an action that lives in the
same repository being checked out, and `./...` is considered an anti-pattern
here (it works, but doesn't express the self-repo relationship explicitly the
way `$/...` does). This matches the fix already applied to a sibling `uses:`
line further down the same file in #44083, and to other workflows in #44040 /
#44116.

Resolves code-scanning alert #2641
(https://github.com/apache/superset/security/code-scanning/2641)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow change, no UI)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-helm-lint-test.yml`
  passes, including the `zizmor (GHA security audit)` hook, confirming the
  alert no longer fires on this line.
- The helm lint/test workflow itself is unchanged in behavior; `$/...` and
  `./...` resolve to the same local action path.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)