### PR TITLE
fix(histogram): preserve null groups and labels

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -373,6 +373,12 @@ data behind a chart (or behind a specific data point, when one is selected). Use
 the modal's toolbar to export the underlying result set as CSV or Excel (XLSX) without leaving the modal —
 the export isn't limited to the page currently visible in the table.
 
+### Missing Values in Histograms
+
+When grouping a histogram, rows with a NULL group value appear in a separate
+`<NULL>` series. Rows with a missing value in the numeric column are excluded
+from the histogram counts.
+
 :::resources
 
 - [Chart Walkthroughs](https://docs.preset.io/docs/chart-walkthroughs) - Detailed guides for most chart types

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Histogram/transformProps.ts
@@ -20,7 +20,7 @@ import type { ComposeOption } from 'echarts/core';
 import type { BarSeriesOption } from 'echarts/charts';
 import type { GridComponentOption } from 'echarts/components';
 import type { CallbackDataParams } from 'echarts/types/src/util/types';
-import { isEmpty } from 'lodash-es';
+import { escape, isEmpty } from 'lodash-es';
 import {
   CategoricalColorNamespace,
   NumberFormats,
@@ -34,6 +34,7 @@ import { defaultGrid, defaultYAxis } from '../defaults';
 import { getLegendProps } from '../utils/series';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { getPercentFormatter } from '../utils/formatters';
+import { NULL_STRING } from '../constants';
 
 export default function transformProps(
   chartProps: HistogramChartProps,
@@ -89,7 +90,9 @@ export default function transformProps(
   const barSeries: BarSeriesOption[] = data.map(datum => {
     const seriesName =
       groupby.length > 0
-        ? groupby.map(key => datum[getColumnLabel(key)]).join(', ')
+        ? groupby
+            .map(key => datum[getColumnLabel(key)] ?? NULL_STRING)
+            .join(', ')
         : getColumnLabel(column);
     const seriesData = Object.keys(datum)
       .filter(key => groupbySet.has(key) === false)
@@ -123,7 +126,10 @@ export default function transformProps(
     const title = params[0].name;
     const rows = params.map(param => {
       const { marker, seriesName, value } = param;
-      return [`${marker}${seriesName}`, yAxisFormatter.format(value as number)];
+      return [
+        `${marker}${escape(seriesName)}`,
+        yAxisFormatter.format(value as number),
+      ];
     });
     if (groupby.length > 0) {
       const total = params.reduce(

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Histogram/transformProps.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ChartProps, DataRecord } from '@superset-ui/core';
+import { supersetTheme } from '@apache-superset/core/theme';
+import type { BarSeriesOption } from 'echarts/charts';
+import type { TooltipComponentOption } from 'echarts/components';
+import transformProps from '../../src/Histogram/transformProps';
+import {
+  HistogramChartProps,
+  HistogramFormData,
+} from '../../src/Histogram/types';
+import { NULL_STRING } from '../../src/constants';
+
+const createChartProps = (data: DataRecord[], groupby = ['category']) =>
+  new ChartProps<HistogramFormData>({
+    formData: {
+      datasource: '1__table',
+      viz_type: 'histogram_v2',
+      column: 'value',
+      groupby,
+      bins: 1,
+      cumulative: false,
+      normalize: false,
+      sliceId: 1,
+      showLegend: true,
+      showValue: false,
+      xAxisFormat: ',d',
+      xAxisTitle: '',
+      yAxisFormat: ',d',
+      yAxisTitle: '',
+    },
+    queriesData: [{ data }],
+    width: 800,
+    height: 600,
+    theme: supersetTheme,
+  }) as HistogramChartProps;
+
+test('keeps null groups distinct from empty strings and other falsy labels', () => {
+  const { echartOptions } = transformProps(
+    createChartProps([
+      { category: null, '0 - 10': 2 },
+      { category: '', '0 - 10': 3 },
+      { category: 0, '0 - 10': 4 },
+      { category: false, '0 - 10': 5 },
+      { category: 'Other', '0 - 10': 6 },
+    ]),
+  );
+
+  expect(echartOptions.series).toEqual([
+    expect.objectContaining({ name: NULL_STRING, data: [2] }),
+    expect.objectContaining({ name: '', data: [3] }),
+    expect.objectContaining({ name: '0', data: [4] }),
+    expect.objectContaining({ name: 'false', data: [5] }),
+    expect.objectContaining({ name: 'Other', data: [6] }),
+  ]);
+  expect(echartOptions.legend).toEqual(
+    expect.objectContaining({
+      data: [NULL_STRING, '', '0', 'false', 'Other'],
+      selected: {
+        [NULL_STRING]: true,
+        '': true,
+        '0': true,
+        false: true,
+        Other: true,
+      },
+    }),
+  );
+});
+
+test.each([
+  [null, 'West', `${NULL_STRING}, West`],
+  ['West', null, `West, ${NULL_STRING}`],
+  [null, null, `${NULL_STRING}, ${NULL_STRING}`],
+  ['', false, ', false'],
+])('formats the group values %p and %p as %s', (category, region, name) => {
+  const { echartOptions } = transformProps(
+    createChartProps(
+      [{ category, region, '0 - 10': 2 }],
+      ['category', 'region'],
+    ),
+  );
+
+  expect(echartOptions.series).toEqual([
+    expect.objectContaining({ name, data: [2] }),
+  ]);
+  expect(echartOptions.legend).toEqual(
+    expect.objectContaining({ data: [name] }),
+  );
+});
+
+test('shows the null group label as text in the tooltip', () => {
+  const { echartOptions } = transformProps(
+    createChartProps([{ category: null, '0 - 10': 2 }]),
+  );
+  const [series] = echartOptions.series as BarSeriesOption[];
+  const { formatter } = echartOptions.tooltip as TooltipComponentOption;
+  if (typeof formatter !== 'function') {
+    throw new Error('Expected a tooltip formatter');
+  }
+  const html = formatter(
+    [
+      {
+        componentType: 'series',
+        componentSubType: 'bar',
+        componentIndex: 0,
+        seriesType: 'bar',
+        seriesIndex: 0,
+        seriesName: String(series.name),
+        name: '0 - 10',
+        dataIndex: 0,
+        data: 2,
+        value: 2,
+        marker: '<span class="marker"></span>',
+        $vars: ['seriesName', 'name', 'value'],
+      },
+    ],
+    '',
+    jest.fn(),
+  );
+  const tooltip = document.createElement('div');
+  tooltip.innerHTML = String(html);
+
+  expect(tooltip.querySelector('td')?.textContent).toBe(NULL_STRING);
+  expect(tooltip.querySelector('.marker')).not.toBeNull();
+});
+
+test('uses the value column name without group by columns', () => {
+  const { echartOptions } = transformProps(
+    createChartProps([{ '0 - 10': 2 }], []),
+  );
+
+  expect(echartOptions.series).toEqual([
+    expect.objectContaining({ name: 'value', data: [2] }),
+  ]);
+});

--- a/superset/utils/pandas_postprocessing/histogram.py
+++ b/superset/utils/pandas_postprocessing/histogram.py
@@ -101,7 +101,7 @@ def histogram(
     else:
         # with grouping
         histogram_df = (
-            df.groupby(groupby)[column]
+            df.groupby(groupby, dropna=False)[column]
             .apply(lambda x: Series(hist_values(x)))
             .unstack(fill_value=0)
         )

--- a/tests/unit_tests/pandas_postprocessing/test_histogram.py
+++ b/tests/unit_tests/pandas_postprocessing/test_histogram.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import numpy as np
 import pytest
 from pandas import DataFrame
+from pandas.testing import assert_frame_equal
 
 from superset.exceptions import InvalidPostProcessingError
 from superset.utils.pandas_postprocessing import histogram
@@ -221,6 +223,59 @@ def test_histogram_rejects_unbounded_bins():
     for bad_bins in (0, -1, 2_000_000_000, "auto", None):
         with pytest.raises(InvalidPostProcessingError):
             histogram(data, "a", [], bad_bins)
+
+
+@pytest.mark.parametrize(
+    ("cumulative", "normalize", "expected_counts"),
+    [
+        (False, False, [[1, 1], [1, 1]]),
+        (True, False, [[1, 2], [1, 2]]),
+        (False, True, [[0.25, 0.25], [0.25, 0.25]]),
+        (True, True, [[1 / 6, 1 / 3], [1 / 6, 1 / 3]]),
+    ],
+)
+def test_histogram_preserves_null_groups(
+    cumulative: bool, normalize: bool, expected_counts: list[list[float]]
+) -> None:
+    """Missing group keys retain observations; missing numeric values do not."""
+    df = DataFrame({"group": ["A", None, "A", None, None], "value": [1, 2, 3, 4, None]})
+    expected = DataFrame(expected_counts, columns=["1.0 - 2.5", "2.5 - 4.0"])
+    expected.insert(0, "group", ["A", np.nan])
+
+    result = histogram(
+        df, "value", ["group"], bins=2, cumulative=cumulative, normalize=normalize
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_histogram_with_only_null_groups() -> None:
+    """An entirely missing grouping column produces one histogram."""
+    df = DataFrame({"group": [None, None, None], "value": [1, 2, 3]})
+    expected = DataFrame({"group": [np.nan], "1.0 - 2.0": [1], "2.0 - 3.0": [2]})
+
+    assert_frame_equal(histogram(df, "value", ["group"], bins=2), expected)
+
+
+def test_histogram_with_multiple_null_group_keys() -> None:
+    """Partial and entirely missing group keys remain distinct groups."""
+    df = DataFrame(
+        {
+            "first": ["A", "A", None, None],
+            "second": ["X", None, "X", None],
+            "value": [1, 2, 3, 4],
+        }
+    )
+    expected = DataFrame(
+        {
+            "first": ["A", "A", np.nan, np.nan],
+            "second": ["X", np.nan, "X", np.nan],
+            "1.0 - 2.5": [1, 1, 0, 0],
+            "2.5 - 4.0": [0, 0, 1, 1],
+        }
+    )
+
+    assert_frame_equal(histogram(df, "value", ["first", "second"], bins=2), expected)
 
 
 def test_histogram_rejects_bool_bins():


### PR DESCRIPTION
### SUMMARY

Keep NULL grouping values in histogram counts and show `<NULL>` in legends and tooltips. Missing numeric values remain excluded. Addresses the histogram portion of #43547.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: NULL groups disappear; an all-NULL grouping column errors.

![Before](https://github.com/user-attachments/assets/e05c86f9-dedc-448c-bb1d-db48d88a5073)

After: all valid observations appear with visible NULL labels.

![After](https://github.com/user-attachments/assets/b0d97eba-e212-4ad6-8ef4-2ea48177fedf)

### TESTING INSTRUCTIONS

Create a histogram with mixed NULL/non-NULL groups. Check counts, legend and tooltip; repeat with all groups NULL and with two grouping columns.

Passed: 146 backend tests, 10 histogram frontend tests, pre-commit (mypy and TypeScript included), frontend/docs production builds, and five live chart API cases. Browser checks used the exact changed backend module and new frontend assets in an existing ARM64 Superset image.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43547 (histogram only)
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
