### PR TITLE
fix(frontend): dispatch warning toasts in downloadAsPdf/downloadAsImage

### DIFF
--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -35,12 +35,14 @@ jest.mock('echarts/core', () => ({
 }));
 
 jest.mock('src/components/MessageToasts/actions', () => ({
-  // Must return a plain action object: the utils now pass the action to
-  // `store.dispatch`, and Redux rejects a dispatched `undefined`.
-  addWarningToast: jest.fn((toast: unknown) => ({
-    type: 'ADD_WARNING_TOAST',
-    toast,
-  })),
+  // Must return a real action object: the utils pass the action to
+  // `store.dispatch`, and Redux rejects a dispatched `undefined`. Delegating
+  // to the actual creator keeps the mocked shape identical to production.
+  addWarningToast: jest.fn((text: string, options?: Record<string, unknown>) =>
+    jest
+      .requireActual('src/components/MessageToasts/actions')
+      .addWarningToast(text, options),
+  ),
 }));
 
 jest.mock('src/views/store', () => ({
@@ -56,6 +58,10 @@ const mockToPng = domToImage.toPng as jest.Mock;
 const mockAddWarningToast = addWarningToast as jest.Mock;
 const mockGetInstanceByDom = getInstanceByDom as jest.Mock;
 const mockDispatch = store.dispatch as jest.Mock;
+// The genuine action the store receives, for dispatch-shape assertions.
+const realAddWarningToast = jest.requireActual(
+  'src/components/MessageToasts/actions',
+).addWarningToast as (text: string) => Record<string, unknown>;
 
 // document.fonts.ready is not implemented in jsdom; provide a resolved promise
 Object.defineProperty(document, 'fonts', {
@@ -221,10 +227,21 @@ test('shows warning toast when element is not found', async () => {
   expect(mockAddWarningToast).toHaveBeenCalledWith(
     'Image download failed, please refresh and try again.',
   );
-  // The action creator's result is what reaches the store, not the toast itself
-  expect(mockDispatch).toHaveBeenCalledWith({
-    type: 'ADD_WARNING_TOAST',
-    toast: 'Image download failed, please refresh and try again.',
+  // The action creator's result is what reaches the store, not the toast
+  // itself. Compared on the stable fields — the toast id is a fresh nanoid
+  // per call, so the full object can never be equal.
+  const dispatched = mockDispatch.mock.calls[0][0] as {
+    type: string;
+    payload: Record<string, unknown>;
+  };
+  const expected = realAddWarningToast(
+    'Image download failed, please refresh and try again.',
+  ) as { type: string; payload: { toastType: string; duration: number } };
+  expect(dispatched.type).toBe(expected.type);
+  expect(dispatched.payload).toMatchObject({
+    toastType: expected.payload.toastType,
+    duration: expected.payload.duration,
+    text: 'Image download failed, please refresh and try again.',
   });
   expect(mockToJpeg).not.toHaveBeenCalled();
 });

--- a/superset-frontend/src/utils/downloadAsImage.test.ts
+++ b/superset-frontend/src/utils/downloadAsImage.test.ts
@@ -19,6 +19,7 @@
 import domToImage from 'dom-to-image-more';
 import { getInstanceByDom } from 'echarts/core';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
+import { store } from 'src/views/store';
 import downloadAsImageOptimized, {
   waitForStableScrollHeight,
 } from './downloadAsImage';
@@ -34,7 +35,16 @@ jest.mock('echarts/core', () => ({
 }));
 
 jest.mock('src/components/MessageToasts/actions', () => ({
-  addWarningToast: jest.fn(),
+  // Must return a plain action object: the utils now pass the action to
+  // `store.dispatch`, and Redux rejects a dispatched `undefined`.
+  addWarningToast: jest.fn((toast: unknown) => ({
+    type: 'ADD_WARNING_TOAST',
+    toast,
+  })),
+}));
+
+jest.mock('src/views/store', () => ({
+  store: { dispatch: jest.fn() },
 }));
 
 jest.mock('@apache-superset/core/translation', () => ({
@@ -45,6 +55,7 @@ const mockToJpeg = domToImage.toJpeg as jest.Mock;
 const mockToPng = domToImage.toPng as jest.Mock;
 const mockAddWarningToast = addWarningToast as jest.Mock;
 const mockGetInstanceByDom = getInstanceByDom as jest.Mock;
+const mockDispatch = store.dispatch as jest.Mock;
 
 // document.fonts.ready is not implemented in jsdom; provide a resolved promise
 Object.defineProperty(document, 'fonts', {
@@ -210,6 +221,11 @@ test('shows warning toast when element is not found', async () => {
   expect(mockAddWarningToast).toHaveBeenCalledWith(
     'Image download failed, please refresh and try again.',
   );
+  // The action creator's result is what reaches the store, not the toast itself
+  expect(mockDispatch).toHaveBeenCalledWith({
+    type: 'ADD_WARNING_TOAST',
+    toast: 'Image download failed, please refresh and try again.',
+  });
   expect(mockToJpeg).not.toHaveBeenCalled();
 });
 

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -19,12 +19,13 @@
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
 import { kebabCase } from 'lodash-es';
-import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
-import { store } from 'src/views/store';
 import type { AgGridContainerElement } from '@superset-ui/core/components';
-import { forceLoadAllCharts, restoreVirtualization } from './downloadUtils';
+import {
+  dispatchWarningToast,
+  forceLoadAllCharts,
+  restoreVirtualization,
+} from './downloadUtils';
 
 const IMAGE_DOWNLOAD_QUALITY = 0.95;
 const PNG_SCALE = 2; // Higher quality for PNG
@@ -389,10 +390,8 @@ export default function downloadAsImageOptimized(
       : event.currentTarget.closest(selector);
 
     if (!elementToPrint) {
-      store.dispatch(
-        addWarningToast(
-          t('Image download failed, please refresh and try again.'),
-        ),
+      await dispatchWarningToast(
+        'Image download failed, please refresh and try again.',
       );
       return;
     }
@@ -436,12 +435,8 @@ export default function downloadAsImageOptimized(
       const isFirstDataRendered = agContainer._agGridFirstDataRendered === true;
 
       if (!isFirstDataRendered) {
-        store.dispatch(
-          addWarningToast(
-            t(
-              'The chart is still loading. Please wait a moment and try again.',
-            ),
-          ),
+        await dispatchWarningToast(
+          'The chart is still loading. Please wait a moment and try again.',
         );
         // This early return skips the capture, so restore virtualization here;
         // otherwise it would stay forced-on for the rest of the session.
@@ -540,10 +535,8 @@ export default function downloadAsImageOptimized(
         link.click();
       } catch (error) {
         console.error('Creating image failed', error);
-        store.dispatch(
-          addWarningToast(
-            t('Image download failed, please refresh and try again.'),
-          ),
+        await dispatchWarningToast(
+          'Image download failed, please refresh and try again.',
         );
       } finally {
         cellFixups.forEach(({ el, minHeight, overflow }) => {
@@ -623,10 +616,8 @@ export default function downloadAsImageOptimized(
       link.click();
     } catch (error) {
       console.error('Creating image failed', error);
-      store.dispatch(
-        addWarningToast(
-          t('Image download failed, please refresh and try again.'),
-        ),
+      await dispatchWarningToast(
+        'Image download failed, please refresh and try again.',
       );
     } finally {
       if (cleanup) cleanup();

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -22,6 +22,7 @@ import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
+import { store } from 'src/views/store';
 import type { AgGridContainerElement } from '@superset-ui/core/components';
 import { forceLoadAllCharts, restoreVirtualization } from './downloadUtils';
 
@@ -388,8 +389,8 @@ export default function downloadAsImageOptimized(
       : event.currentTarget.closest(selector);
 
     if (!elementToPrint) {
-      addWarningToast(
-        t('Image download failed, please refresh and try again.'),
+      store.dispatch(
+        addWarningToast(t('Image download failed, please refresh and try again.')),
       );
       return;
     }
@@ -433,8 +434,10 @@ export default function downloadAsImageOptimized(
       const isFirstDataRendered = agContainer._agGridFirstDataRendered === true;
 
       if (!isFirstDataRendered) {
-        addWarningToast(
-          t('The chart is still loading. Please wait a moment and try again.'),
+        store.dispatch(
+          addWarningToast(
+            t('The chart is still loading. Please wait a moment and try again.'),
+          ),
         );
         // This early return skips the capture, so restore virtualization here;
         // otherwise it would stay forced-on for the rest of the session.
@@ -533,8 +536,8 @@ export default function downloadAsImageOptimized(
         link.click();
       } catch (error) {
         console.error('Creating image failed', error);
-        addWarningToast(
-          t('Image download failed, please refresh and try again.'),
+        store.dispatch(
+          addWarningToast(t('Image download failed, please refresh and try again.')),
         );
       } finally {
         cellFixups.forEach(({ el, minHeight, overflow }) => {
@@ -614,8 +617,8 @@ export default function downloadAsImageOptimized(
       link.click();
     } catch (error) {
       console.error('Creating image failed', error);
-      addWarningToast(
-        t('Image download failed, please refresh and try again.'),
+      store.dispatch(
+        addWarningToast(t('Image download failed, please refresh and try again.')),
       );
     } finally {
       if (cleanup) cleanup();

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -390,7 +390,9 @@ export default function downloadAsImageOptimized(
 
     if (!elementToPrint) {
       store.dispatch(
-        addWarningToast(t('Image download failed, please refresh and try again.')),
+        addWarningToast(
+          t('Image download failed, please refresh and try again.'),
+        ),
       );
       return;
     }
@@ -436,7 +438,9 @@ export default function downloadAsImageOptimized(
       if (!isFirstDataRendered) {
         store.dispatch(
           addWarningToast(
-            t('The chart is still loading. Please wait a moment and try again.'),
+            t(
+              'The chart is still loading. Please wait a moment and try again.',
+            ),
           ),
         );
         // This early return skips the capture, so restore virtualization here;
@@ -537,7 +541,9 @@ export default function downloadAsImageOptimized(
       } catch (error) {
         console.error('Creating image failed', error);
         store.dispatch(
-          addWarningToast(t('Image download failed, please refresh and try again.')),
+          addWarningToast(
+            t('Image download failed, please refresh and try again.'),
+          ),
         );
       } finally {
         cellFixups.forEach(({ el, minHeight, overflow }) => {
@@ -618,7 +624,9 @@ export default function downloadAsImageOptimized(
     } catch (error) {
       console.error('Creating image failed', error);
       store.dispatch(
-        addWarningToast(t('Image download failed, please refresh and try again.')),
+        addWarningToast(
+          t('Image download failed, please refresh and try again.'),
+        ),
       );
     } finally {
       if (cleanup) cleanup();

--- a/superset-frontend/src/utils/downloadAsImage.tsx
+++ b/superset-frontend/src/utils/downloadAsImage.tsx
@@ -19,6 +19,7 @@
 import { SyntheticEvent } from 'react';
 import domToImage from 'dom-to-image-more';
 import { kebabCase } from 'lodash-es';
+import { t } from '@apache-superset/core/translation';
 import { SupersetTheme } from '@apache-superset/core/theme';
 import type { AgGridContainerElement } from '@superset-ui/core/components';
 import {
@@ -391,7 +392,7 @@ export default function downloadAsImageOptimized(
 
     if (!elementToPrint) {
       await dispatchWarningToast(
-        'Image download failed, please refresh and try again.',
+        t('Image download failed, please refresh and try again.'),
       );
       return;
     }
@@ -436,7 +437,7 @@ export default function downloadAsImageOptimized(
 
       if (!isFirstDataRendered) {
         await dispatchWarningToast(
-          'The chart is still loading. Please wait a moment and try again.',
+          t('The chart is still loading. Please wait a moment and try again.'),
         );
         // This early return skips the capture, so restore virtualization here;
         // otherwise it would stay forced-on for the rest of the session.
@@ -536,7 +537,7 @@ export default function downloadAsImageOptimized(
       } catch (error) {
         console.error('Creating image failed', error);
         await dispatchWarningToast(
-          'Image download failed, please refresh and try again.',
+          t('Image download failed, please refresh and try again.'),
         );
       } finally {
         cellFixups.forEach(({ el, minHeight, overflow }) => {
@@ -617,7 +618,7 @@ export default function downloadAsImageOptimized(
     } catch (error) {
       console.error('Creating image failed', error);
       await dispatchWarningToast(
-        'Image download failed, please refresh and try again.',
+        t('Image download failed, please refresh and try again.'),
       );
     } finally {
       if (cleanup) cleanup();

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -22,6 +22,7 @@ import { kebabCase } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
 import { addWarningToast } from 'src/components/MessageToasts/actions';
+import { store } from 'src/views/store';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { forceLoadAllCharts, restoreVirtualization } from './downloadUtils';
 
@@ -56,8 +57,8 @@ export default function downloadAsPdf(
       : event.currentTarget.closest(selector);
 
     if (!elementToPrint) {
-      return addWarningToast(
-        t('PDF download failed, please refresh and try again.'),
+      return store.dispatch(
+        addWarningToast(t('PDF download failed, please refresh and try again.')),
       );
     }
 

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -58,7 +58,9 @@ export default function downloadAsPdf(
 
     if (!elementToPrint) {
       return store.dispatch(
-        addWarningToast(t('PDF download failed, please refresh and try again.')),
+        addWarningToast(
+          t('PDF download failed, please refresh and try again.'),
+        ),
       );
     }
 

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -19,12 +19,13 @@
 import { SyntheticEvent } from 'react';
 import domToPdf from 'dom-to-pdf';
 import { kebabCase } from 'lodash-es';
-import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
-import { addWarningToast } from 'src/components/MessageToasts/actions';
-import { store } from 'src/views/store';
 import getBootstrapData from 'src/utils/getBootstrapData';
-import { forceLoadAllCharts, restoreVirtualization } from './downloadUtils';
+import {
+  dispatchWarningToast,
+  forceLoadAllCharts,
+  restoreVirtualization,
+} from './downloadUtils';
 
 const pdfCompressionLevel = getBootstrapData().common.pdf_compression_level;
 
@@ -57,10 +58,8 @@ export default function downloadAsPdf(
       : event.currentTarget.closest(selector);
 
     if (!elementToPrint) {
-      return store.dispatch(
-        addWarningToast(
-          t('PDF download failed, please refresh and try again.'),
-        ),
+      return dispatchWarningToast(
+        'PDF download failed, please refresh and try again.',
       );
     }
 

--- a/superset-frontend/src/utils/downloadAsPdf.ts
+++ b/superset-frontend/src/utils/downloadAsPdf.ts
@@ -19,6 +19,7 @@
 import { SyntheticEvent } from 'react';
 import domToPdf from 'dom-to-pdf';
 import { kebabCase } from 'lodash-es';
+import { t } from '@apache-superset/core/translation';
 import { logging } from '@apache-superset/core/utils';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import {
@@ -59,7 +60,7 @@ export default function downloadAsPdf(
 
     if (!elementToPrint) {
       return dispatchWarningToast(
-        'PDF download failed, please refresh and try again.',
+        t('PDF download failed, please refresh and try again.'),
       );
     }
 

--- a/superset-frontend/src/utils/downloadUtils.ts
+++ b/superset-frontend/src/utils/downloadUtils.ts
@@ -34,11 +34,12 @@ import {
  * `common.conf`, so a top-level import here would break any suite that
  * transitively imports this util without bootstrapping the app. Warning
  * toasts sit on failure paths only, so resolving the store lazily costs
- * nothing on the happy path.
+ * nothing on the happy path. The message arrives pre-translated — call
+ * sites wrap their literals in `t()` so the extraction keeps them.
  */
 export async function dispatchWarningToast(message: string): Promise<void> {
   const { store } = await import('src/views/store');
-  store.dispatch(addWarningToast(t(message)));
+  store.dispatch(addWarningToast(message));
 }
 
 // Rows carry a `data-row-id` attribute (see Row.tsx) so the export path can

--- a/superset-frontend/src/utils/downloadUtils.ts
+++ b/superset-frontend/src/utils/downloadUtils.ts
@@ -28,6 +28,19 @@ import {
   RESTORE_VIRTUALIZATION_EVENT,
 } from 'src/dashboard/constants';
 
+/**
+ * Dispatches a warning toast through the full app store. The store module
+ * (`src/views/store`) builds the store at import time and needs bootstrap
+ * `common.conf`, so a top-level import here would break any suite that
+ * transitively imports this util without bootstrapping the app. Warning
+ * toasts sit on failure paths only, so resolving the store lazily costs
+ * nothing on the happy path.
+ */
+export async function dispatchWarningToast(message: string): Promise<void> {
+  const { store } = await import('src/views/store');
+  store.dispatch(addWarningToast(t(message)));
+}
+
 // Rows carry a `data-row-id` attribute (see Row.tsx) so the export path can
 // target a subset of them per batch. How many rows get forced into view at
 // once: large enough that a small dashboard finishes in one batch, small


### PR DESCRIPTION
The raw addWarningToast action creators were returned or called without dispatch, so the toasts never reached the reducer and users saw nothing when PDF or image downloads failed.

This routes all five call sites through the redux store, same pattern as ChatHost.

Fixes #44153