### PR TITLE
refactor(list-view): eliminate any usage in ListView/utils.ts

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/TableCollection/index.tsx
@@ -367,4 +367,7 @@ function TableCollection<T extends object>({
   );
 }
 
-export default memo(TableCollection);
+// React.memo erases the wrapped component's generic type parameter; cast
+// back to the original generic signature so callers can still instantiate
+// TableCollection<T> explicitly.
+export default memo(TableCollection) as typeof TableCollection;

--- a/superset-frontend/src/components/ListView/CardCollection.tsx
+++ b/superset-frontend/src/components/ListView/CardCollection.tsx
@@ -17,17 +17,17 @@
  * under the License.
  */
 import { ReactNode, MouseEvent as ReactMouseEvent } from 'react';
-import { TableInstance, Row, UseRowSelectRowProps } from 'react-table';
+import { Row, UseRowSelectRowProps } from 'react-table';
 import { styled } from '@apache-superset/core/theme';
 import { isMobileConsumptionEnabled } from 'src/hooks/useIsMobile';
 import cx from 'classnames';
 
-interface CardCollectionProps {
+interface CardCollectionProps<T extends object = any> {
   bulkSelectEnabled?: boolean;
   loading: boolean;
-  prepareRow: TableInstance['prepareRow'];
+  prepareRow: (row: Row<T>) => void;
   renderCard?: (row: any) => ReactNode;
-  rows: TableInstance['rows'];
+  rows: Row<T>[];
   showThumbnails?: boolean;
 }
 
@@ -68,14 +68,14 @@ const CardWrapper = styled.div`
   }
 `;
 
-export default function CardCollection({
+export default function CardCollection<T extends object = any>({
   bulkSelectEnabled,
   loading,
   prepareRow,
   renderCard,
   rows,
   showThumbnails,
-}: CardCollectionProps) {
+}: CardCollectionProps<T>) {
   function handleClick(
     event: ReactMouseEvent<HTMLDivElement, MouseEvent>,
     toggleRowSelected: (value?: boolean) => void,
@@ -104,14 +104,14 @@ export default function CardCollection({
               className={cx({
                 'card-selected':
                   bulkSelectEnabled &&
-                  (row as Row & UseRowSelectRowProps<any>).isSelected,
+                  (row as Row<T> & UseRowSelectRowProps<T>).isSelected,
                 'bulk-select': bulkSelectEnabled,
               })}
               key={row.id}
               onClick={e =>
                 handleClick(
                   e,
-                  (row as Row & UseRowSelectRowProps<any>).toggleRowSelected,
+                  (row as Row<T> & UseRowSelectRowProps<T>).toggleRowSelected,
                 )
               }
               role="none"

--- a/superset-frontend/src/components/ListView/ListView.tsx
+++ b/superset-frontend/src/components/ListView/ListView.tsx
@@ -612,7 +612,7 @@ export function ListView<T extends object = any>({
           )}
           {viewMode === 'card' && (
             <>
-              <CardCollection
+              <CardCollection<T>
                 bulkSelectEnabled={bulkSelectEnabled}
                 prepareRow={prepareRow}
                 renderCard={renderCard}
@@ -651,7 +651,7 @@ export function ListView<T extends object = any>({
                   <Loading />
                 </FullPageLoadingWrapper>
               ) : (
-                <TableCollection
+                <TableCollection<T>
                   getTableProps={getTableProps}
                   getTableBodyProps={getTableBodyProps}
                   prepareRow={prepareRow}

--- a/superset-frontend/src/components/ListView/utils.ts
+++ b/superset-frontend/src/components/ListView/utils.ts
@@ -18,6 +18,7 @@
  */
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Column,
   useFilters,
   usePagination,
   useRowSelect,
@@ -45,10 +46,17 @@ import {
   ViewModeType,
 } from './types';
 
+type QueryFilterState = {
+  [id: string]: FilterValue['value'];
+};
+
 // Define custom RisonParam for proper encoding/decoding; note that
 // %, &, +, and # must be encoded to avoid breaking the url
-const RisonParam: QueryParamConfig<string, any> = {
-  encode: (data?: any | null) => {
+const RisonParam: QueryParamConfig<
+  QueryFilterState | undefined,
+  QueryFilterState | undefined
+> = {
+  encode: data => {
     if (data === undefined || data === null) return undefined;
 
     const cleanData = JSON.parse(
@@ -67,7 +75,7 @@ const RisonParam: QueryParamConfig<string, any> = {
   decode: (dataStr?: string | string[]) =>
     dataStr === undefined || Array.isArray(dataStr)
       ? undefined
-      : rison.decode(dataStr),
+      : (rison.decode(dataStr) as QueryFilterState),
 };
 
 export const SELECT_WIDTH = 176;
@@ -78,25 +86,16 @@ export class ListViewError extends Error {
   name = 'ListViewError';
 }
 
-// removes element from a list, returns new list
-export function removeFromList(list: any[], index: number): any[] {
-  return list.filter((_, i) => index !== i);
-}
-
 // apply update to elements of object list, returns new list
-function updateInList(list: any[], index: number, update: any): any[] {
+function updateInList<T>(list: T[], index: number, update: Partial<T>): T[] {
   const element = list.find((_, i) => index === i);
 
   return [
     ...list.slice(0, index),
-    { ...element, ...update },
+    { ...element, ...update } as T,
     ...list.slice(index + 1),
   ];
 }
-
-type QueryFilterState = {
-  [id: string]: FilterValue['value'];
-};
 
 function mergeCreateFilterValues(list: Filter[], updateObj: QueryFilterState) {
   return list.map(({ id, urlDisplay, operator }) => {
@@ -143,7 +142,7 @@ export function convertFilters(fts: InternalFilter[]): FilterValue[] {
 
 // convertFilters but to handle new decoded rison format
 export function convertFiltersRison(
-  filterObj: any,
+  filterObj: QueryFilterState,
   list: Filter[],
 ): FilterValue[] {
   const filters: FilterValue[] = [];
@@ -174,21 +173,10 @@ export function convertFiltersRison(
   return filters;
 }
 
-export function extractInputValue(inputType: Filter['input'], event: any) {
-  if (!inputType || inputType === 'text') {
-    return event.currentTarget.value;
-  }
-  if (inputType === 'checkbox') {
-    return event.currentTarget.checked;
-  }
-
-  return null;
-}
-
-interface UseListViewConfig {
-  fetchData: (conf: FetchDataConfig) => any;
-  columns: any[];
-  data: any[];
+interface UseListViewConfig<D extends object = any> {
+  fetchData: (conf: FetchDataConfig) => void;
+  columns: Column<D>[];
+  data: D[];
   count: number;
   initialPageSize: number;
   initialSort?: SortColumn[];
@@ -198,7 +186,7 @@ interface UseListViewConfig {
   forceViewMode?: ViewModeType;
 }
 
-export function useListViewState({
+export function useListViewState<D extends object = any>({
   fetchData,
   columns,
   data,
@@ -209,7 +197,7 @@ export function useListViewState({
   renderCard = false,
   defaultViewMode = 'card',
   forceViewMode,
-}: UseListViewConfig) {
+}: UseListViewConfig<D>) {
   const [query, setQuery] = useQueryParams({
     filters: RisonParam,
     pageIndex: NumberParam,
@@ -282,26 +270,25 @@ export function useListViewState({
     selectedFlatRows,
     toggleAllRowsSelected,
     state: { pageIndex, pageSize, sortBy, filters },
-  } = useTable(
+  } = useTable<D>(
     {
       columns: columnsWithFilter,
       data,
       disableFilters: true,
       disableSortRemove: true,
-      initialState: initialState as any,
+      initialState,
       manualFilters: true,
       manualPagination: true,
       manualSortBy: true,
       autoResetFilters: false,
       pageCount: Math.ceil(count / initialPageSize),
-      ...({ count } as any),
     },
     useFilters,
     useSortBy,
     usePagination,
     useRowState,
     useRowSelect,
-  ) as any;
+  );
 
   const [internalFilters, setInternalFilters] = useState<InternalFilter[]>(
     query.filters && initialFilters.length
@@ -334,7 +321,13 @@ export function useListViewState({
       }
     });
 
-    const queryParams: any = {
+    const queryParams: {
+      filters?: QueryFilterState;
+      pageIndex: number;
+      sortColumn?: string;
+      sortOrder?: 'asc' | 'desc';
+      viewMode?: ViewModeType;
+    } = {
       filters: Object.keys(filterObj).length ? filterObj : undefined,
       pageIndex,
     };
@@ -364,7 +357,7 @@ export function useListViewState({
     }
   }, [query]);
 
-  const applyFilterValue = (index: number, value: any) => {
+  const applyFilterValue = (index: number, value: InnerFilterValue) => {
     setInternalFilters(currentInternalFilters => {
       // skip redundant updates
       if (currentInternalFilters[index].value === value) {

--- a/superset-frontend/src/types/react-table.d.ts
+++ b/superset-frontend/src/types/react-table.d.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @types/react-table intentionally ships TableOptions/TableInstance/TableState
+// as empty base interfaces, to be extended per-project via declaration
+// merging with exactly the plugin hooks in use (documented directly in
+// @types/react-table's own index.d.ts, linking
+// https://gist.github.com/ggascoigne/646e14c9d54258e40588a13aabf0102d as the
+// canonical pattern). Without this, every useTable() call combining plugin
+// hooks needs an `as any` to pass options/read instance properties the base
+// types don't know about. This covers the plugin combination used by
+// ListView (useFilters, useSortBy, usePagination, useRowState, useRowSelect).
+import type {
+  UseFiltersInstanceProps,
+  UseFiltersOptions,
+  UseFiltersState,
+  UsePaginationInstanceProps,
+  UsePaginationOptions,
+  UsePaginationState,
+  UseRowSelectInstanceProps,
+  UseRowSelectOptions,
+  UseRowSelectState,
+  UseRowStateInstanceProps,
+  UseRowStateOptions,
+  UseRowStateState,
+  UseSortByInstanceProps,
+  UseSortByOptions,
+  UseSortByState,
+} from 'react-table';
+
+declare module 'react-table' {
+  export interface TableOptions<D extends object>
+    extends
+      UseFiltersOptions<D>,
+      UseSortByOptions<D>,
+      UsePaginationOptions<D>,
+      UseRowStateOptions<D>,
+      UseRowSelectOptions<D> {}
+
+  export interface TableInstance<D extends object>
+    extends
+      UseFiltersInstanceProps<D>,
+      UseSortByInstanceProps<D>,
+      UsePaginationInstanceProps<D>,
+      UseRowStateInstanceProps<D>,
+      UseRowSelectInstanceProps<D> {}
+
+  export interface TableState<D extends object>
+    extends
+      UseFiltersState<D>,
+      UseSortByState<D>,
+      UsePaginationState<D>,
+      UseRowStateState<D>,
+      UseRowSelectState<D> {}
+}


### PR DESCRIPTION
### SUMMARY
First step in cleaning up the `any` types that leak out of `src/components/ListView/utils.ts` into every consumer that calls `useListViewState` (roughly 21 CRUD list pages across the app inherit it).

`@types/react-table` deliberately ships `TableOptions`/`TableInstance`/`TableState` as near-empty base interfaces — the documented pattern is for each project to extend them via declaration merging with exactly the plugin hooks it uses (see the doc comment in `@types/react-table`'s own `index.d.ts`, linking https://gist.github.com/ggascoigne/646e14c9d54258e40588a13aabf0102d). Superset never set this up, so `useTable(...)` in `ListView/utils.ts` was fully cast through `as any` for its options, initial state, and returned instance.

This adds `src/types/react-table.d.ts`, augmenting those three interfaces with the five plugin hooks `ListView` actually uses (`useFilters`, `useSortBy`, `usePagination`, `useRowState`, `useRowSelect`), then genericizes `useListViewState<D>` and drops every `as any` in the file. Also removed two small pieces of dead code found along the way: `removeFromList` and `extractInputValue` were both exported but had zero call sites anywhere in the codebase, and the `...({ count } as any)` spread into `useTable`'s options was a no-op (`count` isn't a recognized option on any react-table plugin, and `pageCount` — the thing actually derived from it — is already computed on the line above).

`CardCollection` and `TableCollection` needed matching generic plumbing to keep `ListView.tsx` compiling now that the hook's return values are properly typed instead of erased to `any` end-to-end. `TableCollection` also needed a small `as typeof TableCollection` cast after `memo()`, since `React.memo` erases a wrapped component's generic type parameter by default.

`ListView.tsx` itself and its ~21 consumer pages still have plenty of `any` left — this PR is scoped to the shared hook file only, as a first step.

### TESTING INSTRUCTIONS
- `npx tsc -b .` — clean (the handful of remaining errors on a full `--force` rebuild are pre-existing declaration-emit quirks in unrelated files: `d3`/`echarts` types and a couple of `.stories.tsx` files, none of which this PR touches)
- `npx jest src/components/ListView/ListView.test.tsx src/pages/DatasetList/DatasetList.listview.test.tsx src/pages/ChartList/ChartList.listview.test.tsx src/pages/DashboardList/DashboardList.listview.test.tsx packages/superset-ui-core/src/components/TableCollection/TableCollection.test.tsx` — 5 suites, 116 tests, all passing
- `pre-commit run` on the changed files — clean

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API