### PR TITLE
fix(docker): stop CI startup when initialization fails

### DIFF
--- a/docker/entrypoints/docker-ci.sh
+++ b/docker/entrypoints/docker-ci.sh
@@ -15,12 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e
+
 /app/docker/docker-init.sh
 
 # TODO: copy config overrides from ENV vars
 
 # TODO: run celery in detached state
-export SERVER_THREADS_AMOUNT=8
+export SERVER_THREADS_AMOUNT="${SERVER_THREADS_AMOUNT:-8}"
 # start up the web server
 
-/app/docker/entrypoints/run-server.sh
+exec /app/docker/entrypoints/run-server.sh

--- a/docs/admin_docs/installation/docker-builds.mdx
+++ b/docs/admin_docs/installation/docker-builds.mdx
@@ -45,6 +45,12 @@ Here are the build presets that are exposed through the `supersetbot docker` uti
 - `websocket`: For Superset clusters supporting advanced features.
 - `dockerize`: Used by Helm in initContainers to wait for database dependencies to be available.
 
+The `ci` and `showtime` Docker targets share an entrypoint that runs container
+initialization before starting the server and stops if initialization exits with
+a nonzero status. `SERVER_THREADS_AMOUNT` defaults to `8` when unset or empty, while an
+explicit value is preserved. The server then replaces the entrypoint process so
+it receives signals directly and its exit status becomes the container status.
+
 ## Key tags examples
 
 - `latest`: The latest official release build

--- a/tests/unit_tests/docker_ci_entrypoint_test.py
+++ b/tests/unit_tests/docker_ci_entrypoint_test.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Behavioral tests for the CI Docker entrypoint."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _write_executable(path: Path, body: str) -> None:
+    """Write an executable Bash stub at ``path``."""
+    path.write_text(f"#!/usr/bin/env bash\n{body}", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _prepare_entrypoint(tmp_path: Path, init_body: str, server_body: str) -> Path:
+    """Create disposable stubs and relocate only the entrypoint's app paths."""
+    repository_root = Path(__file__).resolve().parents[2]
+    source = repository_root / "docker/entrypoints/docker-ci.sh"
+    docker_root = tmp_path / "app/docker"
+    entrypoints = docker_root / "entrypoints"
+    entrypoints.mkdir(parents=True)
+    _write_executable(docker_root / "docker-init.sh", init_body)
+    _write_executable(entrypoints / "run-server.sh", server_body)
+
+    relocated = tmp_path / "docker-ci.sh"
+    relocated.write_text(
+        source.read_text(encoding="utf-8").replace("/app/docker", str(docker_root)),
+        encoding="utf-8",
+    )
+    return relocated
+
+
+def _entrypoint_environment() -> dict[str, str]:
+    """Return a clean environment with no inherited server thread setting."""
+    environment = os.environ.copy()
+    environment.pop("SERVER_THREADS_AMOUNT", None)
+    return environment
+
+
+def test_init_failure_preserves_status_and_prevents_server_start(
+    tmp_path: Path,
+) -> None:
+    """A failed initialization stops startup and remains the container status."""
+    events = tmp_path / "events"
+    entrypoint = _prepare_entrypoint(
+        tmp_path,
+        'printf "init\\n" >> "${EVENTS_FILE}"\nexit 37\n',
+        'printf "server\\n" >> "${EVENTS_FILE}"\n',
+    )
+    environment = _entrypoint_environment()
+    environment["EVENTS_FILE"] = str(events)
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(entrypoint)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 37, result.stderr
+    assert events.read_text(encoding="utf-8").splitlines() == ["init"]
+
+
+@pytest.mark.parametrize(
+    "thread_value, expected",
+    [(None, "8"), ("23", "23"), ("", "8")],
+    ids=["default", "custom", "empty"],
+)
+def test_successful_startup_orders_init_before_server_and_sets_threads(
+    tmp_path: Path,
+    thread_value: str | None,
+    expected: str,
+) -> None:
+    """Successful startup runs in order with default or supplied thread counts."""
+    events = tmp_path / "events"
+    entrypoint = _prepare_entrypoint(
+        tmp_path,
+        'printf "init\\n" >> "${EVENTS_FILE}"\n',
+        'printf "server:%s\\n" "${SERVER_THREADS_AMOUNT}" >> "${EVENTS_FILE}"\n',
+    )
+    environment = _entrypoint_environment()
+    environment["EVENTS_FILE"] = str(events)
+    if thread_value is not None:
+        environment["SERVER_THREADS_AMOUNT"] = thread_value
+
+    result = subprocess.run(  # noqa: S603
+        ["/bin/bash", str(entrypoint)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert events.read_text(encoding="utf-8").splitlines() == [
+        "init",
+        f"server:{expected}",
+    ]
+
+
+def test_server_replaces_entrypoint_process_and_preserves_status(
+    tmp_path: Path,
+) -> None:
+    """The server inherits the entrypoint PID and its exit status is returned."""
+    server_pid = tmp_path / "server-pid"
+    entrypoint = _prepare_entrypoint(
+        tmp_path,
+        "exit 0\n",
+        'printf "%s\\n" "$$" > "${SERVER_PID_FILE}"\nexit 42\n',
+    )
+    environment = _entrypoint_environment()
+    environment["SERVER_PID_FILE"] = str(server_pid)
+
+    process = subprocess.Popen(  # noqa: S603
+        ["/bin/bash", str(entrypoint)],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 42, f"stdout={stdout}\nstderr={stderr}"
+    assert int(server_pid.read_text(encoding="utf-8")) == process.pid


### PR DESCRIPTION
### SUMMARY

The shared CI/Showtime entrypoint starts the server even when initialization exits nonzero. Stop startup on that failure, preserve explicit `SERVER_THREADS_AMOUNT` values with an eight-thread default, and use `exec` to hand the entrypoint process to the server.

Includes behavioral regression tests and Docker documentation.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No UI changes. Before: failed initialization could still launch the server, thread overrides were discarded, and an outer shell remained. After: initialization failure stops startup, overrides are honored, and the server inherits the entrypoint PID.

### TESTING INSTRUCTIONS

Run the isolated shell-process regression tests (no running Superset or database required):

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --noconftest -o addopts='' -p no:cacheprovider tests/unit_tests/docker_ci_entrypoint_test.py
bash -n docker/entrypoints/docker-ci.sh
```

- All five cases pass: initialization failure propagation, startup order, default/custom/empty thread values, process handoff, and server exit status. Three cases fail against the original script.
- Staged `pre-commit run` passes, including mypy and Ruff.
- Independent review found no issues.
- Full Docker/ECS deployment was not run. This fixes confirmed entrypoint defects; it does not establish the cause of the observed AWS health-check failure.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
