### PR TITLE
feat(semantic-layer): show provider queries from chart results

### DIFF
--- a/docs/docs/using-superset/creating-your-first-dashboard.mdx
+++ b/docs/docs/using-superset/creating-your-first-dashboard.mdx
@@ -190,6 +190,32 @@ Semantic views and native filter support for them are part of the experimental S
 feature and require the `SEMANTIC_LAYERS` feature flag to be enabled.
 :::
 
+### Viewing provider requests for semantic views
+
+With the experimental `SEMANTIC_LAYERS` feature flag enabled, you can inspect the provider requests
+that produced a semantic-view chart's data:
+
+1. Run the chart and wait for its data to load.
+2. In Explore, open the chart's more options menu and select **View query**. On a dashboard, select
+   **View query** from the chart's header menu.
+3. Select **Copy** below a displayed block to copy its complete text, including the request-kind
+   headers. Long requests are scrollable and are not truncated when copied.
+
+View query shows the requests from the chart's latest completed run in the current session. After
+changing filters or other chart settings, let the chart run again to inspect the updated requests.
+Opening View query does not execute a query or provide a preview before the chart runs.
+
+Requests are displayed verbatim, in the order reported, with headers identifying their kind, such as
+SQL, JSON, or GraphQL. Recognized kinds receive syntax highlighting; other kinds appear as plain
+text. The text is not reformatted, and a block can contain multiple requests from the same run.
+
+If no run report is available, the message is **The provider query will be available after the chart
+runs.** Run the chart to make its reported requests available. If a run report is present but has no
+request text for an entry, the message is **No provider query is available for this run.** This can
+occur when a provider does not report request text; it does not mean the chart returned no data.
+
+View query for regular dataset charts is unchanged.
+
 ### Creating charts in Explore view
 
 Superset has 2 main interfaces for exploring data:

--- a/superset-frontend/src/explore/components/controls/SemanticRequestView.test.tsx
+++ b/superset-frontend/src/explore/components/controls/SemanticRequestView.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'spec/helpers/testing-library';
+import copyTextToClipboard from 'src/utils/copy';
+import * as syntaxHighlighter from '@superset-ui/core/components/CodeSyntaxHighlighter';
+import SemanticRequestView, {
+  REQUEST_KIND_LANGUAGES,
+} from './SemanticRequestView';
+
+jest.mock('src/utils/copy', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve()),
+}));
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+});
+
+test('copies the complete raw provider request including headers and whitespace', async () => {
+  const requestText = '-- SQL\n SELECT  1;\n\n-- SQL\nSELECT\t2;\n';
+  const { container } = render(
+    <SemanticRequestView requestText={requestText} />,
+    {
+      useRedux: true,
+    },
+  );
+  await waitFor(() =>
+    expect(container.querySelector('pre')?.textContent).toBe(requestText),
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'Copy' }));
+  const copyMock = jest.mocked(copyTextToClipboard);
+  expect(copyMock).toHaveBeenCalledTimes(1);
+  await expect(copyMock.mock.calls[0][0]()).resolves.toBe(requestText);
+});
+
+test.each(['SQL', 'sql', 'json'])(
+  'uses the known %s kind only as a highlight hint',
+  async kind => {
+    const highlighter = jest.spyOn(syntaxHighlighter, 'default');
+    const requestText = `-- ${kind}\n{ "unformatted" : 1 }\n\n-- other\nprovider text`;
+    const { container } = render(
+      <SemanticRequestView requestText={requestText} />,
+      {
+        useRedux: true,
+      },
+    );
+    expect(highlighter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: REQUEST_KIND_LANGUAGES.get(kind.toLowerCase()),
+        children: requestText,
+        showCopyButton: false,
+      }),
+      expect.anything(),
+    );
+    await waitFor(() =>
+      expect(container.querySelector('pre')?.textContent).toBe(requestText),
+    );
+  },
+);
+
+test.each(['snowflake-sql', 'graphql', 'constructor', 'unknown'])(
+  'renders unknown kind %s as plain verbatim text',
+  kind => {
+    const highlighter = jest.spyOn(syntaxHighlighter, 'default');
+    const requestText = `-- ${kind}\n  query { field }\n\n-- SQL\nSELECT 1;\n`;
+    const { container } = render(
+      <SemanticRequestView requestText={requestText} />,
+      {
+        useRedux: true,
+      },
+    );
+    expect(container.querySelector('pre')?.textContent).toBe(requestText);
+    expect(container.querySelector('pre')?.children).toHaveLength(0);
+    expect(highlighter).not.toHaveBeenCalled();
+  },
+);
+
+test('does not interpret provider text without a first-line host header', () => {
+  const highlighter = jest.spyOn(syntaxHighlighter, 'default');
+  const requestText = 'SELECT  1;\n-- SQL\nSELECT 2;';
+  const { container } = render(
+    <SemanticRequestView requestText={requestText} />,
+    {
+      useRedux: true,
+    },
+  );
+  expect(container.querySelector('pre')?.textContent).toBe(requestText);
+  expect(highlighter).not.toHaveBeenCalled();
+});

--- a/superset-frontend/src/explore/components/controls/SemanticRequestView.tsx
+++ b/superset-frontend/src/explore/components/controls/SemanticRequestView.tsx
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@apache-superset/core/translation';
+import { styled } from '@apache-superset/core/theme';
+import { Button } from '@superset-ui/core/components';
+import CodeSyntaxHighlighter, {
+  SupportedLanguage,
+} from '@superset-ui/core/components/CodeSyntaxHighlighter';
+import { CopyToClipboard } from 'src/components';
+
+export interface SemanticRequestViewProps {
+  requestText: string;
+}
+
+export const REQUEST_KIND_LANGUAGES: ReadonlyMap<string, SupportedLanguage> =
+  new Map([
+    ['sql', 'sql'],
+    ['json', 'json'],
+  ]);
+
+const RequestTextContainer = styled.div`
+  max-height: ${({ theme }) => theme.sizeUnit * 80}px;
+  overflow: auto;
+`;
+
+export default function SemanticRequestView({
+  requestText,
+}: SemanticRequestViewProps) {
+  // Only inspect the first host-authored header; provider text stays opaque.
+  const requestKind = /^-- ([^\r\n]*)/.exec(requestText)?.[1].toLowerCase();
+  const highlightLanguage = REQUEST_KIND_LANGUAGES.get(requestKind ?? '');
+
+  return (
+    <div>
+      <RequestTextContainer>
+        {highlightLanguage ? (
+          <CodeSyntaxHighlighter
+            language={highlightLanguage}
+            showCopyButton={false}
+          >
+            {requestText}
+          </CodeSyntaxHighlighter>
+        ) : (
+          // An undefined highlighter language defaults to SQL, not plain text.
+          <pre>{requestText}</pre>
+        )}
+      </RequestTextContainer>
+      <CopyToClipboard
+        text={requestText}
+        shouldShowText={false}
+        copyNode={<Button>{t('Copy')}</Button>}
+      />
+    </div>
+  );
+}

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.test.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.test.tsx
@@ -17,11 +17,18 @@
  * under the License.
  */
 
-import { screen, render, waitFor } from 'spec/helpers/testing-library';
+import {
+  act,
+  createStore,
+  screen,
+  render,
+  waitFor,
+} from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import * as chartAction from 'src/components/Chart/chartAction';
 import type { ChartDataRequestResponse } from 'src/components/Chart/chartAction';
-import ViewQueryModal from './ViewQueryModal';
+import ViewQueryModal, { getSemanticReportState } from './ViewQueryModal';
+import chartReducer, { chart } from 'src/components/Chart/chartReducer';
 
 const mockFormData = {
   datasource: '1__table',
@@ -216,4 +223,180 @@ test('falls back to empty ownState when prop is omitted', async () => {
       ownState: {},
     }),
   );
+});
+
+test('shows semantic requests verbatim in entry order without fetching', async () => {
+  const getChartDataRequestSpy = jest.spyOn(chartAction, 'getChartDataRequest');
+  const requestTexts = [
+    '-- SQL\nSELECT  1\n\n-- SQL\nSELECT 2;\n',
+    '-- SQL\nSELECT 3;',
+  ];
+  const { container } = render(
+    <ViewQueryModal
+      latestQueryFormData={{
+        datasource: '12__semantic_view',
+        viz_type: 'table',
+      }}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        charts: {
+          0: {
+            ...chart,
+            queriesResponse: requestTexts.map(query => ({ query })),
+          },
+        },
+      },
+    },
+  );
+
+  await waitFor(() =>
+    expect(
+      Array.from(container.querySelectorAll('pre'), pre => pre.textContent),
+    ).toEqual(requestTexts),
+  );
+  expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(2);
+  expect(getChartDataRequestSpy).not.toHaveBeenCalled();
+  expect(fetchMock.callHistory.calls()).toHaveLength(0);
+  expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  expect(screen.queryByText('Run in SQL Lab')).not.toBeInTheDocument();
+});
+
+test('updates semantic request text when the saved chart run is replaced', async () => {
+  const getChartDataRequestSpy = jest.spyOn(chartAction, 'getChartDataRequest');
+  const store = createStore(
+    {
+      charts: {
+        42: {
+          ...chart,
+          id: 42,
+          queriesResponse: [{ query: '-- SQL\nSELECT 1' }],
+        },
+      },
+    },
+    { charts: chartReducer },
+  );
+  const { container } = render(
+    <ViewQueryModal
+      latestQueryFormData={{
+        datasource: '12__semantic_view',
+        viz_type: 'table',
+        slice_id: 42,
+      }}
+    />,
+    { store },
+  );
+  await waitFor(() =>
+    expect(container.querySelector('pre')?.textContent).toBe(
+      '-- SQL\nSELECT 1',
+    ),
+  );
+
+  act(() => {
+    store.dispatch({
+      type: chartAction.CHART_UPDATE_SUCCEEDED,
+      key: 42,
+      queriesResponse: [{ query: '-- SQL\nSELECT 2' }],
+    });
+  });
+  await waitFor(() =>
+    expect(container.querySelector('pre')?.textContent).toBe(
+      '-- SQL\nSELECT 2',
+    ),
+  );
+  expect(container.textContent).not.toContain('SELECT 1');
+  expect(getChartDataRequestSpy).not.toHaveBeenCalled();
+  expect(fetchMock.callHistory.calls()).toHaveLength(0);
+});
+
+test.each<{
+  report: { query?: string }[] | null | undefined;
+  expected: ReturnType<typeof getSemanticReportState>;
+}>([
+  { report: undefined, expected: 'not-run' },
+  { report: null, expected: 'not-run' },
+  { report: [], expected: 'not-run' },
+  { report: [{ query: '' }], expected: 'none-reported' },
+  { report: [{}], expected: 'none-reported' },
+  { report: [{ query: 'x' }], expected: 'has-requests' },
+  { report: [{}, { query: 'x' }], expected: 'has-requests' },
+])('classifies $report as $expected', ({ report, expected }) => {
+  expect(getSemanticReportState(report)).toBe(expected);
+});
+
+test.each<{
+  report: { query?: string }[] | null;
+  message: string;
+  otherMessage: string;
+}>([
+  {
+    report: null,
+    message: 'The provider query will be available after the chart runs.',
+    otherMessage: 'No provider query is available for this run.',
+  },
+  {
+    report: [{ query: '' }],
+    message: 'No provider query is available for this run.',
+    otherMessage: 'The provider query will be available after the chart runs.',
+  },
+  {
+    report: [{}],
+    message: 'No provider query is available for this run.',
+    otherMessage: 'The provider query will be available after the chart runs.',
+  },
+])(
+  'shows an honest empty state for $report',
+  ({ report, message, otherMessage }) => {
+    const getChartDataRequestSpy = jest.spyOn(
+      chartAction,
+      'getChartDataRequest',
+    );
+    render(
+      <ViewQueryModal
+        latestQueryFormData={{
+          datasource: '12__semantic_view',
+          viz_type: 'table',
+        }}
+      />,
+      {
+        useRedux: true,
+        initialState: { charts: { 0: { ...chart, queriesResponse: report } } },
+      },
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(message);
+    expect(screen.queryByText(otherMessage)).not.toBeInTheDocument();
+    expect(getChartDataRequestSpy).not.toHaveBeenCalled();
+    expect(fetchMock.callHistory.calls()).toHaveLength(0);
+  },
+);
+
+test('preserves empty entries alongside reported requests in a mixed run', () => {
+  const requestText = '-- graphql\nquery { measures }';
+  const { container } = render(
+    <ViewQueryModal
+      latestQueryFormData={{
+        datasource: '12__semantic_view',
+        viz_type: 'table',
+      }}
+    />,
+    {
+      useRedux: true,
+      initialState: {
+        charts: {
+          0: {
+            ...chart,
+            queriesResponse: [{}, { query: requestText }, { query: '' }],
+          },
+        },
+      },
+    },
+  );
+  const entries = container.querySelectorAll('[role="alert"], pre');
+  expect(Array.from(entries, entry => entry.textContent)).toEqual([
+    'No provider query is available for this run.',
+    requestText,
+    'No provider query is available for this run.',
+  ]);
+  expect(fetchMock.callHistory.calls()).toHaveLength(0);
 });

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { FC, Fragment, useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { omit } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
@@ -35,7 +34,8 @@ import { Loading } from '@superset-ui/core/components';
 import { SupportedLanguage } from '@superset-ui/core/components/CodeSyntaxHighlighter';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
-import { ExplorePageState } from 'src/explore/types';
+import type { ChartState } from 'src/explore/types';
+import { useAppSelector } from 'src/views/store';
 import SemanticRequestView from './SemanticRequestView';
 
 interface Props {
@@ -71,9 +71,10 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData, ownState }) => {
   const isSemanticView =
     new DatasourceKey(latestQueryFormData.datasource).type ===
     DatasourceType.SemanticView;
-  const queriesResponse = useSelector(
-    (state: ExplorePageState) =>
-      state.charts?.[latestQueryFormData.slice_id ?? 0]?.queriesResponse,
+  const queriesResponse = useAppSelector<
+    ChartState['queriesResponse'] | undefined
+  >(
+    state => state.charts?.[latestQueryFormData.slice_id ?? 0]?.queriesResponse,
   );
   const [result, setResult] = useState<Result[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModal.tsx
@@ -17,10 +17,13 @@
  * under the License.
  */
 import { FC, Fragment, useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { omit } from 'lodash-es';
 import { t } from '@apache-superset/core/translation';
 import {
+  DatasourceKey,
+  DatasourceType,
   ensureIsArray,
   getClientErrorObject,
   JsonObject,
@@ -32,6 +35,8 @@ import { Loading } from '@superset-ui/core/components';
 import { SupportedLanguage } from '@superset-ui/core/components/CodeSyntaxHighlighter';
 import { getChartDataRequest } from 'src/components/Chart/chartAction';
 import ViewQuery from 'src/explore/components/controls/ViewQuery';
+import { ExplorePageState } from 'src/explore/types';
+import SemanticRequestView from './SemanticRequestView';
 
 interface Props {
   latestQueryFormData: QueryFormData;
@@ -44,6 +49,17 @@ type Result = {
   error?: string;
 };
 
+export function getSemanticReportState(
+  queriesResponse: readonly { query?: string }[] | null | undefined,
+): 'has-requests' | 'none-reported' | 'not-run' {
+  if (!queriesResponse?.length) {
+    return 'not-run';
+  }
+  return queriesResponse.some(entry => entry.query)
+    ? 'has-requests'
+    : 'none-reported';
+}
+
 const ViewQueryModalContainer = styled.div`
   height: 100%;
   display: flex;
@@ -52,6 +68,13 @@ const ViewQueryModalContainer = styled.div`
 `;
 
 const ViewQueryModal: FC<Props> = ({ latestQueryFormData, ownState }) => {
+  const isSemanticView =
+    new DatasourceKey(latestQueryFormData.datasource).type ===
+    DatasourceType.SemanticView;
+  const queriesResponse = useSelector(
+    (state: ExplorePageState) =>
+      state.charts?.[latestQueryFormData.slice_id ?? 0]?.queriesResponse,
+  );
   const [result, setResult] = useState<Result[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -90,8 +113,35 @@ const ViewQueryModal: FC<Props> = ({ latestQueryFormData, ownState }) => {
     [latestQueryFormData, ownState],
   );
   useEffect(() => {
-    loadChartData('query');
-  }, [loadChartData]);
+    if (!isSemanticView) {
+      loadChartData('query');
+    }
+  }, [isSemanticView, loadChartData]);
+
+  if (isSemanticView) {
+    const reportState = getSemanticReportState(queriesResponse);
+    const noRequestMessage = t('No provider query is available for this run.');
+    return (
+      <ViewQueryModalContainer>
+        {reportState === 'not-run' ? (
+          <Alert
+            type="info"
+            message={t(
+              'The provider query will be available after the chart runs.',
+            )}
+          />
+        ) : (
+          queriesResponse?.map((entry, index) =>
+            entry.query ? (
+              <SemanticRequestView key={index} requestText={entry.query} />
+            ) : (
+              <Alert key={index} type="info" message={noRequestMessage} />
+            ),
+          )
+        )}
+      </ViewQueryModalContainer>
+    );
+  }
 
   if (isLoading) {
     return <Loading />;

--- a/superset/semantic_layers/models.py
+++ b/superset/semantic_layers/models.py
@@ -366,7 +366,13 @@ class SemanticView(AuditMixinNullable, Model):
         return result
 
     def get_query_str(self, query_obj: QueryObjectDict) -> str:
-        return "Not implemented for semantic layers"
+        """Reject previews because provider queries are returned with chart data."""
+        raise QueryObjectValidationError(
+            _(
+                "A semantic view's provider query is produced when the chart runs "
+                "and returned with its data."
+            )
+        )
 
     @property
     def normalize_columns(self) -> bool:

--- a/superset/translations/ar/LC_MESSAGES/messages.po
+++ b/superset/translations/ar/LC_MESSAGES/messages.po
@@ -1117,6 +1117,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "سيتم حفظ مجموعة بيانات قابلة لإعادة الاستخدام مع الرسم البياني الخاص بك."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10540,6 +10545,9 @@ msgstr "لم يتم العثور على سجلات مطابقة"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "لم تتم إضافة أي فلاتر حاليًا إلى لوحة التحكم هذه."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr " لم يتم العثور على أية سجلات "
 
@@ -16001,6 +16009,9 @@ msgstr "يتم استخدام المقياس الأساسي لتحديد أحج�
 
 msgid "The provided table was not found in the provided database"
 msgstr "لم يتم العثور على الجدول المقدم في قاعدة البيانات المقدمة"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "تم حذف الاستعلام المرتبط بالنتائج."

--- a/superset/translations/ca/LC_MESSAGES/messages.po
+++ b/superset/translations/ca/LC_MESSAGES/messages.po
@@ -1024,6 +1024,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Es desarà un conjunt de dades reutilitzable amb el teu gràfic."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10166,6 +10171,9 @@ msgstr "Cap registre coincident trobat"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Cap filtre està afegit actualment a aquest dashboard."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Cap registre trobat"
 
@@ -15514,6 +15522,9 @@ msgstr "La mètrica primària s'usa per definir les mides dels segments d'arc"
 
 msgid "The provided table was not found in the provided database"
 msgstr "La taula proporcionada no s'ha trobat a la base de dades proporcionada"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "La consulta associada amb els resultats va ser eliminada."

--- a/superset/translations/cs/LC_MESSAGES/messages.po
+++ b/superset/translations/cs/LC_MESSAGES/messages.po
@@ -1019,6 +1019,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "S vaším grafem bude uložena znovupoužitelná sada dat."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9766,6 +9771,9 @@ msgstr "Žádné odpovídající výsledky"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Na této nástěnce nejsou v současné době přidány žádné filtry."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nebyly nalezeny žádné záznamy"
 
@@ -14913,6 +14921,9 @@ msgstr "Primární metrika se používá k definování velikostí segmentů obl
 
 msgid "The provided table was not found in the provided database"
 msgstr "Zadaná tabulka nebyla nalezena v zadané databázi"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Dotaz spojený s výsledky byl smazán."

--- a/superset/translations/de/LC_MESSAGES/messages.po
+++ b/superset/translations/de/LC_MESSAGES/messages.po
@@ -984,6 +984,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Ein wiederverwendbarer Datensatz wird mit Ihrem Diagramm gespeichert."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9499,6 +9504,9 @@ msgstr ""
 "Derzeit sind keine mehrschichtigen Deck.gl-Diagramme zu diesem Dashboard "
 "hinzugefügt."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Keine Einträge gefunden"
 
@@ -14535,6 +14543,9 @@ msgstr "Die primäre Metrik wird verwendet, um die Bogensegmentgrößen zu defin
 
 msgid "The provided table was not found in the provided database"
 msgstr "Die angegebene Tabelle wurde in der angegebenen Datenbank nicht gefunden"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Die den Ergebnissen zugeordnete Abfrage wurde gelöscht."

--- a/superset/translations/en/LC_MESSAGES/messages.po
+++ b/superset/translations/en/LC_MESSAGES/messages.po
@@ -880,6 +880,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr ""
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -8760,6 +8765,9 @@ msgstr ""
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr ""
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr ""
 
@@ -13287,6 +13295,9 @@ msgid "The primary metric is used to define the arc segment sizes"
 msgstr ""
 
 msgid "The provided table was not found in the provided database"
+msgstr ""
+
+msgid "The provider query will be available after the chart runs."
 msgstr ""
 
 msgid "The query associated with the results was deleted."

--- a/superset/translations/es/LC_MESSAGES/messages.po
+++ b/superset/translations/es/LC_MESSAGES/messages.po
@@ -1012,6 +1012,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Se guardará un conjunto de datos reutilizable con tu gráfico."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10045,6 +10050,9 @@ msgstr "No se han encontrado registros coincidentes"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Actualmente no se han añadido filtros a este panel de control."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "No se han encontrado registros"
 
@@ -15383,6 +15391,9 @@ msgid "The provided table was not found in the provided database"
 msgstr ""
 "La tabla proporcionada no se ha encontrado en la base de datos "
 "proporcionada"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "La consulta asociada con los resultados se ha eliminado."

--- a/superset/translations/fa/LC_MESSAGES/messages.po
+++ b/superset/translations/fa/LC_MESSAGES/messages.po
@@ -1030,6 +1030,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "یک مجموعه داده قابل استفاده مجدد با چارت شما ذخیره خواهد شد."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10240,6 +10245,9 @@ msgstr "هیچ رکوردی پیدا نشد"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "فعلاً هیچ فیلتری به این داشبورد اضافه نشده است."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "هیچ رکوردی یافت نشد"
 
@@ -15606,6 +15614,9 @@ msgstr "معیار اصلی برای تعریف اندازه‌های بخش‌�
 
 msgid "The provided table was not found in the provided database"
 msgstr "جدول ارائه شده در پایگاه داده ارائه شده یافت نشد."
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "کوئری مرتبط با نتایج حذف شد."

--- a/superset/translations/fi/LC_MESSAGES/messages.po
+++ b/superset/translations/fi/LC_MESSAGES/messages.po
@@ -1535,6 +1535,11 @@ msgstr "Raportti nimeltä \"%(name)s\" on jo olemassa"
 msgid "A reusable dataset will be saved with your chart."
 msgstr "Uudelleenkäytettävä tietojoukko tallennetaan kaaviosi kanssa."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 #, fuzzy
@@ -16815,6 +16820,9 @@ msgstr "Vastaavia tuloksia ei löydy"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Tähän kojetauluun ei ole tällä hetkellä lisätty suodattimia."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, uk, zh,
 # zh_TW]
@@ -25594,6 +25602,9 @@ msgstr "Ensisijaista mittaria käytetään kaarisegmenttien kokojen määrittäm
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "Annettua taulua ei löytynyt annetusta tietokannasta"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]

--- a/superset/translations/fr/LC_MESSAGES/messages.po
+++ b/superset/translations/fr/LC_MESSAGES/messages.po
@@ -1001,6 +1001,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Un jeu de données réutilisable sera enregistré avec votre graphique."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9693,6 +9698,9 @@ msgstr ""
 "Aucun graphique deck.gl multi-couches n'est actuellement ajouté à ce "
 "tableau de bord."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Aucun enregistrement n'a été trouvé"
 
@@ -14853,6 +14861,9 @@ msgstr ""
 
 msgid "The provided table was not found in the provided database"
 msgstr "La table est introuvable dans la base de données."
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "La requête associée aux résutlats a été supprimée."

--- a/superset/translations/it/LC_MESSAGES/messages.po
+++ b/superset/translations/it/LC_MESSAGES/messages.po
@@ -1258,6 +1258,11 @@ msgstr ""
 "questa tabella. Ripristinalo tramite POST /api/v1/dataset/%(uuid)s/restore "
 "prima di caricare, oppure carica su un nome di tabella diverso."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 msgid "A timeout occurred while executing the query."
 msgstr "Raggiunto timeout nell'eseguire la query."
 
@@ -12258,6 +12263,9 @@ msgstr ""
 "Nessun grafico deck.gl multistrato è attualmente aggiunto a questa "
 "dashboard."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nessun record trovato"
 
@@ -18727,6 +18735,9 @@ msgstr ""
 
 msgid "The provided table was not found in the provided database"
 msgstr "La tabella indicata non è stata trovata nel database indicato"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,

--- a/superset/translations/ja/LC_MESSAGES/messages.po
+++ b/superset/translations/ja/LC_MESSAGES/messages.po
@@ -913,6 +913,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "再利用可能なデータセットがチャートと共に保存されます。"
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "Jinjaテンプレート構文を使用してクエリ内で利用可能になるパラメータのセット"
@@ -8811,6 +8816,9 @@ msgstr "一致する結果が見つかりません"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "このダッシュボードにはマルチレイヤーdeck.glチャートはまだ追加されていません。"
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "レコードが見つかりません"
 
@@ -13387,6 +13395,9 @@ msgstr "主要メトリックは、円セグメントのサイズを定義する
 
 msgid "The provided table was not found in the provided database"
 msgstr "指定されたデータベース内にテーブルが見つかりませんでした"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "結果に関連付けられたクエリが削除されました。"

--- a/superset/translations/ko/LC_MESSAGES/messages.po
+++ b/superset/translations/ko/LC_MESSAGES/messages.po
@@ -1375,6 +1375,11 @@ msgstr "데이터셋 %(name)s 은 이미 존재합니다"
 msgid "A reusable dataset will be saved with your chart."
 msgstr "재사용 가능한 데이터셋이 차트와 함께 저장됩니다."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
@@ -14964,6 +14969,9 @@ msgstr "검색 결과"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "현재 이 대시보드에 추가된 다중 레이어 deck.gl 차트가 없습니다."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ro, ru, sk, sl, sr,
 # sr_Latn, tr, uk, zh, zh_TW]
@@ -22892,6 +22900,9 @@ msgstr "기본 지표는 호 세그먼트의 크기를 정의하는 데 사용�
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "제공된 데이터베이스에서 제공된 테이블을 찾을 수 없습니다"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,

--- a/superset/translations/lv/LC_MESSAGES/messages.po
+++ b/superset/translations/lv/LC_MESSAGES/messages.po
@@ -1019,6 +1019,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Ar jūsu diagrammu tiks saglabāta atkārtoti lietojama datu kopa."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9560,6 +9565,9 @@ msgstr "Nav atrasti atbilstoši rezultāti"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Šim informācijas panelim pašlaik nav pievienotu filtru."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Ieraksti nav atrasti"
 
@@ -14601,6 +14609,9 @@ msgstr "Primārā metrika tiek izmantota loka segmentu izmēru noteikšanai"
 
 msgid "The provided table was not found in the provided database"
 msgstr "Norādītā tabula netika atrasta norādītajā datubāzē"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Ar rezultātiem saistītais vaicājums tika dzēsts."

--- a/superset/translations/messages.pot
+++ b/superset/translations/messages.pot
@@ -886,6 +886,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr ""
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -8754,6 +8759,9 @@ msgstr ""
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr ""
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr ""
 
@@ -13271,6 +13279,9 @@ msgid "The primary metric is used to define the arc segment sizes"
 msgstr ""
 
 msgid "The provided table was not found in the provided database"
+msgstr ""
+
+msgid "The provider query will be available after the chart runs."
 msgstr ""
 
 msgid "The query associated with the results was deleted."

--- a/superset/translations/mi/LC_MESSAGES/messages.po
+++ b/superset/translations/mi/LC_MESSAGES/messages.po
@@ -1015,6 +1015,11 @@ msgstr ""
 "kauwhata."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "He huinga tawhā ka wātea i te pātai mā te tikanga tauira Jinja"
@@ -10073,6 +10078,9 @@ msgstr "Kāore i kitea he rekoata hāngai"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Kāore he tātari kua tāpiritia ki tēnei papatohu i tēnei wā."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Kāore i kitea he rekoata"
 
@@ -15406,6 +15414,9 @@ msgstr "Ka whakamahia te ine matua hei tautuhi i ngā rahi wāhanga kopeka"
 
 msgid "The provided table was not found in the provided database"
 msgstr "Kāore i kitea te ripanga kua tukuna i te pātengi raraunga kua tukuna"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "I mukua te pātai e hāngai ana ki ngā hua."

--- a/superset/translations/nl/LC_MESSAGES/messages.po
+++ b/superset/translations/nl/LC_MESSAGES/messages.po
@@ -1043,6 +1043,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Een herbruikbaar dataset wordt opgeslagen met uw grafiek."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10495,6 +10500,9 @@ msgstr "Geen overeenkomende records gevonden"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Er zijn momenteel geen filters toegevoegd aan dit dashboard."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Geen gegevens gevonden"
 
@@ -16024,6 +16032,9 @@ msgstr "De primaire metriek wordt gebruikt om de boogsegmentformaten te definië
 
 msgid "The provided table was not found in the provided database"
 msgstr "De opgegeven tabel is niet gevonden in de opgegeven database"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "De query die is gekoppeld aan de resultaten is verwijderd."

--- a/superset/translations/pl/LC_MESSAGES/messages.po
+++ b/superset/translations/pl/LC_MESSAGES/messages.po
@@ -1075,6 +1075,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Zostanie zapisany wielokrotnego użytku zestaw danych z twoim wykresem."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10662,6 +10667,9 @@ msgstr "Nie znaleziono pasujących rekordów"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Do tego dashboardu nie dodano żadnych filtrów."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nie znaleziono rekordów"
 
@@ -16340,6 +16348,9 @@ msgstr "Główna metryka jest używana do określenia rozmiarów segmentów łuk
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "Podana tabela nie została znaleziona w podanej bazie danych."
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Zapytanie powiązane z wynikami zostało usunięte."

--- a/superset/translations/pt/LC_MESSAGES/messages.po
+++ b/superset/translations/pt/LC_MESSAGES/messages.po
@@ -1321,6 +1321,11 @@ msgstr "Já existe um relatório com o nome \"%(name)s\""
 msgid "A reusable dataset will be saved with your chart."
 msgstr "Um conjunto de dados reutilizável será guardado com o seu gráfico."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,
 # uk, zh, zh_TW]
@@ -12792,6 +12797,9 @@ msgstr ""
 "Não existem gráficos deck.gl de múltiplas camadas adicionados a este "
 "dashboard."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nenhum registo encontrado"
 
@@ -19592,6 +19600,9 @@ msgstr ""
 
 msgid "The provided table was not found in the provided database"
 msgstr "A tabela indicada não foi encontrada na base de dados indicada"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ro, ru, sk, sl, sr, sr_Latn, tr,

--- a/superset/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/superset/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1024,6 +1024,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Um conjunto de dados reutilizável vai ser salvo com seu gráfico."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10518,6 +10523,9 @@ msgstr "Não foram encontrados registros correspondentes"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Nenhum filtro foi adicionado a esse painel no momento."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Não foram encontrados registos"
 
@@ -16097,6 +16105,9 @@ msgstr "A métrica primária é usada para definir os tamanhos dos segmentos de 
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "A tabela foi excluída ou renomeada no banco de dados."
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "A consulta associada aos resultados foi excluída."

--- a/superset/translations/ro/LC_MESSAGES/messages.po
+++ b/superset/translations/ro/LC_MESSAGES/messages.po
@@ -1077,6 +1077,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Un set de date reutilizabil va fi salvat cu graficul dvs."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -10292,6 +10297,9 @@ msgstr ""
 "Nu există diagrame deck.gl cu mai multe straturi adăugate în prezent la "
 "acest tablou de bord."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nicio înregistrare găsită"
 
@@ -15676,6 +15684,9 @@ msgstr ""
 
 msgid "The provided table was not found in the provided database"
 msgstr "Tabelul furnizat nu a fost găsit în baza de date furnizată"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Interogarea asociată cu rezultatele a fost ștearsă."

--- a/superset/translations/ru/LC_MESSAGES/messages.po
+++ b/superset/translations/ru/LC_MESSAGES/messages.po
@@ -999,6 +999,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Переиспользуемый датасет будет сохранен вместе с диаграммой"
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "Набор параметров, доступных в запросе через шаблоны Jinja"
@@ -9390,6 +9395,9 @@ msgstr "Совпадений не найдено"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "На этот дашборд не добавлена ни одна диаграмма deck.gl."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Записи не найдены"
 
@@ -14286,6 +14294,9 @@ msgstr "Основная мера используется для определ
 
 msgid "The provided table was not found in the provided database"
 msgstr "Таблица не найдена в базе данных"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Запрос, связанный с этими результатами, был удален"

--- a/superset/translations/sk/LC_MESSAGES/messages.po
+++ b/superset/translations/sk/LC_MESSAGES/messages.po
@@ -1012,6 +1012,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "S vaším grafem bude uložena znovupoužitelná sada dat."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9775,6 +9780,9 @@ msgstr "Žiadne zodpovedajúci výsledky"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Na tejto nástenke nesú v současné dobe pridanýy žiadne filtre."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Nebyly nalezeny žiadne záznamy"
 
@@ -14917,6 +14925,9 @@ msgstr "Primární metrika sa používa k definovanie veľkostí segmentů oblou
 
 msgid "The provided table was not found in the provided database"
 msgstr "Zadaná tabuľka nebyla nalezena v zadané databázy"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Dotaz spojený s výsledky bol zmazaný."

--- a/superset/translations/sl/LC_MESSAGES/messages.po
+++ b/superset/translations/sl/LC_MESSAGES/messages.po
@@ -994,6 +994,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Podatkovni set bo shranjen skupaj z grafikonom."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9457,6 +9462,9 @@ msgstr "Ni ustreznih rezultatov"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Na to nadzorno ploščo trenutno ni dodanih večplastnih grafikonov deck.gl."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Ni zapisov"
 
@@ -14377,6 +14385,9 @@ msgstr "Primarna mera določa velikost lokov segmentov"
 
 msgid "The provided table was not found in the provided database"
 msgstr "Podana tabela ni bila najdena v podani podatkovni bazi"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Poizvedba, povezana z rezultati, je bila izbrisana."

--- a/superset/translations/sr/LC_MESSAGES/messages.po
+++ b/superset/translations/sr/LC_MESSAGES/messages.po
@@ -1193,6 +1193,11 @@ msgstr "Извештај са називом \"%(name)s\" већ постоји"
 msgid "A reusable dataset will be saved with your chart."
 msgstr "Скуп података за поновну употребу биће сачуван уз ваш графикон."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 msgid ""
 "A set of parameters that become available in the query using Jinja "
@@ -11871,6 +11876,9 @@ msgstr ""
 "На ову контролну таблу тренутно нису додати никакви вишеслојни deck.gl "
 "графикони."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 # de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, uk, zh,
 # zh_TW]
 msgid "No records found"
@@ -18044,6 +18052,9 @@ msgstr "Примарна метрика се користи за дефинис�
 # de, es, fa, ja, lv, mi, nl, ru, sk, sl, uk]
 msgid "The provided table was not found in the provided database"
 msgstr "Наведена табела није пронађена у наведеној бази података"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 msgid "The query associated with the results was deleted."

--- a/superset/translations/sr_Latn/LC_MESSAGES/messages.po
+++ b/superset/translations/sr_Latn/LC_MESSAGES/messages.po
@@ -1193,6 +1193,11 @@ msgstr "Izveštaj sa nazivom \"%(name)s\" već postoji"
 msgid "A reusable dataset will be saved with your chart."
 msgstr "Skup podataka za ponovnu upotrebu biće sačuvan uz vaš grafikon."
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 msgid ""
 "A set of parameters that become available in the query using Jinja "
@@ -11880,6 +11885,9 @@ msgstr ""
 "Na ovu kontrolnu tablu trenutno nisu dodati nikakvi višeslojni deck.gl "
 "grafikoni."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 # de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, uk, zh,
 # zh_TW]
 msgid "No records found"
@@ -18054,6 +18062,9 @@ msgstr "Primarna metrika se koristi za definisanje veličina segmenata luka"
 # de, es, fa, ja, lv, mi, nl, ru, sk, sl, uk]
 msgid "The provided table was not found in the provided database"
 msgstr "Navedena tabela nije pronađena u navedenoj bazi podataka"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 msgid "The query associated with the results was deleted."

--- a/superset/translations/ta/LC_MESSAGES/messages.po
+++ b/superset/translations/ta/LC_MESSAGES/messages.po
@@ -931,6 +931,11 @@ msgstr ""
 "சேமிக்கப்படும்."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9269,6 +9274,9 @@ msgstr "பொருத்தமான முடிவுகள் எதுவ�
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "இந்த டேஷ்போர்டில் தற்போது வடிகட்டிகள் எதுவும் சேர்க்கப்படவில்லை."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "பதிவுகள் எதுவும் காணப்படவில்லை"
 
@@ -13953,6 +13961,9 @@ msgstr "வில் துண்டு அளவுகளை வரையறு
 
 msgid "The provided table was not found in the provided database"
 msgstr "வழங்கப்பட்ட தரவுத்தளத்தில் வழங்கப்பட்ட அட்டவணை காணப்படவில்லை"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "முடிவுகளுடன் தொடர்புடைய வினவல் நீக்கப்பட்டது."

--- a/superset/translations/th/LC_MESSAGES/messages.po
+++ b/superset/translations/th/LC_MESSAGES/messages.po
@@ -1483,6 +1483,11 @@ msgstr "มีรายงานชื่อ \"%(name)s\" อยู่แล้�
 msgid "A reusable dataset will be saved with your chart."
 msgstr "ชุดข้อมูลที่นำกลับมาใช้ใหม่ได้จะถูกบันทึกพร้อมกับแผนภูมิของคุณ"
 
+msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]
 #, fuzzy
@@ -16599,6 +16604,9 @@ msgstr "ไม่พบผลลัพธ์ที่ตรงกัน"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "ไม่มีตัวกรองที่เพิ่มเข้ามาในแดชบอร์ดนี้ในขณะนี้"
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, it, ja, lv, mi, nl, pl, pt, pt_BR, ru, sk, sl, uk, zh,
 # zh_TW]
@@ -25299,6 +25307,9 @@ msgstr "เมตริกหลักใช้เพื่อกำหนดข
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "ไม่พบตารางที่ระบุในฐานข้อมูลที่กำหนด"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 # Machine-translated via backfill_po.py (claude-sonnet-4-6) [refs: ar, ca, cs,
 # de, es, fa, fr, ja, lv, mi, nl, pl, pt_BR, ru, sk, sl, uk, zh, zh_TW]

--- a/superset/translations/tr/LC_MESSAGES/messages.po
+++ b/superset/translations/tr/LC_MESSAGES/messages.po
@@ -1004,6 +1004,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "Yeniden kullanılabilir bir veri kümesi, grafiğinizle kurtarılacaktır."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "Jinja'yı kullanarak sorguda mevcut olan bir dizi parametre, sözel sözcüm"
@@ -10064,6 +10069,9 @@ msgstr "Sonuç bulunamadı"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Bu panoya şu anda hiçbir çok katmanlı deck.gl grafiği eklenmemiş."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Hiçbir kayıt bulunamadı"
 
@@ -15360,6 +15368,9 @@ msgstr "İlk metrik, ark segment boyutlarını tanımlamak için kullanılır"
 
 msgid "The provided table was not found in the provided database"
 msgstr "Verilen masa, sağlanan veritabanında bulunamadı"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Sonuçlarla ilgili sorgu silindi."

--- a/superset/translations/uk/LC_MESSAGES/messages.po
+++ b/superset/translations/uk/LC_MESSAGES/messages.po
@@ -1033,6 +1033,11 @@ msgstr ""
 "перевикористовувати для інших діаграм."
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr ""
@@ -9547,6 +9552,9 @@ msgstr "Не знайдено відповідних результатів"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "Наразі до цього звіту не додано жодного фільтра."
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "Не знайдено жодного запису"
 
@@ -14590,6 +14598,9 @@ msgstr ""
 
 msgid "The provided table was not found in the provided database"
 msgstr "Таблицю не знайдено в базі даних"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "Запит, який повʼязано з результатом, вилучено."

--- a/superset/translations/zh/LC_MESSAGES/messages.po
+++ b/superset/translations/zh/LC_MESSAGES/messages.po
@@ -1044,6 +1044,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "一个可重复使用的数据集将与您的图表一起保存。"
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "使用 Jinja 模板语法在查询中可用的一组参数"
@@ -9942,6 +9947,9 @@ msgstr "未找到匹配结果"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "当前仪表板未添加任何多层 deck.gl 图表。"
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "没有找到任何记录"
 
@@ -15100,6 +15108,9 @@ msgstr "主计量指标用于定义弧段大小。"
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "该表在数据库中不存在"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "与结果关联的查询已删除。"

--- a/superset/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/superset/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1068,6 +1068,11 @@ msgid "A reusable dataset will be saved with your chart."
 msgstr "可重複使用的資料集將與您的圖表一同儲存。"
 
 msgid ""
+"A semantic view's provider query is produced when the chart runs and "
+"returned with its data."
+msgstr ""
+
+msgid ""
 "A set of parameters that become available in the query using Jinja "
 "templating syntax"
 msgstr "在查詢中可用的一組参數使用 Jinja 模板語法"
@@ -10679,6 +10684,9 @@ msgstr "没有找到任何紀錄"
 msgid "No multilayer deck.gl charts are currently added to this dashboard."
 msgstr "此看板中没有過濾條件。"
 
+msgid "No provider query is available for this run."
+msgstr ""
+
 msgid "No records found"
 msgstr "没有找到任何紀錄"
 
@@ -16225,6 +16233,9 @@ msgstr "主計量指標用於定義弧段大小。"
 #, fuzzy
 msgid "The provided table was not found in the provided database"
 msgstr "該表在資料庫中不存在"
+
+msgid "The provider query will be available after the chart runs."
+msgstr ""
 
 msgid "The query associated with the results was deleted."
 msgstr "與结果關聯的查詢已删除。"

--- a/tests/unit_tests/semantic_layers/models_test.py
+++ b/tests/unit_tests/semantic_layers/models_test.py
@@ -19,12 +19,16 @@
 
 from __future__ import annotations
 
+import os
 import uuid
+from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pyarrow as pa
 import pytest
+from flask.testing import FlaskClient
+from pytest_mock import MockerFixture
 from superset_core.semantic_layers.types import (
     Dimension,
     Grains,
@@ -34,7 +38,9 @@ from superset_core.semantic_layers.types import (
     SemanticRequest,
     SemanticResult,
 )
+from werkzeug.test import TestResponse
 
+from superset.exceptions import QueryObjectValidationError
 from superset.semantic_layers.models import (
     ColumnMetadata,
     get_column_type,
@@ -408,10 +414,69 @@ def test_semantic_view_query_language() -> None:
 
 
 def test_semantic_view_get_query_str() -> None:
-    """Test SemanticView get_query_str method."""
-    view = SemanticView()
-    result = view.get_query_str({})
-    assert result == "Not implemented for semantic layers"
+    """Reject query previews that cannot provide a semantic provider request."""
+    view: SemanticView = SemanticView()
+    with pytest.raises(
+        QueryObjectValidationError, match="produced when the chart runs"
+    ):
+        view.get_query_str({})
+
+
+def test_semantic_query_placeholder_is_absent() -> None:
+    """Keep the retired placeholder out of backend and frontend source."""
+    root: Path = Path(__file__).resolve().parents[3]
+    directory: Path
+    current: str
+    directories: list[str]
+    filenames: list[str]
+    filename: str
+    for directory in (root / "superset", root / "superset-frontend" / "src"):
+        for current, directories, filenames in os.walk(directory):
+            directories[:] = sorted(set(directories) - {"static", "__pycache__"})
+            for filename in filenames:
+                source: Path = Path(current) / filename
+                if source.suffix in {".py", ".ts", ".tsx", ".js", ".jsx"}:
+                    assert (
+                        b"Not implemented for semantic layers"
+                        not in source.read_bytes()
+                    ), str(source)
+
+
+def test_semantic_view_query_endpoint_returns_error(
+    client: FlaskClient,
+    full_api_access: None,
+    mocker: MockerFixture,
+) -> None:
+    """Return a semantic query validation error in the chart-data envelope."""
+    view: SemanticView = SemanticView(id=1)
+    implementation: MagicMock = MagicMock()
+    implementation.get_dimensions.return_value = []
+    implementation.get_metrics.return_value = []
+    mocker.patch.object(
+        SemanticView,
+        "implementation",
+        new_callable=PropertyMock,
+        return_value=implementation,
+    )
+    mocker.patch(
+        "superset.daos.datasource.DatasourceDAO.get_datasource", return_value=view
+    )
+    mocker.patch.object(SemanticView, "raise_for_access")
+
+    response: TestResponse = client.post(
+        "/api/v1/chart/data",
+        json={
+            "datasource": {"id": 1, "type": "semantic_view"},
+            "queries": [{}],
+            "result_type": "query",
+            "result_format": "json",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json["result"][0]["error"]
+    assert response.json["result"][0]["language"] is None
+    assert "query" not in response.json["result"][0]
 
 
 def test_semantic_view_get_extra_cache_keys() -> None:


### PR DESCRIPTION
### SUMMARY

Show semantic-view provider requests in **View query** using the chart's existing run report, in both Explore and the dashboard chart menu.

- Display and copy the complete provider request text verbatim, including host-authored kind headers and multiple request blocks.
- Use SQL/JSON highlighting as a presentation hint, with plain text for unknown kinds.
- Show distinct messages when the chart has not run or no request text is available for the run, including redacted reports.
- Do not fetch or execute anything when opening View query for a semantic view. Regular dataset behavior is unchanged.
- Replace the semantic-view compile-only placeholder with a translated validation error through the existing chart-data response envelope.
- Add tests, translation catalog entries, and user documentation. No new endpoints, provider interfaces, migrations, or dependencies.

Pre-execution preview is out of scope: providers report these requests with chart results. This PR reads that existing report rather than introducing a compile-only provider API.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Before: semantic-view View query displays `Not implemented for semantic layers`.

After: it displays copyable provider request text from the chart's run, or the appropriate empty-state message.

Live check on a local Cube semantic-layer stack (this branch on top of master + #44370): **View query** in Explore shows the Cube provider's reported request for the chart's last run, with a `-- cube` kind header and the JSON Cube query, copyable verbatim.

<img width="1316" height="914" alt="view-query-cube-explore" src="https://github.com/user-attachments/assets/43e284dd-66ad-440f-a177-6bf3835d166b" />

This is in [Cube's query format](https://docs.cube.dev/reference/core-data-apis/rest-api/query-format).

### TESTING INSTRUCTIONS

Automated checks completed locally:

- `npm run test -- ViewQueryModal.test.tsx SemanticRequestView.test.tsx --maxWorkers=2`: 27 tests passed, including the five unchanged existing dataset cases.
- `pytest tests/unit_tests/semantic_layers/models_test.py -q`: 101 tests passed.
- `pre-commit run --files <branch-changed files>`: all applicable hooks passed, including MyPy and frontend type checking; no repository-wide run.
- Source-placeholder absence is checked by an automated regression test.

Manual checks still required:

1. With `SEMANTIC_LAYERS` enabled, run a chart backed by a SQL-producing provider and open **View query** from Explore and a dashboard chart menu.
2. Compare displayed/copied text with the provider's reported request. Check complete headers, whitespace, multiple requests, and long-text scrolling.
3. Rerun with different filters and confirm the request updates with the chart's results.
4. Repeat for a non-SQL provider; unknown kinds must remain readable and copyable.
5. Check the distinct not-run and no-request empty states, and confirm opening the modal adds no chart-data requests.
6. Confirm regular dataset query fetching, formatting, and SQL Lab affordances remain unchanged.

No live-provider or OS-clipboard pass is claimed. CI results will be evaluated separately.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-104912](https://app.shortcut.com/preset/story/104912)
- [x] Required feature flags: `SEMANTIC_LAYERS` (existing flag)
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API: provider-request display; no new API
- [ ] Removes existing feature or API

