### PR TITLE
fix(pie-chart): improve long metric name readability with label truncation and smart legend tooltips

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/controlPanel.tsx
@@ -39,6 +39,8 @@ const {
   labelsOutside,
   labelType,
   labelLine,
+  labelMaxWidth,
+  labelOverflow,
   outerRadius,
   numberFormat,
   showLabels,
@@ -233,6 +235,48 @@ const config: ControlPanelConfig = {
               ),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.show_labels?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'label_max_width',
+            config: {
+              type: 'NumberControl',
+              label: t('Label Max Width'),
+              renderTrigger: true,
+              min: 0,
+              step: 10,
+              default: labelMaxWidth,
+              description: t(
+                'Maximum width (in pixels) for pie chart labels. ' +
+                  'Set to 0 to disable truncation.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.show_labels?.value),
+            },
+          },
+        ],
+        [
+          {
+            name: 'label_overflow',
+            config: {
+              type: 'SelectControl',
+              label: t('Label Overflow'),
+              renderTrigger: true,
+              default: labelOverflow,
+              choices: [
+                ['none', t('None')],
+                ['truncate', t('Truncate')],
+                ['break', t('Break')],
+              ],
+              description: t(
+                'Controls how labels overflow beyond the max width. ' +
+                  '"Truncate" adds an ellipsis. "Break" wraps to the next line.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                Boolean(controls?.show_labels?.value) &&
+                Number(controls?.label_max_width?.value) > 0,
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -260,6 +260,8 @@ export default function transformProps(
     labelLine,
     labelType,
     labelTemplate,
+    labelMaxWidth,
+    labelOverflow,
     legendMargin,
     legendOrientation,
     legendType,
@@ -546,10 +548,18 @@ export default function transformProps(
             position: 'outer',
             alignTo: 'none',
             bleedMargin: 5,
+            ...(labelMaxWidth > 0 && {
+              width: labelMaxWidth,
+              ...(labelOverflow !== 'none' && { overflow: labelOverflow }),
+            }),
           }
         : {
             ...defaultLabel,
             position: 'inner',
+            ...(labelMaxWidth > 0 && {
+              width: labelMaxWidth,
+              ...(labelOverflow !== 'none' && { overflow: labelOverflow }),
+            }),
           },
       emphasis: {
         label: {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Pie/types.ts
@@ -41,6 +41,8 @@ export type EchartsPieFormData = QueryFormData &
     labelLine: boolean;
     labelType: EchartsPieLabelType;
     labelTemplate: string | null;
+    labelMaxWidth: number;
+    labelOverflow: 'none' | 'truncate' | 'break';
     labelsOutside: boolean;
     metric?: string;
     outerRadius: number;
@@ -75,6 +77,8 @@ export const DEFAULT_FORM_DATA: EchartsPieFormData = {
   innerRadius: 30,
   labelLine: false,
   labelType: EchartsPieLabelType.Key,
+  labelMaxWidth: 0,
+  labelOverflow: 'none',
   legendOrientation: LegendOrientation.Top,
   legendType: LegendType.Scroll,
   numberFormat: 'SMART_NUMBER',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/series.ts
@@ -825,6 +825,39 @@ export function getLegendProps(
   const getLegendWidth = (paddingWidth: number) =>
     Math.max(paddingWidth - MARGIN_GUTTER, MIN_LEGEND_WIDTH);
 
+  /**
+   * Returns a legend tooltip config that:
+   * 1. Only appears when the label is actually truncated (name wider than maxTextWidth)
+   * 2. Positions the tooltip ABOVE the legend item to avoid overlapping the chart
+   */
+  const makeLegendTooltip = (maxTextWidth: number): any => ({
+    show: true,
+    confine: false, // allow tooltip to render above the canvas boundary
+    position: (
+      _pos: [number, number],
+      _params: unknown,
+      _el: unknown,
+      elRect: { x: number; y: number; width: number; height: number },
+      size: { contentSize: [number, number]; viewSize: [number, number] },
+    ) => {
+      const tooltipWidth = size.contentSize[0];
+      const tooltipHeight = size.contentSize[1];
+      // Center horizontally over the hovered legend item
+      const x = Math.min(
+        Math.max(elRect.x + elRect.width / 2 - tooltipWidth / 2, 0),
+        size.viewSize[0] - tooltipWidth,
+      );
+      // Place above the legend item; negative y appears above canvas with confine:false
+      const y = elRect.y - tooltipHeight - 8;
+      return [x, y];
+    },
+    formatter: (params: { name: string }) => {
+      // Suppress tooltip when text fits — approx 7.5px per char at default font size
+      const approxMaxChars = Math.floor(maxTextWidth / 7.5);
+      return params.name.length > approxMaxChars ? params.name : '';
+    },
+  });
+
   switch (orientation) {
     case LegendOrientation.Left:
       legend.left = 0;
@@ -833,6 +866,7 @@ export function getLegendProps(
           overflow: 'truncate',
           width: getLegendWidth(padding.left),
         };
+        legend.tooltip = makeLegendTooltip(getLegendWidth(padding.left));
       }
       break;
     case LegendOrientation.Right:
@@ -843,6 +877,7 @@ export function getLegendProps(
           overflow: 'truncate',
           width: getLegendWidth(padding.right),
         };
+        legend.tooltip = makeLegendTooltip(getLegendWidth(padding.right));
       }
       break;
     case LegendOrientation.Bottom:
@@ -853,6 +888,11 @@ export function getLegendProps(
       if (type === LegendType.Plain) {
         legend.right = 0;
       }
+      legend.textStyle = {
+        overflow: 'truncate',
+        width: 150,
+      };
+      legend.tooltip = makeLegendTooltip(150);
       break;
     case LegendOrientation.Top:
       legend.top = 0;
@@ -860,6 +900,11 @@ export function getLegendProps(
       if (type === LegendType.Plain && padding?.left) {
         legend.left = padding.left;
       }
+      legend.textStyle = {
+        overflow: 'truncate',
+        width: 150,
+      };
+      legend.tooltip = makeLegendTooltip(150);
       break;
     default:
       legend.top = 0;

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Pie/transformProps.test.ts
@@ -618,6 +618,63 @@ describe('legend sorting', () => {
   });
 });
 
+describe('Pie label max width and overflow', () => {
+  const makeChartProps = (
+    labelMaxWidth: number,
+    labelOverflow: string,
+    labelsOutside = true,
+  ) =>
+    new ChartProps({
+      formData: {
+        colorScheme: 'bnbColors',
+        datasource: '3__table',
+        granularity_sqla: 'ds',
+        metric: 'sum__num',
+        groupby: ['category'],
+        viz_type: 'pie',
+        label_max_width: labelMaxWidth,
+        label_overflow: labelOverflow,
+        labels_outside: labelsOutside,
+      } as SqlaFormData,
+      width: 800,
+      height: 600,
+      queriesData: [
+        {
+          data: [
+            { category: 'A very long category name indeed', sum__num: 10 },
+            { category: 'Another very long category name', sum__num: 20 },
+          ],
+        },
+      ],
+      theme: supersetTheme,
+    }) as EchartsPieChartProps;
+
+  const getLabel = (props: EchartsPieChartProps) =>
+    (transformProps(props).echartOptions.series as PieSeriesOption[])[0].label;
+
+  test('does not set width or overflow when labelMaxWidth is 0', () => {
+    const label = getLabel(makeChartProps(0, 'truncate'));
+    expect(label).not.toHaveProperty('width');
+    expect(label).not.toHaveProperty('overflow');
+  });
+
+  test('sets width and overflow=truncate when configured for outer labels', () => {
+    const label = getLabel(makeChartProps(120, 'truncate', true));
+    expect(label).toMatchObject({ width: 120, overflow: 'truncate' });
+  });
+
+  test('sets width and overflow=break when configured for inner labels', () => {
+    const label = getLabel(makeChartProps(80, 'break', false));
+    expect(label).toMatchObject({ width: 80, overflow: 'break' });
+  });
+
+  test('sets width but omits overflow field when labelOverflow is none', () => {
+    const label = getLabel(makeChartProps(100, 'none'));
+    expect(label).toMatchObject({ width: 100 });
+    expect(label).not.toHaveProperty('overflow');
+  });
+});
+
 const getAngleChartProps = (
   donut: boolean,
   sweptAngle: number,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
@@ -1032,6 +1032,11 @@ describe('getLegendProps', () => {
       right: 0,
       orient: 'horizontal',
       type: 'scroll',
+      textStyle: {
+        overflow: 'truncate',
+        width: 150,
+      },
+      tooltip: expect.any(Object),
       ...expectedThemeProps,
     });
   });
@@ -1051,6 +1056,11 @@ describe('getLegendProps', () => {
       right: 55,
       orient: 'horizontal',
       type: 'scroll',
+      textStyle: {
+        overflow: 'truncate',
+        width: 150,
+      },
+      tooltip: expect.any(Object),
       ...expectedThemeProps,
     });
   });
@@ -1114,6 +1124,11 @@ describe('getLegendProps', () => {
       right: 0,
       orient: 'horizontal',
       type: 'plain',
+      textStyle: {
+        overflow: 'truncate',
+        width: 150,
+      },
+      tooltip: expect.any(Object),
       ...expectedThemeProps,
     });
   });
@@ -1127,6 +1142,11 @@ describe('getLegendProps', () => {
       right: 0,
       orient: 'horizontal',
       type: 'plain',
+      textStyle: {
+        overflow: 'truncate',
+        width: 150,
+      },
+      tooltip: expect.any(Object),
       ...expectedThemeProps,
     });
   });


### PR DESCRIPTION
### SUMMARY
Resolves an issue where Pie charts with long category or metric names would overflow the chart boundaries, overlap adjacent slices, and become unreadable.

This PR introduces two UI improvements:
1. **Configurable Slice Label Overflow:** Added `Label Max Width` and `Label Overflow` (Truncate/Break) controls to the Pie Chart's label settings, allowing users to cleanly truncate slice labels using ECharts' native text engine. Defaults remain unchanged (0 width, meaning no limit) to preserve backward compatibility.
2. **Legend Truncation & Smart Tooltips:** Fixed an issue where horizontal legends (`Top` / `Bottom`) would raw-clip text instead of showing an ellipsis. Additionally, introduced a smart legend tooltip (`makeLegendTooltip`) that hovers above the legend items to show the full untruncated name. The tooltip is conditionally suppressed if the text is short enough to fit without truncation.

Fixes #39643 
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:**
<img width="450" height="550" alt="image" src="https://github.com/user-attachments/assets/bbfd082d-3683-4254-934a-6ffb1091b1be" />


**After:**
<img width="471" height="542" alt="image" src="https://github.com/user-attachments/assets/ec8fb05b-6f46-4482-8651-6a7dd9d8efda" />

### TESTING INSTRUCTIONS
1. Create a virtual dataset with extremely long category names.
2. Create a Pie Chart grouped by that category.
4. Turn on "Show Labels" and "Put labels outside".
5. Set "Label Max Width" to 120 and "Label Overflow" to Truncate.
6. Verify slice labels truncate cleanly with `...`.
7. Enable the legend and verify that long items truncate with `...` in the legend.
8. Hover over a truncated legend item and verify the tooltip appears *above* the item, showing the full name without overlapping the chart.

### ADDITIONAL INFORMATION
- [x] Has associated issue: (Add your issue # here if there is one)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
