### PR TITLE
docs(mcp): document semantic-layer MCP tools

### DIFF
--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -736,6 +736,7 @@ Each tool declares one or more required FAB permissions. The table below maps to
 | `list_charts`, `get_chart_info`, `get_chart_data`, `get_chart_preview`, `generate_chart`, `update_chart` | `can_read` on `Chart` (read), `can_write` on `Chart` (mutate)         |
 | `list_dashboards`, `get_dashboard_info`, `generate_dashboard`, `add_chart_to_existing_dashboard`         | `can_read` on `Dashboard` (read), `can_write` on `Dashboard` (mutate) |
 | `list_datasets`, `get_dataset_info`, `create_virtual_dataset`                                            | `can_read` on `Dataset` (read), `can_write` on `Dataset` (mutate)     |
+| `list_metrics`, `get_table`, `get_compatible_dimensions`, `get_compatible_metrics`                        | `can_read` on `Dataset`                                               |
 | `list_databases`, `get_database_info`                                                                    | `can_read` on `Database`                                              |
 | `execute_sql`                                                                                            | `can_execute_sql_query` on `SQLLab`                                   |
 | `open_sql_lab_with_context`                                                                              | `can_read` on `SQLLab`                                                |

--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -736,7 +736,7 @@ Each tool declares one or more required FAB permissions. The table below maps to
 | `list_charts`, `get_chart_info`, `get_chart_data`, `get_chart_preview`, `generate_chart`, `update_chart` | `can_read` on `Chart` (read), `can_write` on `Chart` (mutate)         |
 | `list_dashboards`, `get_dashboard_info`, `generate_dashboard`, `add_chart_to_existing_dashboard`         | `can_read` on `Dashboard` (read), `can_write` on `Dashboard` (mutate) |
 | `list_datasets`, `get_dataset_info`, `create_virtual_dataset`                                            | `can_read` on `Dataset` (read), `can_write` on `Dataset` (mutate)     |
-| `list_metrics`, `get_table`, `get_compatible_dimensions`, `get_compatible_metrics`                        | `can_read` on `Dataset`                                               |
+| `list_metrics`, `get_table`, `get_compatible_dimensions`, `get_compatible_metrics`                        | `can_read` on `Dataset`, plus a data-model metadata permission (`can_get_drill_info`, `can_get_or_create_dataset`, or `can_write` on `Dataset`); external semantic views also enforce their own datasource access check |
 | `list_databases`, `get_database_info`                                                                    | `can_read` on `Database`                                              |
 | `execute_sql`                                                                                            | `can_execute_sql_query` on `SQLLab`                                   |
 | `open_sql_lab_with_context`                                                                              | `can_read` on `SQLLab`                                                |

--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -126,6 +126,32 @@ Build ad-hoc SQL datasets that can be used as the basis for charts:
 > "Create a dataset from: SELECT region, SUM(revenue) as total_revenue FROM orders GROUP BY region"
 > "Make a virtual dataset called 'monthly_signups' from the users table filtered to last 12 months"
 
+### Query the Semantic Layer
+
+Discover and query metrics across both built-in datasets and external semantic
+views (when your deployment has semantic views registered), without writing SQL:
+
+- **Discover metrics** -- search metrics by name or description across every dataset and semantic view you can access, with each metric's compatible dimensions included
+- **Query by metric and dimension** -- get tabular results by naming metrics and dimensions instead of writing SQL, with optional filters and time ranges
+- **Progressively refine a query** -- given metrics and/or dimensions already picked, find the ones that can still be added without breaking the query
+
+**Example prompts:**
+
+> "What metrics are available related to revenue?"
+> "Show me revenue by region for the last 30 days"
+> "I've picked the revenue metric -- what dimensions can I break it down by?"
+
+:::tip Recommended workflow
+1. **`list_metrics`** -- search for a metric; note its `dataset_id` (built-in) or `view_id` (external semantic view)
+2. **`get_table`** -- pass that `dataset_id`/`view_id` along with metric and dimension names to get results
+3. **`get_compatible_dimensions`** / **`get_compatible_metrics`** -- as the user adds selections, check what else can validly be combined
+
+Built-in datasets accept any combination of saved metrics and groupby-enabled
+columns since a SQL `GROUP BY` has no metric-level constraints. External
+semantic views can impose additional compatibility rules, which these tools
+surface instead of failing the query outright.
+:::
+
 ### Run SQL Queries
 
 Execute SQL directly through your AI assistant:
@@ -266,6 +292,15 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `get_dataset_info`       | Get dataset metadata (columns, metrics, schema details)                                                                      |
 | `create_virtual_dataset` | Create a virtual dataset from a SQL query                                                                                    |
 | `update_dataset_metric`  | Update a saved metric's expression, name, verbose_name, or format (affects every chart using it; requires dataset ownership) |
+
+### Semantic Layer
+
+| Tool                         | Description                                                                                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `list_metrics`                | Discover metrics by name/description across built-in datasets and external semantic views, with compatible dimensions included    |
+| `get_table`                   | Query a dataset or semantic view by metric and dimension names, with optional filters, time range, and sorting                    |
+| `get_compatible_dimensions`   | Given metrics/dimensions already selected, return the dimensions that can still be added                                          |
+| `get_compatible_metrics`      | Given metrics/dimensions already selected, return the metrics that can still be added                                             |
 
 ### Charts
 


### PR DESCRIPTION
### SUMMARY
#41611 shipped four new MCP tools (`list_metrics`, `get_table`, `get_compatible_dimensions`, `get_compatible_metrics`) forming the recommended semantic-layer query workflow across built-in datasets and external semantic views, but landed with no user-facing or admin documentation.

This adds:
- A "Query the Semantic Layer" workflow section (with example prompts and a recommended-workflow callout) to the end-user AI docs
- A "Semantic Layer" tool reference table alongside the existing Datasets/Charts/etc. tables
- The RBAC permission row for these tools in the admin MCP server configuration guide

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A -- docs only

### TESTING INSTRUCTIONS
1. Build/preview the docs site (or just read the rendered `.mdx`) and confirm the new "Query the Semantic Layer" section renders under `docs/docs/using-superset/using-ai-with-superset.mdx`
2. Confirm the new "Semantic Layer" table appears in the "Available Tools Reference" section
3. Confirm the new RBAC row appears in `docs/admin_docs/configuration/mcp-server.mdx`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

Related: #41611

🤖 Generated with [Claude Code](https://claude.com/claude-code)