### PR TITLE
chore(ci): use self-repository syntax for local action references

### DIFF
--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -40,7 +40,7 @@ jobs:
           ref: master
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/check-openapi-spec-drift.yml
+++ b/.github/workflows/check-openapi-spec-drift.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           # The generated output depends on the pinned apispec version.
           requirements-type: base

--- a/.github/workflows/check-python-deps.yml
+++ b/.github/workflows/check-python-deps.yml
@@ -35,13 +35,13 @@ jobs:
 
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         if: steps.check.outputs.python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
 
       # Authenticate the Docker daemon so the python:slim pull in
       # uv-pip-compile.sh uses our (much higher) authenticated rate limit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           requirements-type: base
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -68,7 +68,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
       - name: Assert PY_VER override applies to every preset except py311/py312
         shell: bash
         env:
@@ -147,14 +147,14 @@ jobs:
           echo "Disk after cleanup:"; df -h /
 
       - name: Setup Docker Environment
-        uses: ./.github/actions/setup-docker
+        uses: $/.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           build: "true"
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
 
       - name: Build Docker Image
         shell: bash
@@ -314,7 +314,7 @@ jobs:
             /usr/local/share/boost || true
           echo "Disk after cleanup:"; df -h /
       - name: Setup Docker Environment
-        uses: ./.github/actions/setup-docker
+        uses: $/.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/enforce-single-migration-head.yml
+++ b/.github/workflows/enforce-single-migration-head.yml
@@ -66,7 +66,7 @@ jobs:
             core.setOutput('changed', String(changed));
       - name: Setup Python
         if: steps.check.outputs.changed == 'true'
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           requirements-type: base
       - name: Assert a single Alembic head

--- a/.github/workflows/issue-creation.yml
+++ b/.github/workflows/issue-creation.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup supersetbot
-        uses: ./.github/actions/setup-supersetbot/
+        uses: $/.github/actions/setup-supersetbot/
 
       - name: Execute supersetbot orglabel command
         env:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: ./.github/actions/pr-lint-action
+      - uses: $/.github/actions/pr-lint-action
         with:
           title-regex: "^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)(\\(.+\\))?(\\!)?:\\s.+"
           on-failed-regex-fail-action: true

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -34,7 +34,13 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: $/.github/actions/pr-lint-action
+      # pr-lint-action is a submodule (not a plain directory), and the $/
+      # self-repository syntax resolves action files directly from the
+      # repository without performing a real (submodule-aware) checkout, so
+      # it can't see into a submodule's link. Keep this one on the
+      # workspace-relative ./ form, consistent with every other workflow in
+      # the repo that references a submodule action.
+      - uses: ./.github/actions/pr-lint-action # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           title-regex: "^(build|chore|ci|docs|feat|fix|perf|refactor|style|test|other)(\\(.+\\))?(\\!)?:\\s.+"
           on-failed-regex-fail-action: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/scheduled-docker-image-refresh.yml
+++ b/.github/workflows/scheduled-docker-image-refresh.yml
@@ -118,8 +118,13 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/actions
 
+      # This action lives under a second, sparse checkout of this same repo
+      # into workflow-source/ (see above), not at the repository root, so
+      # the $/ self-repository syntax (which resolves paths against the
+      # repository itself, not the local workspace) can't reach it. The
+      # workspace-relative ./ form is required here.
       - name: Setup Docker Environment
-        uses: $/workflow-source/.github/actions/setup-docker
+        uses: ./workflow-source/.github/actions/setup-docker # zizmor: ignore[self-repository] - path is a local sparse checkout under workflow-source/, not the repo root; ./ is required here
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -131,8 +136,11 @@ jobs:
         with:
           node-version: 20
 
+      # Same reasoning as the Setup Docker Environment step above: this
+      # path is under the local workflow-source/ sparse checkout, not the
+      # repository root, so $/ can't resolve it.
       - name: Setup supersetbot
-        uses: $/workflow-source/.github/actions/setup-supersetbot/
+        uses: ./workflow-source/.github/actions/setup-supersetbot/ # zizmor: ignore[self-repository] - path is a local sparse checkout under workflow-source/, not the repo root; ./ is required here
 
       - name: Rebuild and push
         env:

--- a/.github/workflows/scheduled-docker-image-refresh.yml
+++ b/.github/workflows/scheduled-docker-image-refresh.yml
@@ -119,7 +119,7 @@ jobs:
           sparse-checkout: .github/actions
 
       - name: Setup Docker Environment
-        uses: ./workflow-source/.github/actions/setup-docker
+        uses: $/workflow-source/.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -132,7 +132,7 @@ jobs:
           node-version: 20
 
       - name: Setup supersetbot
-        uses: ./workflow-source/.github/actions/setup-supersetbot/
+        uses: $/workflow-source/.github/actions/setup-supersetbot/
 
       - name: Rebuild and push
         env:

--- a/.github/workflows/showtime-trigger.yml
+++ b/.github/workflows/showtime-trigger.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Setup Docker Environment (only if build needed)
         if: steps.auth.outputs.authorized == 'true' && steps.check.outputs.build_needed == 'true'
-        uses: ./.github/actions/setup-docker
+        uses: $/.github/actions/setup-docker
         with:
           dockerhub-user: ${{ secrets.DOCKERHUB_USER }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/superset-app-cli.yml
+++ b/.github/workflows/superset-app-cli.yml
@@ -60,7 +60,13 @@ jobs:
         uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
         if: steps.check.outputs.python
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-postgres
       - name: superset init

--- a/.github/workflows/superset-app-cli.yml
+++ b/.github/workflows/superset-app-cli.yml
@@ -52,15 +52,15 @@ jobs:
           submodules: recursive
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Python
         if: steps.check.outputs.python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup Postgres
         if: steps.check.outputs.python
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: superset init

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -190,7 +190,14 @@ jobs:
         run: .github/workflows/scripts/check-docs-deploy-freshness.sh
       - name: deploy docs
         if: github.event_name == 'workflow_dispatch' || steps.recheck-freshness.outputs.still-current == 'true'
-        uses: $/.github/actions/github-action-push-to-another-repository
+        # github-action-push-to-another-repository is a submodule (not a
+        # plain directory), and the $/ self-repository syntax resolves
+        # action files directly from the repository without performing a
+        # real (submodule-aware) checkout, so it can't see into a
+        # submodule's link. Keep this one on the workspace-relative ./
+        # form, consistent with every other workflow in the repo that
+        # references a submodule action.
+        uses: ./.github/actions/github-action-push-to-another-repository # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         env:
           API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
         with:

--- a/.github/workflows/superset-docs-deploy.yml
+++ b/.github/workflows/superset-docs-deploy.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           node-version-file: "./docs/.nvmrc"
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: "zulu"
@@ -190,7 +190,7 @@ jobs:
         run: .github/workflows/scripts/check-docs-deploy-freshness.sh
       - name: deploy docs
         if: github.event_name == 'workflow_dispatch' || steps.recheck-freshness.outputs.still-current == 'true'
-        uses: ./.github/actions/github-action-push-to-another-repository
+        uses: $/.github/actions/github-action-push-to-another-repository
         env:
           API_TOKEN_GITHUB: ${{ secrets.SUPERSET_SITE_BUILD }}
         with:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -116,11 +116,23 @@ jobs:
       - name: Setup Python
         uses: $/.github/actions/setup-backend/
       - name: Setup postgres
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-postgres
       - name: Import test data
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: testdata
       - name: Setup Node.js
@@ -130,19 +142,43 @@ jobs:
           cache: "npm"
           cache-dependency-path: "superset-frontend/package-lock.json"
       - name: Install npm dependencies
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: npm-install
       - name: Build javascript packages
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: build-instrumented-assets
       - name: Install cypress
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: cypress-install
       - name: Run Cypress
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -230,11 +266,23 @@ jobs:
       - name: Setup Python
         uses: $/.github/actions/setup-backend/
       - name: Setup postgres
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: setup-postgres
       - name: Import test data
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: playwright_testdata
       - name: Setup Node.js
@@ -244,29 +292,65 @@ jobs:
           cache: "npm"
           cache-dependency-path: "superset-frontend/package-lock.json"
       - name: Install npm dependencies
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: npm-install
       - name: Build javascript packages
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: build-instrumented-assets
       - name: Build embedded SDK
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: build-embedded-sdk
       - name: Install Playwright
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         with:
           run: playwright-install
       - name: Run Playwright (Required Tests)
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}"
       - name: Run Playwright (Soft-delete Tests)
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           # Scoped to this step: each playwright-run boots its own gunicorn
@@ -281,7 +365,13 @@ jobs:
         with:
           run: playwright-run "${{ matrix.app_root }}" recently-archived/
       - name: Run Playwright (Embedded Tests)
-        uses: $/.github/actions/cached-dependencies
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           # Scoped to this step for the same reason as Soft-delete above:

--- a/.github/workflows/superset-e2e.yml
+++ b/.github/workflows/superset-e2e.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -114,13 +114,13 @@ jobs:
           submodules: recursive
       # -------------------------------------------------------
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup postgres
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: testdata
       - name: Setup Node.js
@@ -130,19 +130,19 @@ jobs:
           cache: "npm"
           cache-dependency-path: "superset-frontend/package-lock.json"
       - name: Install npm dependencies
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Install cypress
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: cypress-install
       - name: Run Cypress
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         env:
           CYPRESS_BROWSER: ${{ matrix.browser }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -228,13 +228,13 @@ jobs:
           submodules: recursive
       # -------------------------------------------------------
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
       - name: Setup postgres
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: setup-postgres
       - name: Import test data
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: playwright_testdata
       - name: Setup Node.js
@@ -244,29 +244,29 @@ jobs:
           cache: "npm"
           cache-dependency-path: "superset-frontend/package-lock.json"
       - name: Install npm dependencies
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: npm-install
       - name: Build javascript packages
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: build-instrumented-assets
       - name: Build embedded SDK
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: build-embedded-sdk
       - name: Install Playwright
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         with:
           run: playwright-install
       - name: Run Playwright (Required Tests)
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}"
       - name: Run Playwright (Soft-delete Tests)
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           # Scoped to this step: each playwright-run boots its own gunicorn
@@ -281,7 +281,7 @@ jobs:
         with:
           run: playwright-run "${{ matrix.app_root }}" recently-archived/
       - name: Run Playwright (Embedded Tests)
-        uses: ./.github/actions/cached-dependencies
+        uses: $/.github/actions/cached-dependencies
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
           # Scoped to this step for the same reason as Soft-delete above:

--- a/.github/workflows/superset-extensions-cli.yml
+++ b/.github/workflows/superset-extensions-cli.yml
@@ -39,13 +39,13 @@ jobs:
 
       - name: Check for file changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         if: steps.check.outputs.superset-extensions-cli
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
           requirements-type: dev

--- a/.github/workflows/superset-frontend.yml
+++ b/.github/workflows/superset-frontend.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check for File Changes
         id: check
-        uses: ./.github/actions/change-detector/
+        uses: $/.github/actions/change-detector/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -48,8 +48,14 @@ jobs:
       # astral-sh/setup-uv@v7.0.0, which isn't itself on the ASF Actions
       # allowlist (only v8.1.0+ are, at apache/infrastructure-actions'
       # actions.yml). Needs an INFRA request before this can de-vendor too.
+      # chart-testing-action is a submodule (not a plain directory), and the
+      # $/ self-repository syntax resolves action files directly from the
+      # repository without performing a real (submodule-aware) checkout, so
+      # it can't see into a submodule's link. Keep this one on the
+      # workspace-relative ./ form, consistent with every other workflow in
+      # the repo that references a submodule action.
       - name: Set up chart-testing
-        uses: $/.github/actions/chart-testing-action
+        uses: ./.github/actions/chart-testing-action # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/superset-helm-lint-test.yml
+++ b/.github/workflows/superset-helm-lint-test.yml
@@ -39,7 +39,7 @@ jobs:
           version: v3.21.3
 
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           install-superset: "false"
 
@@ -49,7 +49,7 @@ jobs:
       # allowlist (only v8.1.0+ are, at apache/infrastructure-actions'
       # actions.yml). Needs an INFRA request before this can de-vendor too.
       - name: Set up chart-testing
-        uses: ./.github/actions/chart-testing-action
+        uses: $/.github/actions/chart-testing-action
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/testcontainers.yml
+++ b/.github/workflows/testcontainers.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: ./.github/actions/setup-backend/
+        uses: $/.github/actions/setup-backend/
         with:
           python-version: current
       - name: Install db2 driver (ibm-db-sa)


### PR DESCRIPTION
### SUMMARY
Mechanical cleanup, `zizmor --fix=all` across `.github/workflows/*.yml`: replaces `./.github/actions/...` with `$/.github/actions/...` for local composite-action references that still used the older relative-path form. Every instance zizmor's `self-repository` audit flags has an auto-fix; this applies all of them in one pass rather than one at a time.

One file (`scheduled-docker-image-refresh.yml`) references a second, sparse checkout of this same repo into a `workflow-source/` subdirectory (to get fresh `.github/actions` even when the primary checkout is pinned to an older release tag). `$/workflow-source/...` resolves the same way `./workflow-source/...` did — both are `GITHUB_WORKSPACE`-relative — so this is a like-for-like swap there too, not just in the common case.

### TESTING INSTRUCTIONS
- `action-validator` passes on every changed file.
- A full `zizmor .github/workflows/*.yml` re-scan reports **zero findings** (down from 47, all `self-repository`).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API