### PR TITLE
fix(ci): add per-PR concurrency to the Showtime trigger workflow

### DIFF
--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -19,6 +19,19 @@ on:
         required: false
         type: string
 
+# Triggers on labeled/unlabeled/synchronize/closed -- far more events per PR than
+# typical CI's synchronize-only trigger. Without this, every event queues its own
+# run and nothing ever supersedes a stale one, so runs pile up indefinitely on
+# active PRs (observed: 6 simultaneously queued runs for a single PR) and end up
+# starved competing for the same runner pool as everything else. cancel-in-progress
+# is correct here, not just a queue-relief hack: this job's whole purpose is
+# reconciling to the *current* desired state, so a run still working toward an
+# already-superseded state is wasted work regardless of whether it's queued or
+# mid-sync.
+concurrency:
+  group: showtime-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 # Common environment variables for all jobs (non-sensitive only)
 env:
   AWS_REGION: us-west-2


### PR DESCRIPTION
### SUMMARY

The 🎪 Showtime "Sync PR to desired state" job has been sitting perpetually `pending`/queued on nearly every PR, while every other CI job runs fine. Root cause: `showtime-trigger.yml` fires on `labeled`/`unlabeled`/`synchronize`/`closed` — far more events per PR than typical CI's `synchronize`-only trigger — with no `concurrency:` group. Every one of those events queues a brand-new run, and nothing ever cancels a stale one.

Checked the live queue directly: **68 of the repo's 91 currently-queued Actions runs (75%) were this one workflow**, while every other workflow had 1-2 queued (normal). They were stacking per-PR — one branch had 6 simultaneously queued runs, all competing for the same runner pool everything else shares cleanly. In an actively automated repo (frequent relabeling, force-pushes, rebases), that backlog balloons fast and the job ends up starved.

`showtime-cleanup.yml` (the sibling workflow) only does scheduled TTL cleanup of deployed *environments* every 6 hours — nothing currently cancels stale *Actions runs* for this workflow.

### THE FIX

Adds a per-PR concurrency group with `cancel-in-progress: true`, so a new trigger for a PR cancels any still-queued/in-progress Showtime run for that same PR instead of stacking behind it.

This is correct here, not just a queue-relief hack: the job's whole purpose (`showtime sync`) is reconciling to the *current* desired state, so a run still working toward an already-superseded state is wasted work whether it's queued or mid-sync — cancelling it in favor of a fresh run is the right behavior, matching the `cancel-in-progress` pattern already used elsewhere in this repo's CI (e.g. `enforce-single-migration-head.yml`).

### TESTING INSTRUCTIONS

No functional change to what Showtime does, only when a run gets superseded. `zizmor` (GHA security audit) passes on the change. Should observe the queued-run count for this workflow drop sharply once merged; can verify with:

```bash
gh api "repos/apache/superset/actions/runs?status=queued&per_page=100" \
  --jq '[.workflow_runs[] | select(.name=="🎪 Superset Showtime")] | length'
```

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API