### PR TITLE
docs(explore): document the Line chart Percent change control

### DIFF
--- a/docs/docs/using-superset/exploring-data.mdx
+++ b/docs/docs/using-superset/exploring-data.mdx
@@ -194,6 +194,12 @@ and Y Axis Label.
 
 <img src={useBaseUrl('/img/tutorial/tutorial_line_chart.png')} />
 
+The Chart Options section of the Customize tab also has a **Percent change** checkbox. Enabling it
+rebases every series to its percent change from a baseline point, the same interactive view the
+legacy nvd3 Time-series Percent Change chart provided. Once it's on, a vertical baseline appears on
+the chart; drag it to any other point to re-index all series against that new baseline without
+re-running the query.
+
 Once you’re done, publish the chart in your Tutorial Dashboard.
 
 ### Markup


### PR DESCRIPTION
### SUMMARY
#42247 added a **Percent change** checkbox to the Line chart's Chart Options (Customize tab), which rebases every series to its percent change from a baseline point and adds a draggable vertical baseline to re-index the view client-side — restoring the interactive behavior of the deprecated nvd3 Time-series Percent Change chart. This wasn't covered anywhere in the docs, so this adds a short paragraph to the existing Line Chart tutorial section, right where the Customize tab is already introduced.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A, text-only addition to an existing tutorial page.

### TESTING INSTRUCTIONS
- Read `docs/docs/using-superset/exploring-data.mdx`, "Line Chart" section, and confirm the new paragraph reads naturally after the Customize tab paragraph.
- `pre-commit run --files docs/docs/using-superset/exploring-data.mdx` passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related to #42247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)