### PR TITLE
fix(ci): skip Showtime jobs for unrelated PR events

### DIFF
--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -1,6 +1,6 @@
 name: 🎪 Superset Showtime
 
-# Ultra-simple: just sync on any PR state change
+# Sync on Showtime label changes and updates to PRs using Showtime.
 on:
   # zizmor: ignore[dangerous-triggers] - required to react to PR label changes; PR code is
   # only checked out and built after the maintainer-authorization gate (write/admin actors)
@@ -32,6 +32,15 @@ permissions:
 jobs:
   sync:
     name: 🎪 Sync PR to desired state
+    # Inspect the changed label so removing the last Showtime label still syncs.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.label.name, '🎪 ') ||
+      (
+        (github.event.action == 'synchronize' ||
+         github.event.action == 'closed') &&
+        contains(join(github.event.pull_request.labels.*.name, ','), '🎪 ')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 90
 

--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -39,7 +39,7 @@ jobs:
       (
         (github.event.action == 'synchronize' ||
          github.event.action == 'closed') &&
-        contains(join(github.event.pull_request.labels.*.name, ','), '🎪 ')
+        contains(toJson(github.event.pull_request.labels.*.name), '"🎪 ')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 90


### PR DESCRIPTION
### SUMMARY

Skip the Showtime sync job for unrelated PR label changes and for pushes or closures on PRs without Showtime labels. The workflow still appears as skipped, but does not allocate a runner for these events.

Continue syncing when a Showtime label is added or removed, including removal of the last label, and when a PR with Showtime labels is updated or closed. Manual dispatch and the existing maintainer authorization checks are preserved.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable; GitHub Actions workflow only.

### TESTING INSTRUCTIONS

Validation completed: `pre-commit run` and `git diff --cached --check` passed. Live GitHub event execution has not been tested; `pull_request_target` uses the base workflow.

After the workflow is available on the base branch:
1. Push to or close a PR without Showtime labels: the sync job should be skipped.
2. Add or remove an unrelated label, including on a PR using Showtime: the sync job should be skipped.
3. As a maintainer, add or remove Showtime start, stop, freeze, or blocked labels: the job should run, including when the removed label was the last Showtime label.
4. Push to or close a PR with a Showtime label: the job should run through the existing authorization gate.
5. Manually dispatch the workflow with a PR number: the job should run.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
