### PR TITLE
ci(python-unit): run the unit suite in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -69,12 +69,17 @@ jobs:
       # even though every test passed. `--dist loadfile` keeps all tests from
       # one file on one worker, which preserves module-scoped fixture state;
       # pytest-cov combines the per-worker coverage data automatically.
+      # `--durations=0` makes `--durations-min` effective (the min flag only
+      # filters an enabled report) so the slow-file critical path under
+      # loadfile stays visible. `--maxfail` is a controller-level stop: tests
+      # already dispatched to workers finish, so the final failure count can
+      # slightly exceed it.
       - name: Python unit tests
         env:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
-          pytest -n auto --dist loadfile --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50 --junit-xml=test-results/junit-unit.xml
+          pytest -n auto --dist loadfile --durations=0 --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50 --junit-xml=test-results/junit-unit.xml
       # COVERAGE_FILE keeps these scoped gates off the default .coverage that
       # the step above wrote. pytest-cov starts a fresh data file per run, so
       # without it the last gate replaces the full-suite data and the report

--- a/.github/workflows/superset-python-unittest.yml
+++ b/.github/workflows/superset-python-unittest.yml
@@ -63,12 +63,18 @@ jobs:
         uses: $/.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
+      # Runs in parallel via pytest-xdist: the serial suite had grown to
+      # ~27-28 min against this job's 30-minute timeout, so the trailing
+      # coverage/upload steps were being killed on ordinary runner variance
+      # even though every test passed. `--dist loadfile` keeps all tests from
+      # one file on one worker, which preserves module-scoped fixture state;
+      # pytest-cov combines the per-worker coverage data automatically.
       - name: Python unit tests
         env:
           SUPERSET_TESTENV: true
           SUPERSET_SECRET_KEY: not-a-secret
         run: |
-          pytest --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50 --junit-xml=test-results/junit-unit.xml
+          pytest -n auto --dist loadfile --durations-min=0.5 --cov-report= --cov=superset ./tests/common ./tests/unit_tests --cache-clear --maxfail=50 --junit-xml=test-results/junit-unit.xml
       # COVERAGE_FILE keeps these scoped gates off the default .coverage that
       # the step above wrote. pytest-cov starts a fresh data file per run, so
       # without it the last gate replaces the full-suite data and the report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,7 @@ development = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
+    "pytest-xdist",
     "python-ldap>=3.4.7",
     "ruff",
     "sqloxide",

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -274,6 +274,8 @@ events==0.5
     # via opensearch-py
 exceptiongroup==1.3.0
     # via fastmcp-slim
+execnet==2.1.2
+    # via pytest-xdist
 fastmcp==3.4.7
     # via apache-superset
 fastmcp-slim==3.4.7
@@ -890,6 +892,7 @@ pytest==7.4.4
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
+    #   pytest-xdist
 pytest-asyncio==0.23.8
     # via apache-superset
 pytest-cov==6.0.0
@@ -900,6 +903,8 @@ pytest-mock==3.10.0
     # via
     #   apache-superset
     #   apache-superset-extensions-cli
+pytest-xdist==3.8.0
+    # via apache-superset
 python-calamine==0.8.2
     # via
     #   -c requirements/base-constraint.txt

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -33,27 +33,31 @@ from superset.commands.report.exceptions import (
 )
 from superset.reports.models import ReportScheduleType
 
-REPORT_TYPES = {
+# Tuples, not sets: these feed ``@pytest.mark.parametrize``, and pytest-xdist
+# requires every worker to collect the same test ids in the same order. A set
+# of strings iterates in per-process hash order (PYTHONHASHSEED), so a set here
+# makes workers disagree and xdist aborts with "Different tests were collected".
+REPORT_TYPES = (
     ReportScheduleType.ALERT,
     ReportScheduleType.REPORT,
-}
+)
 
-TEST_SCHEDULES_EVERY_MINUTE = {
+TEST_SCHEDULES_EVERY_MINUTE = (
     "* * * * *",
     "1-5 * * * *",
     "10-20 * * * *",
     "0,45,10-20 * * * *",
     "23,45,50,51 * * * *",
     "10,20,30,40-45 * * * *",
-}
+)
 
-TEST_SCHEDULES_SINGLE_MINUTES = {
+TEST_SCHEDULES_SINGLE_MINUTES = (
     "1,5,8,10,12 * * * *",
     "10 1 * * *",
     "27,2 1-5 * * *",
-}
+)
 
-TEST_SCHEDULES = TEST_SCHEDULES_EVERY_MINUTE.union(TEST_SCHEDULES_SINGLE_MINUTES)
+TEST_SCHEDULES = TEST_SCHEDULES_EVERY_MINUTE + TEST_SCHEDULES_SINGLE_MINUTES
 
 
 def dynamic_alert_minimum_interval(**kwargs) -> int:

--- a/tests/unit_tests/commands/report/base_test.py
+++ b/tests/unit_tests/commands/report/base_test.py
@@ -37,12 +37,12 @@ from superset.reports.models import ReportScheduleType
 # requires every worker to collect the same test ids in the same order. A set
 # of strings iterates in per-process hash order (PYTHONHASHSEED), so a set here
 # makes workers disagree and xdist aborts with "Different tests were collected".
-REPORT_TYPES = (
+REPORT_TYPES: tuple[ReportScheduleType, ...] = (
     ReportScheduleType.ALERT,
     ReportScheduleType.REPORT,
 )
 
-TEST_SCHEDULES_EVERY_MINUTE = (
+TEST_SCHEDULES_EVERY_MINUTE: tuple[str, ...] = (
     "* * * * *",
     "1-5 * * * *",
     "10-20 * * * *",
@@ -51,13 +51,15 @@ TEST_SCHEDULES_EVERY_MINUTE = (
     "10,20,30,40-45 * * * *",
 )
 
-TEST_SCHEDULES_SINGLE_MINUTES = (
+TEST_SCHEDULES_SINGLE_MINUTES: tuple[str, ...] = (
     "1,5,8,10,12 * * * *",
     "10 1 * * *",
     "27,2 1-5 * * *",
 )
 
-TEST_SCHEDULES = TEST_SCHEDULES_EVERY_MINUTE + TEST_SCHEDULES_SINGLE_MINUTES
+TEST_SCHEDULES: tuple[str, ...] = (
+    TEST_SCHEDULES_EVERY_MINUTE + TEST_SCHEDULES_SINGLE_MINUTES
+)
 
 
 def dynamic_alert_minimum_interval(**kwargs) -> int:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -73,6 +73,26 @@ def session(get_session) -> Iterator[Session]:
     return get_session()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _preload_engine_specs() -> None:
+    """
+    Import every engine-spec module once per test session, before any test.
+
+    ``load_engine_specs()`` imports the spec modules lazily on first use, and
+    some of them pull in third-party drivers that read the local timezone at
+    import time (``clickhouse_connect`` via ``dateutil``). That import fails
+    under a ``freeze_time`` clock. In a serial run some earlier test always
+    paid the import cost outside a frozen clock, so the dependency was
+    invisible; under pytest-xdist every worker starts cold, and whichever
+    ``freeze_time`` test is the first engine-spec importer on its worker
+    fails -- a flake that moves with worker assignment. Loading here gives
+    every worker the same import state a serial run reached by accident.
+    """
+    from superset.db_engine_specs import load_engine_specs
+
+    load_engine_specs()
+
+
 @pytest.fixture(scope="module")
 def app(request: SubRequest) -> Iterator[SupersetApp]:
     """

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -95,9 +95,10 @@ def _preload_clock_reading_drivers() -> None:
     third-party entry point in every worker. Engine-spec discovery itself
     stays lazy, so tests that exercise it still observe a cold state.
     """
-    # Deferred, guarded import: the driver is an optional dependency, so a
-    # module-top import would make this conftest fail to load in an
-    # environment where it is not installed.
+    # Even a guarded module-top import would tie the driver to collection on
+    # every invocation, including --collect-only and partial runs. Session setup
+    # imports it once per worker, after conftest/plugin loading and before any
+    # test can enter freeze_time. Guard ImportError because the driver is optional.
     try:
         import clickhouse_connect  # noqa: F401
     except ImportError:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -74,23 +74,34 @@ def session(get_session) -> Iterator[Session]:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _preload_engine_specs() -> None:
-    """
-    Import every engine-spec module once per test session, before any test.
+def _preload_clock_reading_drivers() -> None:
+    """Import third-party drivers that read the clock at import, before any test.
 
-    ``load_engine_specs()`` imports the spec modules lazily on first use, and
-    some of them pull in third-party drivers that read the local timezone at
-    import time (``clickhouse_connect`` via ``dateutil``). That import fails
-    under a ``freeze_time`` clock. In a serial run some earlier test always
-    paid the import cost outside a frozen clock, so the dependency was
-    invisible; under pytest-xdist every worker starts cold, and whichever
-    ``freeze_time`` test is the first engine-spec importer on its worker
-    fails -- a flake that moves with worker assignment. Loading here gives
-    every worker the same import state a serial run reached by accident.
-    """
-    from superset.db_engine_specs import load_engine_specs
+    ``clickhouse_connect`` normalises the local timezone through ``dateutil``
+    at module import time, which raises ``AttributeError`` under a frozen
+    ``freeze_time`` clock. Superset's ClickHouse engine spec imports it
+    lazily, on the first ``load_engine_specs()`` call, so whichever test
+    first resolves an engine spec pays that import -- and if that test runs
+    under ``freeze_time`` (seven unit-test files combine ``freeze_time`` with
+    engine-spec resolution) the import fails. Serially some earlier test
+    always paid it outside a frozen clock; under pytest-xdist each worker
+    starts cold, so the failure moves with worker assignment.
 
-    load_engine_specs()
+    Only the third-party module is imported here, deliberately: importing
+    Superset's own engine-spec modules this early would also cache
+    app-context-dependent values (the ClickHouse spec resolves its
+    ``product_name`` from ``current_app`` on import), and running full
+    ``load_engine_specs()`` discovery would execute every registered
+    third-party entry point in every worker. Engine-spec discovery itself
+    stays lazy, so tests that exercise it still observe a cold state.
+    """
+    # Deferred, guarded import: the driver is an optional dependency, so a
+    # module-top import would make this conftest fail to load in an
+    # environment where it is not installed.
+    try:
+        import clickhouse_connect  # noqa: F401
+    except ImportError:
+        pass
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit_tests/mcp_service/conftest.py
+++ b/tests/unit_tests/mcp_service/conftest.py
@@ -22,7 +22,33 @@ Disables RBAC permission checks for integration tests.
 RBAC logic is tested directly in test_auth_rbac.py.
 """
 
+from collections.abc import Iterator
+
 import pytest
+
+from superset.mcp_service.auth import _mcp_user_id_var
+
+
+@pytest.fixture(autouse=True)
+def isolate_mcp_user_id_var() -> Iterator[None]:
+    """Reset the ``_mcp_user_id_var`` ContextVar around every MCP test.
+
+    ``_setup_user_context()`` sets the var and relies on ``on_call_tool``'s
+    ``finally`` to clear it. Tests that call ``_setup_user_context()`` (or set
+    the var) directly, without going through the middleware, leave it set in
+    the thread's base context, and pytest-asyncio copies that context into
+    every later async test's task -- so a resolved user id leaks into
+    unrelated tests. In a serial run a middleware-exercising test file that
+    sorts between the leaking file and its victim happened to clear the var;
+    under pytest-xdist the files land on different workers and the leak
+    surfaces as a flake. Scoping the var to each test removes the ordering
+    dependence.
+    """
+    token = _mcp_user_id_var.set(None)
+    try:
+        yield
+    finally:
+        _mcp_user_id_var.reset(token)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit_tests/mcp_service/conftest.py
+++ b/tests/unit_tests/mcp_service/conftest.py
@@ -23,6 +23,7 @@ RBAC logic is tested directly in test_auth_rbac.py.
 """
 
 from collections.abc import Iterator
+from contextvars import Token
 
 import pytest
 
@@ -44,7 +45,7 @@ def isolate_mcp_user_id_var() -> Iterator[None]:
     surfaces as a flake. Scoping the var to each test removes the ordering
     dependence.
     """
-    token = _mcp_user_id_var.set(None)
+    token: Token[int | None] = _mcp_user_id_var.set(None)
     try:
         yield
     finally:

--- a/tests/unit_tests/test_clock_reading_driver_preload.py
+++ b/tests/unit_tests/test_clock_reading_driver_preload.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Pin the harness guarantee behind ``_preload_clock_reading_drivers``.
+
+``clickhouse_connect`` reads the local timezone at import time and fails
+under a ``freeze_time`` clock, so the unit-test session imports it before any
+test runs. A test can therefore resolve the ClickHouse engine spec under a
+frozen clock on any worker, regardless of what ran before it. This test
+asserts that guarantee directly; if the preload fixture is removed, it fails
+on any worker where nothing else happened to import the driver first.
+"""
+
+import importlib.util
+import sys
+
+import pytest
+from freezegun import freeze_time
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("clickhouse_connect") is None,
+    reason="clickhouse_connect is not installed",
+)
+def test_clock_reading_driver_is_preloaded_before_tests() -> None:
+    assert "clickhouse_connect" in sys.modules
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("clickhouse_connect") is None,
+    reason="clickhouse_connect is not installed",
+)
+@freeze_time("2021-04-01T00:00:00Z")
+def test_clickhouse_engine_spec_resolves_under_frozen_clock() -> None:
+    from superset.db_engine_specs import get_engine_spec
+
+    assert get_engine_spec("clickhousedb", "connect") is not None

--- a/tests/unit_tests/test_clock_reading_driver_preload.py
+++ b/tests/unit_tests/test_clock_reading_driver_preload.py
@@ -36,6 +36,7 @@ from freezegun import freeze_time
     reason="clickhouse_connect is not installed",
 )
 def test_clock_reading_driver_is_preloaded_before_tests() -> None:
+    """Verify the session fixture imports the driver before tests run."""
     assert "clickhouse_connect" in sys.modules
 
 
@@ -45,6 +46,12 @@ def test_clock_reading_driver_is_preloaded_before_tests() -> None:
 )
 @freeze_time("2021-04-01T00:00:00Z")
 def test_clickhouse_engine_spec_resolves_under_frozen_clock() -> None:
+    """Verify the ClickHouse Connect engine spec resolves under a frozen clock."""
+    # Defer the engine-spec package import until after the session preload;
+    # a module-top import would execute during collection, before the fixture.
     from superset.db_engine_specs import get_engine_spec
 
-    assert get_engine_spec("clickhousedb", "connect") is not None
+    assert (
+        get_engine_spec("clickhousedb", "connect").__name__
+        == "ClickHouseConnectEngineSpec"
+    )


### PR DESCRIPTION
### SUMMARY

The `unit-tests (current)` job in `Python-Unit` has been getting killed at its 30-minute `timeout-minutes` wall even though every test passes. The serial suite has grown to ~27–28 minutes, so the *trailing* steps (the 100%-coverage gates and the codecov upload) no longer fit on an ordinary slow-runner day:

| run | `Python unit tests` step | then | total |
|---|---|---|---|
| passing | 26m45s ✅ | coverage 1m27s + upload 0m20s | 29m24s — 36 s to spare |
| killed | 28m04s ✅ | killed *during* the coverage gate | 30m21s |
| killed | 27m43s ✅ | coverage ✅, killed *during* codecov upload | 30m11s |

Same tree all three times; the only variable was ~1.3 min of runner speed. Master's own runs take 25–29 min, so the whole repo sits at 85–97% of the budget. On 2026-09-11 alone this killed five otherwise-green PR runs. The step ran `pytest` single-process with coverage instrumentation on, and `pytest-xdist` wasn't installed.

This PR runs the step with **`pytest -n auto --dist loadfile`**:

- `--dist loadfile` keeps every test in a file on one worker, so module-scoped fixture state is preserved.
- `pytest-cov` combines the per-worker data into the single `.coverage` that the later 100%-coverage gates and the codecov upload already read — verified: one combined, fully populated data file, no leftover fragments.
- The two short 100%-coverage gates stay serial (tiny subtrees; xdist startup would cost more than it saves). `timeout-minutes` is unchanged on purpose: the first CI run measured the parallel step at **14m07s** on the 4-core runners — ~2× headroom under the wall instead of 36 seconds. (`--durations=0` is added so the pre-existing `--durations-min` actually emits a report; it immediately shows the critical path under `loadfile`: one 68 s test and ~15 s of module-scoped app setup per file — follow-up material.)
- Lockfile delta is exactly `pytest-xdist==3.8.0` plus its one dependency `execnet==2.1.2` (regenerated with `scripts/uv-pip-compile.sh`).

Parallelism exposed two latent problems in the suite itself. Both are fixed here, each with a fail-without / pass-with control:

1. **Non-deterministic collection order.** `tests/unit_tests/commands/report/base_test.py` parametrized over Python `set`s, so every worker collected the same ids in a different per-process hash order and xdist aborted with *"Different tests were collected between gw4 and gw2"*. Diffing full collections under two `PYTHONHASHSEED` values showed it was the **only** such file out of 15,132 tests. Sets → tuples, with a comment so it doesn't get tidied back.

2. **A hidden import-order dependency (a flake class, not a one-off).** `test_get_sql_results_oauth2` runs under `@freeze_time` and happened to be the first lazy importer of the engine-spec modules on its worker. `clickhouse_connect` reads the local timezone via `dateutil` **at import time**, which raises `AttributeError` under a frozen clock; Superset's `clickhouse.py` guard only catches `ImportError`. Serially, some earlier test had always paid that import outside `freeze_time`, hiding the dependency. **Fifteen** unit-test files use `freeze_time`, so on xdist whichever is first on its worker fails — a flake that moves with worker assignment. A session-scoped autouse fixture in `tests/unit_tests/conftest.py` pre-imports **only `clickhouse_connect`** (the third-party module that reads the clock) once per worker, before any test can freeze the clock — deliberately not Superset's own spec modules (importing the ClickHouse spec pre-app would cache `product_name="dev"` for the session) and not full `load_engine_specs()` discovery (which would run every third-party entry point in every worker). Engine-spec discovery stays lazy. A direct pin of the guarantee is in `tests/unit_tests/test_clock_reading_driver_preload.py`.

3. **A leaked `ContextVar` (found by the first CI run).** `tests/unit_tests/mcp_service/test_middleware_logging.py` failed on CI with `assert 1 == 42`: sync tests that call `_setup_user_context()` (`chart/test_gauge_chart.py` resolves a real user through the resource path; six `test_auth_user_resolution.py` tests leave mocks) set `_mcp_user_id_var` in the thread's base context and never clear it, and pytest-asyncio copies that context into every later async test's task — 2,735 mcp_service tests ran with a polluted context. `on_call_tool`'s `finally` then overrides the patched user id with the leaked one. Serially it passed only because `test_mcp_e2e_smoke.py` sorts between leaker and victim and exercises the real middleware, whose `finally` resets the var; `loadfile` put that file on another worker. A per-test reset fixture in `tests/unit_tests/mcp_service/conftest.py` scopes the var to each test. Control: gauge → middleware_logging in one process reproduces the exact failure without the fixture, passes with it.

Local result (8 workers, coverage on, `TZ=UTC`): **15,128 passed, 5 skipped, 2 xfailed, 0 failed in 3m36s** — versus ~27 min serial.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A (CI configuration).

### TESTING INSTRUCTIONS

1. The `Python-Unit` workflow on this PR is the primary test — `unit-tests (current)` should finish well inside the timeout with all lanes green and coverage uploaded.
2. Locally, with the dev requirements installed:
   ```bash
   SUPERSET_TESTENV=true SUPERSET_SECRET_KEY=not-a-secret \
   pytest -n auto --dist loadfile --cov=superset --cov-report= ./tests/common ./tests/unit_tests --cache-clear
   ```
   then `coverage report` shows a populated combined file.
3. Collection determinism: `pytest --collect-only -q tests/unit_tests` under `PYTHONHASHSEED=1` and `=2` produces identical output.
4. The freeze_time control: stash the `conftest.py` change and run `pytest tests/unit_tests/sql_lab_test.py::test_get_sql_results_oauth2` in a fresh process — it fails with `AttributeError: 'NoneType' object has no attribute 'replace'` from `dateutil/tz`; restore the change and it passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4MGEkUcDpyLReqjQBhPy
