### PR TITLE
docs(config): document AFTER_ASSET_CREATE hook

### DIFF
--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -606,6 +606,28 @@ def FLASK_APP_MUTATOR(app: Flask) -> None:
     app.before_request_funcs.setdefault(None, []).append(make_session_permanent)
 ```
 
+## Reacting to chart and dashboard creation
+
+`AFTER_ASSET_CREATE` is an optional hook that runs after a chart or dashboard
+is created, letting deployments react to new assets without forking the
+creation commands or views — for example to auto-categorize the asset, write
+an audit log entry, or fire a notification.
+
+The hook receives the model instance and the asset type string (`"chart"` or
+`"dashboard"`):
+
+```python
+# superset_config.py
+def _after_asset_create(model, asset_type):
+    audit_log.write(f"{asset_type} {model.id} created by {model.created_by}")
+
+
+AFTER_ASSET_CREATE = _after_asset_create
+```
+
+It defaults to `None`, which is a no-op: with nothing configured, chart and
+dashboard creation behaves exactly as it did before this hook existed.
+
 ## Carrying extra data through chart and dashboard exports
 
 Deployments often attach their own metadata to charts and dashboards — an owning

--- a/docs/admin_docs/configuration/configuring-superset.mdx
+++ b/docs/admin_docs/configuration/configuring-superset.mdx
@@ -628,6 +628,11 @@ AFTER_ASSET_CREATE = _after_asset_create
 It defaults to `None`, which is a no-op: with nothing configured, chart and
 dashboard creation behaves exactly as it did before this hook existed.
 
+The hook runs before the surrounding database transaction commits, so an
+exception raised inside it aborts the chart or dashboard creation. Keep it
+fast and side-effect-light, and avoid raising unless you intend to cancel
+the creation.
+
 ## Carrying extra data through chart and dashboard exports
 
 Deployments often attach their own metadata to charts and dashboards — an owning


### PR DESCRIPTION
### SUMMARY
`AFTER_ASSET_CREATE` (added in #40707, wired into the legacy dashboard-creation view in #42837) was never documented in the config reference. This adds a section covering its signature and no-op-by-default behavior, matching the style of the neighboring chart/dashboard extension hook docs.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs only.

### TESTING INSTRUCTIONS
Read the new "Reacting to chart and dashboard creation" section in `docs/admin_docs/configuration/configuring-superset.mdx`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs for #42837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)