### PR TITLE
fix(bigquery): filter __NULL__ and __UNPARTITIONED__ from max partition query

### DIFF
--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -584,7 +584,9 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
             select(func.max(partitions_table.c.partition_id).label("max_partition_id"))
             .where(partitions_table.c.table_name == table.table)
             .where(
-                partitions_table.c.partition_id.notin_(["__NULL__", "__UNPARTITIONED__"])
+                partitions_table.c.partition_id.notin_(
+                    ["__NULL__", "__UNPARTITIONED__"]
+                )
             )
         )
 

--- a/superset/db_engine_specs/bigquery.py
+++ b/superset/db_engine_specs/bigquery.py
@@ -580,9 +580,13 @@ class BigQueryEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-met
         )
 
         # Build the query
-        query = select(
-            func.max(partitions_table.c.partition_id).label("max_partition_id")
-        ).where(partitions_table.c.table_name == table.table)
+        query = (
+            select(func.max(partitions_table.c.partition_id).label("max_partition_id"))
+            .where(partitions_table.c.table_name == table.table)
+            .where(
+                partitions_table.c.partition_id.notin_(["__NULL__", "__UNPARTITIONED__"])
+            )
+        )
 
         # Compile to BigQuery SQL
         compiled_query = query.compile(

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -1151,12 +1151,13 @@ def test_where_latest_partition_filters_null_partitions(
     """
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
+    database = mock.MagicMock()
     engine = mock.MagicMock()
     engine_ctx = mock.MagicMock()
     engine_ctx.__enter__.return_value = engine
     mocker.patch.object(BigQueryEngineSpec, "get_engine", return_value=engine_ctx)
 
-    # Mock the partition metadata query to return a BigQuery table with __NULL__ partitions
+    # Mock the partition metadata query: __NULL__ partitions are filtered out
     cursor_mock = mock.MagicMock()
     cursor_mock.fetchone.return_value = ("20251231",)
     raw_conn_mock = mock.MagicMock()

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -1134,3 +1134,50 @@ def test_identifier_quote_uses_backticks() -> None:
         "end": "`",
         "escape_by_doubling": False,
     }
+
+
+def test_where_latest_partition_filters_null_partitions(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test that get_max_partition_id excludes __NULL__ and __UNPARTITIONED__.
+
+    When a table has NULL values in the partitioning column, BigQuery creates a
+    partition named __NULL__. If no explicit WHERE filter is applied during
+    the initial scan, BigQuery may also report an __UNPARTITIONED__ partition.
+    Both of these special IDs sort lexicographically higher than numeric
+    YYYYMMDD strings and would otherwise become max(partition_id), causing
+    PARSE_DATE('%Y%m%d', '__NULL__') to fail.
+    """
+    from superset.db_engine_specs.bigquery import BigQueryEngineSpec
+
+    database = mock.Mock()
+    engine = mock.MagicMock()
+    mocker.patch.object(
+        BigQueryEngineSpec, "get_engine"
+    ).return_value.__enter__.return_value = engine
+
+    # Mock the partition metadata query to return a BigQuery table with __NULL__ partitions
+    cursor_mock = mock.MagicMock()
+    cursor_mock.fetchone.return_value = ("20251231",)
+    raw_conn_mock = mock.MagicMock()
+    raw_conn_mock.cursor.return_value = cursor_mock
+    database.get_raw_connection.return_value.__enter__.return_value = raw_conn_mock
+    database.get_dialect.return_value = BigQueryDialect()
+
+    # Mock time_partitioning to identify the partition column
+    client = mocker.patch.object(BigQueryEngineSpec, "_get_client").return_value
+    bq_table_mock = mock.MagicMock()
+    bq_table_mock.time_partitioning.field = "partition_date"
+    client.get_table.return_value = bq_table_mock
+
+    table = Table("test_table", "test_dataset", "test_project")
+
+    # Ensure the generated SQL filters out __NULL__ and __UNPARTITIONED__
+    max_partition = BigQueryEngineSpec.get_max_partition_id(database, table)
+    assert max_partition == "20251231"
+
+    # The returned SQL should be the result of filtering, not one of the special IDs
+    executed_sql = cursor_mock.execute.call_args[0][0]
+    assert "__NULL__" in executed_sql or "NOT IN" in executed_sql
+    assert "__UNPARTITIONED__" in executed_sql or "NOT IN" in executed_sql

--- a/tests/unit_tests/db_engine_specs/test_bigquery.py
+++ b/tests/unit_tests/db_engine_specs/test_bigquery.py
@@ -1151,11 +1151,10 @@ def test_where_latest_partition_filters_null_partitions(
     """
     from superset.db_engine_specs.bigquery import BigQueryEngineSpec
 
-    database = mock.Mock()
     engine = mock.MagicMock()
-    mocker.patch.object(
-        BigQueryEngineSpec, "get_engine"
-    ).return_value.__enter__.return_value = engine
+    engine_ctx = mock.MagicMock()
+    engine_ctx.__enter__.return_value = engine
+    mocker.patch.object(BigQueryEngineSpec, "get_engine", return_value=engine_ctx)
 
     # Mock the partition metadata query to return a BigQuery table with __NULL__ partitions
     cursor_mock = mock.MagicMock()


### PR DESCRIPTION
## SUMMARY
Fixes #44155: BigQuery's special partition IDs `__NULL__` and `__UNPARTITIONED__` are now filtered out when selecting the latest partition, preventing `PARSE_DATE('%Y%m%d', '__NULL__')` query failures.

## BEFORE/AFTER
**Before**: Tables with NULL values in the partition column caused Copy SELECT statement and table preview to generate invalid SQL:
```sql
WHERE partition_date = PARSE_DATE('%Y%m%d', '__NULL__')  -- fails
```

**After**: Special partition IDs are excluded from max(partition_id), ensuring only numeric YYYYMMDD partitions are selected:
```sql
WHERE partition_date = PARSE_DATE('%Y%m%d', '20251231')  -- works
```

If no usable partition exists, the WHERE clause is omitted entirely.

## TEST PLAN
- Added unit test `test_where_latest_partition_filters_null_partitions` that mocks a BigQuery table with `__NULL__` partitions and verifies the generated SQL filters them out.
- Existing BigQuery partition tests remain unchanged.

## ADDITIONAL CONTEXT
This affects:
- SQL Lab Copy SELECT statement (when latest_partition=True)
- Table preview/sample queries for time-partitioned BigQuery tables

The root cause: `get_max_partition_id()` performed `SELECT max(partition_id)` without filtering. Since `__NULL__` and `__UNPARTITIONED__` sort higher than numeric strings, they became the max and then failed inside `PARSE_DATE`.
