### PR TITLE
chore(deps): remove unused underscore dependency

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -34528,6 +34528,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/nomnom/node_modules/underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
+      "dev": true
+    },
     "node_modules/nopt": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
@@ -44164,13 +44170,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
-      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.29.0",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -432,7 +432,6 @@
     },
     "tar": "^7.5.16",
     "typescript-json-schema": "^0.68.0",
-    "underscore": "^1.13.7",
     "uuid": "$uuid"
   },
   "browserslist": [


### PR DESCRIPTION
### SUMMARY
`underscore` has zero first-party usage anywhere in `src`/`plugins`/`packages` — the only hits for the literal string "underscore" in the codebase are `eslint-disable no-underscore-dangle` directive comments, unrelated to the npm package. `lodash-es` already covers the same ground and is what's actually used throughout (178 files).

### CHANGES
- Removed `underscore` from `package.json` `devDependencies`.
- Regenerated `package-lock.json` via `npm install`. The only remaining `underscore` entry afterward is a transitive dependency of `nomnom` (a different, older version, nested under its own `node_modules`) — untouched.

### TESTING INSTRUCTIONS
`grep -rl "from 'underscore'" --exclude-dir=node_modules src plugins packages` returns nothing before or after this change (it was already unused).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API