### PR TITLE
feat(databricks): support OAuth M2M client ID/secret without PAT

### DIFF
--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -605,42 +605,6 @@ Once configured, users can:
 
 This feature works with both "Databricks (legacy)" and "Databricks" engine types and automatically supports all major cloud providers (AWS, Azure, GCP).
 
-##### OAuth M2M (service principal)
-
-Superset can connect to Databricks with a **service principal client ID and client secret**, without a personal access token (PAT). This is machine-to-machine (M2M) auth for a shared database connection — it is **not** the per-user OAuth impersonation flow above.
-
-1. Create a Databricks service principal and an OAuth secret for it. Grant the principal **Can Use** on the SQL warehouse.
-2. In the database form, fill in host, port, HTTP path, catalog, and schema. Leave **Access token** blank, or enter a placeholder such as `m2m`.
-3. Open **Advanced → Security → Secure extra** and paste:
-
-```json
-{
-  "auth_method": "oauth-m2m",
-  "client_id": "<service-principal-application-id>",
-  "client_secret": "<oauth-secret>"
-}
-```
-
-Native Databricks M2M uses the official `credentials_provider` path and requires `databricks-sdk` (included in `apache-superset[databricks]`).
-
-For **Azure Databricks** with an Azure Entra application instead of a Databricks-managed OAuth secret, use:
-
-```json
-{
-  "auth_method": "azure-sp-m2m",
-  "client_id": "<azure-app-id>",
-  "client_secret": "<azure-client-secret>"
-}
-```
-
-Optionally add `"azure_tenant_id": "<tenant-id>"` if the tenant cannot be inferred from the workspace host. The Azure path does not require `databricks-sdk`.
-
-If you configure the connection via a SQLAlchemy URI instead of the dynamic form, a dummy password is enough because M2M takes precedence over `access_token`:
-
-```
-databricks://token:m2m@{host}:443?http_path={http_path}&catalog={catalog}&schema={schema}
-```
-
 #### Denodo
 
 The recommended connector library for Denodo is

--- a/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
+++ b/docs/user_docs_versioned_docs/version-6.0.0/configuration/databases.mdx
@@ -605,6 +605,42 @@ Once configured, users can:
 
 This feature works with both "Databricks (legacy)" and "Databricks" engine types and automatically supports all major cloud providers (AWS, Azure, GCP).
 
+##### OAuth M2M (service principal)
+
+Superset can connect to Databricks with a **service principal client ID and client secret**, without a personal access token (PAT). This is machine-to-machine (M2M) auth for a shared database connection — it is **not** the per-user OAuth impersonation flow above.
+
+1. Create a Databricks service principal and an OAuth secret for it. Grant the principal **Can Use** on the SQL warehouse.
+2. In the database form, fill in host, port, HTTP path, catalog, and schema. Leave **Access token** blank, or enter a placeholder such as `m2m`.
+3. Open **Advanced → Security → Secure extra** and paste:
+
+```json
+{
+  "auth_method": "oauth-m2m",
+  "client_id": "<service-principal-application-id>",
+  "client_secret": "<oauth-secret>"
+}
+```
+
+Native Databricks M2M uses the official `credentials_provider` path and requires `databricks-sdk` (included in `apache-superset[databricks]`).
+
+For **Azure Databricks** with an Azure Entra application instead of a Databricks-managed OAuth secret, use:
+
+```json
+{
+  "auth_method": "azure-sp-m2m",
+  "client_id": "<azure-app-id>",
+  "client_secret": "<azure-client-secret>"
+}
+```
+
+Optionally add `"azure_tenant_id": "<tenant-id>"` if the tenant cannot be inferred from the workspace host. The Azure path does not require `databricks-sdk`.
+
+If you configure the connection via a SQLAlchemy URI instead of the dynamic form, a dummy password is enough because M2M takes precedence over `access_token`:
+
+```
+databricks://token:m2m@{host}:443?http_path={http_path}&catalog={catalog}&schema={schema}
+```
+
 #### Denodo
 
 The recommended connector library for Denodo is

--- a/docs/user_docs_versioned_docs/version-6.1.0/databases/supported/databricks.mdx
+++ b/docs/user_docs_versioned_docs/version-6.1.0/databases/supported/databricks.mdx
@@ -45,11 +45,45 @@ export const databaseInfo = {
     connection_string:
       'databricks://token:{access_token}@{host}:{port}?http_path={http_path}&catalog={catalog}&schema={schema}',
     parameters: {
-      access_token: 'Personal access token from Settings > User Settings',
+      access_token:
+        'Personal access token from Settings > User Settings. Optional when OAuth M2M client ID/secret is set in Secure Extra.',
       host: 'Server hostname from cluster JDBC/ODBC settings',
       port: 'Port (default 443)',
       http_path: 'HTTP path from cluster JDBC/ODBC settings',
     },
+    authentication_methods: [
+      {
+        name: 'Personal Access Token',
+        description:
+          'Default. Use a Databricks personal access token in the Access token field.',
+      },
+      {
+        name: 'OAuth M2M (service principal)',
+        description:
+          'Connect with a Databricks service principal client ID and client secret. No personal access token is required.',
+        requirements:
+          'Create a workspace service principal and OAuth secret. Grant the principal Can Use on the SQL warehouse. Requires databricks-sdk (included in apache-superset[databricks]).',
+        secure_extra: {
+          auth_method: 'oauth-m2m',
+          client_id: '<service-principal-application-id>',
+          client_secret: '<oauth-secret>',
+        },
+        notes:
+          'In the database form, leave Access token blank or use a placeholder such as m2m. Paste the JSON into Advanced → Security → Secure extra.',
+      },
+      {
+        name: 'Azure Entra service principal',
+        description:
+          'Azure Databricks only. Use an Azure Entra application client ID and secret (auth_type=azure-sp-m2m).',
+        secure_extra: {
+          auth_method: 'azure-sp-m2m',
+          client_id: '<azure-app-id>',
+          client_secret: '<azure-client-secret>',
+        },
+        notes:
+          'Does not require databricks-sdk. Optionally include azure_tenant_id in Secure Extra if the tenant cannot be inferred from the workspace host.',
+      },
+    ],
     drivers: [
       {
         name: 'Databricks Python Connector (Recommended)',

--- a/docs/user_docs_versioned_docs/version-6.1.0/databases/supported/databricks.mdx
+++ b/docs/user_docs_versioned_docs/version-6.1.0/databases/supported/databricks.mdx
@@ -74,14 +74,15 @@ export const databaseInfo = {
       {
         name: 'Azure Entra service principal',
         description:
-          'Azure Databricks only. Use an Azure Entra application client ID and secret (auth_type=azure-sp-m2m).',
+          'Azure Databricks only. Use an Azure Entra application via credentials_provider (azure_service_principal).',
         secure_extra: {
           auth_method: 'azure-sp-m2m',
           client_id: '<azure-app-id>',
           client_secret: '<azure-client-secret>',
+          azure_tenant_id: '<tenant-id>',
         },
         notes:
-          'Does not require databricks-sdk. Optionally include azure_tenant_id in Secure Extra if the tenant cannot be inferred from the workspace host.',
+          'Requires databricks-sdk. azure_tenant_id is required. The connector does not accept auth_type=azure-sp-m2m.',
       },
     ],
     drivers: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ databricks = [
     "databricks-sqlalchemy==1.0.5",
     # OAuth M2M (service principal client ID/secret) via credentials_provider.
     # Imported lazily so PAT-only installs of databricks-sql-connector still work.
-    "databricks-sdk>=0.18.0",
+    "databricks-sdk>=0.18.0,<1",
 ]
 datafusion = ["flightsql-dbapi>=0.2.2, <0.3"]
 db2 = ["ibm-db-sa<=0.4.4, >=0.4.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ databend = ["databend-sqlalchemy>=0.5.5, <1.0"]
 databricks = [
     "databricks-sql-connector>=4.5.0, <4.6.0",
     "databricks-sqlalchemy==1.0.5",
+    # OAuth M2M (service principal client ID/secret) via credentials_provider.
+    # Imported lazily so PAT-only installs of databricks-sql-connector still work.
+    "databricks-sdk>=0.18.0",
 ]
 datafusion = ["flightsql-dbapi>=0.2.2, <0.3"]
 db2 = ["ibm-db-sa<=0.4.4, >=0.4.4"]

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -33,7 +33,7 @@ from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.url import URL
 
-from superset.constants import TimeGrain
+from superset.constants import PASSWORD_MASK, TimeGrain
 from superset.databases.utils import make_url_safe
 from superset.db_engine_specs.base import (
     BaseEngineSpec,
@@ -85,13 +85,55 @@ def _parse_json_object(raw: Any) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _has_m2m_credentials(encrypted_extra: dict[str, Any]) -> bool:
-    """Return True when Encrypted Extra has a complete M2M client ID/secret."""
-    return bool(
-        encrypted_extra.get("auth_method") in M2M_AUTH_METHODS
-        and encrypted_extra.get("client_id")
-        and encrypted_extra.get("client_secret")
+def _parse_extra_for_validation(
+    extra_raw: Any,
+) -> tuple[dict[str, Any], SupersetError | None]:
+    """Parse Extra JSON for ``validate_parameters`` without raising."""
+    if isinstance(extra_raw, dict):
+        return extra_raw, None
+    if not extra_raw:
+        return {}, None
+    try:
+        parsed = json.loads(extra_raw)
+    except json.JSONDecodeError:
+        return {}, SupersetError(
+            message="The extra connection parameters are not valid JSON.",
+            error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+            level=ErrorLevel.ERROR,
+            extra={"invalid": ["extra"]},
+        )
+    if isinstance(parsed, dict):
+        return parsed, None
+    return {}, None
+
+
+def _m2m_client_id(encrypted_extra: dict[str, Any]) -> Any:
+    return encrypted_extra.get("client_id") or encrypted_extra.get("azure_client_id")
+
+
+def _m2m_client_secret(encrypted_extra: dict[str, Any]) -> Any:
+    return encrypted_extra.get("client_secret") or encrypted_extra.get(
+        "azure_client_secret"
     )
+
+
+def _has_m2m_credentials(encrypted_extra: dict[str, Any]) -> bool:
+    """Return True when Encrypted Extra has a complete M2M client ID/secret.
+
+    ``mask_encrypted_extra`` redacts every top-level value (inherited ``$.*``),
+    so a masked payload still counts when ``auth_method`` is the password mask
+    and the client-id / client-secret keys (or Azure aliases) are present.
+    """
+    auth_method = encrypted_extra.get("auth_method")
+    if auth_method not in M2M_AUTH_METHODS and auth_method != PASSWORD_MASK:
+        return False
+    if not _m2m_client_id(encrypted_extra) or not _m2m_client_secret(encrypted_extra):
+        return False
+    if auth_method == AUTH_METHOD_AZURE_SP_M2M and not encrypted_extra.get(
+        "azure_tenant_id"
+    ):
+        return False
+    return True
 
 
 def _workspace_hostname(host: str) -> str:
@@ -103,7 +145,14 @@ def _workspace_hostname(host: str) -> str:
     return hostname.rstrip("/")
 
 
-def _load_databricks_m2m_sdk() -> tuple[Any, Any]:
+def _access_token_from_uri_password(password: str | None) -> str:
+    """Drop the dummy ``m2m`` password so the form does not treat it as a PAT."""
+    if not password or password == M2M_PLACEHOLDER_TOKEN:
+        return ""
+    return password
+
+
+def _load_databricks_m2m_sdk() -> tuple[Any, Any, Any]:
     """
     Lazy-import ``databricks-sdk`` so PAT-only installs keep working.
     """
@@ -115,39 +164,76 @@ def _load_databricks_m2m_sdk() -> tuple[Any, Any]:
             "Install it with: pip install 'apache-superset[databricks]' "
             "or pip install databricks-sdk."
         ) from ex
-    return Config, oauth_service_principal
+    try:
+        from databricks.sdk.core import azure_service_principal
+    except ImportError:
+        azure_service_principal = None
+    return Config, oauth_service_principal, azure_service_principal
 
 
-def _build_oauth_m2m_credentials_provider(
-    host: str,
-    client_id: str,
-    client_secret: str,
-) -> Callable[[], Any]:
+class _M2MCredentialsProvider:
     """
-    Official Databricks SQL connector M2M path.
+    Stable ``credentials_provider`` for the Databricks SQL connector.
 
-    Returns a ``credentials_provider`` callable that builds
-    ``oauth_service_principal`` from ``databricks.sdk.core.Config``.
+    ``Database._get_sqla_engine`` includes ``repr(engine_kwargs)`` in the
+    process-wide engine cache key. A new nested function on every build
+    would miss that cache. ``__repr__`` is identity-stable for the same
+    host / client / tenant (secret rotation evicts the cache on save).
     """
-    hostname = _workspace_hostname(host)
-    if not hostname:
-        raise ValueError(
-            "Databricks OAuth M2M requires a workspace host on the connection."
+
+    def __init__(
+        self,
+        host: str,
+        client_id: str,
+        client_secret: str,
+        *,
+        azure: bool = False,
+        azure_tenant_id: str | None = None,
+    ) -> None:
+        hostname = _workspace_hostname(host)
+        if not hostname:
+            raise ValueError(
+                "Databricks OAuth M2M requires a workspace host on the connection."
+            )
+        self._hostname = hostname
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._azure = azure
+        self._azure_tenant_id = azure_tenant_id
+        # Fail at engine creation, not on the first query.
+        self._config_cls, self._oauth_sp, self._azure_sp = _load_databricks_m2m_sdk()
+        if azure and self._azure_sp is None:
+            raise ValueError(
+                "Databricks Azure service-principal M2M requires "
+                "azure_service_principal from databricks-sdk. "
+                "Install it with: pip install 'apache-superset[databricks]' "
+                "or pip install databricks-sdk."
+            )
+
+    def __call__(self) -> Any:
+        if self._azure:
+            return self._azure_sp(
+                self._config_cls(
+                    host=f"https://{self._hostname}",
+                    azure_tenant_id=self._azure_tenant_id,
+                    azure_client_id=self._client_id,
+                    azure_client_secret=self._client_secret,
+                )
+            )
+        return self._oauth_sp(
+            self._config_cls(
+                host=f"https://{self._hostname}",
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+            )
         )
 
-    # Import here so the ImportError message is raised when the provider is
-    # first built (engine creation), not later on first query.
-    config_cls, oauth_service_principal = _load_databricks_m2m_sdk()
-
-    def credentials_provider() -> Any:
-        config = config_cls(
-            host=f"https://{hostname}",
-            client_id=client_id,
-            client_secret=client_secret,
+    def __repr__(self) -> str:
+        return (
+            f"_M2MCredentialsProvider(host={self._hostname!r}, "
+            f"client_id={self._client_id!r}, azure={self._azure!r}, "
+            f"azure_tenant_id={self._azure_tenant_id!r})"
         )
-        return oauth_service_principal(config)
-
-    return credentials_provider
 
 
 try:
@@ -406,11 +492,12 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         "port": "port",
     }
 
-    # Mask the service-principal secret; leave ``auth_method`` / ``client_id``
-    # visible when the database is edited (Snowflake / Redshift pattern).
+    # Keep the inherited ``$.*`` catch-all so unrelated secrets in Encrypted
+    # Extra stay masked. Named paths give clearer import-validation labels.
     # ``$.oauth2_client_info.secret`` is always added by the base class.
     # pylint: disable=invalid-name
     encrypted_extra_sensitive_fields = {
+        "$.*": "Encrypted Extra",
         "$.client_secret": "OAuth Client Secret",
         "$.azure_client_secret": "Azure Client Secret",
     }
@@ -567,7 +654,8 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         * ``auth_method=oauth-m2m`` injects a ``credentials_provider`` (native
           Databricks service-principal M2M). ``client_id`` / ``client_secret``
           are not passed through as driver kwargs.
-        * ``auth_method=azure-sp-m2m`` sets Azure Entra connect args.
+        * ``auth_method=azure-sp-m2m`` injects a ``credentials_provider``
+          built from ``azure_service_principal`` (requires ``azure_tenant_id``).
         * Remaining non-secret keys are merged as before.
         """
         if not database.encrypted_extra:
@@ -591,31 +679,29 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         encrypted_extra.pop("azure_client_secret", None)
         azure_tenant_id = encrypted_extra.pop("azure_tenant_id", None)
 
-        if auth_method == AUTH_METHOD_OAUTH_M2M:
+        if auth_method in M2M_AUTH_METHODS:
             if not client_id or not client_secret:
                 raise ValueError(
                     "Databricks OAuth M2M requires both client_id and "
                     "client_secret in Secure Extra."
                 )
+            is_azure = auth_method == AUTH_METHOD_AZURE_SP_M2M
+            if is_azure and not azure_tenant_id:
+                raise ValueError(
+                    "Databricks Azure service-principal M2M requires "
+                    "azure_tenant_id in Secure Extra."
+                )
             host = ""
             if getattr(database, "url_object", None) is not None:
                 host = database.url_object.host or ""
             connect_args = params.setdefault("connect_args", {})
-            connect_args["credentials_provider"] = (
-                _build_oauth_m2m_credentials_provider(host, client_id, client_secret)
+            connect_args["credentials_provider"] = _M2MCredentialsProvider(
+                host,
+                client_id,
+                client_secret,
+                azure=is_azure,
+                azure_tenant_id=azure_tenant_id,
             )
-        elif auth_method == AUTH_METHOD_AZURE_SP_M2M:
-            if not client_id or not client_secret:
-                raise ValueError(
-                    "Databricks Azure service-principal M2M requires both "
-                    "client_id and client_secret in Secure Extra."
-                )
-            connect_args = params.setdefault("connect_args", {})
-            connect_args["auth_type"] = AUTH_METHOD_AZURE_SP_M2M
-            connect_args["azure_client_id"] = client_id
-            connect_args["azure_client_secret"] = client_secret
-            if azure_tenant_id:
-                connect_args["azure_tenant_id"] = azure_tenant_id
 
         if encrypted_extra:
             params.update(encrypted_extra)
@@ -696,8 +782,9 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         ],
     ) -> list[SupersetError]:
         errors: list[SupersetError] = []
-        extra_raw = properties.get("extra")
-        extra = json.loads(extra_raw) if extra_raw else {}  # type: ignore
+        extra, extra_error = _parse_extra_for_validation(properties.get("extra"))
+        if extra_error:
+            errors.append(extra_error)
         connect_args: dict[str, Any] = extra.get("engine_params", {}).get(
             "connect_args", {}
         )
@@ -851,7 +938,7 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
             item in url.query.items() for item in cls.encryption_parameters.items()
         )
         return {
-            "access_token": url.password,
+            "access_token": _access_token_from_uri_password(url.password),
             "host": url.host,
             "port": url.port,
             "database": url.database,
@@ -1010,17 +1097,17 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
                 "name": "Azure Entra service principal",
                 "description": (
                     "Azure Databricks only. Use an Azure Entra application "
-                    "client ID and secret (auth_type=azure-sp-m2m)."
+                    "via credentials_provider (azure_service_principal)."
                 ),
                 "secure_extra": {
                     "auth_method": "azure-sp-m2m",
                     "client_id": "<azure-app-id>",
                     "client_secret": "<azure-client-secret>",
+                    "azure_tenant_id": "<tenant-id>",
                 },
                 "notes": (
-                    "Does not require databricks-sdk. Optionally include "
-                    "azure_tenant_id in Secure Extra if the tenant cannot be "
-                    "inferred from the workspace host."
+                    "Requires databricks-sdk. azure_tenant_id is required. "
+                    "The connector does not accept auth_type=azure-sp-m2m."
                 ),
             },
         ],
@@ -1136,7 +1223,7 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
             item in url.query.items() for item in cls.encryption_parameters.items()
         )
         return {
-            "access_token": url.password,
+            "access_token": _access_token_from_uri_password(url.password),
             "host": url.host,
             "port": url.port,
             "http_path_field": query["http_path"],

--- a/superset/db_engine_specs/databricks.py
+++ b/superset/db_engine_specs/databricks.py
@@ -20,7 +20,7 @@ import logging
 import re
 from datetime import datetime
 from re import Pattern
-from typing import Any, Callable, cast, TYPE_CHECKING, TypedDict, Union
+from typing import Any, Callable, cast, NotRequired, TYPE_CHECKING, TypedDict, Union
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -61,6 +61,93 @@ logger = logging.getLogger(__name__)
 INSUFFICIENT_PERMISSIONS_REGEX: Pattern[str] = re.compile(
     r"\[INSUFFICIENT_PERMISSIONS\]|\bSQLSTATE:\s*42501\b"
 )
+
+# Per-database service-principal auth (discussion #39405). Secrets live in
+# Encrypted Extra; the engine spec injects driver args at connect time.
+AUTH_METHOD_OAUTH_M2M = "oauth-m2m"
+AUTH_METHOD_AZURE_SP_M2M = "azure-sp-m2m"
+M2M_AUTH_METHODS = frozenset({AUTH_METHOD_OAUTH_M2M, AUTH_METHOD_AZURE_SP_M2M})
+# The Databricks dialect always reads ``url.password``; a dummy token is
+# enough when M2M credentials_provider / Azure SP auth wins.
+M2M_PLACEHOLDER_TOKEN = "m2m"  # noqa: S105
+
+
+def _parse_json_object(raw: Any) -> dict[str, Any]:
+    """Parse a JSON object from a string or return a dict unchanged."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw or not isinstance(raw, str):
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _has_m2m_credentials(encrypted_extra: dict[str, Any]) -> bool:
+    """Return True when Encrypted Extra has a complete M2M client ID/secret."""
+    return bool(
+        encrypted_extra.get("auth_method") in M2M_AUTH_METHODS
+        and encrypted_extra.get("client_id")
+        and encrypted_extra.get("client_secret")
+    )
+
+
+def _workspace_hostname(host: str) -> str:
+    """Strip a scheme/trailing slash so Config.host is ``https://{hostname}``."""
+    hostname = host.strip()
+    for prefix in ("https://", "http://"):
+        if hostname.startswith(prefix):
+            hostname = hostname[len(prefix) :]
+    return hostname.rstrip("/")
+
+
+def _load_databricks_m2m_sdk() -> tuple[Any, Any]:
+    """
+    Lazy-import ``databricks-sdk`` so PAT-only installs keep working.
+    """
+    try:
+        from databricks.sdk.core import Config, oauth_service_principal
+    except ImportError as ex:
+        raise ValueError(
+            "Databricks OAuth M2M requires the databricks-sdk package. "
+            "Install it with: pip install 'apache-superset[databricks]' "
+            "or pip install databricks-sdk."
+        ) from ex
+    return Config, oauth_service_principal
+
+
+def _build_oauth_m2m_credentials_provider(
+    host: str,
+    client_id: str,
+    client_secret: str,
+) -> Callable[[], Any]:
+    """
+    Official Databricks SQL connector M2M path.
+
+    Returns a ``credentials_provider`` callable that builds
+    ``oauth_service_principal`` from ``databricks.sdk.core.Config``.
+    """
+    hostname = _workspace_hostname(host)
+    if not hostname:
+        raise ValueError(
+            "Databricks OAuth M2M requires a workspace host on the connection."
+        )
+
+    # Import here so the ImportError message is raised when the provider is
+    # first built (engine creation), not later on first query.
+    config_cls, oauth_service_principal = _load_databricks_m2m_sdk()
+
+    def credentials_provider() -> Any:
+        config = config_cls(
+            host=f"https://{hostname}",
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        return oauth_service_principal(config)
+
+    return credentials_provider
 
 
 try:
@@ -130,7 +217,7 @@ class DatabricksBaseSchema(Schema):
     dynamic form.
     """
 
-    access_token = fields.Str(required=True)
+    access_token = fields.Str(required=False, allow_none=True)
     host = fields.Str(required=True)
     port = fields.Integer(
         required=True,
@@ -149,7 +236,7 @@ class DatabricksBaseParametersType(TypedDict):
     These are used to build the sqlalchemy uri.
     """
 
-    access_token: str
+    access_token: NotRequired[str]
     host: str
     port: int
     encryption: bool
@@ -311,11 +398,21 @@ class DatabricksODBCEngineSpec(DatabricksBaseEngineSpec):
 class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngineSpec):
     default_driver = ""
     encryption_parameters = {"ssl": "1"}
-    required_parameters = {"access_token", "host", "port"}
+    # ``access_token`` is required unless Encrypted Extra has M2M credentials.
+    required_parameters = {"host", "port"}
     context_key_mapping = {
         "access_token": "password",
         "host": "hostname",
         "port": "port",
+    }
+
+    # Mask the service-principal secret; leave ``auth_method`` / ``client_id``
+    # visible when the database is edited (Snowflake / Redshift pattern).
+    # ``$.oauth2_client_info.secret`` is always added by the base class.
+    # pylint: disable=invalid-name
+    encrypted_extra_sensitive_fields = {
+        "$.client_secret": "OAuth Client Secret",
+        "$.azure_client_secret": "Azure Client Secret",
     }
 
     # The Databricks SQL driver has no dedicated authentication exception, so an
@@ -462,13 +559,16 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         database: Database, params: dict[str, Any]
     ) -> None:
         """
-        Merge ``encrypted_extra`` into the connection params, dropping the
-        ``oauth2_client_info`` block.
+        Merge ``encrypted_extra`` into the connection params.
 
-        ``oauth2_client_info`` holds the per-database OAuth2 client configuration
-        consumed by ``Database.get_oauth2_config``; it is not a Databricks driver
-        connection argument, so it must be stripped here to avoid poisoning the
-        connection when OAuth2 is configured on the database itself.
+        * ``oauth2_client_info`` is the per-database U2M OAuth2 client config
+          consumed by ``Database.get_oauth2_config``; it must not reach the
+          driver.
+        * ``auth_method=oauth-m2m`` injects a ``credentials_provider`` (native
+          Databricks service-principal M2M). ``client_id`` / ``client_secret``
+          are not passed through as driver kwargs.
+        * ``auth_method=azure-sp-m2m`` sets Azure Entra connect args.
+        * Remaining non-secret keys are merged as before.
         """
         if not database.encrypted_extra:
             return
@@ -478,7 +578,47 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
             logger.error(ex, exc_info=True)
             raise
         encrypted_extra.pop("oauth2_client_info", None)
-        params.update(encrypted_extra)
+
+        auth_method = encrypted_extra.pop("auth_method", None)
+        client_id = encrypted_extra.pop("client_id", None) or encrypted_extra.pop(
+            "azure_client_id", None
+        )
+        client_secret = encrypted_extra.pop("client_secret", None) or (
+            encrypted_extra.pop("azure_client_secret", None)
+        )
+        # Always drop the Azure-named aliases so they never reach create_engine.
+        encrypted_extra.pop("azure_client_id", None)
+        encrypted_extra.pop("azure_client_secret", None)
+        azure_tenant_id = encrypted_extra.pop("azure_tenant_id", None)
+
+        if auth_method == AUTH_METHOD_OAUTH_M2M:
+            if not client_id or not client_secret:
+                raise ValueError(
+                    "Databricks OAuth M2M requires both client_id and "
+                    "client_secret in Secure Extra."
+                )
+            host = ""
+            if getattr(database, "url_object", None) is not None:
+                host = database.url_object.host or ""
+            connect_args = params.setdefault("connect_args", {})
+            connect_args["credentials_provider"] = (
+                _build_oauth_m2m_credentials_provider(host, client_id, client_secret)
+            )
+        elif auth_method == AUTH_METHOD_AZURE_SP_M2M:
+            if not client_id or not client_secret:
+                raise ValueError(
+                    "Databricks Azure service-principal M2M requires both "
+                    "client_id and client_secret in Secure Extra."
+                )
+            connect_args = params.setdefault("connect_args", {})
+            connect_args["auth_type"] = AUTH_METHOD_AZURE_SP_M2M
+            connect_args["azure_client_id"] = client_id
+            connect_args["azure_client_secret"] = client_secret
+            if azure_tenant_id:
+                connect_args["azure_tenant_id"] = azure_tenant_id
+
+        if encrypted_extra:
+            params.update(encrypted_extra)
 
     @staticmethod
     def get_extra_params(
@@ -531,6 +671,23 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         return super().extract_errors(ex, context, database_name)
 
     @classmethod
+    def _required_parameters_for_properties(
+        cls,
+        properties: dict[str, Any],
+    ) -> set[str]:
+        """
+        ``access_token`` is required unless Encrypted Extra has M2M credentials.
+        """
+        required = set(cls.required_parameters)
+        encrypted_extra = _parse_json_object(
+            properties.get("masked_encrypted_extra")
+            or properties.get("encrypted_extra")
+        )
+        if not _has_m2m_credentials(encrypted_extra):
+            required.add("access_token")
+        return required
+
+    @classmethod
     def validate_parameters(  # type: ignore
         cls,
         properties: Union[
@@ -539,10 +696,11 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
         ],
     ) -> list[SupersetError]:
         errors: list[SupersetError] = []
-        connect_args: dict[str, Any] = {}
-        if extra := json.loads(properties.get("extra")):  # type: ignore
-            engine_params = extra.get("engine_params", {})
-            connect_args = engine_params.get("connect_args", {})
+        extra_raw = properties.get("extra")
+        extra = json.loads(extra_raw) if extra_raw else {}  # type: ignore
+        connect_args: dict[str, Any] = extra.get("engine_params", {}).get(
+            "connect_args", {}
+        )
         parameters = {
             **properties,
             **properties.get("parameters", {}),
@@ -551,8 +709,9 @@ class DatabricksDynamicBaseEngineSpec(BasicParametersMixin, DatabricksBaseEngine
             parameters["http_path"] = connect_args.get("http_path")
 
         present = {key for key in parameters if parameters.get(key, ())}
+        required = cls._required_parameters_for_properties(properties)  # type: ignore
 
-        if missing := sorted(cls.required_parameters - present):
+        if missing := sorted(required - present):
             errors.append(
                 SupersetError(
                     message=f"One or more parameters are missing: {', '.join(missing)}",
@@ -676,7 +835,7 @@ class DatabricksNativeEngineSpec(DatabricksDynamicBaseEngineSpec):
         return URL.create(
             f"{cls.engine}+{cls.default_driver}".rstrip("+"),
             username="token",
-            password=parameters.get("access_token"),
+            password=parameters.get("access_token") or M2M_PLACEHOLDER_TOKEN,
             host=parameters["host"],
             port=parameters["port"],
             database=parameters["database"],
@@ -808,11 +967,63 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
             "?http_path={http_path}&catalog={catalog}&schema={schema}"
         ),
         "parameters": {
-            "access_token": "Personal access token from Settings > User Settings",
+            "access_token": (
+                "Personal access token from Settings > User Settings. "
+                "Optional when OAuth M2M client ID/secret is set in Secure Extra."
+            ),
             "host": "Server hostname from cluster JDBC/ODBC settings",
             "port": "Port (default 443)",
             "http_path": "HTTP path from cluster JDBC/ODBC settings",
         },
+        "authentication_methods": [
+            {
+                "name": "Personal Access Token",
+                "description": (
+                    "Default. Use a Databricks personal access token in the "
+                    "Access token field."
+                ),
+            },
+            {
+                "name": "OAuth M2M (service principal)",
+                "description": (
+                    "Connect with a Databricks service principal client ID and "
+                    "client secret. No personal access token is required."
+                ),
+                "requirements": (
+                    "Create a workspace service principal and OAuth secret. "
+                    "Grant the principal Can Use on the SQL warehouse. "
+                    "Requires databricks-sdk (included in "
+                    "apache-superset[databricks])."
+                ),
+                "secure_extra": {
+                    "auth_method": "oauth-m2m",
+                    "client_id": "<service-principal-application-id>",
+                    "client_secret": "<oauth-secret>",
+                },
+                "notes": (
+                    "In the database form, leave Access token blank or use a "
+                    "placeholder such as m2m. Paste the JSON into Advanced → "
+                    "Security → Secure extra."
+                ),
+            },
+            {
+                "name": "Azure Entra service principal",
+                "description": (
+                    "Azure Databricks only. Use an Azure Entra application "
+                    "client ID and secret (auth_type=azure-sp-m2m)."
+                ),
+                "secure_extra": {
+                    "auth_method": "azure-sp-m2m",
+                    "client_id": "<azure-app-id>",
+                    "client_secret": "<azure-client-secret>",
+                },
+                "notes": (
+                    "Does not require databricks-sdk. Optionally include "
+                    "azure_tenant_id in Secure Extra if the tenant cannot be "
+                    "inferred from the workspace host."
+                ),
+            },
+        ],
         "drivers": [
             {
                 "name": "Databricks Python Connector (Recommended)",
@@ -905,7 +1116,7 @@ class DatabricksPythonConnectorEngineSpec(DatabricksDynamicBaseEngineSpec):
         return URL.create(
             cls.engine,
             username="token",
-            password=parameters.get("access_token"),
+            password=parameters.get("access_token") or M2M_PLACEHOLDER_TOKEN,
             host=parameters["host"],
             port=parameters["port"],
             query=query,

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -17,7 +17,7 @@
 # pylint: disable=unused-argument, import-outside-toplevel, protected-access
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, cast, Optional
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -36,6 +36,11 @@ from superset.utils import json
 from superset.utils.oauth2 import decode_oauth2_state
 from tests.unit_tests.db_engine_specs.utils import assert_convert_dttm
 from tests.unit_tests.fixtures.common import dttm  # noqa: F401
+
+
+def _validate_native_parameters(properties: dict[str, Any]) -> list[SupersetError]:
+    """Avoid TypedDict ambiguity when tests omit unused connection fields."""
+    return DatabricksNativeEngineSpec.validate_parameters(cast(Any, properties))
 
 
 def test_get_parameters_from_uri() -> None:
@@ -891,7 +896,7 @@ def test_parse_json_object_branches() -> None:
 def test_parse_extra_for_validation_branches() -> None:
     from superset.db_engine_specs.databricks import _parse_extra_for_validation
 
-    extra = {"engine_params": {}}
+    extra: dict[str, Any] = {"engine_params": {}}
     assert _parse_extra_for_validation(extra) == (extra, None)
     assert _parse_extra_for_validation(None) == ({}, None)
     assert _parse_extra_for_validation("") == ({}, None)
@@ -901,6 +906,7 @@ def test_parse_extra_for_validation_branches() -> None:
     parsed, error = _parse_extra_for_validation("{not json")
     assert parsed == {}
     assert error is not None
+    assert error.extra is not None
     assert error.extra["invalid"] == ["extra"]
 
 
@@ -1203,8 +1209,8 @@ def test_validate_parameters_access_token_required_without_m2m(
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "host": "dbc-abc.cloud.databricks.com",
                 "port": 443,
@@ -1226,7 +1232,9 @@ def test_validate_parameters_access_token_required_without_m2m(
         if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
     ]
     assert missing
-    assert "access_token" in missing[0].extra["missing"]
+    extra = missing[0].extra
+    assert extra is not None
+    assert "access_token" in extra["missing"]
 
 
 def test_validate_parameters_access_token_optional_with_m2m(
@@ -1240,8 +1248,8 @@ def test_validate_parameters_access_token_optional_with_m2m(
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "host": "dbc-abc.cloud.databricks.com",
                 "port": 443,
@@ -1283,8 +1291,8 @@ def test_validate_parameters_access_token_optional_with_azure_aliases(
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "host": "adb-123.azuredatabricks.net",
                 "port": 443,
@@ -1327,8 +1335,8 @@ def test_validate_parameters_access_token_optional_with_masked_m2m(
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "host": "dbc-abc.cloud.databricks.com",
                 "port": 443,
@@ -1370,8 +1378,8 @@ def test_validate_parameters_access_token_required_for_incomplete_azure(
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "host": "adb-123.azuredatabricks.net",
                 "port": 443,
@@ -1400,7 +1408,9 @@ def test_validate_parameters_access_token_required_for_incomplete_azure(
         if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
     ]
     assert missing
-    assert "access_token" in missing[0].extra["missing"]
+    extra = missing[0].extra
+    assert extra is not None
+    assert "access_token" in extra["missing"]
 
 
 def test_validate_parameters_accepts_dict_extra(mocker: MockerFixture) -> None:
@@ -1409,8 +1419,8 @@ def test_validate_parameters_accepts_dict_extra(mocker: MockerFixture) -> None:
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "access_token": "abc12345",
                 "host": "dbc-abc.cloud.databricks.com",
@@ -1439,8 +1449,8 @@ def test_validate_parameters_malformed_extra_json(mocker: MockerFixture) -> None
     )
     mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
 
-    errors = DatabricksNativeEngineSpec.validate_parameters(
-        {  # type: ignore[arg-type]
+    errors = _validate_native_parameters(
+        {
             "parameters": {
                 "access_token": "abc12345",
                 "host": "dbc-abc.cloud.databricks.com",
@@ -1453,6 +1463,7 @@ def test_validate_parameters_malformed_extra_json(mocker: MockerFixture) -> None
 
     assert any(
         error.message == "The extra connection parameters are not valid JSON."
+        and error.extra is not None
         and error.extra.get("invalid") == ["extra"]
         for error in errors
     )

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -672,18 +672,20 @@ def test_update_params_invalid_encrypted_extra_raises(mocker: MockerFixture) -> 
 
 def test_encrypted_extra_sensitive_fields() -> None:
     """
-    ``client_secret`` is listed so it is masked in ``masked_encrypted_extra``.
+    Inherited ``$.*`` is kept so unrelated Encrypted Extra secrets stay masked.
     """
     from superset.db_engine_specs.databricks import DatabricksDynamicBaseEngineSpec
 
     paths = DatabricksDynamicBaseEngineSpec.encrypted_extra_sensitive_field_paths()
+    assert "$.*" in paths
     assert "$.client_secret" in paths
     assert "$.oauth2_client_info.secret" in paths
 
 
 def test_mask_encrypted_extra_client_secret() -> None:
     """
-    ``client_secret`` is redacted; ``auth_method`` and ``client_id`` stay visible.
+    ``$.*`` redacts every top-level Encrypted Extra value, including M2M fields
+    and unrelated driver secrets.
     """
     from superset.db_engine_specs.databricks import DatabricksDynamicBaseEngineSpec
 
@@ -692,13 +694,15 @@ def test_mask_encrypted_extra_client_secret() -> None:
             "auth_method": "oauth-m2m",
             "client_id": "sp-application-id",
             "client_secret": "super-secret",
+            "password": "unrelated-driver-secret",
         }
     )
     assert DatabricksDynamicBaseEngineSpec.mask_encrypted_extra(config) == json.dumps(
         {
-            "auth_method": "oauth-m2m",
-            "client_id": "sp-application-id",
+            "auth_method": "XXXXXXXXXX",
+            "client_id": "XXXXXXXXXX",
             "client_secret": "XXXXXXXXXX",
+            "password": "XXXXXXXXXX",
         }
     )
 
@@ -716,7 +720,7 @@ def test_update_params_oauth_m2m_injects_credentials_provider(
     mock_oauth = mocker.MagicMock(return_value="oauth-provider")
     mocker.patch(
         "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
-        return_value=(mock_config_cls, mock_oauth),
+        return_value=(mock_config_cls, mock_oauth, None),
     )
 
     database = mocker.MagicMock()
@@ -759,7 +763,7 @@ def test_update_params_oauth_m2m_strips_oauth2_client_info(
 
     mocker.patch(
         "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
-        return_value=(mocker.MagicMock(), mocker.MagicMock()),
+        return_value=(mocker.MagicMock(), mocker.MagicMock(), None),
     )
     database = mocker.MagicMock()
     database.url_object.host = "dbc-abc.cloud.databricks.com"
@@ -847,15 +851,19 @@ def test_load_databricks_m2m_sdk_import_error(mocker: MockerFixture) -> None:
 
 def test_update_params_azure_sp_m2m(mocker: MockerFixture) -> None:
     """
-    Azure SP M2M sets connector ``auth_type`` / Azure kwargs and does not
-    require ``databricks-sdk``.
+    Azure SP M2M uses ``azure_service_principal`` via credentials_provider.
     """
     from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
 
-    load_sdk = mocker.patch(
-        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk"
+    mock_config_cls = mocker.MagicMock()
+    mock_oauth = mocker.MagicMock()
+    mock_azure = mocker.MagicMock(return_value="azure-provider")
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mock_config_cls, mock_oauth, mock_azure),
     )
     database = mocker.MagicMock()
+    database.url_object.host = "adb-123.azuredatabricks.net"
     database.encrypted_extra = json.dumps(
         {
             "auth_method": "azure-sp-m2m",
@@ -868,13 +876,48 @@ def test_update_params_azure_sp_m2m(mocker: MockerFixture) -> None:
 
     DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
 
-    load_sdk.assert_not_called()
     assert "client_id" not in params
     assert "client_secret" not in params
-    assert params["connect_args"]["auth_type"] == "azure-sp-m2m"
-    assert params["connect_args"]["azure_client_id"] == "azure-app-id"
-    assert params["connect_args"]["azure_client_secret"] == "azure-secret"  # noqa: S105
-    assert params["connect_args"]["azure_tenant_id"] == "tenant-123"
+    assert "auth_type" not in params.get("connect_args", {})
+    provider = params["connect_args"]["credentials_provider"]
+    assert provider() == "azure-provider"
+    mock_config_cls.assert_called_once_with(
+        host="https://adb-123.azuredatabricks.net",
+        azure_tenant_id="tenant-123",
+        azure_client_id="azure-app-id",
+        azure_client_secret="azure-secret",  # noqa: S106
+    )
+    mock_azure.assert_called_once()
+    mock_oauth.assert_not_called()
+
+
+def test_update_params_azure_sp_m2m_aliases(mocker: MockerFixture) -> None:
+    """
+    Azure-named client ID/secret keys are accepted and never passed to the driver.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()),
+    )
+    database = mocker.MagicMock()
+    database.url_object.host = "adb-123.azuredatabricks.net"
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "azure-sp-m2m",
+            "azure_client_id": "azure-app-id",
+            "azure_client_secret": "azure-secret",
+            "azure_tenant_id": "tenant-123",
+        }
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "azure_client_id" not in params
+    assert "azure_client_secret" not in params
+    assert "credentials_provider" in params["connect_args"]
 
 
 def test_update_params_azure_sp_m2m_missing_credentials_raises(
@@ -887,6 +930,70 @@ def test_update_params_azure_sp_m2m_missing_credentials_raises(
 
     with pytest.raises(ValueError, match="client_id and client_secret"):
         DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_update_params_azure_sp_m2m_missing_tenant_raises(
+    mocker: MockerFixture,
+) -> None:
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "azure-sp-m2m",
+            "client_id": "azure-app-id",
+            "client_secret": "azure-secret",
+        }
+    )
+
+    with pytest.raises(ValueError, match="azure_tenant_id"):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_m2m_credentials_provider_repr_is_stable(mocker: MockerFixture) -> None:
+    """
+    ``repr`` is identity-stable (and secret-free) so the engine cache key matches.
+    """
+    from superset.db_engine_specs.databricks import _M2MCredentialsProvider
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()),
+    )
+    first = _M2MCredentialsProvider(
+        "https://dbc-abc.cloud.databricks.com/",
+        "sp-application-id",
+        "old-secret",
+    )
+    second = _M2MCredentialsProvider(
+        "dbc-abc.cloud.databricks.com",
+        "sp-application-id",
+        "rotated-secret",
+    )
+    assert repr(first) == repr(second)
+    assert "old-secret" not in repr(first)
+    assert "rotated-secret" not in repr(second)
+
+
+def test_get_parameters_from_uri_strips_m2m_placeholder() -> None:
+    """
+    The dummy ``m2m`` URI password is not treated as a personal access token.
+    """
+    parameters = DatabricksNativeEngineSpec.get_parameters_from_uri(
+        "databricks+connector://token:m2m@my_hostname:1234/test"
+    )
+    assert parameters["access_token"] == ""
+
+
+def test_python_connector_get_parameters_from_uri_strips_m2m_placeholder() -> None:
+    """
+    The dummy ``m2m`` URI password is stripped for the Python connector too.
+    """
+    parameters = DatabricksPythonConnectorEngineSpec.get_parameters_from_uri(
+        "databricks://token:m2m@my_hostname:443"
+        "?http_path=/sql/1.0/warehouses/x&catalog=main&schema=default"
+    )
+    assert parameters["access_token"] == ""
 
 
 def test_build_sqlalchemy_uri_placeholder_without_access_token() -> None:
@@ -986,6 +1093,121 @@ def test_validate_parameters_access_token_optional_with_m2m(
         if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
     ]
     assert missing == []
+
+
+def test_validate_parameters_access_token_optional_with_azure_aliases(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Azure-named client ID/secret keys count as complete M2M credentials.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "host": "adb-123.azuredatabricks.net",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": json.dumps(
+                {
+                    "engine_params": {
+                        "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                    }
+                }
+            ),
+            "masked_encrypted_extra": json.dumps(
+                {
+                    "auth_method": "azure-sp-m2m",
+                    "azure_client_id": "azure-app-id",
+                    "azure_client_secret": "azure-secret",
+                    "azure_tenant_id": "tenant-123",
+                }
+            ),
+        }
+    )
+
+    missing = [
+        error
+        for error in errors
+        if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
+    ]
+    assert missing == []
+
+
+def test_validate_parameters_access_token_optional_with_masked_m2m(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Fully redacted Encrypted Extra still makes ``access_token`` optional.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "host": "dbc-abc.cloud.databricks.com",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": json.dumps(
+                {
+                    "engine_params": {
+                        "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                    }
+                }
+            ),
+            "masked_encrypted_extra": json.dumps(
+                {
+                    "auth_method": "XXXXXXXXXX",
+                    "client_id": "XXXXXXXXXX",
+                    "client_secret": "XXXXXXXXXX",
+                }
+            ),
+        }
+    )
+
+    missing = [
+        error
+        for error in errors
+        if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
+    ]
+    assert missing == []
+
+
+def test_validate_parameters_malformed_extra_json(mocker: MockerFixture) -> None:
+    """
+    Invalid Extra JSON is a validation error, not a 500.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "access_token": "abc12345",
+                "host": "dbc-abc.cloud.databricks.com",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": "{not valid json",
+        }
+    )
+
+    assert any(
+        error.message == "The extra connection parameters are not valid JSON."
+        and error.extra.get("invalid") == ["extra"]
+        for error in errors
+    )
 
 
 @pytest.fixture

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -849,6 +849,150 @@ def test_load_databricks_m2m_sdk_import_error(mocker: MockerFixture) -> None:
         _load_databricks_m2m_sdk()
 
 
+def test_load_databricks_m2m_sdk_missing_azure_helper(mocker: MockerFixture) -> None:
+    """
+    Native M2M still loads when ``azure_service_principal`` is absent.
+    """
+    import builtins
+    from types import SimpleNamespace
+
+    from superset.db_engine_specs.databricks import _load_databricks_m2m_sdk
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "databricks.sdk.core":
+            fromlist = kwargs.get("fromlist") or (args[2] if len(args) > 2 else ())
+            if fromlist and "azure_service_principal" in fromlist:
+                raise ImportError("azure_service_principal is unavailable")
+            return SimpleNamespace(Config=object, oauth_service_principal=object)
+        return real_import(name, *args, **kwargs)
+
+    mocker.patch("builtins.__import__", side_effect=fake_import)
+    config_cls, oauth_sp, azure_sp = _load_databricks_m2m_sdk()
+    assert config_cls is object
+    assert oauth_sp is object
+    assert azure_sp is None
+
+
+def test_parse_json_object_branches() -> None:
+    from superset.db_engine_specs.databricks import _parse_json_object
+
+    payload = {"auth_method": "oauth-m2m"}
+    assert _parse_json_object(payload) is payload
+    assert _parse_json_object(None) == {}
+    assert _parse_json_object("") == {}
+    assert _parse_json_object(123) == {}
+    assert _parse_json_object("{not json") == {}
+    assert _parse_json_object("[1, 2]") == {}
+    assert _parse_json_object(json.dumps(payload)) == payload
+
+
+def test_parse_extra_for_validation_branches() -> None:
+    from superset.db_engine_specs.databricks import _parse_extra_for_validation
+
+    extra = {"engine_params": {}}
+    assert _parse_extra_for_validation(extra) == (extra, None)
+    assert _parse_extra_for_validation(None) == ({}, None)
+    assert _parse_extra_for_validation("") == ({}, None)
+    parsed, error = _parse_extra_for_validation("[1]")
+    assert parsed == {}
+    assert error is None
+    parsed, error = _parse_extra_for_validation("{not json")
+    assert parsed == {}
+    assert error is not None
+    assert error.extra["invalid"] == ["extra"]
+
+
+def test_has_m2m_credentials_requires_complete_azure_config() -> None:
+    from superset.constants import PASSWORD_MASK
+    from superset.db_engine_specs.databricks import _has_m2m_credentials
+
+    assert _has_m2m_credentials({}) is False
+    assert _has_m2m_credentials({"auth_method": "oauth-m2m"}) is False
+    assert (
+        _has_m2m_credentials(
+            {
+                "auth_method": "azure-sp-m2m",
+                "client_id": "azure-app-id",
+                "client_secret": "azure-secret",
+            }
+        )
+        is False
+    )
+    assert (
+        _has_m2m_credentials(
+            {
+                "auth_method": PASSWORD_MASK,
+                "client_id": PASSWORD_MASK,
+                "client_secret": PASSWORD_MASK,
+            }
+        )
+        is True
+    )
+
+
+def test_workspace_hostname_strips_http_prefix() -> None:
+    from superset.db_engine_specs.databricks import _workspace_hostname
+
+    assert _workspace_hostname("http://dbc-abc.cloud.databricks.com/") == (
+        "dbc-abc.cloud.databricks.com"
+    )
+
+
+def test_access_token_from_uri_password_keeps_real_pat() -> None:
+    from superset.db_engine_specs.databricks import _access_token_from_uri_password
+
+    assert _access_token_from_uri_password(None) == ""
+    assert _access_token_from_uri_password("abc12345") == "abc12345"
+
+
+def test_m2m_credentials_provider_requires_host(mocker: MockerFixture) -> None:
+    from superset.db_engine_specs.databricks import _M2MCredentialsProvider
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock()),
+    )
+    with pytest.raises(ValueError, match="workspace host"):
+        _M2MCredentialsProvider("", "sp-application-id", "super-secret")
+
+
+def test_m2m_credentials_provider_azure_missing_helper_raises(
+    mocker: MockerFixture,
+) -> None:
+    from superset.db_engine_specs.databricks import _M2MCredentialsProvider
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mocker.MagicMock(), mocker.MagicMock(), None),
+    )
+    with pytest.raises(ValueError, match="azure_service_principal"):
+        _M2MCredentialsProvider(
+            "adb-123.azuredatabricks.net",
+            "azure-app-id",
+            "azure-secret",
+            azure=True,
+            azure_tenant_id="tenant-123",
+        )
+
+
+def test_update_params_oauth_m2m_missing_host_raises(mocker: MockerFixture) -> None:
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    database = mocker.MagicMock()
+    database.url_object = None
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "super-secret",
+        }
+    )
+    with pytest.raises(ValueError, match="workspace host"):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
 def test_update_params_azure_sp_m2m(mocker: MockerFixture) -> None:
     """
     Azure SP M2M uses ``azure_service_principal`` via credentials_provider.
@@ -994,6 +1138,39 @@ def test_python_connector_get_parameters_from_uri_strips_m2m_placeholder() -> No
         "?http_path=/sql/1.0/warehouses/x&catalog=main&schema=default"
     )
     assert parameters["access_token"] == ""
+
+
+def test_python_connector_build_sqlalchemy_uri_placeholder_without_access_token() -> (
+    None
+):
+    """
+    An empty access token becomes the ``m2m`` URI placeholder for the
+    Python connector as well.
+    """
+    from superset.db_engine_specs.databricks import (
+        DatabricksPythonConnectorParametersType,
+    )
+
+    parameters = DatabricksPythonConnectorParametersType(
+        {
+            "host": "my_hostname",
+            "port": 443,
+            "http_path_field": "/sql/1.0/warehouses/x",
+            "default_catalog": "main",
+            "default_schema": "default",
+            "encryption": True,
+        }
+    )
+    sqlalchemy_uri = DatabricksPythonConnectorEngineSpec.build_sqlalchemy_uri(
+        parameters, None
+    )
+    url = make_url(sqlalchemy_uri)
+    assert url.password == "m2m"  # noqa: S105
+    assert url.host == "my_hostname"
+    assert url.query["http_path"] == "/sql/1.0/warehouses/x"
+    assert url.query["catalog"] == "main"
+    assert url.query["schema"] == "default"
+    assert url.query["ssl"] == "1"
 
 
 def test_build_sqlalchemy_uri_placeholder_without_access_token() -> None:
@@ -1180,6 +1357,77 @@ def test_validate_parameters_access_token_optional_with_masked_m2m(
         if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
     ]
     assert missing == []
+
+
+def test_validate_parameters_access_token_required_for_incomplete_azure(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Azure M2M without ``azure_tenant_id`` still requires a PAT.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "host": "adb-123.azuredatabricks.net",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": json.dumps(
+                {
+                    "engine_params": {
+                        "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                    }
+                }
+            ),
+            "encrypted_extra": json.dumps(
+                {
+                    "auth_method": "azure-sp-m2m",
+                    "client_id": "azure-app-id",
+                    "client_secret": "azure-secret",
+                }
+            ),
+        }
+    )
+
+    missing = [
+        error
+        for error in errors
+        if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
+    ]
+    assert missing
+    assert "access_token" in missing[0].extra["missing"]
+
+
+def test_validate_parameters_accepts_dict_extra(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "access_token": "abc12345",
+                "host": "dbc-abc.cloud.databricks.com",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": {
+                "engine_params": {
+                    "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                }
+            },
+        }
+    )
+    assert not any(
+        error.error_type == SupersetErrorType.GENERIC_DB_ENGINE_ERROR
+        for error in errors
+    )
 
 
 def test_validate_parameters_malformed_extra_json(mocker: MockerFixture) -> None:

--- a/tests/unit_tests/db_engine_specs/test_databricks.py
+++ b/tests/unit_tests/db_engine_specs/test_databricks.py
@@ -101,7 +101,7 @@ def test_parameters_json_schema() -> None:
     assert json_schema == {
         "type": "object",
         "properties": {
-            "access_token": {"type": "string"},
+            "access_token": {"type": "string", "nullable": True},
             "database": {"type": "string"},
             "encryption": {
                 "description": "Use an encrypted connection to the database",
@@ -116,7 +116,7 @@ def test_parameters_json_schema() -> None:
                 "type": "integer",
             },
         },
-        "required": ["access_token", "database", "host", "http_path", "port"],
+        "required": ["database", "host", "http_path", "port"],
     }
 
 
@@ -668,6 +668,324 @@ def test_update_params_invalid_encrypted_extra_raises(mocker: MockerFixture) -> 
 
     with pytest.raises(json.JSONDecodeError):
         DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_encrypted_extra_sensitive_fields() -> None:
+    """
+    ``client_secret`` is listed so it is masked in ``masked_encrypted_extra``.
+    """
+    from superset.db_engine_specs.databricks import DatabricksDynamicBaseEngineSpec
+
+    paths = DatabricksDynamicBaseEngineSpec.encrypted_extra_sensitive_field_paths()
+    assert "$.client_secret" in paths
+    assert "$.oauth2_client_info.secret" in paths
+
+
+def test_mask_encrypted_extra_client_secret() -> None:
+    """
+    ``client_secret`` is redacted; ``auth_method`` and ``client_id`` stay visible.
+    """
+    from superset.db_engine_specs.databricks import DatabricksDynamicBaseEngineSpec
+
+    config = json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "super-secret",
+        }
+    )
+    assert DatabricksDynamicBaseEngineSpec.mask_encrypted_extra(config) == json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "XXXXXXXXXX",
+        }
+    )
+
+
+def test_update_params_oauth_m2m_injects_credentials_provider(
+    mocker: MockerFixture,
+) -> None:
+    """
+    Encrypted Extra M2M builds a ``credentials_provider`` and does not pass
+    ``client_id`` / ``client_secret`` through as driver kwargs.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    mock_config_cls = mocker.MagicMock()
+    mock_oauth = mocker.MagicMock(return_value="oauth-provider")
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mock_config_cls, mock_oauth),
+    )
+
+    database = mocker.MagicMock()
+    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "super-secret",
+            "http_headers": [["X-Custom", "value"]],
+        }
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "client_id" not in params
+    assert "client_secret" not in params
+    assert "auth_method" not in params
+    assert params["http_headers"] == [["X-Custom", "value"]]
+    provider = params["connect_args"]["credentials_provider"]
+    assert callable(provider)
+
+    assert provider() == "oauth-provider"
+    mock_config_cls.assert_called_once_with(
+        host="https://dbc-abc.cloud.databricks.com",
+        client_id="sp-application-id",
+        client_secret="super-secret",  # noqa: S106
+    )
+    mock_oauth.assert_called_once()
+
+
+def test_update_params_oauth_m2m_strips_oauth2_client_info(
+    mocker: MockerFixture,
+) -> None:
+    """
+    U2M ``oauth2_client_info`` is still stripped when M2M is also configured.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        return_value=(mocker.MagicMock(), mocker.MagicMock()),
+    )
+    database = mocker.MagicMock()
+    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "super-secret",
+            "oauth2_client_info": {
+                "id": "u2m-client-id",
+                "secret": "u2m-client-secret",
+            },
+        }
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    assert "oauth2_client_info" not in params
+    assert "credentials_provider" in params["connect_args"]
+
+
+def test_update_params_oauth_m2m_missing_credentials_raises(
+    mocker: MockerFixture,
+) -> None:
+    """
+    ``auth_method=oauth-m2m`` without both credentials fails with a clear error.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps(
+        {"auth_method": "oauth-m2m", "client_id": "sp-application-id"}
+    )
+
+    with pytest.raises(ValueError, match="client_id and client_secret"):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_update_params_oauth_m2m_missing_sdk_raises(mocker: MockerFixture) -> None:
+    """
+    Missing ``databricks-sdk`` fails with an install hint, not a driver error.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk",
+        side_effect=ValueError(
+            "Databricks OAuth M2M requires the databricks-sdk package."
+        ),
+    )
+    database = mocker.MagicMock()
+    database.url_object.host = "dbc-abc.cloud.databricks.com"
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "oauth-m2m",
+            "client_id": "sp-application-id",
+            "client_secret": "super-secret",
+        }
+    )
+
+    with pytest.raises(ValueError, match="databricks-sdk"):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_load_databricks_m2m_sdk_import_error(mocker: MockerFixture) -> None:
+    """
+    The lazy import surfaces a clear error when ``databricks-sdk`` is absent.
+    """
+    import builtins
+
+    from superset.db_engine_specs.databricks import _load_databricks_m2m_sdk
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "databricks.sdk.core":
+            raise ImportError("No module named databricks.sdk")
+        return real_import(name, *args, **kwargs)
+
+    mocker.patch("builtins.__import__", side_effect=fake_import)
+    with pytest.raises(ValueError, match="databricks-sdk"):
+        _load_databricks_m2m_sdk()
+
+
+def test_update_params_azure_sp_m2m(mocker: MockerFixture) -> None:
+    """
+    Azure SP M2M sets connector ``auth_type`` / Azure kwargs and does not
+    require ``databricks-sdk``.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    load_sdk = mocker.patch(
+        "superset.db_engine_specs.databricks._load_databricks_m2m_sdk"
+    )
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps(
+        {
+            "auth_method": "azure-sp-m2m",
+            "client_id": "azure-app-id",
+            "client_secret": "azure-secret",
+            "azure_tenant_id": "tenant-123",
+        }
+    )
+    params: dict[str, Any] = {}
+
+    DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, params)
+
+    load_sdk.assert_not_called()
+    assert "client_id" not in params
+    assert "client_secret" not in params
+    assert params["connect_args"]["auth_type"] == "azure-sp-m2m"
+    assert params["connect_args"]["azure_client_id"] == "azure-app-id"
+    assert params["connect_args"]["azure_client_secret"] == "azure-secret"  # noqa: S105
+    assert params["connect_args"]["azure_tenant_id"] == "tenant-123"
+
+
+def test_update_params_azure_sp_m2m_missing_credentials_raises(
+    mocker: MockerFixture,
+) -> None:
+    from superset.db_engine_specs.databricks import DatabricksNativeEngineSpec
+
+    database = mocker.MagicMock()
+    database.encrypted_extra = json.dumps({"auth_method": "azure-sp-m2m"})
+
+    with pytest.raises(ValueError, match="client_id and client_secret"):
+        DatabricksNativeEngineSpec.update_params_from_encrypted_extra(database, {})
+
+
+def test_build_sqlalchemy_uri_placeholder_without_access_token() -> None:
+    """
+    An empty access token becomes the ``m2m`` URI placeholder so the dialect
+    still has a password while M2M auth wins at connect time.
+    """
+    from superset.db_engine_specs.databricks import DatabricksNativeParametersType
+
+    parameters = DatabricksNativeParametersType(
+        {
+            "host": "my_hostname",
+            "port": 1234,
+            "database": "test",
+            "encryption": False,
+        }
+    )
+    sqlalchemy_uri = DatabricksNativeEngineSpec.build_sqlalchemy_uri(parameters, None)
+    assert sqlalchemy_uri == "databricks+connector://token:m2m@my_hostname:1234/test"
+
+
+def test_validate_parameters_access_token_required_without_m2m(
+    mocker: MockerFixture,
+) -> None:
+    """
+    PAT-only connections still require ``access_token``.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "host": "dbc-abc.cloud.databricks.com",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": json.dumps(
+                {
+                    "engine_params": {
+                        "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                    }
+                }
+            ),
+        }
+    )
+
+    missing = [
+        error
+        for error in errors
+        if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
+    ]
+    assert missing
+    assert "access_token" in missing[0].extra["missing"]
+
+
+def test_validate_parameters_access_token_optional_with_m2m(
+    mocker: MockerFixture,
+) -> None:
+    """
+    ``access_token`` is not required when Encrypted Extra has M2M credentials.
+    """
+    mocker.patch(
+        "superset.db_engine_specs.databricks.is_hostname_valid", return_value=True
+    )
+    mocker.patch("superset.db_engine_specs.databricks.is_port_open", return_value=True)
+
+    errors = DatabricksNativeEngineSpec.validate_parameters(
+        {  # type: ignore[arg-type]
+            "parameters": {
+                "host": "dbc-abc.cloud.databricks.com",
+                "port": 443,
+                "database": "hive_metastore",
+            },
+            "extra": json.dumps(
+                {
+                    "engine_params": {
+                        "connect_args": {"http_path": "/sql/1.0/warehouses/x"}
+                    }
+                }
+            ),
+            "masked_encrypted_extra": json.dumps(
+                {
+                    "auth_method": "oauth-m2m",
+                    "client_id": "sp-application-id",
+                    "client_secret": "super-secret",
+                }
+            ),
+        }
+    )
+
+    missing = [
+        error
+        for error in errors
+        if error.error_type == SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR
+    ]
+    assert missing == []
 
 
 @pytest.fixture


### PR DESCRIPTION
### SUMMARY
Add per-database Databricks service-principal auth via Encrypted Extra (`client_id` / `client_secret`), so a SQL warehouse can be connected without a personal access token.

- Native M2M injects a stable `credentials_provider` (`databricks-sdk`) in `update_params_from_encrypted_extra`.
- Azure Entra M2M uses the same `credentials_provider` path with `azure_service_principal` (requires `azure_tenant_id` and `databricks-sdk`). The connector does not accept `auth_type=azure-sp-m2m`.
- PAT remains the default; existing per-user OAuth impersonation is unchanged.
- Encrypted Extra keeps the inherited `$.*` mask so unrelated secrets stay redacted; `oauth2_client_info` is still stripped from driver kwargs.

Addresses https://github.com/apache/superset/discussions/39405

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
- [ ] PAT-only Databricks connection still works (no Encrypted Extra).
- [ ] Encrypted Extra with `auth_method=oauth-m2m`, `client_id`, and `client_secret`: leave Access token blank (or `m2m`); Test Connection succeeds against a SQL warehouse.
- [ ] Secrets in Encrypted Extra are masked when editing the database.
- [ ] Missing `client_id` or `client_secret` with `auth_method=oauth-m2m` fails with a clear error.
- [ ] Azure path: `auth_method=azure-sp-m2m` with `azure_tenant_id` uses `azure_service_principal` (requires `databricks-sdk`).
- [ ] SQL Lab: `SELECT current_user()` runs as the service principal.

### ADDITIONAL INFORMATION
- [x] Has associated issue: https://github.com/apache/superset/discussions/39405
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API
- [ ] Removes existing feature or API