### PR TITLE
fix(security): use self-repository syntax in frontend workflow

### DIFF
--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check for File Changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` audit flags the workspace-relative `./...` form used to reference the in-repo `change-detector` action in `superset-frontend.yml`. GitHub now supports a dedicated `$/...` self-repository syntax for referencing same-repo actions/reusable workflows in `uses:` clauses, which has security/policy benefits over `./...`:

- It isn't subject to runtime filesystem state (can't accidentally resolve to an action checked out by a prior step).
- It's treated as a "pinned" reference, which allows enforcing a fully-pinned-actions policy.

This PR switches the single flagged `uses: ./.github/actions/change-detector/` line to `uses: $/.github/actions/change-detector/`, matching the pattern already used for the same action in other workflows (`superset-python-unittest.yml`, `superset-python-integrationtest.yml`, `superset-playwright.yml`, `superset-translations.yml`, `superset-python-presto-hive.yml`). The `change-detector` action is a plain in-tree directory (not a git submodule), so `$/` resolves it correctly.

Resolves code-scanning alert #2640.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow file only)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-frontend.yml` passes, including the `zizmor (GHA security audit)` hook (no findings).
- CI on this PR itself will exercise the `frontend-build` job, confirming the `Check for File Changes` step still resolves and runs the `change-detector` action correctly.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)