### PR TITLE
fix(mcp): downgrade synthetic tool ToolError log level to WARNING (SC-120340)

### DIFF
--- a/superset/mcp_service/server.py
+++ b/superset/mcp_service/server.py
@@ -696,7 +696,8 @@ def _apply_tool_search_transform(mcp_instance: Any, config: dict[str, Any]) -> N
             if name in {transform._call_tool_name, transform._search_tool_name}:
                 raise ToolError(
                     f"'{name}' is a synthetic search tool and cannot be "
-                    f"called via the call_tool proxy"
+                    f"called via the call_tool proxy",
+                    log_level=logging.WARNING,
                 )
             if arguments:
                 target_tool = await ctx.fastmcp.get_tool(name)

--- a/tests/unit_tests/mcp_service/test_tool_search_transform.py
+++ b/tests/unit_tests/mcp_service/test_tool_search_transform.py
@@ -17,6 +17,7 @@
 
 """Tests for MCP tool search transform configuration and application."""
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1229,6 +1230,45 @@ def test_create_serializer_include_schemas_true_with_compact():
 
 
 # -- search_tools optional query tests --
+
+
+def test_call_tool_proxy_rejects_synthetic_names_with_warning_log_level() -> None:
+    """call_tool proxy raises ToolError(log_level=WARNING) for synthetic names.
+
+    FastMCP logs ToolError at the exception's log_level before middleware sees
+    it.  Synthetic-name rejections are LLM misuse (a 400-class error), not
+    system failures, so WARNING prevents them from reaching Sentry via the
+    ERROR-level LoggingIntegration.
+    """
+    import asyncio
+
+    from fastmcp.exceptions import ToolError as FastMCPToolError
+
+    mock_mcp = MagicMock()
+    config = {
+        "strategy": "bm25",
+        "max_results": 5,
+        "always_visible": [],
+        "search_tool_name": "search_tools",
+        "call_tool_name": "call_tool",
+    }
+    _apply_tool_search_transform(mock_mcp, config)
+    transform = mock_mcp.add_transform.call_args[0][0]
+    call_tool_obj = transform._make_call_tool()
+
+    async def _run_and_capture(name: str) -> FastMCPToolError:
+        import pytest
+
+        with pytest.raises(FastMCPToolError) as exc_info:
+            await call_tool_obj.fn(name=name, arguments=None, ctx=None)
+        return exc_info.value
+
+    for synthetic_name in ("search_tools", "call_tool"):
+        exc = asyncio.run(_run_and_capture(synthetic_name))
+        assert exc.log_level == logging.WARNING, (
+            f"Expected WARNING for '{synthetic_name}', got {exc.log_level}"
+        )
+        assert synthetic_name in str(exc)
 
 
 def test_search_tool_query_is_optional_in_schema() -> None:


### PR DESCRIPTION
### SUMMARY

**Root cause**: The `call_tool` proxy in `_make_normalizing_call_tool` (`superset/mcp_service/server.py`) raises `ToolError` when an LLM/MCP client attempts to call synthetic search-tool names (`search_tools`, `call_tool`) via the proxy. This is a user/LLM misuse pattern (400-class), not a system failure.

However, `ToolError` inherits from `FastMCPError`, which defaults `log_level=logging.ERROR`. FastMCP's own `call_tool` handler catches `FastMCPError` and calls `logger.log(e.log_level, ...)` — logging at ERROR — *before* Superset's `GlobalErrorHandlerMiddleware` ever sees the exception. Sentry's `LoggingIntegration(event_level=logging.ERROR)` then promotes this log line to a Sentry event, bypassing Superset's middleware classification that correctly identifies `ToolError` as a user error (WARNING, no Sentry forwarding via `MCP_ERROR_HOOK`).

**Fix**: Pass `log_level=logging.WARNING` explicitly on this one `ToolError` raise. This is FastMCP's first-class, documented mechanism for per-exception log severity. It aligns with Superset's existing `_USER_ERROR_TYPES` classification in `middleware.py` and requires no changes to Sentry config or logger suppression.

### Tradeoffs

No behavior change. The MCP response returned to the client (the `ToolError` message and error semantics) is completely unchanged. Only the log severity changes — from ERROR to WARNING — which prevents this expected-in-normal-operation error from reaching Sentry via the `LoggingIntegration`. Nothing else in the codebase keys off this `ToolError`'s log level or relies on it reaching Sentry.

### TESTING INSTRUCTIONS

```bash
python -m pytest tests/unit_tests/mcp_service/test_tool_search_transform.py::test_call_tool_proxy_rejects_synthetic_names_with_warning_log_level -xvs
```

The test:
- Builds the BM25 search transform via `_apply_tool_search_transform`
- Gets the `call_tool` Tool from `transform._make_call_tool()`
- Calls it with `name="search_tools"` and `name="call_tool"` (both synthetic names)
- Asserts the raised `ToolError` has `log_level == logging.WARNING`
- Verified non-vacuous: test fails without the fix (asserts ERROR ≠ WARNING)

### ADDITIONAL INFORMATION
- [x] Has associated issue: Fixes SUPERSET-PYTHON-12QC
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API