### PR TITLE
fix(boxplot): preserve null grouping values

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -196,6 +196,12 @@ and Y Axis Label.
 
 Once you’re done, publish the chart in your Tutorial Dashboard.
 
+### Box Plot
+
+In box plots, missing grouping values appear as `<NULL>` instead of dropping the
+corresponding rows. Missing numeric values are excluded when calculating the mean,
+median, quartiles, and whiskers.
+
 ### Markup
 
 In this section, we will add some text to our dashboard. If you’re there already, you can navigate

--- a/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/BoxPlot/transformProps.test.ts
@@ -20,6 +20,8 @@ import { ChartProps, SqlaFormData } from '@superset-ui/core';
 import { supersetTheme } from '@apache-superset/core/theme';
 import { EchartsBoxPlotChartProps } from '../../src/BoxPlot/types';
 import transformProps from '../../src/BoxPlot/transformProps';
+import { NULL_STRING } from '../../src/constants';
+import { allEventHandlers } from '../../src/utils/eventHandlers';
 
 describe('BoxPlot transformProps', () => {
   const formData: SqlaFormData = {
@@ -71,12 +73,15 @@ describe('BoxPlot transformProps', () => {
     theme: supersetTheme,
   });
 
-  const buildChartProps = (formDataOverrides: Partial<SqlaFormData> = {}) =>
+  const buildChartProps = (
+    formDataOverrides: Partial<SqlaFormData> = {},
+    data = chartProps.queriesData[0].data,
+  ) =>
     new ChartProps({
       formData: { ...formData, ...formDataOverrides },
       width: 800,
       height: 600,
-      queriesData: chartProps.queriesData,
+      queriesData: [{ ...chartProps.queriesData[0], data }],
       theme: supersetTheme,
     }) as EchartsBoxPlotChartProps;
 
@@ -134,6 +139,161 @@ describe('BoxPlot transformProps', () => {
       }),
     );
   });
+
+  test('keeps NULL groups distinct from empty strings, zero, and false', () => {
+    const values = [null, '', 0, false];
+    const labels = [NULL_STRING, '', '0', 'false'];
+    const { echartOptions, labelMap } = transformProps(
+      buildChartProps(
+        { groupby: ['type'] },
+        values.map(type => ({ ...chartProps.queriesData[0].data[0], type })),
+      ),
+    );
+
+    expect(echartOptions.xAxis).toEqual(
+      expect.objectContaining({ data: labels }),
+    );
+    expect(labelMap).toEqual({
+      [NULL_STRING]: [null],
+      '': [''],
+      '0': [0],
+      false: [false],
+    });
+    expect(echartOptions.series).toEqual([
+      expect.objectContaining({
+        data: labels.map(name => expect.objectContaining({ name })),
+      }),
+      ...labels.map(name => expect.objectContaining({ data: [[name, 2.735]] })),
+    ]);
+  });
+
+  test('retains partially and entirely NULL groups across multiple columns', () => {
+    const groups = [
+      { type: null, region: 'Charlotte' },
+      { type: 'organic', region: null },
+      { type: null, region: null },
+    ];
+    const { echartOptions, labelMap } = transformProps(
+      buildChartProps(
+        {},
+        groups.map(group => ({
+          ...chartProps.queriesData[0].data[0],
+          ...group,
+        })),
+      ),
+    );
+
+    expect(echartOptions.xAxis).toEqual(
+      expect.objectContaining({
+        data: [
+          `${NULL_STRING}, Charlotte`,
+          `organic, ${NULL_STRING}`,
+          `${NULL_STRING}, ${NULL_STRING}`,
+        ],
+      }),
+    );
+    expect(labelMap).toEqual({
+      [`${NULL_STRING}, Charlotte`]: [null, 'Charlotte'],
+      [`organic, ${NULL_STRING}`]: ['organic', null],
+      [`${NULL_STRING}, ${NULL_STRING}`]: [null, null],
+    });
+  });
+
+  test('renders NULL labels as text in box and outlier tooltips', () => {
+    const { echartOptions } = transformProps(
+      buildChartProps({ groupby: ['type'], numberFormat: '.3f' }, [
+        { ...chartProps.queriesData[0].data[0], type: null },
+      ]),
+    );
+    const [boxplot, outlier] = echartOptions.series as [
+      {
+        data: { name: string; value: unknown[] }[];
+        tooltip: {
+          formatter: (param: { name: string; value: unknown[] }) => string;
+        };
+      },
+      {
+        data: [string, number][];
+        tooltip: { formatter: (param: { data: [string, number] }) => string };
+      },
+    ];
+    const point = boxplot.data[0];
+    const boxTooltip = document.createElement('div');
+    // ECharts prepends the category index to the box statistics.
+    boxTooltip.innerHTML = boxplot.tooltip.formatter({
+      name: point.name,
+      value: [0, ...point.value],
+    });
+    const outlierTooltip = document.createElement('div');
+    outlierTooltip.innerHTML = outlier.tooltip.formatter({
+      data: outlier.data[0],
+    });
+
+    expect(boxTooltip.querySelector('strong')?.textContent).toBe(NULL_STRING);
+    expect(boxTooltip.textContent).toContain('# Observations: 39');
+    expect(boxTooltip.textContent).toContain('# Outliers: 1');
+    expect(outlierTooltip.querySelector('strong')?.textContent).toBe(
+      NULL_STRING,
+    );
+    expect(outlierTooltip.textContent).toContain('2.735');
+  });
+
+  test.each([
+    { type: null, label: NULL_STRING, filter: { col: 'type', op: 'IS NULL' } },
+    { type: '', label: '', filter: { col: 'type', op: 'IN', val: [''] } },
+    { type: 0, label: '0', filter: { col: 'type', op: 'IN', val: [0] } },
+    {
+      type: false,
+      label: 'false',
+      filter: { col: 'type', op: 'IN', val: [false] },
+    },
+  ])(
+    'preserves $type in cross-filters and context-menu filters',
+    ({ type, label, filter }) => {
+      const setDataMask = jest.fn();
+      const onContextMenu = jest.fn();
+      const transformedProps = transformProps(
+        buildChartProps({}, [{ ...chartProps.queriesData[0].data[0], type }]),
+      );
+      const handlers = allEventHandlers({
+        ...transformedProps,
+        setDataMask,
+        onContextMenu,
+        emitCrossFilters: true,
+      });
+      const name = `${label}, Charlotte`;
+      const dataMask = {
+        extraFormData: {
+          filters: [filter, { col: 'region', op: 'IN', val: ['Charlotte'] }],
+        },
+        filterState: {
+          value: [[type, 'Charlotte']],
+          selectedValues: [name],
+        },
+      };
+      handlers.click({ name });
+      expect(setDataMask).toHaveBeenCalledWith(dataMask);
+
+      handlers.contextmenu({
+        name,
+        event: { stop: jest.fn(), event: { clientX: 10, clientY: 20 } },
+      });
+      const drillFilters = [
+        { col: 'type', op: '==', val: type, formattedVal: label },
+        {
+          col: 'region',
+          op: '==',
+          val: 'Charlotte',
+          formattedVal: 'Charlotte',
+        },
+      ];
+      expect(onContextMenu).toHaveBeenCalledWith(10, 20, {
+        drillToDetail: drillFilters,
+        crossFilter: { dataMask, isCurrentValueSelected: false },
+        drillBy: { filters: drillFilters, groupbyFieldName: 'groupby' },
+      });
+    },
+  );
 
   test('should add a vertical Y-axis slider to dataZoom when yAxisSlider is enabled', () => {
     const { echartOptions } = transformProps(

--- a/superset/utils/pandas_postprocessing/aggregate.py
+++ b/superset/utils/pandas_postprocessing/aggregate.py
@@ -40,7 +40,7 @@ def aggregate(
     aggregates = aggregates or {}
     aggregate_funcs = _get_aggregate_funcs(df, aggregates)
     if groupby:
-        df_groupby = df.groupby(by=groupby)
+        df_groupby = df.groupby(by=groupby, dropna=False)
     else:
         df_groupby = df.groupby(lambda _: True)
     return df_groupby.agg(**aggregate_funcs).reset_index(drop=not groupby)

--- a/tests/unit_tests/pandas_postprocessing/test_aggregate.py
+++ b/tests/unit_tests/pandas_postprocessing/test_aggregate.py
@@ -14,6 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
 from superset.utils.pandas_postprocessing import aggregate
 from tests.unit_tests.fixtures.dataframes import categories_df
 from tests.unit_tests.pandas_postprocessing.utils import series_to_list
@@ -66,3 +70,87 @@ def test_aggregate_count_includes_nulls():
     df = aggregate(df=categories_df, groupby=["constant"], aggregates=aggregates)
     # idx_nulls has 101 rows total; np.ma.count returns all 101 (NaN included)
     assert series_to_list(df["null_count"])[0] == 101
+
+
+def test_aggregate_preserves_null_groups() -> None:
+    """Missing group keys form one group without changing metric aggregation."""
+    df = pd.DataFrame(
+        {
+            "category": ["alpha", None, np.nan, pd.NA, "beta"],
+            "value": [1, 2, 3, None, 5],
+        }
+    )
+
+    result = aggregate(
+        df,
+        groupby=["category"],
+        aggregates={
+            "total": {"column": "value", "operator": "sum"},
+            "mean": {"column": "value", "operator": "mean"},
+            "count": {"column": "value", "operator": "count"},
+        },
+    )
+
+    assert_frame_equal(
+        result,
+        pd.DataFrame(
+            {
+                "category": ["alpha", "beta", np.nan],
+                "total": [1.0, 5.0, 5.0],
+                "mean": [1.0, 5.0, 2.5],
+                "count": [1, 1, 3],
+            }
+        ),
+    )
+
+
+def test_aggregate_preserves_null_keys_in_multiple_grouping_columns() -> None:
+    """NULL in either grouping column retains the distinct key combination."""
+    df = pd.DataFrame(
+        {
+            "category": ["alpha", "alpha", None, None, "alpha", None],
+            "region": ["east", None, "east", None, None, None],
+            "value": [1, 2, 3, 4, None, 6],
+        }
+    )
+
+    result = aggregate(
+        df,
+        groupby=["category", "region"],
+        aggregates={"total": {"column": "value", "operator": "sum"}},
+    )
+
+    assert_frame_equal(
+        result,
+        pd.DataFrame(
+            {
+                "category": ["alpha", "alpha", np.nan, np.nan],
+                "region": ["east", np.nan, "east", np.nan],
+                "total": [1.0, 2.0, 3.0, 10.0],
+            }
+        ),
+    )
+
+
+def test_aggregate_with_only_null_group_keys() -> None:
+    """An entirely missing grouping column still produces its aggregate."""
+    result = aggregate(
+        pd.DataFrame({"category": [None, np.nan, pd.NA], "value": [1, None, 3]}),
+        groupby=["category"],
+        aggregates={"mean": {"column": "value", "operator": "mean"}},
+    )
+
+    assert len(result) == 1
+    assert pd.isna(result.loc[0, "category"])
+    assert result.loc[0, "mean"] == 2.0
+
+
+def test_aggregate_without_grouping_columns() -> None:
+    """Ungrouped aggregation still combines every row into one result."""
+    result = aggregate(
+        pd.DataFrame({"category": ["alpha", None], "value": [1, 3]}),
+        groupby=[],
+        aggregates={"total": {"column": "value", "operator": "sum"}},
+    )
+
+    assert_frame_equal(result, pd.DataFrame({"total": [4]}))

--- a/tests/unit_tests/pandas_postprocessing/test_boxplot.py
+++ b/tests/unit_tests/pandas_postprocessing/test_boxplot.py
@@ -16,6 +16,7 @@
 # under the License.
 import warnings
 
+import pandas as pd
 import pytest
 
 from superset.exceptions import InvalidPostProcessingError
@@ -44,7 +45,7 @@ def test_boxplot_tukey():
         "cars__outliers",
         "region",
     }
-    assert len(df) == 4
+    assert len(df) == 5
 
 
 def test_boxplot_mean_median_no_future_warning():
@@ -52,7 +53,7 @@ def test_boxplot_mean_median_no_future_warning():
     GroupBy.agg, else pandas raises a FutureWarning. Also verify the values
     match a plain pandas groupby, since the string and callable forms could
     silently diverge on a future pandas version."""
-    expected = names_df.groupby("region")["cars"].agg(["mean", "median"])
+    expected = names_df.groupby("region", dropna=False)["cars"].agg(["mean", "median"])
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
@@ -74,7 +75,7 @@ def test_boxplot_minmax_no_future_warning():
     raises a FutureWarning. Also verify the values match a plain pandas
     groupby, since the string and callable forms could silently diverge on a
     future pandas version."""
-    expected = names_df.groupby("region")["cars"].agg(["max", "min"])
+    expected = names_df.groupby("region", dropna=False)["cars"].agg(["max", "min"])
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
@@ -109,7 +110,7 @@ def test_boxplot_min_max():
         "cars__outliers",
         "region",
     }
-    assert len(df) == 4
+    assert len(df) == 5
 
 
 def test_boxplot_percentile():
@@ -132,7 +133,7 @@ def test_boxplot_percentile():
         "cars__outliers",
         "region",
     }
-    assert len(df) == 4
+    assert len(df) == 5
 
 
 def test_boxplot_percentile_incorrect_params():
@@ -194,4 +195,77 @@ def test_boxplot_type_coercion():
         "cars__outliers",
         "region",
     }
-    assert len(df) == 4
+    assert len(df) == 5
+
+
+@pytest.mark.parametrize(
+    "whisker_type,minimum,maximum,outliers",
+    [
+        (PostProcessingBoxplotWhiskerType.TUKEY, 1, 4, [100.0]),
+        (PostProcessingBoxplotWhiskerType.MINMAX, 1, 100, []),
+        (PostProcessingBoxplotWhiskerType.PERCENTILE, 2, 4, [100.0, 1.0]),
+    ],
+)
+@pytest.mark.parametrize("all_null", [False, True])
+def test_boxplot_preserves_null_group_statistics(
+    whisker_type: PostProcessingBoxplotWhiskerType,
+    minimum: float,
+    maximum: float,
+    outliers: list[float],
+    all_null: bool,
+) -> None:
+    """NULL categories retain statistics and the existing missing-value rules."""
+    df = pd.DataFrame({"category": [None] * 6, "value": [1, 2, 3, 4, 100, None]})
+    if not all_null:
+        df = pd.concat(
+            [df, pd.DataFrame({"category": ["alpha"] * 3, "value": [10, 20, 30]})],
+            ignore_index=True,
+        )
+
+    result = boxplot(
+        df,
+        groupby=["category"],
+        metrics=["value"],
+        whisker_type=whisker_type,
+        percentiles=[25, 75],
+    )
+
+    assert len(result) == (1 if all_null else 2)
+    null_group = result[result["category"].isna()].iloc[0]
+    assert null_group.drop(labels="category").to_dict() == {
+        "value__mean": 22.0,
+        "value__median": 3.0,
+        "value__min": minimum,
+        "value__max": maximum,
+        "value__q1": 2.0,
+        "value__q3": 4.0,
+        # Boxplot count includes missing observations, as for non-NULL groups.
+        "value__count": 6,
+        "value__outliers": outliers,
+    }
+    if not all_null:
+        assert result.loc[result["category"] == "alpha", "value__mean"].item() == 20
+
+
+def test_boxplot_preserves_null_keys_in_multiple_grouping_columns() -> None:
+    """NULL keys in either dimension remain distinct boxplot groups."""
+    result = boxplot(
+        pd.DataFrame(
+            {
+                "category": ["alpha", "alpha", None, None],
+                "region": ["east", None, "east", None],
+                "value": [1, 2, 3, 4],
+            }
+        ),
+        groupby=["category", "region"],
+        metrics=["value"],
+        whisker_type=PostProcessingBoxplotWhiskerType.TUKEY,
+    )
+
+    assert len(result) == 4
+    assert result["category"].isna().tolist() == [False, False, True, True]
+    assert result["region"].isna().tolist() == [False, True, False, True]
+    for statistic in ["mean", "median", "min", "max", "q1", "q3"]:
+        assert result[f"value__{statistic}"].tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert result["value__count"].tolist() == [1, 1, 1, 1]
+    assert result["value__outliers"].tolist() == [[], [], [], []]


### PR DESCRIPTION
### SUMMARY

Preserve NULL grouping values in box plots so their observations contribute to the displayed distributions. Adds regression coverage for statistics, labels, tooltips, and filters. Addresses the box-plot portion of #43547.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: NULL groups disappear; an all-NULL grouping column shows no results.

![Before](https://github.com/user-attachments/assets/a51b10b5-57b3-4ea8-b8b5-0a40f2485821)

After: the missing boxes and their statistics appear with `<NULL>` labels.

![After](https://github.com/user-attachments/assets/d4d6b74a-553b-4130-a089-bf1e30b722b8)

### TESTING INSTRUCTIONS

Create a box plot with mixed NULL/non-NULL groups. Repeat with all groups NULL, two grouping columns, and each whisker mode.

Passed: 151 backend tests, 15 box-plot frontend tests, pre-commit (mypy and TypeScript included), and the production docs build. Nine live chart API cases and browser rendering passed with the exact changed backend module in an existing ARM64 Superset image.

### ADDITIONAL INFORMATION

- [x] Has associated issue: #43547 (box plots only)
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
