### PR TITLE
fix(i18n): make module-level error constants lazy gettext

### DIFF
--- a/superset/exceptions.py
+++ b/superset/exceptions.py
@@ -206,7 +206,18 @@ class SpatialException(SupersetException):
 
 
 class CertificateException(SupersetException):
-    message = _("Invalid certificate")
+    def __init__(
+        self,
+        message: str = "",
+        exception: Optional[Exception] = None,
+        error_type: Optional[SupersetErrorType] = None,
+    ) -> None:
+        """Translate the default certificate error when constructing the exception."""
+        super().__init__(
+            message=message or _("Invalid certificate"),
+            exception=exception,
+            error_type=error_type,
+        )
 
 
 class DatabaseNotFound(SupersetException):

--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, TYPE_CHECKING
 
-from flask_babel import gettext as __, ngettext
+from flask_babel import gettext as __, lazy_gettext as _, ngettext
 from jinja2 import TemplateError
 from jinja2.meta import find_undeclared_variables
 
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
     from superset.jinja_context import BaseTemplateProcessor
     from superset.sqllab.sqllab_execution_context import SqlJsonExecutionContext
 
-PARAMETER_MISSING_ERR = __(
+# Lazy on purpose: evaluated at import time, an eager constant would be
+# frozen in the default locale (see the same convention in views/core.py).
+PARAMETER_MISSING_ERR = _(
     "Please check your template parameters for syntax errors and make sure "
     "they match across your SQL query and Set Parameters. Then, try running "
     "your query again."
@@ -114,7 +116,7 @@ class SqlQueryRenderImpl(SqlQueryRender):
                 len(undefined_parameters),
                 parameters=utils.format_list(undefined_parameters),
             ),
-            suggestion_help_msg=PARAMETER_MISSING_ERR,
+            suggestion_help_msg=str(PARAMETER_MISSING_ERR),
             extra={
                 "undefined_parameters": list(undefined_parameters),
                 "template_parameters": execution_context.template_params,

--- a/superset/sqllab/query_render.py
+++ b/superset/sqllab/query_render.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any, Callable, TYPE_CHECKING
 
 from flask_babel import gettext as __, lazy_gettext as _, ngettext
+from flask_babel.speaklater import LazyString
 from jinja2 import TemplateError
 from jinja2.meta import find_undeclared_variables
 
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
 
 # Lazy on purpose: evaluated at import time, an eager constant would be
 # frozen in the default locale (see the same convention in views/core.py).
-PARAMETER_MISSING_ERR = _(
+PARAMETER_MISSING_ERR: LazyString = _(
     "Please check your template parameters for syntax errors and make sure "
     "they match across your SQL query and Set Parameters. Then, try running "
     "your query again."

--- a/superset/utils/core.py
+++ b/superset/utils/core.py
@@ -1619,7 +1619,9 @@ def parse_ssl_cert(certificate: str) -> Certificate:
     try:
         return load_pem_x509_certificate(certificate.encode("utf-8"), default_backend())
     except ValueError as ex:
-        raise CertificateException("Invalid certificate") from ex
+        # No explicit message: the exception's own default is translated at
+        # construction, whereas a literal here would bypass translation.
+        raise CertificateException() from ex
 
 
 def create_ssl_cert_file(certificate: str) -> str:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -41,6 +41,7 @@ from flask_appbuilder.security.decorators import (
     has_access_api,
 )
 from flask_babel import gettext as __, lazy_gettext as _
+from flask_babel.speaklater import LazyString
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.utils import safe_join
 
@@ -108,7 +109,7 @@ logger = logging.getLogger(__name__)
 # locale forever. Lazy at module scope, coerced with str() at the point of
 # use inside a request — the mirror of the "eager __() in request context"
 # convention for inline error bodies.
-DATASOURCE_MISSING_ERR = _("The data source seems to have been deleted")
+DATASOURCE_MISSING_ERR: LazyString = _("The data source seems to have been deleted")
 
 SqlResults = dict[str, Any]
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -103,13 +103,12 @@ from superset.views.utils import (
 
 logger = logging.getLogger(__name__)
 
-DATASOURCE_MISSING_ERR = __("The data source seems to have been deleted")
-USER_MISSING_ERR = __("The user seems to have been deleted")
-PARAMETER_MISSING_ERR = __(
-    "Please check your template parameters for syntax errors and make sure "
-    "they match across your SQL query and Set Parameters. Then, try running "
-    "your query again."
-)
+# Lazy on purpose: a module-level constant is evaluated at import time,
+# outside any request, so eager gettext would freeze it in the default
+# locale forever. Lazy at module scope, coerced with str() at the point of
+# use inside a request — the mirror of the "eager __() in request context"
+# convention for inline error bodies.
+DATASOURCE_MISSING_ERR = _("The data source seems to have been deleted")
 
 SqlResults = dict[str, Any]
 
@@ -681,7 +680,7 @@ class Superset(BaseSupersetView):
         )
         # Check if datasource exists
         if not datasource:
-            return json_error_response(DATASOURCE_MISSING_ERR)
+            return json_error_response(str(DATASOURCE_MISSING_ERR))
 
         datasource.raise_for_access()
         return json_success(json.dumps(sanitize_datasource_data(datasource.data)))

--- a/tests/unit_tests/views/test_i18n_constants.py
+++ b/tests/unit_tests/views/test_i18n_constants.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""sc-120397: module-level user-facing constants must be LAZY gettext.
+
+A module-level constant is evaluated once at import time, outside any
+request, so eager ``__()`` freezes it in the default locale for every
+user forever. The convention (paired with sc-120052's inverse): eager
+``__()`` for strings built inside request handlers; lazy ``_()`` for
+module-scope constants, coerced with ``str()`` at the point of use.
+"""
+
+import pathlib
+import re
+
+import pytest
+from flask_babel import force_locale
+from flask_babel.speaklater import LazyString
+
+from superset.sqllab.query_render import PARAMETER_MISSING_ERR
+from superset.views.core import DATASOURCE_MISSING_ERR
+
+_FR_MO = (
+    pathlib.Path(__file__).parents[3]
+    / "superset"
+    / "translations"
+    / "fr"
+    / "LC_MESSAGES"
+    / "messages.mo"
+)
+
+
+@pytest.mark.parametrize("constant", [DATASOURCE_MISSING_ERR, PARAMETER_MISSING_ERR])
+def test_module_constants_are_lazy(constant: object) -> None:
+    """The constants must be LazyString, not import-time-resolved str."""
+    assert isinstance(constant, LazyString)
+
+
+@pytest.mark.skipif(
+    not _FR_MO.exists(),
+    reason="fr catalog not compiled in this checkout; the LazyString pin above "
+    "still guards the laziness",
+)
+def test_constant_translates_per_request_locale(app_context: None) -> None:
+    """The same constant renders per-locale — the point of being lazy."""
+    with force_locale("fr"):
+        assert str(DATASOURCE_MISSING_ERR) == (
+            "La source de données semble avoir été effacée"
+        )
+    with force_locale("en"):
+        assert str(DATASOURCE_MISSING_ERR) == (
+            "The data source seems to have been deleted"
+        )
+
+
+def test_no_module_level_eager_gettext_constants() -> None:
+    """Inverse-convention tripwire (pairs with sc-120052's lazy-in-request
+    scan): in any module binding ``__`` to eager gettext, no module-level
+    ``NAME = __(...)`` constant may exist — it would freeze in the default
+    locale at import. If this fires, make the constant lazy ``_()`` and
+    coerce with ``str()`` at the point of use."""
+    import superset
+
+    pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\s*=\s*__\(", re.M)
+    offenders: list[str] = []
+    package_root = pathlib.Path(superset.__file__).parent
+    for path in package_root.rglob("*.py"):
+        source = path.read_text(errors="ignore")
+        if "gettext as __" not in source:
+            continue
+        for match in pattern.finditer(source):
+            line = source.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path}:{line}")
+    assert not offenders, f"module-level eager gettext constants at: {offenders}"

--- a/tests/unit_tests/views/test_i18n_constants.py
+++ b/tests/unit_tests/views/test_i18n_constants.py
@@ -27,20 +27,11 @@ import pathlib
 import re
 
 import pytest
-from flask_babel import force_locale
 from flask_babel.speaklater import LazyString
+from pytest_mock import MockerFixture
 
 from superset.sqllab.query_render import PARAMETER_MISSING_ERR
 from superset.views.core import DATASOURCE_MISSING_ERR
-
-_FR_MO = (
-    pathlib.Path(__file__).parents[3]
-    / "superset"
-    / "translations"
-    / "fr"
-    / "LC_MESSAGES"
-    / "messages.mo"
-)
 
 
 @pytest.mark.parametrize("constant", [DATASOURCE_MISSING_ERR, PARAMETER_MISSING_ERR])
@@ -49,21 +40,22 @@ def test_module_constants_are_lazy(constant: object) -> None:
     assert isinstance(constant, LazyString)
 
 
-@pytest.mark.skipif(
-    not _FR_MO.exists(),
-    reason="fr catalog not compiled in this checkout; the LazyString pin above "
-    "still guards the laziness",
-)
-def test_constant_translates_per_request_locale(app_context: None) -> None:
-    """The same constant renders per-locale — the point of being lazy."""
-    with force_locale("fr"):
-        assert str(DATASOURCE_MISSING_ERR) == (
-            "La source de données semble avoir été effacée"
-        )
-    with force_locale("en"):
-        assert str(DATASOURCE_MISSING_ERR) == (
-            "The data source seems to have been deleted"
-        )
+def test_constant_resolves_through_the_live_translation_lookup(
+    mocker: MockerFixture,
+) -> None:
+    """str(constant) consults the active translation machinery per call.
+
+    Stubbing flask-babel's domain proves every render goes through the
+    lookup — an eager constant would have been frozen to a plain str
+    before the stub existed and could never produce the sentinel. Runs on
+    every backend, unlike a compiled-catalog-dependent locale pin."""
+    domain = mocker.Mock()
+    domain.gettext.side_effect = lambda s, **kw: f"[[{s}]]"
+    mocker.patch("flask_babel.get_domain", return_value=domain)
+
+    assert str(DATASOURCE_MISSING_ERR) == (
+        "[[The data source seems to have been deleted]]"
+    )
 
 
 def test_no_module_level_eager_gettext_constants() -> None:

--- a/tests/unit_tests/views/test_i18n_constants.py
+++ b/tests/unit_tests/views/test_i18n_constants.py
@@ -23,13 +23,16 @@ user forever. The convention (paired with sc-120052's inverse): eager
 module-scope constants, coerced with ``str()`` at the point of use.
 """
 
+import ast
 import pathlib
-import re
+from unittest.mock import Mock
 
 import pytest
 from flask_babel.speaklater import LazyString
 from pytest_mock import MockerFixture
 
+from superset.errors import SupersetErrorType
+from superset.exceptions import CertificateException
 from superset.sqllab.query_render import PARAMETER_MISSING_ERR
 from superset.views.core import DATASOURCE_MISSING_ERR
 
@@ -49,7 +52,7 @@ def test_constant_resolves_through_the_live_translation_lookup(
     lookup — an eager constant would have been frozen to a plain str
     before the stub existed and could never produce the sentinel. Runs on
     every backend, unlike a compiled-catalog-dependent locale pin."""
-    domain = mocker.Mock()
+    domain: Mock = mocker.Mock()
     domain.gettext.side_effect = lambda s, **kw: f"[[{s}]]"
     mocker.patch("flask_babel.get_domain", return_value=domain)
 
@@ -58,22 +61,196 @@ def test_constant_resolves_through_the_live_translation_lookup(
     )
 
 
+@pytest.mark.parametrize("message", ["", "Custom certificate error"])
+def test_certificate_error_translates_default_at_construction(
+    mocker: MockerFixture, message: str
+) -> None:
+    """Translate default instance messages while preserving explicit error details."""
+    translate: Mock = mocker.patch(
+        "superset.exceptions._", return_value="Translated certificate error"
+    )
+    cause: Exception = ValueError("Invalid PEM")
+    error: CertificateException = CertificateException(
+        message, cause, SupersetErrorType.GENERIC_BACKEND_ERROR
+    )
+    expected: str = message or "Translated certificate error"
+    assert str(error) == expected
+    assert error.to_dict()["message"] == expected
+    assert error.exception is cause
+    assert error.error_type == SupersetErrorType.GENERIC_BACKEND_ERROR
+    if message:
+        translate.assert_not_called()
+    else:
+        translate.assert_called_once_with("Invalid certificate")
+
+
+def _is_eager_gettext_call(node: ast.expr, bindings: dict[str, str]) -> bool:
+    """Recognize calls to imported eager Babel functions or module attributes."""
+    eager_names: set[str] = {"gettext", "ngettext", "pgettext", "npgettext"}
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id) in eager_names
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and bindings.get(node.value.id) == "flask_babel"
+        and node.attr in eager_names
+    )
+
+
+def _record_gettext_import(node: ast.AST, bindings: dict[str, str]) -> None:
+    """Resolve Babel import aliases to their original function or module names."""
+    alias: ast.alias
+    if isinstance(node, ast.ImportFrom):
+        if node.module == "flask_babel" and node.level == 0:
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = alias.name
+    elif isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name == "flask_babel":
+                bindings[alias.asname or alias.name] = "flask_babel"
+
+
+def _find_eager_gettext_assignments(source: str) -> list[int]:
+    """Return line numbers of direct eager gettext assignments at import time."""
+    offenders: list[int] = []
+
+    def visit(node: ast.AST, bindings: dict[str, str]) -> None:
+        """Track imports through executable blocks, excluding function bodies."""
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return
+        if isinstance(node, ast.ClassDef):
+            bindings = bindings.copy()
+        _record_gettext_import(node, bindings)
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            if isinstance(node.value, ast.Call) and _is_eager_gettext_call(
+                node.value.func, bindings
+            ):
+                offenders.append(node.lineno)
+        child: ast.AST
+        for child in ast.iter_child_nodes(node):
+            visit(child, bindings)
+
+    visit(ast.parse(source), {})
+    return offenders
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ('from flask_babel import gettext as __\nERR = __("missing")', [2]),
+        ('from flask_babel import lazy_gettext as __\nERR = __("missing")', []),
+        (
+            "from flask_babel import gettext as __\n"
+            'def render():\n    err = __("missing")',
+            [],
+        ),
+        ('from flask_babel import gettext as __\nERR: str = __("missing")', [2]),
+        ('from flask_babel import gettext\nERR = gettext("missing")', [2]),
+        ('from flask_babel import ngettext as tr\nERR = tr("one", "many", 2)', [2]),
+        ('from flask_babel import pgettext as tr\nERR = tr("ctx", "missing")', [2]),
+        (
+            "from flask_babel import npgettext as tr\n"
+            'ERR = tr("ctx", "one", "many", 2)',
+            [2],
+        ),
+        ('import flask_babel\nERR = flask_babel.gettext("missing")', [2]),
+        ('import flask_babel as fb\nERR = fb.gettext("missing")', [2]),
+        ('import flask_babel as fb\nERR = fb.lazy_gettext("missing")', []),
+        (
+            "from flask_babel import gettext as __\n"
+            '"""Example:\nERR = __("missing")\n"""',
+            [],
+        ),
+        (
+            "from flask_babel import gettext as __\n"
+            'class Errors:\n    ERR = __("missing")',
+            [3],
+        ),
+        (
+            "from flask_babel import gettext as __\n"
+            'if enabled:\n    ERR = __("missing")',
+            [3],
+        ),
+        (
+            "from flask_babel import gettext as __\n"
+            'try:\n    ERR = __("missing")\n'
+            'except Exception:\n    ERR = __("fallback")\n'
+            'else:\n    ERR = __("else")\n'
+            'finally:\n    ERR = __("finally")',
+            [3, 5, 7, 9],
+        ),
+        (
+            "with context():\n    from flask_babel import gettext as __\n"
+            '    ERR = __("missing")',
+            [3],
+        ),
+        (
+            "async def render():\n    from flask_babel import gettext as __\n"
+            '    err = __("missing")',
+            [],
+        ),
+        (
+            "from flask_babel import gettext as __\nclass Errors:\n"
+            "    from flask_babel import lazy_gettext as __\n"
+            '    ERR = __("missing")\nERR = __("missing")',
+            [5],
+        ),
+        ('from flask_babel import lazy_ngettext as gettext\nERR = gettext("x")', []),
+        ('from flask_babel import lazy_pgettext as gettext\nERR = gettext("x")', []),
+    ],
+)
+def test_eager_gettext_assignment_classifier(source: str, expected: list[int]) -> None:
+    """Distinguish import-time eager assignments from lazy and deferred calls."""
+    assert _find_eager_gettext_assignments(source) == expected
+
+
 def test_no_module_level_eager_gettext_constants() -> None:
-    """Inverse-convention tripwire (pairs with sc-120052's lazy-in-request
-    scan): in any module binding ``__`` to eager gettext, no module-level
-    ``NAME = __(...)`` constant may exist — it would freeze in the default
-    locale at import. If this fires, make the constant lazy ``_()`` and
-    coerce with ``str()`` at the point of use."""
+    """Reject import-time eager gettext constants throughout the Superset package."""
     import superset
 
-    pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\s*=\s*__\(", re.M)
     offenders: list[str] = []
-    package_root = pathlib.Path(superset.__file__).parent
+    package_root: pathlib.Path = pathlib.Path(superset.__file__).parent
+    path: pathlib.Path
+    source: str
+    line: int
     for path in package_root.rglob("*.py"):
         source = path.read_text(errors="ignore")
-        if "gettext as __" not in source:
-            continue
-        for match in pattern.finditer(source):
-            line = source.count("\n", 0, match.start()) + 1
+        for line in _find_eager_gettext_assignments(source):
             offenders.append(f"{path}:{line}")
     assert not offenders, f"module-level eager gettext constants at: {offenders}"
+
+
+def test_constant_renders_in_the_locale_of_each_request(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Two requests with different locales render the SAME constant differently.
+
+    Stronger than the ``get_domain`` stub above: this proves per-request
+    locale SELECTION end to end through real Babel machinery — a compiled
+    catalog on disk, flask-babel's locale selector (it performs no
+    Accept-Language negotiation without one, mirroring how Superset
+    installs its own), and the LazyString deferring resolution to each
+    request. An eager constant would render identically in both requests.
+    """
+    from babel.messages.catalog import Catalog
+    from babel.messages.mofile import write_mo
+    from flask import Flask, request
+    from flask_babel import Babel
+
+    msgid = "The data source seems to have been deleted"
+    translated = "Die Datenquelle scheint geloescht worden zu sein"
+    catalog: Catalog = Catalog(locale="de")
+    catalog.add(msgid, translated)
+    mo_dir: pathlib.Path = tmp_path / "de" / "LC_MESSAGES"
+    mo_dir.mkdir(parents=True)
+    with (mo_dir / "messages.mo").open("wb") as buf:
+        write_mo(buf, catalog)
+
+    app: Flask = Flask(__name__)
+    app.config["BABEL_TRANSLATION_DIRECTORIES"] = str(tmp_path)
+    Babel(app, locale_selector=lambda: request.headers.get("X-Locale", "en"))
+
+    with app.test_request_context(headers={"X-Locale": "de"}):
+        assert str(DATASOURCE_MISSING_ERR) == translated
+    with app.test_request_context(headers={"X-Locale": "en"}):
+        assert str(DATASOURCE_MISSING_ERR) == msgid


### PR DESCRIPTION
### SUMMARY

`DATASOURCE_MISSING_ERR` (`views/core.py`) and `PARAMETER_MISSING_ERR` (`sqllab/query_render.py`) were built with the **eager** gettext alias at **module scope**, so each was resolved exactly once at import time — no request, no locale context — and then served in the default locale to every user forever. This is the mirror image of the bug fixed in #44090 (lazy gettext inside request handlers), and together they define the convention:

- **eager `__()`** for strings built inside request handlers;
- **lazy `_()`** for module-scope constants, **coerced with `str()` at the point of use** inside the request.

The point-of-use `str()` also makes this PR independent of #44090's `LazyString` coercion in `json_error_response` — correct in either merge order.

Also removed: `USER_MISSING_ERR` and `views/core.py`'s duplicate `PARAMETER_MISSING_ERR`, which had **no consumers anywhere** (dead constants).

**Review round** (Codex, python lens): the package tripwire was rewritten from a text scan to an AST scanner — the substring approach had a false-positive class (`"gettext as __"` also matches `lazy_gettext as __`) and blind spots (annotated assignments, bare `gettext(...)`, other aliases, class-body constants, docstring text). The AST scanner resolves each module's actual Babel import bindings and inspects `Assign`/`AnnAssign` at import-time scopes only. It immediately caught a **fourth real offender** the old scan could not see: `CertificateException`'s class-level default message (`exceptions.py` binds `_` to **eager** gettext). The default is now translated at construction — explicit messages, causes, and error types preserved — and `parse_ssl_cert` drops its redundant untranslated literal so the translated default is reachable. No consumer reads the class attribute or the exception's message (the DB schema validator emits its own).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — i18n behavior. Before: a French user got "The data source seems to have been deleted". After: "La source de données semble avoir été effacée".

### TESTING INSTRUCTIONS

`pytest tests/unit_tests/views/test_i18n_constants.py` (27 tests) —

- the constants are pinned as `LazyString` (fails pre-fix);
- a translation-lookup pin stubs flask-babel's `get_domain` with a sentinel catalog and asserts every `str()` of the constant consults the live lookup — runs on every backend, no compiled catalog needed;
- a **two-locale pin** compiles a real catalog into a temp dir and renders the same constant under two request contexts with different locales through real Babel selection (an eager constant would render identically in both);
- the inverse-convention tripwire scans the whole package with the AST scanner (fails pre-fix on all four eager constants incl. `CertificateException`; pairs with #44090's lazy-in-request scan), and 20 classifier self-test cases pin the scanner's corners (lazy aliases not flagged, function bodies skipped, annotated assignments and class bodies caught, docstrings inert, class-local rebinding scoped);
- `CertificateException` construction is pinned: default message translated exactly once, explicit message bypasses translation, cause and error type preserved.

Reverting the production change flips the LazyString pins and the tripwire.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRLEJS4mUqKBoPjSjviKUW
