### PR TITLE
fix(database): reject non-dict encrypted_extra at schema validation layer

### DIFF
--- a/superset/databases/schemas.py
+++ b/superset/databases/schemas.py
@@ -245,11 +245,21 @@ def encrypted_extra_validator(value: str | None) -> None:
     """
     if value:
         try:
-            json.loads(value)
+            encrypted_extra = json.loads(value)
         except json.JSONDecodeError as ex:
             raise ValidationError(
                 [_("Field cannot be decoded by JSON. %(msg)s", msg=str(ex))]
             ) from ex
+
+        if not isinstance(encrypted_extra, dict):
+            raise ValidationError(
+                [
+                    _(
+                        "Encrypted extra field must be a mapping"
+                        " from string keys to values."
+                    )
+                ]
+            )
 
 
 def masked_encrypted_extra_validator(value: str) -> None:

--- a/tests/unit_tests/databases/schema_tests.py
+++ b/tests/unit_tests/databases/schema_tests.py
@@ -614,6 +614,27 @@ def test_extra_validator_rejects_non_dict_top_level_value(value: Any) -> None:
     assert "must be a mapping" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("value", [123, None, [1, 2], True, "abc"])
+def test_encrypted_extra_validator_rejects_non_dict_top_level_value(
+    value: Any,
+) -> None:
+    """
+    Test that encrypted_extra_validator rejects a top-level value that is valid
+    JSON but not a mapping (int, null, list, bool, string), instead of letting
+    AttributeError propagate from downstream .get() calls.
+    """
+    from superset.databases.schemas import DatabasePostSchema
+
+    schema = DatabasePostSchema()
+    payload = {
+        "database_name": "test_db",
+        "masked_encrypted_extra": json.dumps(value),
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        schema.load(payload)
+    assert "must be a mapping" in str(exc_info.value)
+
+
 def test_cache_timeout_rejects_values_below_minus_one() -> None:
     """
     Test that cache_timeout rejects values less than -1.


### PR DESCRIPTION
### SUMMARY

`encrypted_extra_validator` in `superset/databases/schemas.py` validates that its input is valid JSON but does not check that the decoded value is a `dict`. Non-dict JSON values (`123`, `null`, `[1, 2]`, `true`, `"abc"`) pass schema validation and later cause an `AttributeError` in `_handle_oauth2()` when `.get()` is called on a non-mapping — surfacing as an opaque 500 instead of a client-facing validation error (400 on `PUT`, 422 on `POST` — see below).

This adds an `isinstance(…, dict)` guard to `encrypted_extra_validator`, mirroring the identical fix applied to `extra_validator` in #44092 (which was preceded by PRs #42366 and #42401 for the same bug class on other fields).

**Problem:** `PUT /api/v1/database/<pk>/` with `masked_encrypted_extra` set to e.g. `"123"` passes schema validation, then hits:
```python
encrypted_extra = json.loads(self._properties["encrypted_extra"])
new_config = encrypted_extra.get("oauth2_client_info", {})  # AttributeError on int
```
This is reachable on any database whose engine spec has OAuth2 configured (Snowflake/BigQuery/Databricks with OAuth2). The `AttributeError` is not caught by the route or the `@transaction` decorator, so it escapes as a raw 500.

**Fix:** Reject non-dict `encrypted_extra` at the schema validation layer (same location, same pattern as `extra_validator`). `masked_encrypted_extra_validator` delegates to `encrypted_extra_validator`, so it's covered automatically — no other files need changes.

**Tradeoffs:** This changes a 500 (`AttributeError`, unhandled) into a `ValidationError` for this one malformed-input shape — a strict improvement, no other behavior change. Note the status code differs by verb: `DatabaseRestApi.put()` catches schema `ValidationError` via `response_400` (400), while `.post()` catches it via `response_422` (422) — both existing, unrelated-to-this-PR routing choices, not something this fix changes. The error message style matches the existing `extra_validator` pattern.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — API-only change, no UI impact.

### TESTING INSTRUCTIONS

1. Run the new parametrized test:
   ```bash
   pytest tests/unit_tests/databases/schema_tests.py::test_encrypted_extra_validator_rejects_non_dict_top_level_value -v
   ```
2. Verify the existing sibling test still passes:
   ```bash
   pytest tests/unit_tests/databases/schema_tests.py::test_extra_validator_rejects_non_dict_top_level_value -v
   ```
3. Optionally, confirm the fix end-to-end:
   ```bash
   curl -X PUT http://localhost:8088/api/v1/database/1/ \
     -H "Content-Type: application/json" \
     -d '{"masked_encrypted_extra": "123"}' \
     -H "Authorization: Bearer <token>"
   ```
   Should return 400 (this endpoint is `PUT`, which routes schema `ValidationError` through `response_400`) with "must be a mapping" instead of 500.

### ADDITIONAL INFORMATION
- [x] Has associated issue: [sc-120257](https://app.shortcut.com/preset/story/120257)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

