### PR TITLE
fix(security): use self-repository syntax in extensions-cli workflow

### DIFF
--- a/.github/workflows/superset-extensions-cli.yml
+++ b/.github/workflows/superset-extensions-cli.yml
@@ -39,13 +39,13 @@ jobs:
 
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         if: steps.check.outputs.superset-extensions-cli
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
           requirements-type: dev


### PR DESCRIPTION
### SUMMARY
zizmor's `self-repository` audit flags the workspace-relative `./...` refs to
in-repo actions in `.github/workflows/superset-extensions-cli.yml`: GitHub
has a dedicated `$/...` syntax for referencing an action that lives in the
same repository being checked out, and `./...` is treated as an anti-pattern
here (it works, but doesn't express the self-repo relationship explicitly,
and can't be enforced by a "fully pinned" policy the way `$/...` can).

This rewrites both flagged refs in the file (`change-detector` and
`setup-backend`) to the `$/...` form, matching the fix already applied to
the same pair of actions elsewhere (e.g. `superset-translations.yml`, and
recent PRs for `superset-helm-lint-test.yml` / `testcontainers.yml`), where
CI (including `asf-allowlist-check`) has already confirmed the `$/` form
resolves correctly.

Resolves code-scanning alert #2639
(https://github.com/apache/superset/security/code-scanning/2639), and
incidentally alert #2638 for the sibling `change-detector` ref on the
adjacent line in the same file.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (CI workflow YAML change only, no UI)

### TESTING INSTRUCTIONS
- `pre-commit run --files .github/workflows/superset-extensions-cli.yml`
  passes, including the `zizmor (GHA security audit)` hook, confirming the
  alert no longer fires on this line.
- The workflow's behavior is unchanged; `$/...` and `./...` resolve to the
  same local action path.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)