### PR TITLE
chore(deps): bump pymongosql to 0.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,7 +233,7 @@ kylin = ["kylinpy>=2.8.4, <2.9"]
 # the plain mysql dialect, same driver as mysql.
 mariadb = ["apache-superset[mysql]"]
 monetdb = ["sqlalchemy-monetdb>=2.1.0, <3", "pymonetdb>=1.9.1, <2"]
-mongodb = ["pymongosql>=0.7.3, <1"]
+mongodb = ["pymongosql>=0.7.4, <1"]
 mssql = ["pymssql>=2.3.13, <3"]
 # motherduck is an alias for duckdb - MotherDuck works via the duckdb driver
 motherduck = ["apache-superset[duckdb]"]

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -857,7 +857,7 @@ pymongo==4.17.0
     # via
     #   pymongosql
     #   testcontainers
-pymongosql==0.7.3
+pymongosql==0.7.4
     # via apache-superset
 pymssql==2.3.13
     # via


### PR DESCRIPTION
### SUMMARY
Bumps the `mongodb` extra and the compiled dev pin from pymongosql 0.7.3 to 0.7.4. The new release fixes the SQLAlchemy dialect rebuilding the MongoDB URI from already-decoded credentials (passren/PyMongoSQL#41), so a password containing `@` connects when URL-encoded as `%40` instead of failing with "Username and password must be escaped according to RFC 3986". Runtime dependencies are unchanged between the two releases, so no other pins move.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable, dependency bump only.

### TESTING INSTRUCTIONS
1. `pip install "pymongosql==0.7.4"`.
2. Add a MongoDB database with `mongodb://user:p%40ssword@host:27017/db?mode=superset`.
3. Test connection succeeds; on 0.7.3 it fails with the RFC 3986 escaping error.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: No
- [ ] Required feature flags: None
- [ ] Changes UI: No
- [ ] Includes DB Migration: No
- [ ] Introduces new feature or API: No
- [ ] Removes existing feature or API: No