### PR TITLE
test(semantic-layers): fix mypy call_args error on values endpoint test

### DIFF
--- a/tests/unit_tests/semantic_layers/values_endpoint_test.py
+++ b/tests/unit_tests/semantic_layers/values_endpoint_test.py
@@ -22,7 +22,7 @@ values, search pass-through, the 400 naming an unknown column, and the cache
 header contract.
 """
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pyarrow as pa
@@ -105,7 +105,7 @@ def test_semantic_view_values_endpoint_passes_search_to_the_provider(
     response = _get(client, "category/values/?q=oo")
 
     assert response.status_code == 200
-    implementation = semantic_view_datasource.implementation
+    implementation = cast(MagicMock, semantic_view_datasource.implementation)
     _, filters = implementation.get_values.call_args.args
     (narrowing,) = filters
     assert narrowing.value == "%oo%"


### PR DESCRIPTION
### SUMMARY
`master` is red on the mypy pre-commit/CI check:

```
tests/unit_tests/semantic_layers/values_endpoint_test.py:109: error: "Callable[[Dimension, set[Filter] | None], SemanticResult]" has no attribute "call_args"  [attr-defined]
```

`SemanticView.implementation` is typed to return `SemanticViewABC`, so mypy sees `implementation.get_values` as a concrete `Callable` with no `.call_args`. At runtime it's the `MagicMock` from the fixture. Casting to `MagicMock` matches runtime and leaves the assertion unchanged.

Introduced by #43777. It passed there because per-PR CI runs mypy only on changed files, where the property resolves loosely (`Any`) and `.call_args` is accepted. The precise return type only resolves on a whole-tree run — the nightly full-tree sweep in `.github/workflows/pre-commit.yml`, which is what caught it. mypy is blocking; it just runs per-file on PRs, not whole-tree.

### TESTING INSTRUCTIONS
`pre-commit run mypy --all-files` — passes with this change, fails without it (per-file runs don't reproduce).

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API