### PR TITLE
docs(pivot-table): document the "Show values as" percentage display option

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -165,6 +165,16 @@ control can override a simple metric's own aggregation (to Sum or Average) for t
 only — metrics built from custom SQL keep their own aggregation regardless.
 :::
 
+In the **Options** panel, the **Show values as** control displays each cell as a percentage of its
+row total, column total, or grand total instead of its actual value:
+
+:::note
+Totals and subtotals are still computed correctly first, as described above; **Show values as**
+only changes how the already-correct cell, row-total, column-total, and grand-total values are
+displayed. Because the result is always a percentage, a per-metric custom formatter (currency,
+decimal precision, etc.) doesn't apply while a fraction option is selected.
+:::
+
 ### Line Chart
 
 In this section, we are going to create a line chart to understand the average price of a ticket by

--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -171,8 +171,11 @@ row total, column total, or grand total instead of its actual value:
 :::note
 Totals and subtotals are still computed correctly first, as described above; **Show values as**
 only changes how the already-correct cell, row-total, column-total, and grand-total values are
-displayed. Because the result is always a percentage, a per-metric custom formatter (currency,
-decimal precision, etc.) doesn't apply while a fraction option is selected.
+displayed, not how they're calculated. Switching it does re-run the query, though: for non-additive
+metrics, a percentage option can pull in an additional rollup level for its denominator even when
+the matching Total row/column isn't shown. Because the result is always a percentage, a per-metric
+custom formatter (currency, decimal precision, etc.) doesn't apply while a fraction option is
+selected.
 :::
 
 ### Line Chart


### PR DESCRIPTION
### SUMMARY
#42761 reintroduced a Pivot Table **"Show values as"** control (Options panel) that displays each cell as a percentage of its row, column, or grand total, but only documented the change in `UPDATING.md`. The exploring-data tutorial's Pivot Table note (added for the related totals/subtotals fix) never mentioned this option. This adds a short note covering it, matching the style of the existing note in the same section.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, docs-only change.

### TESTING INSTRUCTIONS
Read `docs/docs/using-superset/exploring-data.mdx`, Pivot Table section, and confirm the new note renders correctly (`npm run start` under `docs/` if you want to preview).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Follow-up docs for #42761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)