### PR TITLE
fix(archive): hide recovery actions from read-only users

### DIFF
--- a/docs/docs/using-superset/recently-archived.mdx
+++ b/docs/docs/using-superset/recently-archived.mdx
@@ -54,6 +54,11 @@ returns to its normal list and disappears from the archive. Recovering is
 limited to the object's editors and admins; you can only recover objects you
 are able to see in this view.
 
+Seeing an archived object and acting on it are separate permissions: objects
+you can view but not edit still appear in the list, but their rows carry no
+actions. The **Recover** and **Delete permanently** buttons are shown only
+for objects you have permission to edit.
+
 ## Deleting an object permanently
 
 Use the **Delete permanently** action on a row to remove an object for good.
@@ -62,7 +67,8 @@ You will be asked to confirm.
 This cannot be undone. Unlike archiving, it does not move the object anywhere
 — the object and its version history are erased, and no retention window
 applies. The same audience that can recover an object can delete it
-permanently: its editors and admins.
+permanently: its editors and admins. As with recovery, the action appears
+only on rows you have permission to edit.
 
 Some objects cannot be deleted permanently while something still depends on
 them. A chart used by an alert or report, for example, is refused until that

--- a/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
@@ -256,7 +256,16 @@ test.each([
     ).not.toBeInTheDocument();
     expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
     expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
-    userEvent.hover(rowName);
+    // findBy waits out antd's tooltip mouseEnterDelay, so the read-only copy
+    // appearing is the timing anchor — only then is asserting the absence of
+    // the editor copy meaningful (a query fired before the delay elapses
+    // passes vacuously for either string).
+    await userEvent.hover(rowName);
+    expect(
+      await screen.findByText(
+        'Archived items must be recovered before they can be opened.',
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText('Recover this item to open it'),
     ).not.toBeInTheDocument();
@@ -266,9 +275,13 @@ test.each([
   },
 );
 
-test.each(['Chart', 'Dashboard', 'Dataset'])(
-  '%s write permission retains archived row actions',
-  async label => {
+test.each([
+  { label: 'Chart', name: 'Deleted Chart One' },
+  { label: 'Dashboard', name: 'Deleted Dashboard One' },
+  { label: 'Dataset', name: 'deleted_table_one' },
+])(
+  '$label write permission retains archived row actions',
+  async ({ label, name }) => {
     mockRoutes();
     renderArchivedList(storeWithReadAccess(label));
 
@@ -276,6 +289,14 @@ test.each(['Chart', 'Dashboard', 'Dataset'])(
       (await screen.findAllByTestId('archived-row-restore'))[0],
     ).toBeEnabled();
     expect(screen.getAllByTestId('archived-row-purge')[0]).toBeEnabled();
+
+    // Positive tooltip control: the editor DOES get the recover prompt —
+    // proving the hover-and-wait mechanism can surface a tooltip at all,
+    // which is what makes the read-only test's absence assertion credible.
+    await userEvent.hover(screen.getByText(name));
+    expect(
+      await screen.findByText('Recover this item to open it'),
+    ).toBeInTheDocument();
   },
 );
 

--- a/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
+++ b/superset-frontend/src/pages/ArchivedList/ArchivedList.test.tsx
@@ -157,21 +157,32 @@ const mockRoutes = (
   restoreStatus = 200,
   purgeResponse: Parameters<typeof fetchMock.post>[1] = {},
   impactResponse: Parameters<typeof fetchMock.get>[1] = buildPositiveImpact(),
+  infoResponses: Partial<
+    Record<
+      'chart' | 'dashboard' | 'dataset',
+      Parameters<typeof fetchMock.get>[1]
+    >
+  > = {},
 ) => {
-  fetchMock.get(infoEndpoint, { permissions: ['can_read', 'can_write'] });
+  fetchMock.get(
+    infoEndpoint,
+    infoResponses.chart ?? { permissions: ['can_read', 'can_write'] },
+  );
   fetchMock.get(listEndpoint, { result: mockCharts, count: mockCharts.length });
   fetchMock.post(restoreEndpoint, restoreStatus === 200 ? {} : restoreStatus);
   fetchMock.post(purgeEndpoint, purgeResponse);
-  fetchMock.get(dashboardInfoEndpoint, {
-    permissions: ['can_read', 'can_write'],
-  });
+  fetchMock.get(
+    dashboardInfoEndpoint,
+    infoResponses.dashboard ?? { permissions: ['can_read', 'can_write'] },
+  );
   fetchMock.get(dashboardListEndpoint, {
     result: mockDashboards,
     count: mockDashboards.length,
   });
-  fetchMock.get(datasetInfoEndpoint, {
-    permissions: ['can_read', 'can_write'],
-  });
+  fetchMock.get(
+    datasetInfoEndpoint,
+    infoResponses.dataset ?? { permissions: ['can_read', 'can_write'] },
+  );
   fetchMock.get(datasetListEndpoint, {
     result: mockDatasets,
     count: mockDatasets.length,
@@ -225,6 +236,106 @@ test('issues the deleted-only baseline filter on the list request', async () => 
     expect(calls.length).toBeGreaterThanOrEqual(1);
     expect(calls[0].url).toContain('col:id,opr:chart_deleted_state,value:only');
   });
+});
+
+test.each([
+  { resource: 'chart', label: 'Chart', name: 'Deleted Chart One' },
+  { resource: 'dashboard', label: 'Dashboard', name: 'Deleted Dashboard One' },
+  { resource: 'dataset', label: 'Dataset', name: 'deleted_table_one' },
+])(
+  'read-only $label rows do not offer recovery or purge',
+  async ({ resource, label, name }) => {
+    mockRoutes(200, {}, buildPositiveImpact(), {
+      [resource]: { permissions: ['can_read', 'can_export'] },
+    });
+    renderArchivedList(storeWithReadAccess(label));
+
+    const rowName = await screen.findByText(name);
+    expect(
+      screen.queryByRole('columnheader', { name: 'Actions' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
+    expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
+    userEvent.hover(rowName);
+    expect(
+      screen.queryByText('Recover this item to open it'),
+    ).not.toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls(/\/(restore|purge|purge-impact)$/),
+    ).toHaveLength(0);
+  },
+);
+
+test.each(['Chart', 'Dashboard', 'Dataset'])(
+  '%s write permission retains archived row actions',
+  async label => {
+    mockRoutes();
+    renderArchivedList(storeWithReadAccess(label));
+
+    expect(
+      (await screen.findAllByTestId('archived-row-restore'))[0],
+    ).toBeEnabled();
+    expect(screen.getAllByTestId('archived-row-purge')[0]).toBeEnabled();
+  },
+);
+
+test('delete permission alone does not authorize archived dashboard actions', async () => {
+  mockRoutes(200, {}, buildPositiveImpact(), {
+    dashboard: { permissions: ['can_read', 'can_delete'] },
+  });
+  renderArchivedList(storeWithReadAccess('Dashboard'));
+
+  await screen.findByText('Deleted Dashboard One');
+  expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
+  expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
+});
+
+test('switching to a read-only type does not retain write actions', async () => {
+  mockRoutes(200, {}, buildPositiveImpact(), {
+    dashboard: { permissions: ['can_read'] },
+  });
+  renderArchivedList();
+  await screen.findAllByTestId('archived-row-restore');
+
+  await selectOption('Dashboard', 'Type');
+  await screen.findByText('Deleted Dashboard One');
+  expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
+  expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
+
+  await selectOption('Chart', 'Type');
+  expect(
+    (await screen.findAllByTestId('archived-row-restore'))[0],
+  ).toBeEnabled();
+});
+
+test('archived actions remain hidden until write permissions load', async () => {
+  let resolveInfo!: (response: { permissions: string[] }) => void;
+  const infoResponse = new Promise<{ permissions: string[] }>(resolve => {
+    resolveInfo = resolve;
+  });
+  mockRoutes(200, {}, buildPositiveImpact(), {
+    dashboard: () => infoResponse,
+  });
+  renderArchivedList(storeWithReadAccess('Dashboard'));
+
+  await screen.findByText('Deleted Dashboard One');
+  expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
+  expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
+
+  resolveInfo({ permissions: ['can_read', 'can_write'] });
+  expect(
+    (await screen.findAllByTestId('archived-row-restore'))[0],
+  ).toBeEnabled();
+});
+
+test('archived actions remain hidden when permissions cannot be loaded', async () => {
+  mockRoutes(200, {}, buildPositiveImpact(), { dashboard: 500 });
+  renderArchivedList(storeWithReadAccess('Dashboard'));
+
+  await screen.findByText('Deleted Dashboard One');
+  await waitFor(() => expect(mockAddDangerToast).toHaveBeenCalled());
+  expect(screen.queryAllByTestId('archived-row-restore')).toHaveLength(0);
+  expect(screen.queryAllByTestId('archived-row-purge')).toHaveLength(0);
 });
 
 test('restore posts to the per-type endpoint and refetches on success', async () => {

--- a/superset-frontend/src/pages/ArchivedList/index.tsx
+++ b/superset-frontend/src/pages/ArchivedList/index.tsx
@@ -434,13 +434,20 @@ function ArchivedListBody({
           // error — the reader is shown what looks like an empty new chart
           // rather than told anything. Neither is a preview, and the silent
           // one is the worse of the two, so no row links out until the object
-          // is recovered.
-          return canWrite ? (
-            <Tooltip title={t('Recover this item to open it')}>
+          // is recovered. Both audiences get told why: editors are prompted
+          // to recover; readers, who cannot recover, learn the precondition.
+          return (
+            <Tooltip
+              title={
+                canWrite
+                  ? t('Recover this item to open it')
+                  : t(
+                      'Archived items must be recovered before they can be opened.',
+                    )
+              }
+            >
               <span>{name}</span>
             </Tooltip>
-          ) : (
-            <span>{name}</span>
           );
         },
         accessor: config.nameField,

--- a/superset-frontend/src/pages/ArchivedList/index.tsx
+++ b/superset-frontend/src/pages/ArchivedList/index.tsx
@@ -179,6 +179,7 @@ function ArchivedListBody({
     state: { loading, resourceCount, resourceCollection },
     fetchData,
     refreshData,
+    hasPerm,
   } = useListViewResource<ArchivedItem>(
     config.resource,
     TYPE_LABELS[type](),
@@ -187,11 +188,13 @@ function ArchivedListBody({
     [],
     baseFilters,
   );
+  // Restore and purge both require the selected resource's write permission.
+  const canWrite = hasPerm('can_write');
 
   // Restore is immediate (no confirm dialog). On success, refetch the full page
   // so the server-side count/pagination stays consistent and the row drops out;
-  // on any error surface a danger toast and leave the row in place. The list
-  // read is already owner-scoped, so every visible row is restorable.
+  // on any error surface a danger toast and leave the row in place. List
+  // visibility does not imply write permission; the API also checks ownership.
   // A second activation while a request is in flight races the first: by the
   // time the retry lands the row is already restored (or purged), so the
   // server answers 404 and the user is shown a failure after a success. The
@@ -432,10 +435,12 @@ function ArchivedListBody({
           // rather than told anything. Neither is a preview, and the silent
           // one is the worse of the two, so no row links out until the object
           // is recovered.
-          return (
+          return canWrite ? (
             <Tooltip title={t('Recover this item to open it')}>
               <span>{name}</span>
             </Tooltip>
+          ) : (
+            <span>{name}</span>
           );
         },
         accessor: config.nameField,
@@ -490,12 +495,14 @@ function ArchivedListBody({
         ),
         Header: t('Actions'),
         id: 'actions',
+        hidden: !canWrite,
         disableSortBy: true,
         size: 'sm',
       },
     ],
     [
       config.nameField,
+      canWrite,
       type,
       handleRestore,
       handlePurge,


### PR DESCRIPTION
### SUMMARY

Fixes the Recently Archived view offering Recover and Delete permanently actions to read-only users. The shared list now uses the selected resource's existing `can_write` permission from `_info`, matching the restore/purge API permission mappings for dashboards, charts, and datasets.

Readable archived rows remain visible, but the Actions column and recovery tooltip are hidden without write permission. Existing server-side authorization and ownership checks are unchanged. Permissions remain fail-closed while loading or after an info request failure, and reset when switching object types.

Associated ticket: [SC-120335](https://app.shortcut.com/preset/story/120335).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Captured on a local dev build as a read-only user (Gamma, viewer of an archived dataset, without class-level write on the type). "Before" is `master` with this PR's `ArchivedList/index.tsx` reverted; "after" is this branch.

**Before** — the read-only user's row shows Recover and Delete permanently icons, and the name tooltip reads "Recover this item to open it"; clicking Recover is denied by the server.

![before](https://raw.githubusercontent.com/mikebridge/superset/sc-119620-assets/readonly-before.png)

**After** — the Actions column is empty for the read-only user, and the name tooltip explains the state: "Archived items must be recovered before they can be opened."

![after](https://raw.githubusercontent.com/mikebridge/superset/sc-119620-assets/readonly-after.png)

Write-enabled users are unaffected — the row keeps its Recover/Delete controls and the "Recover this item to open it" name tooltip:

<img src="https://raw.githubusercontent.com/mikebridge/superset/sc-119620-assets/44179-name-tooltip-editor.png" width="560" alt="write-enabled user retains the recover controls and tooltip" />

### TESTING INSTRUCTIONS

Automated verification:

```bash
cd superset-frontend
npm run test -- --maxWorkers=2 src/pages/ArchivedList/ArchivedList.test.tsx
```

39 tests pass, including 10 added cases covering read-only/write-enabled access across all three types, delete-only permissions, permission loading/failure, and type switching. All applicable staged pre-commit hooks pass, including TypeScript.

Manual verification (outstanding):

1. Enable `SOFT_DELETE` and archive a dashboard readable by a user with Dashboard read/export permissions but no write permission.
2. As that user, open Recently Archived and select Dashboard. Confirm readable rows remain visible but no Actions column, Recover/Delete permanently buttons, or recovery tooltip appears.
3. Repeat for Chart and Dataset with readable archived objects and read-only permissions.
4. As a write-enabled editor or admin, confirm Recover remains available and restores an eligible object successfully.
5. Switch between types for which the user has different write permissions and confirm controls follow the selected type.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-120335](https://app.shortcut.com/preset/story/120335)
- [x] Required feature flags: `SOFT_DELETE`
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

No schema, API, dependency, or permission-definition changes.

