### PR TITLE
feat(mcp): improve dataset discovery and add role-based routing scope

### DIFF
--- a/docs/admin_docs/configuration/mcp-server.mdx
+++ b/docs/admin_docs/configuration/mcp-server.mdx
@@ -1038,3 +1038,61 @@ boundaries are not labeled UTC: dataset timezone or legacy hour-offset settings
 can adjust the SQL comparisons. Use the applied filters and datasource settings
 as well when explaining such queries. `query_dataset.applied_filters` retains the
 original expressions so callers can compare the requested and resolved ranges.
+
+## Dataset discovery and routing
+
+`list_datasets` searches schema, SQL, table name, UUID, and **description** using
+escaped, case-insensitive substring matching. Write descriptions with business
+terminology to make differently named datasets discoverable. Matching datasets
+are candidates, ordered by the requested sort (last modified by default), not
+ranked recommendations. Compare descriptions and metrics, present alternatives
+when ambiguous, and clarify before querying. No matches does not prove that data
+does not exist; search only covers accessible datasets and the configured scope.
+
+`query_dataset` returns `dataset_id` and `dataset_name`; `get_table` additionally
+returns `source` and the corresponding dataset or external-view identity. Cite
+these fields in answers rather than guessing the source from the query text.
+Neither tool selects an alternative dataset automatically.
+
+### Optional per-role dataset scope
+
+Set `MCP_DATASET_ROLE_ALLOWLIST` in `superset_config.py` to constrain MCP to a
+curated set of registered datasets:
+
+```python
+MCP_DATASET_ROLE_ALLOWLIST = {
+    "Finance Readers": ["00000000-0000-0000-0000-000000000001"],
+    "Operations Readers": ["00000000-0000-0000-0000-000000000002"],
+}
+```
+
+Obtain dataset UUIDs from `get_dataset_info` (or request `uuid` in
+`list_datasets.select_columns`). Use UUIDs, not names or numeric IDs, in config.
+Effective roles, including group roles, contribute the **union** of their lists.
+That union is **intersected with existing dataset access**. Unconfigured roles
+contribute nothing; Admin has no routing exemption. `None` (the default) disables
+this feature; `{}` allows no datasets. Invalid entries cause a configuration
+error on tool calls rather than silently disabling the restriction.
+
+Scoped mode supports `list_datasets`, `get_dataset_info`, `query_dataset`, and
+`get_table` with a built-in dataset, plus `health_check` and `get_schema`.
+Discovery filters before counting and pagination. Other tools refuse in this
+mode, including SQL Lab, chart/dashboard previews and data, cached query results,
+external semantic sources, mutations, and extension tools. These paths cannot
+all be attributed reliably to registered dataset UUIDs; scoped mode deliberately
+refuses them instead of attempting SQL lineage inference. Use dataset tools for
+scoped conversations. This restriction applies to every caller of the MCP tools,
+not just a particular chat client.
+
+An out-of-scope request returns an explicit refusal. The assistant must explain
+that limitation, never silently substitute an allowed but different dataset.
+This feature controls routing and usability, **not authorization or SQL table
+access**. Existing dataset permissions, query validation, and row-level security
+remain mandatory and unchanged. A registered virtual dataset may itself query
+multiple physical tables; this configuration selects registered dataset objects,
+not their underlying SQL dependencies. It does not restrict the Superset UI/API.
+
+Description search adds one text predicate to an existing catalog substring
+scan, without joins or additional queries. It is not an indexed full-text search:
+large catalogs and long descriptions can increase scan time. Benchmark with your
+metadata database and catalog size when tuning discovery latency.

--- a/superset/mcp_service/app.py
+++ b/superset/mcp_service/app.py
@@ -173,6 +173,13 @@ Alerts & Reports:
 - list_reports: List alerts and reports with filtering and search (1-based pagination)
 - get_report_info: Get detailed alert/report schedule info by ID
 
+Dataset discovery and attribution:
+- Search includes dataset descriptions; returned matches are candidates, not ranked recommendations.
+- Compare candidate descriptions and metrics. If the choice is ambiguous, show the candidate dataset IDs/names and clarify before querying.
+- Cite the dataset_id/dataset_name or source identity returned by query_dataset/get_table in answers.
+- No matches does not mean the data does not exist. State the search/scope limitation.
+- If a dataset or operation is outside the configured MCP dataset scope, refuse plainly. Never silently substitute an allowed-but-different dataset.
+
 Dataset Management:
 - list_datasets: List datasets with advanced filters (1-based pagination)
 - get_dataset_info: Get detailed dataset information by ID (includes columns/metrics)

--- a/superset/mcp_service/auth.py
+++ b/superset/mcp_service/auth.py
@@ -1189,6 +1189,8 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
     import inspect
     import types
 
+    from superset.mcp_service.dataset_scope import enforce_tool_dataset_scope
+
     is_async = inspect.iscoroutinefunction(tool_func)
 
     # Detect if the original function expects a ctx: Context parameter.
@@ -1237,6 +1239,10 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                     )
 
                 try:
+                    enforce_tool_dataset_scope(
+                        tool_func.__name__,
+                        _tool_sig.bind_partial(*args, **kwargs).arguments,
+                    )
                     logger.debug(
                         "MCP tool call: user=%s, tool=%s",
                         user.username,
@@ -1284,6 +1290,10 @@ def mcp_auth_hook(tool_func: F) -> F:  # noqa: C901
                     )
 
                 try:
+                    enforce_tool_dataset_scope(
+                        tool_func.__name__,
+                        _tool_sig.bind_partial(*args, **kwargs).arguments,
+                    )
                     logger.debug(
                         "MCP tool call: user=%s, tool=%s",
                         user.username,

--- a/superset/mcp_service/dataset/schemas.py
+++ b/superset/mcp_service/dataset/schemas.py
@@ -72,6 +72,7 @@ class DatasetFilter(ColumnOperator):
     """
 
     col: Literal[  # pyright: ignore[reportIncompatibleVariableOverride]
+        "uuid",
         "table_name",
         "schema",
         "database_name",

--- a/superset/mcp_service/dataset/tool/list_datasets.py
+++ b/superset/mcp_service/dataset/tool/list_datasets.py
@@ -40,6 +40,7 @@ from superset.mcp_service.dataset.schemas import (
     ListDatasetsRequest,
     serialize_dataset_object,
 )
+from superset.mcp_service.dataset_scope import get_dataset_scope
 from superset.mcp_service.mcp_core import ModelListCore
 from superset.mcp_service.privacy import (
     DATA_MODEL_METADATA_ERROR_TYPE,
@@ -90,6 +91,12 @@ async def list_datasets(
     time. Set ``request.certified`` to true to return only governed,
     semantic-layer datasets; false returns only uncertified datasets, while
     omitting it preserves the unfiltered behavior.
+
+    Search matches schema, SQL, table name, UUID, and description. Results are
+    candidates, not a relevance ranking. Compare descriptions and metadata; when
+    multiple candidates fit, explain the alternatives and clarify before querying.
+    An empty search result does not establish that the requested data does not
+    exist. Never substitute a different dataset for one outside the MCP scope.
 
     **IMPORTANT**: All parameters must be wrapped in a ``request`` object.
     Do NOT pass ``search``, ``page``, ``page_size``, etc. as top-level
@@ -179,7 +186,7 @@ async def list_datasets(
             item_serializer=_serialize_dataset,
             filter_type=DatasetFilter,
             default_columns=DEFAULT_DATASET_COLUMNS,
-            search_columns=["schema", "sql", "table_name", "uuid"],
+            search_columns=["schema", "sql", "table_name", "uuid", "description"],
             list_field_name="datasets",
             output_list_schema=DatasetList,
             all_columns=all_columns,
@@ -195,8 +202,16 @@ async def list_datasets(
                         DatasetCertifiedFilter, request.certified
                     )
                 }
+            filters = list(request.filters or [])
+            scope = get_dataset_scope()
+            if scope is not None:
+                filters.append(
+                    DatasetFilter(
+                        col="uuid", opr="in", value=[str(uid) for uid in scope]
+                    )
+                )
             result = tool.run_tool(
-                filters=request.filters,
+                filters=filters,
                 search=request.search,
                 select_columns=request.select_columns,
                 order_column=request.order_column,

--- a/superset/mcp_service/dataset_scope.py
+++ b/superset/mcp_service/dataset_scope.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Optional MCP dataset routing constraints, independent of authorization."""
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from fastmcp.exceptions import ToolError
+from flask import current_app, g, has_app_context
+
+from superset import security_manager
+
+SCOPE_ERROR = (
+    "The requested dataset or operation is outside the configured MCP dataset scope. "
+    "No query was run. Do not substitute another dataset; explain the scope "
+    "limitation and ask an administrator to review the routing configuration."
+)
+
+# Only these tools can operate in dataset-scoped mode. Other paths can read data
+# through SQL, cached results, screenshots, or external semantic sources without
+# a registered dataset identity. Refuse them rather than guess at their lineage.
+SCOPED_TOOLS = frozenset(
+    {
+        "health_check",
+        "get_schema",
+        "list_datasets",
+        "get_dataset_info",
+        "query_dataset",
+        "get_table",
+    }
+)
+
+
+def get_dataset_scope() -> frozenset[UUID] | None:
+    """Union effective roles' UUID allowlists; None disables routing constraints.
+
+    Missing roles contribute nothing, including Admin. Authorization is applied
+    separately by the dataset DAO and the normal query execution/RLS machinery.
+    No scope is cached across calls or users.
+    """
+    if not has_app_context():
+        return None
+    config = current_app.config.get("MCP_DATASET_ROLE_ALLOWLIST")
+    if config is None:
+        return None
+    if not isinstance(config, dict):
+        raise ToolError("MCP_DATASET_ROLE_ALLOWLIST must map role names to UUID lists.")
+    normalized: dict[str, set[UUID]] = {}
+    try:
+        for role, identifiers in config.items():
+            if not isinstance(role, str) or not isinstance(identifiers, (list, tuple)):
+                raise ValueError("Expected role names and UUID lists")
+            normalized[role] = {UUID(str(identifier)) for identifier in identifiers}
+    except (ValueError, TypeError, AttributeError) as ex:
+        raise ToolError("Invalid dataset UUID allowlist configuration.") from ex
+    if not getattr(g, "user", None):
+        return frozenset()
+    return frozenset(
+        identifier
+        for role in security_manager.get_user_roles()
+        for identifier in normalized.get(role.name, set())
+    )
+
+
+def enforce_tool_dataset_scope(tool_name: str, arguments: Mapping[str, Any]) -> None:
+    """Refuse unsupported paths or out-of-scope datasets before tool execution.
+
+    Lookup uses the ordinary access-filtered DAO, never skip_base_filter. An
+    allowlist entry therefore cannot grant access to an otherwise hidden dataset.
+    """
+    scope = get_dataset_scope()
+    if scope is None:
+        return
+    if tool_name not in SCOPED_TOOLS:
+        raise ToolError(SCOPE_ERROR)
+    if tool_name not in {"get_dataset_info", "query_dataset", "get_table"}:
+        return
+
+    request = arguments.get("request")
+    field = "identifier" if tool_name == "get_dataset_info" else "dataset_id"
+    identifier = (
+        request.get(field)
+        if isinstance(request, dict)
+        else getattr(request, field, None)
+    )
+    if identifier is None:
+        # External semantic views are not registered datasets.
+        raise ToolError(SCOPE_ERROR)
+    from superset.mcp_service.dataset.dataset_utils import resolve_dataset
+
+    dataset = resolve_dataset(identifier)
+    if dataset is None or dataset.uuid not in scope:
+        raise ToolError(SCOPE_ERROR)

--- a/superset/mcp_service/mcp_config.py
+++ b/superset/mcp_service/mcp_config.py
@@ -63,6 +63,11 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 # user's Superset administrator and the Apache Superset issue tracker.
 MCP_BUG_REPORT_CONTACT: str | None = None
 
+# Optional dataset routing mode: effective role names -> registered dataset UUIDs.
+# None preserves the complete MCP tool surface; {} permits no datasets.
+# This only narrows access and is not a substitute for permissions or RLS.
+MCP_DATASET_ROLE_ALLOWLIST: dict[str, list[str]] | None = None
+
 # MCP Debug mode - shows suppressed initialization output in stdio mode
 MCP_DEBUG = False
 

--- a/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py
@@ -2621,3 +2621,158 @@ class TestListDatasetsRequestWrapper:
             or "Unexpected" in error_text
             or "request" in error_text
         )
+
+
+@pytest.mark.asyncio
+async def test_description_discovery_uses_dao_search_and_exposes_alternatives(
+    mcp_server: fastmcp.FastMCP,
+) -> None:
+    """Description-only matches are candidates with explicit source identities."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from superset.connectors.sqla.models import SqlaTable
+    from superset.daos.dataset import DatasetDAO
+
+    engine = create_engine("sqlite://")
+    SqlaTable.__table__.create(engine)
+    with Session(engine) as session:
+        session.execute(
+            SqlaTable.__table__.insert(),
+            [
+                {
+                    "id": 1,
+                    "database_id": 1,
+                    "table_name": "events",
+                    "description": "Order fulfillment",
+                },
+                {
+                    "id": 2,
+                    "database_id": 1,
+                    "table_name": "shipments",
+                    "description": "Order history",
+                },
+                {
+                    "id": 3,
+                    "database_id": 1,
+                    "table_name": "private",
+                    "description": "Order details",
+                },
+                {
+                    "id": 4,
+                    "database_id": 1,
+                    "table_name": "unrelated",
+                    "description": None,
+                },
+            ],
+        )
+        session.commit()
+        # Keep the production DAO search and pagination; model an access filter
+        # that hides dataset 3 before either matching or counting.
+        with (
+            patch("superset.daos.base.db.session", session),
+            patch.object(
+                DatasetDAO,
+                "_apply_base_filter",
+                side_effect=lambda query, **kwargs: query.filter(SqlaTable.id != 3),
+            ),
+        ):
+            rows, count = DatasetDAO.list(
+                search="ORDER",
+                search_columns=["schema", "sql", "table_name", "uuid", "description"],
+                columns=["id", "table_name", "description"],
+                order_column="id",
+                order_direction="asc",
+            )
+            assert count == 2
+            assert [row.id for row in rows] == [1, 2]
+            from superset.daos.base import ColumnOperator
+
+            # UUID union (including an inaccessible dataset) is intersected by
+            # the existing access filter before count and page boundaries.
+            identifiers = (
+                session.query(SqlaTable.uuid).filter(SqlaTable.id.in_([1, 3])).all()
+            )
+            scoped_rows, scoped_count = DatasetDAO.list(
+                search="Order",
+                search_columns=["description"],
+                columns=["id"],
+                column_operators=[
+                    ColumnOperator(
+                        col="uuid",
+                        opr="in",
+                        value=[str(row.uuid) for row in identifiers],
+                    )
+                ],
+                page_size=1,
+                page=1,
+            )
+            assert scoped_count == 1
+            assert scoped_rows == []
+            assert (
+                DatasetDAO.list(
+                    columns=["id"],
+                    column_operators=[ColumnOperator(col="uuid", opr="in", value=[])],
+                )[1]
+                == 0
+            )
+            for search in ("no matching description", "%", "_"):
+                assert (
+                    DatasetDAO.list(
+                        search=search,
+                        search_columns=["description"],
+                        columns=["id"],
+                    )[1]
+                    == 0
+                )
+
+    candidates = [create_mock_dataset(1, "events"), create_mock_dataset(2, "shipments")]
+    for candidate in candidates:
+        candidate.description = "Order fulfillment"
+    with patch.object(DatasetDAO, "list", return_value=(candidates, 2)) as listing:
+        async with Client(mcp_server) as client:
+            result = await client.call_tool(
+                "list_datasets", {"request": {"search": "Order"}}
+            )
+        data = json.loads(result.content[0].text)
+    assert "description" in listing.call_args.kwargs["search_columns"]
+    assert [(row["id"], row["table_name"]) for row in data["datasets"]] == [
+        (1, "events"),
+        (2, "shipments"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scoped_discovery_filters_before_pagination(
+    mcp_server: fastmcp.FastMCP,
+) -> None:
+    """The routing filter is ANDed with caller filters by the normal DAO."""
+    from uuid import UUID
+
+    uid = UUID("00000000-0000-0000-0000-000000000001")
+    with (
+        patch(
+            "superset.mcp_service.dataset_scope.get_dataset_scope", return_value={uid}
+        ),
+        patch.object(list_datasets_module, "get_dataset_scope", return_value={uid}),
+        patch("superset.daos.dataset.DatasetDAO.list", return_value=([], 0)) as listing,
+    ):
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "list_datasets",
+                {
+                    "request": {
+                        "filters": [
+                            {"col": "table_name", "opr": "eq", "value": "events"}
+                        ],
+                        "page": 2,
+                        "page_size": 5,
+                    }
+                },
+            )
+    operators = listing.call_args.kwargs["column_operators"]
+    assert [(op.col, op.opr, op.value) for op in operators] == [
+        ("table_name", "eq", "events"),
+        ("uuid", "in", [str(uid)]),
+    ]
+    assert listing.call_args.kwargs["page"] == 1

--- a/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
+++ b/tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py
@@ -1578,3 +1578,33 @@ async def test_query_dataset_cached_bounds_across_rollover(
     assert cached_data["performance"]["cache_status"] == (
         "no_data" if empty else "cached"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identifier", [1, "1", "00000000-0000-0000-0000-000000000001"])
+async def test_out_of_scope_query_refuses_without_execution(
+    mcp_server: FastMCP,
+    identifier: int | str,
+) -> None:
+    """The authenticated MCP entry point refuses rather than queries a substitute."""
+    from uuid import UUID
+
+    from fastmcp.exceptions import ToolError
+
+    dataset = _make_dataset()
+    dataset.uuid = UUID("00000000-0000-0000-0000-000000000001")
+    with (
+        patch(
+            "superset.mcp_service.dataset_scope.get_dataset_scope",
+            return_value=frozenset(),
+        ),
+        patch("superset.daos.dataset.DatasetDAO.find_by_id", return_value=dataset),
+        patch.object(query_dataset_module, "execute_tabular_query") as execute,
+    ):
+        async with Client(mcp_server) as client:
+            with pytest.raises(ToolError, match="Do not substitute"):
+                await client.call_tool(
+                    "query_dataset",
+                    {"request": {"dataset_id": identifier, "metrics": ["count"]}},
+                )
+        execute.assert_not_called()

--- a/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
+++ b/tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
@@ -159,6 +159,7 @@ async def test_get_table_builtin_happy_path(mcp_server: FastMCP) -> None:
     assert data["row_count"] == 1
     assert data["source"] == "builtin"
     assert data["dataset_id"] == 42
+    assert data["dataset_name"] == mock_ds.table_name
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/mcp_service/test_dataset_scope.py
+++ b/tests/unit_tests/mcp_service/test_dataset_scope.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Dataset routing is additive across roles and never grants data access."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from fastmcp.exceptions import ToolError
+from flask import Flask, g
+
+from superset.mcp_service.dataset_scope import (
+    enforce_tool_dataset_scope,
+    get_dataset_scope,
+)
+
+FIRST = UUID("00000000-0000-0000-0000-000000000001")
+SECOND = UUID("00000000-0000-0000-0000-000000000002")
+THIRD = UUID("00000000-0000-0000-0000-000000000003")
+
+
+def test_role_union_uses_effective_roles_and_missing_roles_contribute_nothing(
+    app: Flask,
+) -> None:
+    """The security manager resolves direct, group, and public roles."""
+    with (
+        app.app_context(),
+        patch(
+            "superset.mcp_service.dataset_scope.security_manager.get_user_roles",
+            return_value=[
+                SimpleNamespace(name="Readers"),
+                SimpleNamespace(name="Analysts"),
+                SimpleNamespace(name="Unconfigured"),
+            ],
+        ) as roles,
+        patch.dict(
+            app.config,
+            MCP_DATASET_ROLE_ALLOWLIST={
+                "Readers": [str(FIRST)],
+                "Analysts": [str(FIRST), str(SECOND)],
+                "Other": [str(THIRD)],
+            },
+        ),
+    ):
+        g.user = SimpleNamespace(id=1)
+        assert get_dataset_scope() == {FIRST, SECOND}
+        roles.assert_called_once_with()
+
+
+@pytest.mark.parametrize("config", [None, {}, {"Other": [str(FIRST)]}])
+def test_disabled_and_empty_scope(app: Flask, config: object) -> None:
+    """Only None disables scoping; an empty mapping denies all datasets."""
+    with (
+        app.app_context(),
+        patch.dict(app.config, MCP_DATASET_ROLE_ALLOWLIST=config),
+        patch(
+            "superset.mcp_service.dataset_scope.security_manager.get_user_roles",
+            return_value=[SimpleNamespace(name="Admin")],
+        ),
+    ):
+        g.user = SimpleNamespace(id=1)
+        assert get_dataset_scope() == (None if config is None else frozenset())
+
+
+@pytest.mark.parametrize("config", [[], {"Readers": "*"}, {"Readers": ["bad"]}])
+def test_invalid_config_refuses(app: Flask, config: object) -> None:
+    """Malformed config never disables the restriction."""
+    with (
+        app.app_context(),
+        patch.dict(app.config, MCP_DATASET_ROLE_ALLOWLIST=config),
+        pytest.raises(ToolError),
+    ):
+        get_dataset_scope()
+
+
+@pytest.mark.parametrize("identifier", [1, "1", str(FIRST)])
+def test_scope_lookup_retains_dao_access_filter(identifier: int | str) -> None:
+    """An allowed UUID cannot grant access when the normal DAO denies lookup."""
+    with (
+        patch(
+            "superset.mcp_service.dataset_scope.get_dataset_scope",
+            return_value=frozenset({FIRST}),
+        ),
+        patch("superset.daos.dataset.DatasetDAO.find_by_id", return_value=None) as find,
+    ):
+        with pytest.raises(ToolError, match="outside.*scope"):
+            enforce_tool_dataset_scope(
+                "query_dataset", {"request": SimpleNamespace(dataset_id=identifier)}
+            )
+        assert find.call_count == 1
+        assert "skip_base_filter" not in find.call_args.kwargs
+
+
+@pytest.mark.parametrize("dataset_uuid,allowed", [(FIRST, True), (THIRD, False)])
+def test_role_union_intersects_actual_access(dataset_uuid: UUID, allowed: bool) -> None:
+    """An accessible dataset must also be in the union; no alternative is selected."""
+    with (
+        patch(
+            "superset.mcp_service.dataset_scope.get_dataset_scope",
+            return_value=frozenset({FIRST, SECOND}),
+        ),
+        patch(
+            "superset.daos.dataset.DatasetDAO.find_by_id",
+            return_value=SimpleNamespace(uuid=dataset_uuid),
+        ) as find,
+    ):
+        if allowed:
+            enforce_tool_dataset_scope("get_table", {"request": {"dataset_id": 1}})
+        else:
+            with pytest.raises(ToolError, match="Do not substitute"):
+                enforce_tool_dataset_scope("get_table", {"request": {"dataset_id": 1}})
+        find.assert_called_once_with(1, query_options=None)
+
+
+@pytest.mark.parametrize(
+    "tool_name,payload",
+    [
+        ("execute_sql", {"database_id": 1, "sql": "SELECT 1"}),
+        ("get_chart_data", {"identifier": 1}),
+        ("get_chart_preview", {"identifier": 1}),
+        ("get_table", {"view_id": 1}),
+        ("get_query_info", {"identifier": 1}),
+        ("unrecognized_extension_tool", {}),
+    ],
+)
+def test_unscopable_operations_refuse(
+    tool_name: str, payload: dict[str, object]
+) -> None:
+    """Alternative execution and cached-result paths cannot evade routing mode."""
+    with (
+        patch(
+            "superset.mcp_service.dataset_scope.get_dataset_scope",
+            return_value=frozenset({FIRST}),
+        ),
+        pytest.raises(ToolError, match="No query was run"),
+    ):
+        enforce_tool_dataset_scope(tool_name, {"request": payload})


### PR DESCRIPTION
### SUMMARY

Improve dataset discovery and add optional role-based MCP dataset routing:

- Search `description` alongside schema, SQL, table name, and UUID. The existing DAO supports it through escaped, case-insensitive substring predicates. The original implementation omitted it, and the later change returning descriptions did not change search; no documented exclusion rationale was found.
- Preserve existing query provenance (`dataset_id` / `dataset_name`, and `get_table` source identity), strengthen regression coverage, and instruct clients to compare discovery candidates, disclose ambiguous alternatives, and cite the actual query source. No redundant provenance response format is introduced.
- Add `MCP_DATASET_ROLE_ALLOWLIST`, mapping effective role names to dataset UUIDs. Role lists are unioned, then constrained by normal dataset access. `None` preserves existing behavior; an empty mapping permits no datasets. Unconfigured roles contribute nothing, including Admin. Permissions, query validation, and RLS remain unchanged.
- Enforce routing in the shared MCP invocation layer, and filter discovery before count/pagination. Requests outside scope refuse explicitly and never select a substitute.

**Conservative scoped-mode surface:** dataset discovery/info, `query_dataset`, built-in-dataset `get_table`, `health_check`, and `get_schema`. Other operations refuse when this optional mode is enabled, including SQL Lab, chart/dashboard data and previews, cached query results, external semantic views, mutations, and extension tools. Their data cannot all be reliably attributed to registered dataset UUIDs. This avoids pretending to enforce SQL lineage. Scope is a usability control over registered datasets, not a security boundary or physical-table allowlist.

**Search cost:** a local synthetic SQLite benchmark with 100,000 rows, approximately 500-byte SQL and 1 KB descriptions, measured median count-plus-page latency across six iterations:

| Search | Four fields | With description |
| --- | ---: | ---: |
| Description-only match | 399 ms | 613 ms |
| No match | 391 ms | 730 ms |

Both plans remain a catalog scan; no joins or queries are added. This is measurable overhead, not an indexed-search optimization. Documentation calls out large-catalog latency and deployment-specific benchmarking. The production DAO is also exercised against SQLite in the regression test.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable (MCP backend).

Before: business terms appearing only in descriptions were undiscoverable. After: those datasets appear among the search candidates. Existing searches with no matches already return zero results; there is no server-side recent-dataset fallback to preserve or remove.

Before: MCP had no per-role routing scope. After: operators can opt into a curated dataset-only tool surface, without granting any additional access.

### TESTING INSTRUCTIONS

1. Give an accessible dataset a description containing a term absent from its name, schema, SQL, and UUID. Call `list_datasets` with that term and verify it appears. Verify unmatched terms return no results and literal `%`/`_` are escaped.
2. Configure two roles with overlapping UUID lists. Give a user both roles and access to only a subset of the union. Verify discovery and queries expose only the intersection, including correct count/page behavior.
3. Query an accessible dataset outside the allowlist by numeric ID, numeric string, and UUID. Verify an explicit refusal and no query execution or substitution. An allowlisted but inaccessible dataset must also refuse.
4. Query an allowed dataset with `query_dataset` and `get_table`; verify the response identifies the requested source. Confirm normal query validation and RLS remain in effect.
5. With scope enabled, try SQL, chart data/preview, and external-view queries; verify refusal. With `MCP_DATASET_ROLE_ALLOWLIST = None`, verify existing behavior is preserved.

Validation:

```bash
pytest tests/unit_tests/mcp_service/test_dataset_scope.py \
  tests/unit_tests/mcp_service/dataset/tool/test_dataset_tools.py \
  tests/unit_tests/mcp_service/dataset/tool/test_query_dataset.py \
  tests/unit_tests/mcp_service/semantic_layer/tool/test_get_table.py
uvx pre-commit run --files <changed files>
```

The focused suite passes (240 tests). The full local MCP suite also passes: **3,983 passed, 1 skipped, 1 deselected**. The known clean-tree failure `test_tools_call_health_check_over_real_asgi_transport` is excluded from that local run, not modified or skipped in the repository. Changed-file pre-commit passes, including mypy. One adversarial review round found no actionable findings and passed 24 additional targeted tests.

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
