### PR TITLE
fix(charts): don't auto-migrate table charts to ag-grid-table on import unless enabled

### DIFF
--- a/superset/commands/chart/importers/v1/utils.py
+++ b/superset/commands/chart/importers/v1/utils.py
@@ -25,6 +25,7 @@ from superset.commands.importers.v1.utils import (
     apply_extra_import_fields,
     find_existing_for_import,
 )
+from superset.extensions import feature_flag_manager
 from superset.migrations.shared.migrate_viz import processors
 from superset.migrations.shared.migrate_viz.base import MigrateViz
 from superset.models.slice import Slice
@@ -252,7 +253,16 @@ def migrate_chart(config: dict[str, Any]) -> dict[str, Any]:
     if config["viz_type"] not in migrators:
         return output
 
-    migrator = migrators[config["viz_type"]](output["params"])
+    migrator_class = migrators[config["viz_type"]]
+    required_flag = migrator_class.requires_feature_flag
+    # Importing a chart isn't itself an opt-in to a target viz type that's
+    # still gated off by default (see MigrateViz.requires_feature_flag) --
+    # leave the chart as its original viz_type rather than silently handing
+    # back one the frontend may not have registered.
+    if required_flag and not feature_flag_manager.is_feature_enabled(required_flag):
+        return output
+
+    migrator = migrator_class(output["params"])
     # pylint: disable=protected-access
     migrator._pre_action()
     migrator._migrate()

--- a/superset/migrations/shared/migrate_viz/base.py
+++ b/superset/migrations/shared/migrate_viz/base.py
@@ -62,6 +62,13 @@ class MigrateViz:
     source_viz_type: str
     target_viz_type: str
     has_x_axis_control: bool = False
+    # When set, the *import* path (superset/commands/chart/importers/v1/
+    # utils.py::migrate_chart) only applies this migration while the named
+    # feature flag is on, since importing a chart isn't itself an opt-in to
+    # a still-`IN DEVELOPMENT` target viz type the way running the
+    # `migrate_viz` CLI is. The CLI (superset/cli/viz_migrations.py) ignores
+    # this: invoking it is already the deliberate opt-in.
+    requires_feature_flag: str | None = None
 
     def __init__(self, form_data: str) -> None:
         self.data = try_load_json(form_data)

--- a/superset/migrations/shared/migrate_viz/processors.py
+++ b/superset/migrations/shared/migrate_viz/processors.py
@@ -767,6 +767,12 @@ def _get_table_chart_totals_metrics(
 class MigrateTableChart(MigrateViz):
     source_viz_type = "table"
     target_viz_type = "ag-grid-table"
+    # Table V2 is still `IN DEVELOPMENT`, gated behind AG_GRID_TABLE_ENABLED.
+    # Without this, importing any `table` chart (e.g. `load_examples` on a
+    # fresh install with the flag at its default False) would silently turn
+    # it into an ag-grid-table chart the frontend can't render at all: "Item
+    # with key ag-grid-table is not registered."
+    requires_feature_flag = "AG_GRID_TABLE_ENABLED"
     # allow_rearrange_columns/allow_render_html are kept as-is: v2 reads them
     # under the same names (see rename_keys below), so nothing to remove.
     # (allow_rearrange_columns still gets a value materialized in

--- a/tests/unit_tests/charts/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/utils_test.py
@@ -244,13 +244,20 @@ def _table_chart_config() -> dict[str, Any]:
     }
 
 
-def test_migrate_chart_table_leaves_viz_type_unchanged_by_default() -> None:
+def test_migrate_chart_table_leaves_viz_type_unchanged_by_default(
+    mocker: MockerFixture,
+) -> None:
     """
     Table V2 (``ag-grid-table``) is gated behind ``AG_GRID_TABLE_ENABLED``,
     off by default. Importing a ``table`` chart -- e.g. ``load_examples`` on
     a fresh install -- must not silently hand back an ag-grid-table chart
     the frontend hasn't registered the plugin for.
     """
+    mocker.patch.object(
+        feature_flag_manager,
+        "is_feature_enabled",
+        side_effect=lambda flag: False,
+    )
     chart_config = _table_chart_config()
 
     new_config = migrate_chart(chart_config)

--- a/tests/unit_tests/charts/commands/importers/v1/utils_test.py
+++ b/tests/unit_tests/charts/commands/importers/v1/utils_test.py
@@ -15,7 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Any
+
+from pytest_mock import MockerFixture
+
 from superset.commands.chart.importers.v1.utils import migrate_chart
+from superset.extensions import feature_flag_manager
 from superset.utils import json
 
 
@@ -212,3 +217,60 @@ def test_migrate_chart_query_context_form_data_is_dict() -> None:
 
     assert query_context["form_data"]["viz_type"] == "pivot_table_v2"
     assert isinstance(query_context["form_data"], dict)
+
+
+def _table_chart_config() -> dict[str, Any]:
+    return {
+        "slice_name": "Games",
+        "description": None,
+        "certified_by": None,
+        "certification_details": None,
+        "viz_type": "table",
+        "query_context": None,
+        "params": json.dumps(
+            {
+                "datasource": "1__table",
+                "viz_type": "table",
+                "query_mode": "aggregate",
+                "groupby": ["name"],
+                "metrics": ["count"],
+                "row_limit": 1000,
+            }
+        ),
+        "cache_timeout": None,
+        "uuid": "2a5e562b-ab37-1b9b-1de3-1be4335c8e83",
+        "version": "1.0.0",
+        "dataset_uuid": "a18b9cb0-b8d3-42ed-bd33-0f0fadbf0f6d",
+    }
+
+
+def test_migrate_chart_table_leaves_viz_type_unchanged_by_default() -> None:
+    """
+    Table V2 (``ag-grid-table``) is gated behind ``AG_GRID_TABLE_ENABLED``,
+    off by default. Importing a ``table`` chart -- e.g. ``load_examples`` on
+    a fresh install -- must not silently hand back an ag-grid-table chart
+    the frontend hasn't registered the plugin for.
+    """
+    chart_config = _table_chart_config()
+
+    new_config = migrate_chart(chart_config)
+
+    assert new_config == chart_config
+
+
+def test_migrate_chart_table_migrates_when_flag_enabled(
+    mocker: MockerFixture,
+) -> None:
+    """With the flag on, importing a `table` chart migrates it to v2, same
+    as any other viz migration."""
+    mocker.patch.object(
+        feature_flag_manager,
+        "is_feature_enabled",
+        side_effect=lambda flag: flag == "AG_GRID_TABLE_ENABLED",
+    )
+    chart_config = _table_chart_config()
+
+    new_config = migrate_chart(chart_config)
+
+    assert new_config["viz_type"] == "ag-grid-table"
+    assert json.loads(new_config["params"])["viz_type"] == "ag-grid-table"


### PR DESCRIPTION
### SUMMARY

`migrate_chart()` (used by both example loading and the chart import API) unconditionally migrated any imported `viz_type: table` chart to `ag-grid-table`, regardless of `AG_GRID_TABLE_ENABLED`. Since that flag defaults to `False` and the frontend only registers the `ag-grid-table` plugin (`MainPreset.ts`) when it's on, every fresh install running `superset load_examples` ended up with charts whose stored `viz_type` the running frontend can't render at all:

```
Error: Item with key "ag-grid-table" is not registered.
```

At least seven of the bundled example dashboards are affected (`fcc_new_coder_survey`, `featured_charts`, `sales_dashboard`, `slack_dashboard`, `usa_births_names`, `video_game_sales`, `world_health`), and any external import of a `table`-viz chart hits the same failure.

Adds `MigrateViz.requires_feature_flag`, set on `MigrateTableChart`, and checks it only in the importer path (`superset/commands/chart/importers/v1/utils.py::migrate_chart`). `superset/cli/viz_migrations.py`'s `migrate_viz` CLI is untouched: running that command is already the deliberate opt-in the flag exists to gate.

### TESTING INSTRUCTIONS

1. On a fresh install with `AG_GRID_TABLE_ENABLED` left at its default (`False`), run `superset load_examples` and open any of the affected dashboards (e.g. `video_game_sales`). Every chart renders instead of showing the "not registered" error.
2. `pytest tests/unit_tests/charts/commands/importers/v1/utils_test.py tests/unit_tests/migrations/` — includes two new tests: importing a `table` chart leaves it as `table` by default, and still migrates normally to `ag-grid-table` when the flag is enabled.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
