### PR TITLE
docs(mcp): document restore_chart and restore_dashboard tools

### DIFF
--- a/docs/docs/using-superset/using-ai-with-superset.mdx
+++ b/docs/docs/using-superset/using-ai-with-superset.mdx
@@ -281,6 +281,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `update_chart_preview`  | Update a cached chart preview without saving                                                                                                      |
 | `generate_explore_link` | Generate an Explore URL for interactive visualization                                                                                             |
 | `delete_chart`          | Delete a chart by ID or UUID (soft-deletes to trash when `SOFT_DELETE` is enabled; fails if alerts/reports are still attached, checked before editorship; otherwise returns `permission_denied` if the caller isn't an editor of the chart — owners, Admins, and explicitly granted editors qualify)   |
+| `restore_chart`         | Restore a soft-deleted chart from trash by ID or UUID; not gated on `SOFT_DELETE`, so rows trashed while it was enabled stay recoverable, but only soft-deleted charts can be restored — permanently deleted charts are unrecoverable; returns `permission_denied` if the caller isn't an editor of the chart |
 
 ### Dashboards
 
@@ -291,6 +292,7 @@ Ask your admin for the MCP server URL and any authentication tokens you need.
 | `generate_dashboard`              | Create a new dashboard with specified charts                                                                                                                                         |
 | `add_chart_to_existing_dashboard` | Add a chart to an existing dashboard                                                                                                                                                 |
 | `delete_dashboard`                | Delete a dashboard by ID, UUID, or slug; leaves its charts intact (soft-deletes to trash when `SOFT_DELETE` is enabled; fails if alerts/reports are still attached, checked before editorship; otherwise returns `permission_denied` if the caller isn't an editor of the dashboard — owners, Admins, and explicitly granted editors qualify) |
+| `restore_dashboard`               | Restore a soft-deleted dashboard from trash by ID or UUID (slug lookup does not cover trashed dashboards); not gated on `SOFT_DELETE`, so rows trashed while it was enabled stay recoverable, but only soft-deleted dashboards can be restored — permanently deleted dashboards are unrecoverable; returns `permission_denied` if the caller isn't an editor of the dashboard |
 
 ### SQL
 


### PR DESCRIPTION
### SUMMARY
#41842 added the `restore_chart` and `restore_dashboard` MCP tools but the "Using AI with Superset" tool reference table was never updated to list them, so they're missing from the docs right next to the `delete_chart`/`delete_dashboard` entries they pair with. This adds the two rows.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A (docs-only table addition)

### TESTING INSTRUCTIONS
Render `docs/docs/using-superset/using-ai-with-superset.mdx` (or just read the diff) and confirm the Charts and Dashboards tool tables now include `restore_chart` and `restore_dashboard` alongside `delete_chart`/`delete_dashboard`.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

🤖 Generated with [Claude Code](https://claude.com/claude-code)