### PR TITLE
ci(playwright): run the recently-archived e2e specs

### DIFF
--- a/.github/workflows/superset-playwright.yml
+++ b/.github/workflows/superset-playwright.yml
@@ -177,6 +177,24 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
         with:
           run: playwright-run "${{ matrix.app_root }}" experimental/
+      - name: Run Playwright (Recently Archived)
+        # The archive specs guard themselves with skipUnlessFeatureEnabled
+        # ('SOFT_DELETE'); the backend this job boots uses
+        # tests.integration_tests.superset_test_config, which inherits the
+        # default-on flag, so they execute rather than skip here. They are
+        # not part of the experimental/ or mobile/ selections above, so
+        # without this step the suite is never collected in CI at all.
+        # cached-dependencies is a submodule (not a plain directory), and
+        # the $/ self-repository syntax resolves action files directly from
+        # the repository without performing a real (submodule-aware)
+        # checkout, so it can't see into a submodule's link. Keep this one
+        # on the workspace-relative ./ form, consistent with every other
+        # workflow in the repo that references this action.
+        uses: ./.github/actions/cached-dependencies # zizmor: ignore[self-repository] - $/ cannot resolve an action that lives in a submodule; ./ is required here
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        with:
+          run: playwright-run "${{ matrix.app_root }}" recently-archived/
       - name: Run Playwright (Mobile Tests)
         # cached-dependencies is a submodule (not a plain directory), and
         # the $/ self-repository syntax resolves action files directly from


### PR DESCRIPTION
### SUMMARY

The Recently Archived e2e specs (`superset-frontend/playwright/tests/recently-archived/`) were written to run once `SOFT_DELETE` reached CI: they guard themselves with `skipUnlessFeatureEnabled(page, 'SOFT_DELETE')` and were expected to start executing when the flag flipped (it shipped default-on in #42800, and the Playwright job's backend — `tests.integration_tests.superset_test_config` — inherits that default with no override).

Verifying that expectation against recent green master runs showed a third state nobody predicted: the suite neither runs nor skips, because the workflow only ever selects the `experimental/` and `mobile/` subsets (`playwright-run "…" experimental/` / `… mobile/`). The archive suite is simply never collected — invisible rather than dormant, which is exactly the silently-green failure mode the spec guard's own comments warn about.

This adds one step to the Playwright job selecting `recently-archived/`, mirroring the experimental step. No feature-flag or config change is needed; the specs' self-guard remains as defense against environments where the flag is off.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

N/A — CI-only change. The evidence is this PR's own Playwright run: the "Run Playwright (Recently Archived)" step should report the archive tests as executed and passing (not skipped).

### TESTING INSTRUCTIONS

1. Open this PR's `superset-playwright` workflow run and expand the new "Run Playwright (Recently Archived)" step: the reporter should list the `recently-archived` tests with ✓ (executed), and the summary should show them passed — not `- … (skipped)`.
2. Locally: `cd superset-frontend && npx playwright test recently-archived/` against a backend using `superset_test_config`.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7U5oFfrqUyM6hJTZiW2uf
