### PR TITLE
fix(sqla): guard unprotected Jinja template rendering in ExploreMixin

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -4405,7 +4405,26 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         col = sa.column(column.get("column_name"), type_=type_)
 
         if template_processor:
-            expression = template_processor.process_template(column["column_name"])
+            try:
+                expression = template_processor.process_template(column["column_name"])
+            except UndefinedError as ex:
+                raise QueryObjectValidationError(
+                    _(
+                        "Time column template error: %(msg)s",
+                        msg=str(ex),
+                    )
+                ) from ex
+            except (TemplateError, SupersetSyntaxErrorException) as ex:
+                if isinstance(ex, TemplateError):
+                    error_msg = ex.message
+                else:
+                    error_msg = str(ex.errors[0].message if ex.errors else ex)
+                raise QueryObjectValidationError(
+                    _(
+                        "Error while rendering time column expression: %(msg)s",
+                        msg=error_msg,
+                    )
+                ) from ex
             expression = self._validate_stored_expression(expression)
             col = sa.literal_column(expression, type_=type_)
 
@@ -4426,7 +4445,27 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
         type_ = column_spec.sqla_type if column_spec else None
         if expression := tbl_column.expression:
             if template_processor:
-                expression = template_processor.process_template(expression)
+                try:
+                    expression = template_processor.process_template(expression)
+                except UndefinedError as ex:
+                    raise QueryObjectValidationError(
+                        _(
+                            "Calculated column template error: %(msg)s",
+                            msg=str(ex),
+                        )
+                    ) from ex
+                except (TemplateError, SupersetSyntaxErrorException) as ex:
+                    if isinstance(ex, TemplateError):
+                        error_msg = ex.message
+                    else:
+                        error_msg = str(ex.errors[0].message if ex.errors else ex)
+                    raise QueryObjectValidationError(
+                        _(
+                            "Error while rendering calculated column "
+                            "expression: %(msg)s",
+                            msg=error_msg,
+                        )
+                    ) from ex
                 if expression != tbl_column.expression:
                     # Re-check the rendered expression before embedding it.
                     expression = validate_rendered_expression(

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -1679,6 +1679,138 @@ def test_convert_tbl_column_to_sqla_col_rejects_stored_subquery(
         datasource.convert_tbl_column_to_sqla_col(tbl_column)
 
 
+def test_get_timestamp_expression_wraps_jinja_undefined_error(
+    mocker: MockerFixture,
+) -> None:
+    """``UndefinedError`` from a time column template is wrapped in
+    ``QueryObjectValidationError`` instead of escaping raw."""
+    from jinja2.exceptions import UndefinedError
+
+    datasource = mocker.MagicMock()
+    datasource.db_engine_spec.get_column_spec.return_value = None
+    datasource.get_timestamp_expression = ExploreMixin.get_timestamp_expression.__get__(
+        datasource
+    )
+
+    template_processor = mocker.MagicMock()
+    template_processor.process_template.side_effect = UndefinedError(
+        "'nonexistent_var' is undefined"
+    )
+
+    with pytest.raises(
+        QueryObjectValidationError,
+        match=r"Time column template error",
+    ):
+        datasource.get_timestamp_expression(
+            column={"column_name": "{{ nonexistent_var.attr }}", "type": "DATETIME"},
+            time_grain=None,
+            template_processor=template_processor,
+        )
+
+
+def test_get_timestamp_expression_wraps_jinja_template_error(
+    mocker: MockerFixture,
+) -> None:
+    """``TemplateError`` from a time column template is wrapped in
+    ``QueryObjectValidationError`` instead of escaping raw."""
+    from jinja2.exceptions import TemplateSyntaxError
+
+    datasource = mocker.MagicMock()
+    datasource.db_engine_spec.get_column_spec.return_value = None
+    datasource.get_timestamp_expression = ExploreMixin.get_timestamp_expression.__get__(
+        datasource
+    )
+
+    template_processor = mocker.MagicMock()
+    template_processor.process_template.side_effect = TemplateSyntaxError(
+        "unexpected '}'", lineno=1
+    )
+
+    with pytest.raises(
+        QueryObjectValidationError,
+        match=r"Error while rendering time column expression",
+    ):
+        datasource.get_timestamp_expression(
+            column={"column_name": "{{ bad_syntax }", "type": "DATETIME"},
+            time_grain=None,
+            template_processor=template_processor,
+        )
+
+
+def test_convert_tbl_column_to_sqla_col_wraps_jinja_undefined_error(
+    mocker: MockerFixture,
+) -> None:
+    """``UndefinedError`` from a calculated column template is wrapped in
+    ``QueryObjectValidationError`` instead of escaping raw."""
+    from jinja2.exceptions import UndefinedError
+
+    datasource = mocker.MagicMock()
+    datasource.database = _database_for_expression(mocker)
+    datasource.catalog = None
+    datasource.schema = "public"
+    datasource.db_engine_spec.engine = "sqlite"
+    datasource._validate_stored_expression = (
+        ExploreMixin._validate_stored_expression.__get__(datasource)
+    )
+    datasource.convert_tbl_column_to_sqla_col = (
+        ExploreMixin.convert_tbl_column_to_sqla_col.__get__(datasource)
+    )
+
+    template_processor = mocker.MagicMock()
+    template_processor.process_template.side_effect = UndefinedError(
+        "'nonexistent_var' is undefined"
+    )
+
+    tbl_column = TableColumn(
+        column_name="calc_col",
+        expression="{{ nonexistent_var.attr }}",
+    )
+    with pytest.raises(
+        QueryObjectValidationError,
+        match=r"Calculated column template error",
+    ):
+        datasource.convert_tbl_column_to_sqla_col(
+            tbl_column, template_processor=template_processor
+        )
+
+
+def test_convert_tbl_column_to_sqla_col_wraps_jinja_template_error(
+    mocker: MockerFixture,
+) -> None:
+    """``TemplateError`` from a calculated column template is wrapped in
+    ``QueryObjectValidationError`` instead of escaping raw."""
+    from jinja2.exceptions import TemplateSyntaxError
+
+    datasource = mocker.MagicMock()
+    datasource.database = _database_for_expression(mocker)
+    datasource.catalog = None
+    datasource.schema = "public"
+    datasource.db_engine_spec.engine = "sqlite"
+    datasource._validate_stored_expression = (
+        ExploreMixin._validate_stored_expression.__get__(datasource)
+    )
+    datasource.convert_tbl_column_to_sqla_col = (
+        ExploreMixin.convert_tbl_column_to_sqla_col.__get__(datasource)
+    )
+
+    template_processor = mocker.MagicMock()
+    template_processor.process_template.side_effect = TemplateSyntaxError(
+        "unexpected '}'", lineno=1
+    )
+
+    tbl_column = TableColumn(
+        column_name="calc_col",
+        expression="{{ bad_syntax }",
+    )
+    with pytest.raises(
+        QueryObjectValidationError,
+        match=r"Error while rendering calculated column expression",
+    ):
+        datasource.convert_tbl_column_to_sqla_col(
+            tbl_column, template_processor=template_processor
+        )
+
+
 def test_get_sqla_col_falls_back_when_stored_expression_unparseable(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
### SUMMARY

Two `process_template` call sites in `ExploreMixin` — `get_timestamp_expression()` and `convert_tbl_column_to_sqla_col()` — lack exception handling for Jinja template errors. When a user writes a Jinja expression (e.g. `{{ filter_values('col')[0] }}` or `{{ undefined_var.attr }}`) in a time column or calculated column, and the template raises `UndefinedError` or `TemplateError`, the raw jinja2 exception escapes unhandled instead of being surfaced as a `QueryObjectValidationError`.

This is the same bug class fixed by #42366 and proposed in #42401 for `get_rendered_sql()`, which already has the correct two-clause exception handler. These two sibling methods in the same class were missed.

**Root cause**: `BaseTemplateProcessor.process_template` wraps parse-time `TemplateSyntaxError` as `SupersetSyntaxErrorException`, but during the render phase it only catches `RecursionError` and a narrow pattern-matched `UndefinedError`; any other `UndefinedError` and any other `TemplateError` subtype raised during rendering escape raw. Both methods are called from `get_sqla_query()` (the main chart-rendering / SQL Lab query path) with no upstream catch.

**Fix**: Wrap both `process_template` calls with the same two-clause handler (`except UndefinedError` → `QueryObjectValidationError`, then `except (TemplateError, SupersetSyntaxErrorException)` → `QueryObjectValidationError`), mirroring the existing pattern in `get_rendered_sql()`. All needed imports were already present in the file.

This is additive exception handling only — no behavior change for the success path.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A — backend-only change affecting error handling, no UI changes.

### TESTING INSTRUCTIONS
1. Create a dataset with a calculated column expression containing `{{ undefined_var.attr }}`
2. Try to query/chart using that column
3. **Before**: raw `jinja2.exceptions.UndefinedError` escapes, producing an opaque 500 error
4. **After**: `QueryObjectValidationError` with message "Calculated column template error: 'undefined_var' is undefined" — a clean, user-facing error

Automated regression tests are included covering both `UndefinedError` and `TemplateSyntaxError` for both fixed methods.

### ADDITIONAL INFORMATION
- [x] Has associated issue: [sc-120357](https://app.shortcut.com/preset/story/120357)
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

